### PR TITLE
Make setup.py compatible with pip version 10

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,14 @@ from setuptools import setup, find_packages
 import setuptools.command.build_ext as _build_ext
 import sys
 import platform
-from pip._internal import main  # https://github.com/pypa/pip/issues/5240
+import pip
+
+pip_major = int(pip.__version__.split(".")[0])
+if pip_major < 10:
+    # https://github.com/pypa/pip/issues/5240
+    from pip import main
+else:
+    from pip._internal import main
 
 python_version = platform.python_version()[:3]
 


### PR DESCRIPTION
In response to: https://github.com/pypa/pip/issues/5240.

Pip did a large refactor of their internals, which affects some of our code in setup.py. This makes it compatible with pip 10, while retaining backwards compatibility. 