### PR TITLE
Fixed abs

### DIFF
--- a/modin/data_management/data_manager.py
+++ b/modin/data_management/data_manager.py
@@ -1058,10 +1058,7 @@ class PandasDataManager(object):
 
     def abs(self):
         func = self._prepare_method(pandas.DataFrame.abs)
-        new_dtypes = pandas.Series(
-            [np.dtype("float64") for _ in self.columns], index=self.columns
-        )
-        return self.map_partitions(func, new_dtypes=new_dtypes)
+        return self.map_partitions(func, new_dtypes=self.dtypes.copy())
 
     def applymap(self, func):
         remote_func = self._prepare_method(pandas.DataFrame.applymap, func=func)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -418,10 +418,7 @@ class DataFrame(object):
         Returns:
             A new DataFrame with the applied absolute value.
         """
-        for t in self.dtypes:
-            if np.dtype("O") == t:
-                # TODO Give a more accurate error to Pandas
-                raise TypeError("bad operand type for abs():", "str")
+        self._validate_dtypes(numeric_only=True)
 
         return DataFrame(data_manager=self._data_manager.abs())
 


### PR DESCRIPTION
## What do these changes do?

Does dtype checking and returns the original dtypes instead of the old dtype checking and returning all dtypes as `np.dtype("float64")`

## Related issue number

Resolves #198

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
