### PR TITLE
Fixing filter for read_csv args

### DIFF
--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -16,7 +16,6 @@ import numpy as np
 
 from .dataframe import DataFrame
 from .utils import from_pandas
-from ..pandas import Series, Index
 from ..data_management.partitioning.partition_collections import RayBlockPartitions
 from ..data_management.partitioning.remote_partition import PandasOnRayRemotePartition
 from ..data_management.partitioning.axis_partition import (
@@ -290,8 +289,8 @@ def read_csv(
             kw: kwargs[kw]
             for kw in kwargs
             if kw in defaults
-            and not isinstance(
-                kwargs[kw], type(defaults[kw])) and kwargs[kw] != defaults[kw]
+            and not isinstance(kwargs[kw], type(defaults[kw]))
+            and kwargs[kw] != defaults[kw]
         }
     # This happens on Python2, we will just default to serializing the entire dictionary
     except AttributeError:

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -291,8 +291,7 @@ def read_csv(
             for kw in kwargs
             if kw in defaults
             and not isinstance(
-                kwargs[kw], type(defaults[kw]) and kwargs[kw] != defaults[kw]
-            )
+                kwargs[kw], type(defaults[kw])) and kwargs[kw] != defaults[kw]
         }
     # This happens on Python2, we will just default to serializing the entire dictionary
     except AttributeError:

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -289,7 +289,10 @@ def read_csv(
         kwargs = {
             kw: kwargs[kw]
             for kw in kwargs
-            if kw in defaults and (isinstance(kwargs[kw], (Series, Index, DataFrame)) or kwargs[kw] != defaults[kw])
+            if kw in defaults
+            and not isinstance(
+                kwargs[kw], type(defaults[kw]) and kwargs[kw] != defaults[kw]
+            )
         }
     # This happens on Python2, we will just default to serializing the entire dictionary
     except AttributeError:

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -16,6 +16,7 @@ import numpy as np
 
 from .dataframe import DataFrame
 from .utils import from_pandas
+from ..pandas import Series, Index
 from ..data_management.partitioning.partition_collections import RayBlockPartitions
 from ..data_management.partitioning.remote_partition import PandasOnRayRemotePartition
 from ..data_management.partitioning.axis_partition import (
@@ -288,7 +289,7 @@ def read_csv(
         kwargs = {
             kw: kwargs[kw]
             for kw in kwargs
-            if kw in defaults and kwargs[kw] != defaults[kw]
+            if kw in defaults and (isinstance(kwargs[kw], (Series, Index, DataFrame)) or kwargs[kw] != defaults[kw])
         }
     # This happens on Python2, we will just default to serializing the entire dictionary
     except AttributeError:


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Fixes filtering on the `names` argument in `read_csv`.
<!-- Please give a short brief about these changes. -->

## Related issue number
Resolves #239 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
