### PR TITLE
Fixed Min and Max

### DIFF
--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -921,10 +921,17 @@ class PandasDataManager(object):
         # without ignoring any non-numeric types. We must check explicitly if
         # numeric_only is False because if it is None, it will default to True
         # if the operation fails with mixed dtypes.
-        if axis and numeric_only == False and np.unique([is_numeric_dtype(dtype) for dtype in self.dtypes]).size == 2:
+        if (
+            axis
+            and numeric_only is False
+            and np.unique([is_numeric_dtype(dtype) for dtype in self.dtypes]).size == 2
+        ):
             # check if there are columns with dtypes datetime or timedelta
-            if all(dtype != np.dtype("datetime64[ns]") and dtype != np.dtype("timedelta64[ns]")
-                   for dtype in self.dtypes):
+            if all(
+                dtype != np.dtype("datetime64[ns]")
+                and dtype != np.dtype("timedelta64[ns]")
+                for dtype in self.dtypes
+            ):
                 raise TypeError("Cannot compare Numeric and Non-Numeric Types")
 
         numeric_only = True if axis else kwargs.get("numeric_only", False)

--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -903,6 +903,39 @@ class PandasDataManager(object):
             result.index = data_manager.index
         return result
 
+    def _process_min_max(self, func, **kwargs):
+        """Calculates the min or max of the DataFrame.
+
+        Return:
+           Pandas series containing the min or max values from each column or
+           row.
+        """
+        # Pandas default is 0 (though not mentioned in docs)
+        axis = kwargs.get("axis", 0)
+        numeric_only = kwargs.get("numeric_only", None)
+
+        # If our DataFrame has both numeric and non-numeric dtypes then
+        # comparisons between these types do not make sense and we must raise a
+        # TypeError. The exception to this rule is when there are datetime and
+        # timedelta objects, in which case we proceed with the comparison
+        # without ignoring any non-numeric types. We must check explicitly if
+        # numeric_only is False because if it is None, it will default to True
+        # if the operation fails with mixed dtypes.
+        if axis and numeric_only == False and np.unique([is_numeric_dtype(dtype) for dtype in self.dtypes]).size == 2:
+            # check if there are columns with dtypes datetime or timedelta
+            if all(dtype != np.dtype("datetime64[ns]") and dtype != np.dtype("timedelta64[ns]")
+                   for dtype in self.dtypes):
+                raise TypeError("Cannot compare Numeric and Non-Numeric Types")
+
+        numeric_only = True if axis else kwargs.get("numeric_only", False)
+
+        def min_max_builder(df, **kwargs):
+            if not df.empty:
+                return func(df, **kwargs)
+
+        map_func = self._prepare_method(min_max_builder, **kwargs)
+        return self.full_reduce(axis, map_func, numeric_only=numeric_only)
+
     def count(self, **kwargs):
         """Counts the number of non-NaN objects for each column or row.
 
@@ -921,11 +954,7 @@ class PandasDataManager(object):
         Return:
             Pandas series with the maximum values from each column or row.
         """
-        # Pandas default is 0 (though not mentioned in docs)
-        axis = kwargs.get("axis", 0)
-        numeric_only = True if axis else kwargs.get("numeric_only", False)
-        func = self._prepare_method(pandas.DataFrame.max, **kwargs)
-        return self.full_reduce(axis, func, numeric_only=numeric_only)
+        return self._process_min_max(pandas.DataFrame.max, **kwargs)
 
     def mean(self, **kwargs):
         """Returns the mean for each numerical column or row.
@@ -944,23 +973,7 @@ class PandasDataManager(object):
         Return:
             Pandas series with the minimum value from each column or row.
         """
-        # Pandas default is 0 (though not mentioned in docs)
-        axis = kwargs.get("axis", 0)
-        numeric_only = kwargs.get("numeric_only", None)
-        if numeric_only == False and not all(is_numeric_dtype(dtype) for dtype in
-                self.dtypes) and axis:
-            found = False
-            for d in self.dtypes:
-                if d == np.dtype("datetime64[ns]") or d == np.dtype("timedelta64[ns]"):
-                    found = True
-            if not found:
-                raise TypeError("Cannot compare Numeric and Non-Numeric Types")
-        numeric_only = True if axis else kwargs.get("numeric_only", False)
-        def min_func(df, **kwargs):
-            if not df.empty:
-                return df.min(**kwargs)
-        func = self._prepare_method(min_func, **kwargs)
-        return self.full_reduce(axis, func, numeric_only=numeric_only)
+        return self._process_min_max(pandas.DataFrame.min, **kwargs)
 
     def prod(self, **kwargs):
         """Returns the product of each numerical column or row.


### PR DESCRIPTION
`df.min()` and `df.max()` work correctly on DataFrames with mixed data types. Fixes https://github.com/modin-project/modin/issues/162 and https://github.com/modin-project/modin/issues/163 

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
