### PR TITLE
Ignore Double ray_init errors

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -79,6 +79,7 @@ try:
             include_webui=False,
             redirect_worker_output=True,
             use_raylet=True,
+            ignore_reinit_error=True,
         )
 except AssertionError:
     pass


### PR DESCRIPTION
Exception thrown if we `ray_init()` before importing modin. This PR fixes that issue.

- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check modin/`
