### PR TITLE
Fixed cumulative functions

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1012,6 +1012,9 @@ class DataFrame(object):
             The cumulative maximum of the DataFrame.
         """
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
+        if axis:
+            self._validate_dtypes()
+
         return DataFrame(
             data_manager=self._data_manager.cummax(axis=axis, skipna=skipna, **kwargs)
         )
@@ -1027,6 +1030,9 @@ class DataFrame(object):
             The cumulative minimum of the DataFrame.
         """
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
+        if axis:
+            self._validate_dtypes()
+
         return DataFrame(
             data_manager=self._data_manager.cummin(axis=axis, skipna=skipna, **kwargs)
         )
@@ -1042,6 +1048,8 @@ class DataFrame(object):
             The cumulative product of the DataFrame.
         """
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
+        self._validate_dtypes(numeric_only=True)
+
         return DataFrame(
             data_manager=self._data_manager.cumprod(axis=axis, skipna=skipna, **kwargs)
         )
@@ -1057,6 +1065,8 @@ class DataFrame(object):
             The cumulative sum of the DataFrame.
         """
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
+        self._validate_dtypes(numeric_only=True)
+
         return DataFrame(
             data_manager=self._data_manager.cumsum(axis=axis, skipna=skipna, **kwargs)
         )
@@ -4628,3 +4638,12 @@ class DataFrame(object):
                         "given {1}".format(len(self.columns), len(other))
                     )
         return other
+
+    def _validate_dtypes(self, numeric_only=False):
+        """Helper method to check that all the dtypes are the same"""
+        dtype = self.dtypes[0]
+        for t in self.dtypes:
+            if numeric_only and not is_numeric_dtype(t):
+                raise TypeError("{0} is not a numeric data type".format(t))
+            elif not numeric_only and t != dtype:
+                raise TypeError("Cannot compare type '{0}' with type '{1}'".format(t, dtype))

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -4646,4 +4646,6 @@ class DataFrame(object):
             if numeric_only and not is_numeric_dtype(t):
                 raise TypeError("{0} is not a numeric data type".format(t))
             elif not numeric_only and t != dtype:
-                raise TypeError("Cannot compare type '{0}' with type '{1}'".format(t, dtype))
+                raise TypeError(
+                    "Cannot compare type '{0}' with type '{1}'".format(t, dtype)
+                )

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1014,7 +1014,6 @@ class DataFrame(object):
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
         if axis:
             self._validate_dtypes()
-
         return DataFrame(
             data_manager=self._data_manager.cummax(axis=axis, skipna=skipna, **kwargs)
         )
@@ -1032,7 +1031,6 @@ class DataFrame(object):
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
         if axis:
             self._validate_dtypes()
-
         return DataFrame(
             data_manager=self._data_manager.cummin(axis=axis, skipna=skipna, **kwargs)
         )
@@ -1049,7 +1047,6 @@ class DataFrame(object):
         """
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
         self._validate_dtypes(numeric_only=True)
-
         return DataFrame(
             data_manager=self._data_manager.cumprod(axis=axis, skipna=skipna, **kwargs)
         )
@@ -1066,7 +1063,6 @@ class DataFrame(object):
         """
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
         self._validate_dtypes(numeric_only=True)
-
         return DataFrame(
             data_manager=self._data_manager.cumsum(axis=axis, skipna=skipna, **kwargs)
         )


### PR DESCRIPTION
## What do these changes do?

Ensures that the columns are all numeric when necessary for cumulative functions such as `cummax` and `cumsum`. Also throws a `TypeError` when the columns are not all numeric but should be. This error message is different from that of pandas' in order to have `_validate_dtypes` be a more general purpose function instead of only for cumulative functions. 

## Related issue number

Resolves #126 

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
