### PR TITLE
Ignoring flake8 error in regex

### DIFF
--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -23,7 +23,7 @@ from ..data_management.partitioning.axis_partition import (
 )
 from ..data_management.data_manager import PandasDataManager
 
-PQ_INDEX_REGEX = re.compile("__index_level_\d+__")
+PQ_INDEX_REGEX = re.compile("__index_level_\d+__")  # noqa W605
 
 
 # Parquet


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
