### PR TITLE
Stop __git_revision__ from throwing errors in non-git repos

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 
 
-def git_version():
+def _git_version():
     def _execute_cmd_in_temp_env(cmd):
         # construct environment
         env = {}
@@ -36,12 +36,11 @@ def get_partition_format():
     return "Pandas"
 
 
-__git_revision__ = git_version()
+__git_revision__ = _git_version()
 __version__ = "0.1.2"
 __execution_engine__ = get_execution_engine()
 __partition_format__ = get_partition_format()
 
 # We don't want these used outside of this file.
-del git_version
 del get_execution_engine
 del get_partition_format

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -16,13 +16,11 @@ def _git_version():
         env["LC_ALL"] = "C"
         return subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env).communicate()[0]
 
-    if os.path.exists("./.git"):
-        try:
-            git_revision = _execute_cmd_in_temp_env(["git", "rev-parse", "HEAD"])
-            return git_revision.strip().decode()
-        except OSError:
-            return "Unknown"
-    else:
+    os.chdir(os.path.dirname(os.path.abspath(__file__)))
+    try:
+        git_revision = _execute_cmd_in_temp_env(["git", "rev-parse", "HEAD"])
+        return git_revision.strip().decode()
+    except OSError:
         return "Unknown"
 
 

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -16,10 +16,13 @@ def _git_version():
         env["LC_ALL"] = "C"
         return subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env).communicate()[0]
 
-    try:
-        git_revision = _execute_cmd_in_temp_env(["git", "rev-parse", "HEAD"])
-        return git_revision.strip().decode()
-    except OSError:
+    if os.path.exists("./.git"):
+        try:
+            git_revision = _execute_cmd_in_temp_env(["git", "rev-parse", "HEAD"])
+            return git_revision.strip().decode()
+        except OSError:
+            return "Unknown"
+    else:
         return "Unknown"
 
 
@@ -42,5 +45,8 @@ __execution_engine__ = get_execution_engine()
 __partition_format__ = get_partition_format()
 
 # We don't want these used outside of this file.
+del _git_version
 del get_execution_engine
 del get_partition_format
+del os
+del subprocess

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -16,12 +16,15 @@ def _git_version():
         env["LC_ALL"] = "C"
         return subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env).communicate()[0]
 
+    cwd = os.getcwd()
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     try:
         git_revision = _execute_cmd_in_temp_env(["git", "rev-parse", "HEAD"])
-        return git_revision.strip().decode()
+        rev_string =  git_revision.strip().decode()
     except OSError:
-        return "Unknown"
+        rev_string = "Unknown"
+    os.chdir(cwd)
+    return rev_string
 
 
 def get_execution_engine():

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -20,7 +20,7 @@ def _git_version():
     os.chdir(os.path.dirname(os.path.abspath(__file__)))
     try:
         git_revision = _execute_cmd_in_temp_env(["git", "rev-parse", "HEAD"])
-        rev_string =  git_revision.strip().decode()
+        rev_string = git_revision.strip().decode()
     except OSError:
         rev_string = "Unknown"
     os.chdir(cwd)

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -49,5 +49,3 @@ __partition_format__ = get_partition_format()
 del _git_version
 del get_execution_engine
 del get_partition_format
-del os
-del subprocess

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -35,7 +35,7 @@ import threading
 import os
 import ray
 
-from .. import __git_revision__, __version__
+from .. import _git_version, __version__
 from .concat import concat
 from .dataframe import DataFrame
 from .datetimes import to_datetime
@@ -56,6 +56,7 @@ from .io import (
 )
 from .reshape import get_dummies
 
+__git_revision__ = git_version()
 # Set this so that Pandas doesn't try to multithread by itself
 os.environ["OMP_NUM_THREADS"] = "1"
 

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -35,7 +35,7 @@ import threading
 import os
 import ray
 
-from .. import _git_version, __version__
+from .. import __git_revision__, __version__
 from .concat import concat
 from .dataframe import DataFrame
 from .datetimes import to_datetime
@@ -56,7 +56,6 @@ from .io import (
 )
 from .reshape import get_dummies
 
-__git_revision__ = git_version()
 # Set this so that Pandas doesn't try to multithread by itself
 os.environ["OMP_NUM_THREADS"] = "1"
 


### PR DESCRIPTION

## What do these changes do?
 
Currently there is a bunch of git errors thrown when you are not running from the default directory.
This will get the `__git_revision__` hash regardless of where the code is being run from.
<!-- Please give a short brief about these changes. -->

## Related issue number
Resolves #82 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
