### PR TITLE
Make classes inherit from object

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -127,7 +127,7 @@ def _compute_ndim(row_loc, col_loc):
     return ndim
 
 
-class _Location_Indexer_Base():
+class _Location_Indexer_Base(object):
     """Base class for location indexer like loc and iloc
     """
 

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -15,7 +15,7 @@ _NAN_BLOCKS = {}
 _MEMOIZER_CAPACITY = 1000  # Capacity per function
 
 
-class LRUCache:
+class LRUCache(object):
     """A LRUCache implemented with collections.OrderedDict
 
     Notes:
@@ -48,7 +48,7 @@ class LRUCache:
         self.cache[key] = value
 
 
-class memoize:
+class memoize(object):
     """A basic memoizer that cache the input and output of the remote function
 
     Notes:


### PR DESCRIPTION
Some classes don't inherit from object which causes errors in python 2. This PR fixes this issue.