### PR TITLE
Revert some changes in behavior for sum/prod

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -980,6 +980,8 @@ class PandasQueryCompiler(object):
                     return False
                 return True
 
+            # Iterate through the sums to check that we can divide them. If not, then
+            # drop the record. This matches pandas behavior.
             return pandas.Series(
                 {
                     idx: sums[idx] / counts[idx]

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -986,7 +986,7 @@ class PandasQueryCompiler(object):
         numeric_only = kwargs.get("numeric_only", None) if not axis else True
         min_count = kwargs.get("min_count", 1)
         reduce_index = self.columns if axis else self.index
-
+        print(numeric_only)
         if numeric_only:
             result, query_compiler = self.numeric_function_clean_dataframe(axis)
         else:
@@ -1002,8 +1002,6 @@ class PandasQueryCompiler(object):
         map_func = self._prepare_method(sum_prod_builder, **kwargs)
 
         if min_count == 1:
-            if numeric_only is None:
-                numeric_only = True
             return self.full_reduce(axis, map_func, numeric_only=numeric_only)
         elif min_count > len(reduce_index):
             return pandas.Series(


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Revert some of the changes to `sum` and `prod` that reverted behaviors.
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
