### PR TITLE
Fix repr(df.T) performance

### DIFF
--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -1814,17 +1814,21 @@ class PandasDataManager(object):
         Returns:
             DataManager containing the first n columns of the original DataManager.
         """
+        new_dtypes = (
+            self._dtype_cache if self._dtype_cache is None else self._dtype_cache[:n]
+        )
         # See head for an explanation of the transposed behavior
         if self._is_transposed:
             result = self.__constructor__(
                 self.data.transpose().take(0, n).transpose(),
                 self.index,
                 self.columns[:n],
+                new_dtypes,
             )
             result._is_transposed = True
         else:
             result = self.__constructor__(
-                self.data.take(1, n), self.index, self.columns[:n], self.dtypes[:n]
+                self.data.take(1, n), self.index, self.columns[:n], new_dtypes
             )
         return result
 
@@ -1837,17 +1841,21 @@ class PandasDataManager(object):
         Returns:
             DataManager containing the last n columns of the original DataManager.
         """
+        new_dtypes = (
+            self._dtype_cache if self._dtype_cache is None else self._dtype_cache[-n:]
+        )
         # See head for an explanation of the transposed behavior
         if self._is_transposed:
             result = self.__constructor__(
                 self.data.transpose().take(0, -n).transpose(),
                 self.index,
                 self.columns[-n:],
+                new_dtypes,
             )
             result._is_transposed = True
         else:
             result = self.__constructor__(
-                self.data.take(1, -n), self.index, self.columns[-n:], self.dtypes[-n:]
+                self.data.take(1, -n), self.index, self.columns[-n:], new_dtypes
             )
         return result
 

--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -1820,7 +1820,6 @@ class PandasDataManager(object):
                 self.data.transpose().take(0, n).transpose(),
                 self.index,
                 self.columns[:n],
-                self.dtypes[:n],
             )
             result._is_transposed = True
         else:
@@ -1844,7 +1843,6 @@ class PandasDataManager(object):
                 self.data.transpose().take(0, -n).transpose(),
                 self.index,
                 self.columns[-n:],
-                self.dtypes[-n:],
             )
             result._is_transposed = True
         else:


### PR DESCRIPTION

## What do these changes do?

Improve performance of `repr(df.T)` by a significant factor.

```python
import modin.pandas as pd
import numpy as np
frame_data = np.random.randint(0, 100, size=(2**20, 2**8))
df = pd.DataFrame(frame_data)

repr(df.T)
```

The `repr(df.T)` previously took more than 20 seconds. 

After this change it takes ~350 ms. 

The change is related to removing the cost of computing `dtype` if we aren't going to use them. `dtype` can be expensive to compute if there are a large number of columns.

## Related issue number

Resolves #110 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
