### PR TITLE
Fixing issue iterating over groupby with multiple columns

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -66,9 +66,19 @@ class DataFrameGroupBy(object):
                 # aware.
                 warnings.warn("Defaulting to Pandas implementation", UserWarning)
                 if self._axis == 0:
-                    self._index_grouped_cache = {k: v.index for k, v in pandas.concat([self._df[col] for col in self._by], axis=1).groupby(by=self._by)}
+                    self._index_grouped_cache = {
+                        k: v.index
+                        for k, v in pandas.concat(
+                            [self._df[col] for col in self._by], axis=1
+                        ).groupby(by=self._by)
+                    }
                 else:
-                    self._index_grouped_cache = {k: v.index for k, v in self._df._query_compiler.getitem_row_array(self._by).to_pandas().groupby(by=self._by)}
+                    self._index_grouped_cache = {
+                        k: v.index
+                        for k, v in self._df._query_compiler.getitem_row_array(self._by)
+                        .to_pandas()
+                        .groupby(by=self._by)
+                    }
             else:
                 if self._axis == 0:
                     self._index_grouped_cache = self._index.groupby(self._by)

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -6,6 +6,7 @@ import pandas
 import pandas.core.groupby
 from pandas.core.dtypes.common import is_list_like
 import pandas.core.common as com
+import warnings
 
 from .utils import _inherit_docstrings
 
@@ -28,6 +29,8 @@ class DataFrameGroupBy(object):
         self._index = self._query_compiler.index
         self._columns = self._query_compiler.columns
         self._by = by
+        # This tells us whether or not there are multiple columns/rows in the groupby
+        self._is_multi_by = all(obj in self._df for obj in self._by)
         self._level = level
         self._kwargs = {
             "sort": sort,
@@ -57,10 +60,20 @@ class DataFrameGroupBy(object):
     @property
     def _index_grouped(self):
         if self._index_grouped_cache is None:
-            if self._axis == 0:
-                self._index_grouped_cache = self._index.groupby(self._by)
+            if self._is_multi_by:
+                # Because we are doing a collect (or to_pandas) here and then groupby,
+                # we end up using pandas implementation. Add the warning so the user is
+                # aware.
+                warnings.warn("Defaulting to Pandas implementation", UserWarning)
+                if self._axis == 0:
+                    self._index_grouped_cache = {k: v.index for k, v in pandas.concat([self._df[col] for col in self._by], axis=1).groupby(by=self._by)}
+                else:
+                    self._index_grouped_cache = {k: v.index for k, v in self._df._query_compiler.getitem_row_array(self._by).to_pandas().groupby(by=self._by)}
             else:
-                self._index_grouped_cache = self._columns.groupby(self._by)
+                if self._axis == 0:
+                    self._index_grouped_cache = self._index.groupby(self._by)
+                else:
+                    self._index_grouped_cache = self._columns.groupby(self._by)
         return self._index_grouped_cache
 
     _keys_and_values_cache = None
@@ -380,7 +393,7 @@ class DataFrameGroupBy(object):
         assert callable(f), "'{0}' object is not callable".format(type(f))
         from .dataframe import DataFrame
 
-        if all(obj in self._df for obj in self._by):
+        if self._is_multi_by:
             return self._default_to_pandas(f, **kwargs)
 
         new_manager = self._query_compiler.groupby_agg(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -61,16 +61,18 @@ class DataFrameGroupBy(object):
     def _index_grouped(self):
         if self._index_grouped_cache is None:
             if self._is_multi_by:
-                # Because we are doing a collect (or to_pandas) here and then groupby,
-                # we end up using pandas implementation. Add the warning so the user is
+                # Because we are doing a collect (to_pandas) here and then groupby, we
+                # end up using pandas implementation. Add the warning so the user is
                 # aware.
                 warnings.warn("Defaulting to Pandas implementation", UserWarning)
                 if self._axis == 0:
                     self._index_grouped_cache = {
                         k: v.index
-                        for k, v in pandas.concat(
-                            [self._df[col] for col in self._by], axis=1
-                        ).groupby(by=self._by)
+                        for k, v in self._df._query_compiler.getitem_column_array(
+                            self._by
+                        )
+                        .to_pandas()
+                        .groupby(by=self._by)
                     }
                 else:
                     self._index_grouped_cache = {


### PR DESCRIPTION

## What do these changes do?

Because of the complexities with iterating over groups in `groupby`, we use a different method of grouping (that way we don't trigger full computation when we are accessing only a subset of groups).

For `groupby` where multiple columns are given, we were not correctly returning the groups. For now, we have to default to pandas, pending the distributed `Series` object completion.

## Related issue number

Resolves #234 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
