### PR TITLE
Fixing bug in drop where col_partitions were set incorrectly

### DIFF
--- a/modin/pandas/index_metadata.py
+++ b/modin/pandas/index_metadata.py
@@ -390,6 +390,9 @@ class _IndexMetadata(object):
                 new_coord_df['partition'][new_coord_df['partition'] == i] \
                     -= num_dropped
 
+        new_coord_df['index_within_partition'] = [i for l in self._lengths
+                                                  for i in range(l)]
+
         self._coord_df = new_coord_df
         return dropped
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Refactors `drop` so that there is not a loop of `df._col_partitions` being set. Should be more performant as well.
## Related issue number
#52 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
