### PR TITLE
Info default to pandas

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1813,6 +1813,7 @@ class DataFrame(object):
         # over the data
         buf = sys.stdout if not buf else buf
         import io
+
         with io.StringIO() as tmp_buf:
             self._default_to_pandas_func(
                 pandas.DataFrame.info,
@@ -1823,7 +1824,9 @@ class DataFrame(object):
                 null_counts=null_counts,
             )
             result = tmp_buf.getvalue()
-            result = result.replace("pandas.core.frame.DataFrame", "modin.pandas.dataframe.DataFrame")
+            result = result.replace(
+                "pandas.core.frame.DataFrame", "modin.pandas.dataframe.DataFrame"
+            )
             buf.write(result)
         return None
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1817,7 +1817,7 @@ class DataFrame(object):
             buf=buf,
             max_cols=max_cols,
             memory_usage=memory_usage,
-            null_counts=null_counts
+            null_counts=null_counts,
         )
 
         index = self.index

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1811,14 +1811,21 @@ class DataFrame(object):
         """
         # We will default to pandas because it will be faster than doing two passes
         # over the data
-        return self._default_to_pandas_func(
-            pandas.DataFrame.info,
-            verbose=verbose,
-            buf=buf,
-            max_cols=max_cols,
-            memory_usage=memory_usage,
-            null_counts=null_counts,
-        )
+        buf = sys.stdout if not buf else buf
+        import io
+        with io.StringIO() as tmp_buf:
+            self._default_to_pandas_func(
+                pandas.DataFrame.info,
+                verbose=verbose,
+                buf=tmp_buf,
+                max_cols=max_cols,
+                memory_usage=memory_usage,
+                null_counts=null_counts,
+            )
+            result = tmp_buf.getvalue()
+            result = result.replace("pandas.core.frame.DataFrame", "modin.pandas.dataframe.DataFrame")
+            buf.write(result)
+        return None
 
         index = self.index
         columns = self.columns

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1809,6 +1809,17 @@ class DataFrame(object):
         Returns:
             Prints the summary of a DataFrame and returns None.
         """
+        # We will default to pandas because it will be faster than doing two passes
+        # over the data
+        return self._default_to_pandas_func(
+            pandas.DataFrame.info,
+            verbose=verbose,
+            buf=buf,
+            max_cols=max_cols,
+            memory_usage=memory_usage,
+            null_counts=null_counts
+        )
+
         index = self.index
         columns = self.columns
         dtypes = self.dtypes


### PR DESCRIPTION
## What do these changes do?

`info` will now default to pandas until we have a faster implementation

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
