### PR TITLE
[WIP] Enable multilevel index in various functions

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1007,6 +1007,20 @@ class PandasQueryCompiler(object):
         Return:
             Pandas Series with sum or prod of DataFrame.
         """
+
+        # kwargs["new_index"] = new_index
+        # func = self._prepare_method(sum_level_builder, **kwargs)
+        # new_data = self.map_across_full_axis(axis, func)
+        # new_index = self.compute_index(axis, new_data, compute_diff=False)
+        # if not axis:
+        #     return self.__constructor__(
+        #         new_data, new_index, self.columns, self._dtype_cache
+        #     )
+        # return self.__constructor__(
+        #     new_data, self.index, new_index, self._dtype_cache
+        # )
+
+
         axis = kwargs.get("axis", 0)
         numeric_only = kwargs.get("numeric_only", None) if not axis else True
         min_count = kwargs.get("min_count", 1)
@@ -1020,6 +1034,11 @@ class PandasQueryCompiler(object):
 
         def sum_prod_builder(df, **kwargs):
             if not df.empty:
+                # axis = kwargs.get("axis", 0)
+                # if not axis:
+                #     df.index = kwargs.get("new_index", None)
+                # else:
+                #     df.columns = kwargs.get("new_index", None)
                 return func(df, **kwargs)
             else:
                 return pandas.DataFrame([])
@@ -1050,6 +1069,41 @@ class PandasQueryCompiler(object):
             Pandas series with the sum of each numerical column or row.
         """
         return self._process_sum_prod(pandas.DataFrame.sum, **kwargs)
+
+        # # Pandas default is 0 (though not mentioned in docs)
+        # level = kwargs.get("level", None)
+        # axis = kwargs.get("axis", 0)
+        # numeric_only = True if axis else kwargs.get("numeric_only", False)
+        # if level is None:
+        #     func = self._prepare_method(pandas.DataFrame.sum, **kwargs)
+        #     return self.full_reduce(axis, func, numeric_only=numeric_only)
+        # else:
+        #
+        #     def sum_level_builder(df, **kwargs):
+        #         axis = kwargs.get("axis", 0)
+        #         level = kwargs.get("level", None)
+        #         if not axis:
+        #             df.index = kwargs.get("new_index", None)
+        #         else:
+        #             df.columns = kwargs.get("new_index", None)
+        #         return df.sum(axis=axis, level=level)
+        #
+        #     if not axis:
+        #         new_index = self.index
+        #     else:
+        #         new_index = self.columns
+        #
+        #     kwargs["new_index"] = new_index
+        #     func = self._prepare_method(sum_level_builder, **kwargs)
+        #     new_data = self.map_across_full_axis(axis, func)
+        #     new_index = self.compute_index(axis, new_data, compute_diff=False)
+        #     if not axis:
+        #         return self.__constructor__(
+        #             new_data, new_index, self.columns, self._dtype_cache
+        #         )
+        #     return self.__constructor__(
+        #         new_data, self.index, new_index, self._dtype_cache
+        #     )
 
     # END Full Reduce operations
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2758,7 +2758,8 @@ class DataFrame(object):
         """
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
         self._validate_dtypes_sum_prod_mean(axis, numeric_only, ignore_axis=True)
-        return self._query_compiler.prod(
+
+        result = self._query_compiler.prod(
             axis=axis,
             skipna=skipna,
             level=level,
@@ -2766,6 +2767,9 @@ class DataFrame(object):
             min_count=min_count,
             **kwargs
         )
+        if not level:
+            return result
+        return self._create_dataframe_from_manager(new_manager=result)
 
     def product(
         self,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -663,9 +663,12 @@ class DataFrame(object):
         else:
             if bool_only:
                 raise ValueError("Axis must be 0 or 1 (got {})".format(axis))
-        return self._query_compiler.all(
+        result = self._query_compiler.all(
             axis=axis, bool_only=bool_only, skipna=skipna, level=level, **kwargs
         )
+        if level is None:
+            return result
+        return self._create_dataframe_from_manager(new_manager=result)
 
     def any(self, axis=0, bool_only=None, skipna=None, level=None, **kwargs):
         """Return whether any elements are True over requested axis
@@ -679,9 +682,12 @@ class DataFrame(object):
         else:
             if bool_only:
                 raise ValueError("Axis must be 0 or 1 (got {})".format(axis))
-        return self._query_compiler.any(
+        result = self._query_compiler.any(
             axis=axis, bool_only=bool_only, skipna=skipna, level=level, **kwargs
         )
+        if level is None:
+            return result
+        return self._create_dataframe_from_manager(new_manager=result)
 
     def append(self, other, ignore_index=False, verify_integrity=False, sort=None):
         """Append another DataFrame/list/Series to this one.

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -404,7 +404,7 @@ class DataFrame(object):
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
         self._validate_dtypes_sum_prod_mean(axis, numeric_only, ignore_axis=False)
 
-        return self._query_compiler.sum(
+        result = self._query_compiler.sum(
             axis=axis,
             skipna=skipna,
             level=level,
@@ -412,6 +412,9 @@ class DataFrame(object):
             min_count=min_count,
             **kwargs
         )
+        if level is None:
+            return result
+        return self._create_dataframe_from_manager(new_manager=result)
 
     def abs(self):
         """Apply an absolute value function to all numeric columns.

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -414,7 +414,7 @@ class DataFrame(object):
         )
         if level is None:
             return result
-        return self._create_dataframe_from_manager(new_manager=result)
+        return self._create_dataframe_from_compiler(new_query_compiler=result)
 
     def abs(self):
         """Apply an absolute value function to all numeric columns.
@@ -668,7 +668,7 @@ class DataFrame(object):
         )
         if level is None:
             return result
-        return self._create_dataframe_from_manager(new_manager=result)
+        return self._create_dataframe_from_compiler(new_query_compiler=result)
 
     def any(self, axis=0, bool_only=None, skipna=None, level=None, **kwargs):
         """Return whether any elements are True over requested axis
@@ -687,7 +687,7 @@ class DataFrame(object):
         )
         if level is None:
             return result
-        return self._create_dataframe_from_manager(new_manager=result)
+        return self._create_dataframe_from_compiler(new_query_compiler=result)
 
     def append(self, other, ignore_index=False, verify_integrity=False, sort=None):
         """Append another DataFrame/list/Series to this one.
@@ -2775,7 +2775,7 @@ class DataFrame(object):
         )
         if not level:
             return result
-        return self._create_dataframe_from_manager(new_manager=result)
+        return self._create_dataframe_from_compiler(new_query_compiler=result)
 
     def product(
         self,


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

This pull request is to enable multilevel index in various functions that take in `level` parameter. Current changes experiment using `map_across_full_axis` in `sum` for multilevel index dataframes, and experiment with` inter_df_op` operations. This is WIP and there are many more changes to be made:

Implementations:
- [x] clean up current implementation in `sum` and add more error checking
- [x] modify other methods using `map_across_axis` to follow `sum` example
- [ ] modify other methods using `inter_df_op_handler` to follow `add` example (need to double check what modifications should be done after removing `level` check)
- [ ] modify `drop` to take in `level` parameter

Testing:
- [ ] complete the new test suite `test_multilevel_dataframe` to test various operations with level parameter
- [ ] modify existing test functions to take in multilevel dataframes and `level` as parameters


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
