### PR TITLE
Adding hugepages by default

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -36,6 +36,7 @@ from pandas import (
 import threading
 import os
 import ray
+import sys
 
 from .. import __version__
 from .concat import concat
@@ -77,12 +78,18 @@ os.environ["OMP_NUM_THREADS"] = "1"
 if execution_engine == "Ray":
     try:
         if threading.current_thread().name == "MainThread":
+            # Plasma can only enable huge_pages on Linux
+            if sys.platform == "linux" or sys.platform == "linux2":
+                huge_pages = True
+            else:
+                huge_pages = False
             ray.init(
                 redirect_output=True,
                 include_webui=False,
                 redirect_worker_output=True,
                 use_raylet=True,
                 ignore_reinit_error=True,
+                huge_pages=huge_pages,
             )
     except AssertionError:
         pass


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Sometimes during shuffle, the size of individual objects can exceed plasma's 2GB limit
<!-- Please give a short brief about these changes. -->

## Related issue number
#266 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
