### PR TITLE
Performance boost in _blocks_to_col by np.concatenate

### DIFF
--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -408,8 +408,7 @@ def _create_blocks_helper(df, npartitions, axis):
 @ray.remote
 def _blocks_to_col(*partition):
     if len(partition):
-        return pandas.concat(partition, axis=0, copy=False)\
-            .reset_index(drop=True)
+        return pandas.DataFrame(np.concatenate(partition, axis=0))
     else:
         return pandas.Series()
 
@@ -417,8 +416,8 @@ def _blocks_to_col(*partition):
 @memoize
 @ray.remote
 def _blocks_to_row(*partition):
-    row_part = pandas.concat(partition, axis=1, copy=False)\
-        .reset_index(drop=True)
+    row_part = pandas.DataFrame(np.concatenate(partition, axis=1))
+
     # Because our block partitions contain different indices (for the
     # columns), this change is needed to ensure correctness.
     row_part.columns = pandas.RangeIndex(0, len(row_part.columns))

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -410,7 +410,7 @@ def _blocks_to_col(*partition):
     if len(partition):
         df = pandas.DataFrame(np.concatenate(partition, axis=0))
 
-        if len(np.unique(partition.dtypes.values)) > 1:  # heterogenous types
+        if len(np.unique(partition[0].dtypes.values)) > 1:  # heterogenous types
             df = df.astype(partition[0].dtypes, copy=False)
 
         return df

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -410,7 +410,8 @@ def _blocks_to_col(*partition):
     if len(partition):
         df = pandas.DataFrame(np.concatenate(partition, axis=0))
 
-        if len(np.unique(partition[0].dtypes.values)) > 1:  # heterogenous types
+        # heterogenous types
+        if len(np.unique(partition[0].dtypes.values)) > 1:
             df = df.astype(partition[0].dtypes, copy=False)
 
         return df

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -410,9 +410,9 @@ def _blocks_to_col(*partition):
     if len(partition):
         df = pandas.DataFrame(np.concatenate(partition, axis=0))
 
-        if len(np.unique(partition.dtypes.values)) > 1: # heterogenous type
+        if len(np.unique(partition.dtypes.values)) > 1:  # heterogenous type
             df = df.astype(partition[0].dtypes, copy=False)
-            
+
         return df
     else:
         return pandas.Series()

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -410,7 +410,7 @@ def _blocks_to_col(*partition):
     if len(partition):
         df = pandas.DataFrame(np.concatenate(partition, axis=0))
 
-        if len(np.unique(partition.dtypes.values)) > 1:  # heterogenous type
+        if len(np.unique(partition.dtypes.values)) > 1:  # heterogenous types
             df = df.astype(partition[0].dtypes, copy=False)
 
         return df


### PR DESCRIPTION
In `_blocks_to_col`, we can use `np.concatenate` instead of `pd.concat` to speedup our concatenation. Because blocks belongs to the same column group often have the same type or (due to limited col width) few types, the casting will be fast even when it is required. 