### PR TITLE
Adding __git_revision__ and __version__

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -1,1 +1,29 @@
+import os
+import subprocess
+
+
+def git_version():
+    def _execute_cmd_in_temp_env(cmd):
+        # construct environment
+        env = {}
+        for k in ['SYSTEMROOT', 'PATH', 'HOME']:
+            v = os.environ.get(k)
+            if v is not None:
+                env[k] = v
+        # LANGUAGE is used on win32
+        env['LANGUAGE'] = 'C'
+        env['LANG'] = 'C'
+        env['LC_ALL'] = 'C'
+        return subprocess.Popen(cmd,
+                                stdout=subprocess.PIPE,
+                                env=env).communicate()[0]
+
+    try:
+        git_revision = _execute_cmd_in_temp_env(['git', 'rev-parse', 'HEAD'])
+        return git_revision.strip().decode('ascii')
+    except OSError:
+        return "Unknown"
+
+
+__git_revision__ = git_version()
 __version__ = "0.1.1"

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -14,9 +14,8 @@ def git_version():
         env['LANGUAGE'] = 'C'
         env['LANG'] = 'C'
         env['LC_ALL'] = 'C'
-        return subprocess.Popen(cmd,
-                                stdout=subprocess.PIPE,
-                                env=env).communicate()[0]
+        return subprocess.Popen(
+            cmd, stdout=subprocess.PIPE, env=env).communicate()[0]
 
     try:
         git_revision = _execute_cmd_in_temp_env(['git', 'rev-parse', 'HEAD'])

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -13,6 +13,8 @@ import threading
 import os
 import ray
 
+from .. import __git_revision__, __version__
+
 try:
     if threading.current_thread().name == "MainThread":
         ray.init(
@@ -58,5 +60,5 @@ __all__ = [
     "Panel", "date_range", "Index", "MultiIndex", "Series", "bdate_range",
     "DatetimeIndex", "to_timedelta", "set_eng_float_format", "set_option",
     "CategoricalIndex", "Timedelta", "Timestamp", "NaT", "PeriodIndex",
-    "Categorical"
+    "Categorical", "__git_revision__", "__version__"
 ]


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Adds `__git_revision__` and `__version__` to `modin.pandas`.

```python
In [1]: import modin

In [2]: modin.__version__
Out[2]: '0.1.1'

In [3]: modin.__git_revision__
Out[3]: '98fb533f6b8b20615e62f9c10a412d3c781349c9'

In [4]: import modin.pandas as pd
Process STDOUT and STDERR is being redirected to /tmp/raylogs/.
Waiting for redis server at 127.0.0.1:16321 to respond...
Waiting for redis server at 127.0.0.1:11240 to respond...
Starting local scheduler with the following resources: {'CPU': 8, 'GPU': 0}.

In [5]: pd.__version__
Out[5]: '0.1.1'

In [6]: pd.__git_revision__
Out[6]: '98fb533f6b8b20615e62f9c10a412d3c781349c9'
```

## Related issue number
Resolves #71, Resolves #72 

cc @jangorecki
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
