### PR TITLE
Adding pytest benchmarks folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,3 +162,6 @@ fabric.properties
 tags
 cscope.files
 cscope.out
+
+# PYTest Benchmarks
+.benchmarks/


### PR DESCRIPTION

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
