### PR TITLE
Fix issue where empty partitions caused incorrect behavior

### DIFF
--- a/modin/data_management/partitioning/partition_collections.py
+++ b/modin/data_management/partitioning/partition_collections.py
@@ -60,6 +60,7 @@ class BlockPartitions(object):
         return self._partitions_cache
 
     def _set_partitions(self, new_partitions):
+        self._filtered_empties = False
         self._partitions_cache = new_partitions
 
     partitions = property(_get_partitions, _set_partitions)

--- a/modin/data_management/partitioning/partition_collections.py
+++ b/modin/data_management/partitioning/partition_collections.py
@@ -983,7 +983,7 @@ class RayBlockPartitions(BlockPartitions):
     _partition_class = RayRemotePartition
 
     def __init__(self, partitions):
-        self._partitions_cache = partitions
+        self.partitions = partitions
 
     # We override these for performance reasons.
     # Lengths of the blocks

--- a/modin/data_management/partitioning/partition_collections.py
+++ b/modin/data_management/partitioning/partition_collections.py
@@ -43,9 +43,21 @@ class BlockPartitions(object):
 
     def _get_partitions(self):
         if 0 in self.block_lengths:
-            self._partitions_cache = np.array([self._partitions_cache[i] for i in range(len(self._partitions_cache)) if self.block_lengths[i] != 0])
+            self._partitions_cache = np.array(
+                [
+                    self._partitions_cache[i]
+                    for i in range(len(self._partitions_cache))
+                    if self.block_lengths[i] != 0
+                ]
+            )
         if 0 in self.block_widths:
-            self._partitions_cache = np.array([self._partitions_cache.T[i] for i in range(len(self._partitions_cache.T)) if self.block_widths[i] != 0]).T
+            self._partitions_cache = np.array(
+                [
+                    self._partitions_cache.T[i]
+                    for i in range(len(self._partitions_cache.T))
+                    if self.block_widths[i] != 0
+                ]
+            ).T
         self._remove_empty_blocks()
         return self._partitions_cache
 
@@ -115,7 +127,9 @@ class BlockPartitions(object):
             # The first column will have the correct lengths. We have an
             # invariant that requires that all blocks be the same length in a
             # row of blocks.
-            self._lengths_cache = [obj.length().get() for obj in self._partitions_cache.T[0]]
+            self._lengths_cache = [
+                obj.length().get() for obj in self._partitions_cache.T[0]
+            ]
         return self._lengths_cache
 
     # Widths of the blocks
@@ -132,7 +146,9 @@ class BlockPartitions(object):
             # The first column will have the correct lengths. We have an
             # invariant that requires that all blocks be the same width in a
             # column of blocks.
-            self._widths_cache = [obj.width().get() for obj in self._partitions_cache[0]]
+            self._widths_cache = [
+                obj.width().get() for obj in self._partitions_cache[0]
+            ]
         return self._widths_cache
 
     def _remove_empty_blocks(self):

--- a/modin/data_management/partitioning/partition_collections.py
+++ b/modin/data_management/partitioning/partition_collections.py
@@ -40,25 +40,23 @@ class BlockPartitions(object):
     # Partition class is the class to use for storing each partition. It must
     # extend the `RemotePartition` class.
     _partition_class = None
+    # Whether or not we have already filtered out the empty partitions.
+    _filtered_empties = False
 
     def _get_partitions(self):
-        if 0 in self.block_lengths:
+        if not self._filtered_empties:
             self._partitions_cache = np.array(
                 [
-                    self._partitions_cache[i]
+                    [
+                        self._partitions_cache[i][j]
+                        for j in range(len(self._partitions_cache[i]))
+                        if self.block_lengths[i] != 0 or self.block_widths[j] != 0
+                    ]
                     for i in range(len(self._partitions_cache))
-                    if self.block_lengths[i] != 0
                 ]
             )
-        if 0 in self.block_widths:
-            self._partitions_cache = np.array(
-                [
-                    self._partitions_cache.T[i]
-                    for i in range(len(self._partitions_cache.T))
-                    if self.block_widths[i] != 0
-                ]
-            ).T
-        self._remove_empty_blocks()
+            self._remove_empty_blocks()
+            self._filtered_empties = True
         return self._partitions_cache
 
     def _set_partitions(self, new_partitions):
@@ -127,9 +125,11 @@ class BlockPartitions(object):
             # The first column will have the correct lengths. We have an
             # invariant that requires that all blocks be the same length in a
             # row of blocks.
-            self._lengths_cache = [
-                obj.length().get() for obj in self._partitions_cache.T[0]
-            ]
+            self._lengths_cache = (
+                [obj.length().get() for obj in self._partitions_cache.T[0]]
+                if len(self._partitions_cache.T) > 0
+                else []
+            )
         return self._lengths_cache
 
     # Widths of the blocks
@@ -146,14 +146,20 @@ class BlockPartitions(object):
             # The first column will have the correct lengths. We have an
             # invariant that requires that all blocks be the same width in a
             # column of blocks.
-            self._widths_cache = [
-                obj.width().get() for obj in self._partitions_cache[0]
-            ]
+            self._widths_cache = (
+                [obj.width().get() for obj in self._partitions_cache[0]]
+                if len(self._partitions_cache) > 0
+                else []
+            )
         return self._widths_cache
 
     def _remove_empty_blocks(self):
-        self._widths_cache = [width for width in self._widths_cache if width != 0]
-        self._lengths_cache = [length for length in self._lengths_cache if length != 0]
+        if self._widths_cache is not None:
+            self._widths_cache = [width for width in self._widths_cache if width != 0]
+        if self._lengths_cache is not None:
+            self._lengths_cache = [
+                length for length in self._lengths_cache if length != 0
+            ]
 
     @property
     def shape(self) -> Tuple[int, int]:
@@ -996,8 +1002,10 @@ class RayBlockPartitions(BlockPartitions):
             # The first column will have the correct lengths. We have an
             # invariant that requires that all blocks be the same length in a
             # row of blocks.
-            self._lengths_cache = ray.get(
-                [obj.length().oid for obj in self._partitions_cache.T[0]]
+            self._lengths_cache = (
+                ray.get([obj.length().oid for obj in self._partitions_cache.T[0]])
+                if len(self._partitions_cache.T) > 0
+                else []
             )
         return self._lengths_cache
 
@@ -1015,8 +1023,10 @@ class RayBlockPartitions(BlockPartitions):
             # The first column will have the correct lengths. We have an
             # invariant that requires that all blocks be the same width in a
             # column of blocks.
-            self._widths_cache = ray.get(
-                [obj.width().oid for obj in self._partitions_cache[0]]
+            self._widths_cache = (
+                ray.get([obj.width().oid for obj in self._partitions_cache[0]])
+                if len(self._partitions_cache) > 0
+                else []
             )
         return self._widths_cache
 


### PR DESCRIPTION
## What do these changes do?

Sometimes we can get `np.nan` values when we are performing `mean` across rows.

## Related issue number
Resolves #118

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
