### PR TITLE
Fix to_pandas for Series objects

### DIFF
--- a/modin/data_management/partitioning/axis_partition/pandas_on_ray.py
+++ b/modin/data_management/partitioning/axis_partition/pandas_on_ray.py
@@ -105,7 +105,9 @@ def deploy_ray_axis_func(axis, func, num_splits, kwargs, *partitions):
     """
     dataframe = pandas.concat(partitions, axis=axis, copy=False)
     result = func(dataframe, **kwargs)
-    if num_splits != len(partitions) or isinstance(result, pandas.Series):
+    if isinstance(result, pandas.Series):
+        return [result] + [pandas.Series([]) for _ in range(num_splits - 1)]
+    if num_splits != len(partitions):
         lengths = None
     else:
         if axis == 0:

--- a/modin/data_management/partitioning/partition_collections/base_block_partitions.py
+++ b/modin/data_management/partitioning/partition_collections/base_block_partitions.py
@@ -429,10 +429,6 @@ class BaseBlockPartitions(object):
                 for part in row
             ):
                 axis = 0
-                # We take the transpose here so that the results from the same
-                # partition will be concated together first before results
-                # from different partitions.
-                retrieved_objects = np.array(retrieved_objects).T
             elif all(
                 isinstance(part, pandas.DataFrame)
                 for row in retrieved_objects


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Fixes `to_pandas` for `Series` objects. Instead of splitting the `Series` we just return it whole.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
