### PR TITLE
Fixed Sum and Prod and Mean

### DIFF
--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -949,7 +949,7 @@ class PandasDataManager(object):
         numeric_only = True if axis else kwargs.get("numeric_only", False)
         func = self._prepare_method(pandas.DataFrame.min, **kwargs)
         return self.full_reduce(axis, func, numeric_only=numeric_only)
- 
+
     def _process_sum_prod(self, func, ignore_axis=False, **kwargs):
         """Calculates the sum or product of the DataFrame.
 
@@ -1021,7 +1021,6 @@ class PandasDataManager(object):
             )
         else:
             return self.full_axis_reduce(map_func, axis, new_index)
-
 
     def prod(self, **kwargs):
         """Returns the product of each numerical column or row.

--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -962,36 +962,6 @@ class PandasDataManager(object):
         numeric_only = kwargs.get("numeric_only", None)
         min_count = kwargs.get("min_count", 0)
 
-        # We cannot add datetime types, so if we are summing a column with
-        # dtype datetime64 and cannot ignore non-numeric types, we must throw a
-        # TypeError.
-        if (
-            not axis
-            and numeric_only is False
-            and any(dtype == np.dtype("datetime64[ns]") for dtype in self.dtypes)
-        ):
-            raise TypeError("Cannot add Timestamp Types")
-
-        # If our DataFrame has both numeric and non-numeric dtypes then
-        # operations between these types do not make sense and we must raise a
-        # TypeError. The exception to this rule is when there are datetime and
-        # timedelta objects, in which case we proceed with the comparison
-        # without ignoring any non-numeric types. We must check explicitly if
-        # numeric_only is False because if it is None, it will default to True
-        # if the operation fails with mixed dtypes.
-        if (
-            (axis or ignore_axis)
-            and numeric_only is False
-            and np.unique([is_numeric_dtype(dtype) for dtype in self.dtypes]).size == 2
-        ):
-            # check if there are columns with dtypes datetime or timedelta
-            if all(
-                dtype != np.dtype("datetime64[ns]")
-                and dtype != np.dtype("timedelta64[ns]")
-                for dtype in self.dtypes
-            ):
-                raise TypeError("Cannot operate on Numeric and Non-Numeric Types")
-
         numeric_only = True if axis else kwargs.get("numeric_only", False)
 
         reduce_index = self.columns if axis else self.index

--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -977,8 +977,7 @@ class PandasDataManager(object):
         if (
             not axis
             and numeric_only is False
-            and any(dtype == np.dtype("datetime64[ns]") for dtype in
-                self.dtypes)
+            and any(dtype == np.dtype("datetime64[ns]") for dtype in self.dtypes)
         ):
             raise TypeError("Cannot add Timestamp Types")
 
@@ -1018,16 +1017,16 @@ class PandasDataManager(object):
         map_func = self._prepare_method(sum_builder, **kwargs)
 
         if all(
-            dtype == np.dtype("datetime64[ns]")
-            or dtype == np.dtype("timedelta64[ns]")
+            dtype == np.dtype("datetime64[ns]") or dtype == np.dtype("timedelta64[ns]")
             for dtype in self.dtypes
         ):
             return self.full_axis_reduce(map_func, axis)
         elif min_count == 0:
             return self.full_reduce(axis, map_func, numeric_only=numeric_only)
         elif min_count > len(reduce_index):
-            return pandas.Series([np.nan] * len(new_index),
-                    index=new_index, dtype=np.dtype('object'))
+            return pandas.Series(
+                [np.nan] * len(new_index), index=new_index, dtype=np.dtype("object")
+            )
         else:
             return self.full_axis_reduce(map_func, axis, new_index)
 
@@ -1175,9 +1174,13 @@ class PandasDataManager(object):
         if result.empty:
             return result
         if not axis:
-            result.index = alternate_index if alternate_index is not None else self.columns
+            result.index = (
+                alternate_index if alternate_index is not None else self.columns
+            )
         else:
-            result.index = alternate_index if alternate_index is not None else self.index
+            result.index = (
+                alternate_index if alternate_index is not None else self.index
+            )
         return result
 
     def all(self, **kwargs):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2197,8 +2197,7 @@ class DataFrame(object):
             The mean of the DataFrame. (Pandas series)
         """
         axis = pandas.DataFrame()._get_axis_number(axis) if axis is not None else 0
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
+
         return self._data_manager.mean(
             axis=axis, skipna=skipna, level=level, numeric_only=numeric_only, **kwargs
         )

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -4696,8 +4696,7 @@ class DataFrame(object):
         if (
             not axis
             and numeric_only is False
-            and any(dtype == np.dtype("datetime64[ns]") for dtype in
-                self.dtypes)
+            and any(dtype == np.dtype("datetime64[ns]") for dtype in self.dtypes)
         ):
             raise TypeError("Cannot add Timestamp Types")
 


### PR DESCRIPTION
Fixed issues in`df.sum()` and `df.prod()` related to throwing TypeErrors for invalid arguments and computing the result with the `min_counts` argument. Fixes #169 and https://github.com/modin-project/modin/issues/172 and #167  and #166 

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
