### PR TITLE
Dropping git revision because it causes problems for some Ubuntu users

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -2,42 +2,6 @@ import os
 import subprocess
 
 
-def _git_version():
-    def _execute_cmd_in_temp_env(cmd):
-        # construct environment
-        env = {}
-        for k in ["SYSTEMROOT", "PATH", "HOME"]:
-            v = os.environ.get(k)
-            if v is not None:
-                env[k] = v
-        # LANGUAGE is used on win32
-        env["LANGUAGE"] = "C"
-        env["LANG"] = "C"
-        env["LC_ALL"] = "C"
-        return subprocess.Popen(cmd, stdout=subprocess.PIPE, env=env).communicate()[0]
-
-    cwd = os.getcwd()
-    os.chdir(os.path.dirname(os.path.abspath(__file__)))
-    # Check that this is a git repo first.
-    if (
-        subprocess.call(
-            ["git", "-C", "./", "status"],
-            stderr=subprocess.STDOUT,
-            stdout=open(os.devnull, "w"),
-        )
-        == 0
-    ):
-        try:
-            git_revision = _execute_cmd_in_temp_env(["git", "rev-parse", "HEAD"])
-            rev_string = git_revision.strip().decode()
-        except OSError:
-            rev_string = "Unknown"
-    else:
-        rev_string = "Unknown"
-    os.chdir(cwd)
-    return rev_string
-
-
 def get_execution_engine():
     # In the future, when there are multiple engines and different ways of
     # backing the DataFrame, there will have to be some changed logic here to
@@ -55,12 +19,10 @@ def get_partition_format():
     return "Pandas"
 
 
-__git_revision__ = _git_version()
 __version__ = "0.2.2"
 __execution_engine__ = get_execution_engine()
 __partition_format__ = get_partition_format()
 
 # We don't want these used outside of this file.
-del _git_version
 del get_execution_engine
 del get_partition_format

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -1,5 +1,4 @@
 import os
-import subprocess
 
 
 def get_execution_engine():

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -37,7 +37,7 @@ import threading
 import os
 import ray
 
-from .. import __git_revision__, __version__
+from .. import __version__
 from .concat import concat
 from .dataframe import DataFrame
 from .datetimes import to_datetime


### PR DESCRIPTION

## What do these changes do?

Some Ubuntu users are unable to use Modin because of the `__git_revision__` addition. I don't think we use this in our regular development, and since it's causing problems we can just drop it and revisit a new fix if others are using it in their development.
<!-- Please give a short brief about these changes. -->

## Related issue number
#235 multiple users reporting this issue
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
