### PR TITLE
Adds requirements.txt with ray wheel dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,11 @@
+pandas==0.22
+# Install Ray from latest wheels
+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.4.0-cp27-cp27mu-manylinux1_x86_64.whl ; sys_platform == "linux2" and python_version == "2.7"
+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.4.0-cp33-cp33m-manylinux1_x86_64.whl ; sys_platform == "linux" and python_version == "3.3"
+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.4.0-cp34-cp34m-manylinux1_x86_64.whl ; sys_platform == "linux" and python_version == "3.4"
+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.4.0-cp35-cp35m-manylinux1_x86_64.whl ; sys_platform == "linux" and python_version == "3.5"
+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.4.0-cp36-cp36m-manylinux1_x86_64.whl ; sys_platform == "linux" and python_version == "3.6"
+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.4.0-cp27-cp27m-macosx_10_6_intel.whl ; sys_platform == "darwin" and python_version == "2.7"
+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.4.0-cp34-cp34m-macosx_10_6_intel.whl ; sys_platform == "darwin" and python_version == "3.4"
+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.4.0-cp35-cp35m-macosx_10_6_intel.whl ; sys_platform == "darwin" and python_version == "3.5"
+https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-0.4.0-cp36-cp36m-macosx_10_6_intel.whl ; sys_platform == "darwin" and python_version == "3.6"

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,41 @@ from __future__ import division
 from __future__ import print_function
 
 from setuptools import setup, find_packages
+import setuptools.command.build_ext as _build_ext
+import sys
+import platform
+import pip
+
+python_version = platform.python_version()[:3]
+
+ray_whl = "ray"  # Fall back on pip install if no relevant wheel exists
+ray_whl_prefix = "https://s3-us-west-2.amazonaws.com/ray-wheels/latest/"
+if sys.platform.startswith('linux'):
+    if python_version == "2.7":
+        ray_whl = ray_whl_prefix + \
+            "ray-0.4.0-cp27-cp27mu-manylinux1_x86_64.whl"
+    elif python_version == "3.3":
+        ray_whl = ray_whl_prefix + "ray-0.4.0-cp33-cp33m-manylinux1_x86_64.whl"
+    elif python_version == "3.4":
+        ray_whl = ray_whl_prefix + "ray-0.4.0-cp34-cp34m-manylinux1_x86_64.whl"
+    elif python_version == "3.5":
+        ray_whl = ray_whl_prefix + "ray-0.4.0-cp35-cp35m-manylinux1_x86_64.whl"
+    elif python_version == "3.6":
+        ray_whl = ray_whl_prefix + "ray-0.4.0-cp36-cp36m-manylinux1_x86_64.whl"
+elif sys.platform == "darwin":
+    if python_version == "2.7":
+        ray_whl = ray_whl_prefix + "ray-0.4.0-cp27-cp27m-macosx_10_6_intel.whl"
+    elif python_version == "3.4":
+        ray_whl = ray_whl_prefix + "ray-0.4.0-cp34-cp34m-macosx_10_6_intel.whl"
+    elif python_version == "3.5":
+        ray_whl = ray_whl_prefix + "ray-0.4.0-cp35-cp35m-macosx_10_6_intel.whl"
+    elif python_version == "3.6":
+        ray_whl = ray_whl_prefix + "ray-0.4.0-cp36-cp36m-macosx_10_6_intel.whl"
+
+
+class build_ext(_build_ext.build_ext):
+    def run(self):
+        pip.main(['install', ray_whl])
 
 
 setup(
@@ -11,5 +46,6 @@ setup(
     description="Modin: Pandas on Ray - Make your pandas code run faster with "
                 "a single line of code change.",
     packages=find_packages(),
+    cmdclass={"build_ext": build_ext},
     url="https://github.com/modin-project/modin",
     install_requires=["pandas==0.22"])


### PR DESCRIPTION
This adds the requirements.txt file.

It also adds support for installing ray from its latest wheels in setup.py.

The requirements are rather hacky as they rely on matching the os and python versions to the specific wheel and installing it manually in setup.py. It might make sense to exclude as the dependency on wheels will be resolved in the Ray 0.5.0 release.

This is rebased on #2.