### PR TITLE
pin pytest version to 3.9.3

### DIFF
--- a/.jenkins/build-tests/Dockerfile
+++ b/.jenkins/build-tests/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6.6-stretch
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
-RUN pip install -q awscli pytest pytest-xdist pytest-html feather-format lxml openpyxl xlrd numpy matplotlib
+RUN pip install -q pytest==3.9.3 awscli pytest-xdist pytest-html feather-format lxml openpyxl xlrd numpy matplotlib
 
 COPY . .
 RUN pip install -e .

--- a/.jenkins/performance-tests/Dockerfile
+++ b/.jenkins/performance-tests/Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.6.6-stretch
 
 COPY requirements.txt requirements.txt
 RUN pip install -r requirements.txt
-RUN pip install -q awscli pytest pytest-benchmark feather-format lxml openpyxl xlrd numpy matplotlib
+RUN pip install -q pytest==3.9.3 awscli pytest-benchmark feather-format lxml openpyxl xlrd numpy matplotlib
 
 COPY . .
 RUN pip install -e .


### PR DESCRIPTION
Pytest 4 has some new functionality that cause our current tests to break. This pins the pytest version to 3.9.3 for the Jenkins builds.

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
