### PR TITLE
Fixing partitioning offset

### DIFF
--- a/modin/data_management/partitioning/axis_partition.py
+++ b/modin/data_management/partitioning/axis_partition.py
@@ -152,6 +152,8 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
         num_splits: The number of even splits to create.
         result: The result of the computation. This should be a Pandas
             DataFrame.
+        length_list: The list of lengths to split this DataFrame into. This is used to
+            return the DataFrame to its original partitioning schema.
 
     Returns:
         A list of Pandas DataFrames.

--- a/modin/data_management/partitioning/axis_partition.py
+++ b/modin/data_management/partitioning/axis_partition.py
@@ -158,11 +158,12 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
     if length_list is not None:
         length_list = [0] + length_list
         import numpy as np
+
         sums = np.cumsum(length_list)
         if axis == 0 or type(result) is pandas.Series:
-            return [result.iloc[sums[i]: sums[i + 1]] for i in range(len(sums) - 1)]
+            return [result.iloc[sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
         else:
-            return [result.iloc[:, sums[i]: sums[i + 1]] for i in range(len(sums) - 1)]
+            return [result.iloc[:, sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
     # We do this to restore block partitioning
     if axis == 0 or type(result) is pandas.Series:
         chunksize = compute_chunksize(len(result), num_splits)
@@ -194,7 +195,9 @@ def deploy_ray_axis_func(axis, func, num_splits, kwargs, *partitions):
     """
     dataframe = pandas.concat(partitions, axis=axis, copy=False)
     result = func(dataframe, **kwargs)
-    return split_result_of_axis_func_pandas(axis, num_splits, result, [len(part) for part in partitions])
+    return split_result_of_axis_func_pandas(
+        axis, num_splits, result, [len(part) for part in partitions]
+    )
 
 
 @ray.remote

--- a/modin/data_management/partitioning/axis_partition.py
+++ b/modin/data_management/partitioning/axis_partition.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as np
 import pandas
 import ray
 
@@ -156,9 +157,7 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
         A list of Pandas DataFrames.
     """
     if length_list is not None:
-        length_list = [0] + length_list
-        import numpy as np
-
+        length_list.insert(0, 0)
         sums = np.cumsum(length_list)
         if axis == 0 or type(result) is pandas.Series:
             return [result.iloc[sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]

--- a/modin/data_management/partitioning/axis_partition.py
+++ b/modin/data_management/partitioning/axis_partition.py
@@ -156,7 +156,7 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
     Returns:
         A list of Pandas DataFrames.
     """
-    if length_list is not None and type(result) is not pandas.Series:
+    if length_list is not None:
         length_list.insert(0, 0)
         sums = np.cumsum(length_list)
         if axis == 0:
@@ -194,7 +194,7 @@ def deploy_ray_axis_func(axis, func, num_splits, kwargs, *partitions):
     """
     dataframe = pandas.concat(partitions, axis=axis, copy=False)
     result = func(dataframe, **kwargs)
-    if num_splits != len(partitions):
+    if num_splits != len(partitions) or isinstance(result, pandas.Series):
         lengths = None
     else:
         if axis == 0:


### PR DESCRIPTION
## What do these changes do?

The partitioning can become off when we operate on specific columns or rows. This is particularly evident after a `read_csv`.

This fixes the issue by returning the partitioning in the same number of partitions it was given along a single axis.
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
