### PR TITLE
Re-enable disabled regression test and fix a minor bug in equals method

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2009,7 +2009,7 @@ class DataFrame(object):
         """
         if isinstance(other, pandas.DataFrame):
             # Copy into a Ray DataFrame to simplify logic below
-            other = DataFrame(other) 
+            other = DataFrame(other)
 
         if not self.index.equals(other.index) or not \
                 self.columns.equals(other.columns):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2007,6 +2007,9 @@ class DataFrame(object):
         Returns:
             Boolean: True if equal, otherwise False
         """
+        if isinstance(other, pandas.DataFrame):
+            # Copy into a Ray DataFrame to simplify logic below
+            other = DataFrame(other) 
 
         if not self.index.equals(other.index) or not \
                 self.columns.equals(other.columns):

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -144,7 +144,7 @@ def test_int_dataframe():
     test_pipe(ray_df, pandas_df)
 
     # test_loc(ray_df, pandas_df)
-    # test_iloc(ray_df, pandas_df)
+    test_iloc(ray_df, pandas_df)
 
     labels = ['a', 'b', 'c', 'd']
     test_set_axis(ray_df, pandas_df, labels, 0)
@@ -314,7 +314,7 @@ def test_float_dataframe():
     test_itertuples(ray_df, pandas_df)
 
     # test_loc(ray_df, pandas_df)
-    # test_iloc(ray_df, pandas_df)
+    test_iloc(ray_df, pandas_df)
 
     labels = ['a', 'b', 'c', 'd']
     test_set_axis(ray_df, pandas_df, labels, 0)
@@ -496,7 +496,7 @@ def test_mixed_dtype_dataframe():
     test_itertuples(ray_df, pandas_df)
 
     # test_loc(ray_df, pandas_df)
-    # test_iloc(ray_df, pandas_df)
+    test_iloc(ray_df, pandas_df)
 
     labels = ['a', 'b', 'c', 'd']
     test_set_axis(ray_df, pandas_df, labels, 0)
@@ -647,7 +647,7 @@ def test_nan_dataframe():
     test_itertuples(ray_df, pandas_df)
 
     # test_loc(ray_df, pandas_df)
-    # test_iloc(ray_df, pandas_df)
+    test_iloc(ray_df, pandas_df)
 
     labels = ['a', 'b', 'c', 'd']
     test_set_axis(ray_df, pandas_df, labels, 0)

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -441,6 +441,11 @@ def extractor(df_chunk, row_loc, col_loc):
     except AttributeError:
         # Locators might be scaler or python list
         pass
+    # Python2 doesn't allow writable flag to be set on this object. Copying
+    # into a list allows it to be used by iloc.
+    except ValueError:
+        row_loc = list(row_loc)
+        col_loc = list(col_loc)
     return df_chunk.iloc[row_loc, col_loc]
 
 


### PR DESCRIPTION
## What do these changes do?

These changes re-enable disabled regression tests for the `iloc()` method. The newly-enabled tests exposed a minor bug in `DataFrame.equals()`, so I fixed that too. After these changes, all regression tests pass on my local copy.

## Related issue number
N/A
