### PR TITLE
Fixed python backend to flush call queue

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -2590,7 +2590,7 @@ class PandasQueryCompilerView(PandasQueryCompiler):
 
     In particular, the following constraints are broken:
     - (len(self.index), len(self.columns)) != self.data.shape
-    
+
     Note:
         The constraint will be satisfied when we get the data
     """

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -2590,6 +2590,9 @@ class PandasQueryCompilerView(PandasQueryCompiler):
 
     In particular, the following constraints are broken:
     - (len(self.index), len(self.columns)) != self.data.shape
+    
+    Note:
+        The constraint will be satisfied when we get the data
     """
 
     def __init__(


### PR DESCRIPTION
## What do these changes do?

Flushes `self.call_queue` when we call `get` in `PandasOnPythonRemotePartition`

## Related issue number

#286 

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
