### PR TITLE
Fix all any

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -11,6 +11,7 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_numeric_dtype,
     is_datetime_or_timedelta_dtype,
+    is_bool_dtype,
 )
 from pandas.core.index import _ensure_index
 
@@ -1196,7 +1197,7 @@ class PandasQueryCompiler(object):
         Return:
             Pandas Series containing boolean values or boolean.
         """
-        return self._process_all_any(pandas.DataFrame.all, **kwargs)
+        return self._process_all_any(pandas.DataFrame.all, "all", **kwargs)
 
     def any(self, **kwargs):
         """Returns whether any the elements are true, potentially over an axis.
@@ -1204,30 +1205,47 @@ class PandasQueryCompiler(object):
         Return:
             Pandas Series containing boolean values or boolean.
         """
-        return self._process_all_any(pandas.DataFrame.any, **kwargs)
+        return self._process_all_any(pandas.DataFrame.any, "any", **kwargs)
 
-    def _process_all_any(self, func, **kwargs):
+    def _process_all_any(self, func, func_name, **kwargs):
         """Calculates if any or all the values are true.
 
         Return:
             Pandas Series containing boolean values or boolean.
         """
         axis = kwargs.get("axis", 0)
+        axis_none = True if axis is None else False
+        axis = 0 if axis is None else axis
+        kwargs['axis'] = axis
         bool_only = kwargs.get("bool_only", None)
-        index = self.index if axis else self.columns
+        bool_none = True if bool_only is None else False
+        kwargs['bool_only'] = False if bool_only is None else bool_only
+
+        not_bool_col = []
+        numeric_col_count = 0
+        for col, dtype in zip(self.columns, self.dtypes):
+            if not is_bool_dtype(dtype):
+                not_bool_col.append(col)
+            numeric_col_count += 1 if is_numeric_dtype(dtype) else 0
+
         if bool_only:
-            not_bool = []
-            for index, dtype in zip(index, self.dtypes):
-                if dtype != bool:
-                    not_bool.append(index)
-            if axis:
-                query_compiler = self.drop(index=not_bool)
-            else:
-                query_compiler = self.drop(columns=not_bool)
+            if axis == 0 and not axis_none and len(not_bool_col) == len(self.columns):
+                return pandas.Series(dtype=bool)
+            query_compiler = self.drop(columns=not_bool_col)
         else:
+            if bool_only is False and axis_none and len(not_bool_col) == len(self.columns) and numeric_col_count != len(self.columns):
+                if func_name == "all":
+                    return self.getitem_single_key(self.columns[-1])[self.index[-1]]
+                elif func_name == "any":
+                    return self.getitem_single_key(self.columns[0])[self.index[0]]
             query_compiler = self
-        func = query_compiler._prepare_method(func, **kwargs)
-        return query_compiler.full_axis_reduce(func, axis)
+
+        builder_func = query_compiler._prepare_method(func, **kwargs)
+        result = query_compiler.full_axis_reduce(builder_func, axis)
+        if axis_none:
+            return func(result)
+        else:
+            return result
 
     def first_valid_index(self):
         """Returns index of first non-NaN/NULL value.

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -670,6 +670,8 @@ class DataFrame(object):
         if axis is not None:
             axis = pandas.DataFrame()._get_axis_number(axis)
         else:
+            if bool_only:
+                raise ValueError("Axis must be 0 or 1 (got {})".format(axis))
             axis = None
         result = self._query_compiler.all(
             axis=axis, bool_only=bool_only, skipna=skipna, level=level, **kwargs
@@ -689,6 +691,8 @@ class DataFrame(object):
         if axis is not None:
             axis = pandas.DataFrame()._get_axis_number(axis)
         else:
+            if bool_only:
+                raise ValueError("Axis must be 0 or 1 (got {})".format(axis))
             axis = None
         result = self._query_compiler.any(
             axis=axis, bool_only=bool_only, skipna=skipna, level=level, **kwargs

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -672,14 +672,9 @@ class DataFrame(object):
         else:
             if bool_only:
                 raise ValueError("Axis must be 0 or 1 (got {})".format(axis))
-            axis = None
-        result = self._query_compiler.all(
+        return self._query_compiler.all(
             axis=axis, bool_only=bool_only, skipna=skipna, level=level, **kwargs
         )
-        if axis is not None:
-            return result
-        else:
-            return result.all()
 
     def any(self, axis=0, bool_only=None, skipna=None, level=None, **kwargs):
         """Return whether any elements are True over requested axis
@@ -693,14 +688,9 @@ class DataFrame(object):
         else:
             if bool_only:
                 raise ValueError("Axis must be 0 or 1 (got {})".format(axis))
-            axis = None
-        result = self._query_compiler.any(
+        return self._query_compiler.any(
             axis=axis, bool_only=bool_only, skipna=skipna, level=level, **kwargs
         )
-        if axis is not None:
-            return result
-        else:
-            return result.any()
 
     def append(self, other, ignore_index=False, verify_integrity=False, sort=None):
         """Append another DataFrame/list/Series to this one.


### PR DESCRIPTION
## What do these changes do?

Aligns `all` and `any` to match pandas behavior

## Related issue number

Resolves #214 

- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check modin/`
