### PR TITLE
Fix repr when cols<=20 and rows>60

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -385,18 +385,16 @@ class DataFrame(object):
         if len(self.index) >= 60:
             head_blocks = self._head_block_builder(30)
             tail_blocks = self._tail_block_builder(30)
-            length_of_index = 30
+            index_of_head = self.index[:30]
+            index_of_tail = self.index[-30:]
         else:
             head_blocks = self._block_partitions
             # We set this to None so we know
             tail_blocks = None
-            length_of_index = len(self.index)
+            index_of_head = self.index
 
         # Get first and last 10 columns if there are more than 20 columns
         if len(self._col_metadata) >= 20:
-
-            index_of_head = self.index[:length_of_index]
-
             # Building the front blocks from head_blocks
             front_blocks = \
                 front_block_builder(head_blocks, 10, index_of_head)
@@ -410,7 +408,6 @@ class DataFrame(object):
 
             # True only if we have >60 rows in the DataFrame
             if tail_blocks is not None:
-                index_of_tail = self.index[-30:]
                 # Building the font blocks from tail_blocks
                 front_blocks = \
                     front_block_builder(tail_blocks, 10, index_of_tail)
@@ -435,6 +432,7 @@ class DataFrame(object):
             ]
             full_head = pandas.concat(list_of_head_rows)
             full_head.columns = self.columns
+            full_head.index = index_of_head
 
             # True only if we have >60 rows in the DataFrame
             if tail_blocks is not None:
@@ -444,6 +442,7 @@ class DataFrame(object):
                      for df in tail_blocks]
                 full_tail = pandas.concat(list_of_tail_rows)
                 full_tail.columns = self.columns
+                full_tail.index = index_of_tail
 
                 return row_dots_builder(full_head, full_tail)
             else:

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -3415,11 +3415,11 @@ def test___repr__():
     #
     # assert repr(pandas_df) == repr(ray_df)
 
-    # ___repr___ method has a different code path depending on 
+    # ___repr___ method has a different code path depending on
     # whether the number of rows is >60; and a different code path
-    # depending on the number of columns is >20.  
-    # Previous test cases already check the case when cols>20 
-    # and rows>60. The cases that follow exercise the other three 
+    # depending on the number of columns is >20.
+    # Previous test cases already check the case when cols>20
+    # and rows>60. The cases that follow exercise the other three
     # combinations.
     # rows <= 60, cols > 20
     frame_data = np.random.randint(0, 100, size=(10, 100))

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -3415,13 +3415,28 @@ def test___repr__():
     #
     # assert repr(pandas_df) == repr(ray_df)
 
+    # ___repr___ method has a different code path depending on 
+    # whether the number of rows is >60; and a different code path
+    # depending on the number of columns is >20.  
+    # Previous test cases already check the case when cols>20 
+    # and rows>60. The cases that follow exercise the other three 
+    # combinations.
+    # rows <= 60, cols > 20
     frame_data = np.random.randint(0, 100, size=(10, 100))
     pandas_df = pandas.DataFrame(frame_data)
     ray_df = pd.DataFrame(frame_data)
 
     assert repr(pandas_df) == repr(ray_df)
 
+    # rows <= 60, cols <= 20
     frame_data = np.random.randint(0, 100, size=(10, 10))
+    pandas_df = pandas.DataFrame(frame_data)
+    ray_df = pd.DataFrame(frame_data)
+
+    assert repr(pandas_df) == repr(ray_df)
+
+    # rows > 60, cols <= 20
+    frame_data = np.random.randint(0, 100, size=(100, 10))
     pandas_df = pandas.DataFrame(frame_data)
     ray_df = pd.DataFrame(frame_data)
 


### PR DESCRIPTION
## What do these changes do?
The `__repr__()` method of Modin dataframes hits different code paths depending on whether the number of colums is >20, as well as on whether the number of rows is >60. The case where columns<=20 and rows>60 was not covered by the regression tests and had a bug. The bug caused the index column not to be rendered properly in Jupyter notebooks, displaying: 
![screen shot 2018-08-09 at 1 32 37 pm](https://user-images.githubusercontent.com/12436991/43924193-cd2bea54-9bd8-11e8-92c0-93af91edf27a.png)
instead of:
![screen shot 2018-08-09 at 1 32 03 pm](https://user-images.githubusercontent.com/12436991/43924201-d3a54a9c-9bd8-11e8-8ff9-88f0038cbfe5.png)

This PR fixes the bug and adds a regression test that covers the previously untested case.

## Related issue number
N/A
- [x ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
