### PR TITLE
Updating so more functionality does not default to pandas

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -380,7 +380,7 @@ class DataFrameGroupBy(object):
         assert callable(f), "'{0}' object is not callable".format(type(f))
         from .dataframe import DataFrame
 
-        if isinstance(self._by, list):
+        if all(obj in self._df for obj in self._by):
             return self._default_to_pandas(f, **kwargs)
 
         new_manager = self._data_manager.groupby_agg(


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Makes a minor change so that we support more functionality without defaulting to pandas. This functionality was already supported, but now we do not default to pandas when trying to use it.

Edit: These changes are specific to `groupby`
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
