### PR TITLE
Improve speed of read_parquet by reading sets of columns in parallel

### DIFF
--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -659,4 +659,3 @@ def _read_parquet_columns(path, columns, num_splits, kwargs):
     df = pq.read_pandas(path, columns=columns, **kwargs).to_pandas()
     # Append the length of the index here to build it externally
     return split_result_of_axis_func_pandas(0, num_splits, df) + [len(df.index)]
-

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -56,7 +56,10 @@ def _read_parquet_pandas_on_ray(path, engine, columns, **kwargs):
     num_splits = min(len(columns), RayBlockPartitions._compute_num_partitions())
     num_cpus = int(ray.global_state.available_resources()['CPU'])
     # Each item in this list will be a list of column names of the original df
-    col_partitions = [columns[i:i + num_cpus] for i in range(0, len(columns), num_cpus)]
+    column_splits = len(columns) // num_cpus if len(columns) % num_cpus == 0 \
+        else len(columns) // num_cpus + 1
+    col_partitions = [columns[i:i + column_splits]
+                      for i in range(0, len(columns), column_splits)]
     # Each item in this list will be a list of columns of original df
     # partitioned to smaller pieces along rows.
     # We need to transpose the oids array to fit our schema.


### PR DESCRIPTION
## What do these changes do?

modin.pandas.io.read_parquet now partitions columns into sets of size equal to the available CPU cores (according to Ray) and then reads multiple columns at once 

## Related issue number

#205

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
