### PR TITLE
Adding black check to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,4 @@ Thank you for your contribution!
 <!-- Are there any issues opened that will be resolved by merging this change? -->
 
 - [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
+- [ ] passes `black --check modin/`


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Adding `black --check modin/` to the template to help prevent lint errors.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
