### PR TITLE
Several Cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,3 +165,6 @@ cscope.out
 
 # PYTest Benchmarks
 .benchmarks/
+
+# Dask workspace
+dask-worker-space/

--- a/.jenkins/performance-tests/run_perf_test.sh
+++ b/.jenkins/performance-tests/run_perf_test.sh
@@ -4,6 +4,8 @@ source activate py3
 
 # wget http://noaa-ghcn-pds.s3.amazonaws.com/csv/2017.csv
 python -c "import ray; ray.init()"
+MODIN_ENGINE=dask pytest --benchmark-autosave --disable-pytest-warnings modin/pandas/test/performance-tests/test_performance.py
+MODIN_ENGINE=python pytest --benchmark-autosave --disable-pytest-warnings modin/pandas/test/performance-tests/test_performance.py
 pytest --benchmark-autosave --disable-pytest-warnings modin/pandas/test/performance-tests/test_performance.py
 
 sha_tag=`git rev-parse --verify --short HEAD`

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -7,7 +7,8 @@ def get_execution_engine():
     # decide these things. In the meantime, we will use the currently supported
     # execution engine + backing (Pandas + Ray).
     if "MODIN_ENGINE" in os.environ:
-        engine = os.environ["MODIN_ENGINE"]
+        # .title allows variants like ray, RAY, Ray
+        engine = os.environ["MODIN_ENGINE"].title()
     else:
         engine = "Ray" if "MODIN_DEBUG" not in os.environ else "Python"
     return engine

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -76,7 +76,8 @@ if pandas.__version__ != __pandas_version__:
 os.environ["OMP_NUM_THREADS"] = "1"
 num_cpus = 1
 
-if execution_engine == "Ray":
+execution_engine = execution_engine.lower()
+if execution_engine == "ray":
     try:
         if threading.current_thread().name == "MainThread":
             ray.init(
@@ -88,7 +89,7 @@ if execution_engine == "Ray":
             num_cpus = ray.global_state.cluster_resources()["CPU"]
     except AssertionError:
         pass
-elif execution_engine == "Dask":
+elif execution_engine == "dask":
     try:
         if threading.current_thread().name == "MainThread":
             # initialize the dask client
@@ -96,7 +97,7 @@ elif execution_engine == "Dask":
             num_cpus = sum(client.ncores().values())
     except AssertionError:
         pass
-elif execution_engine != "Python":
+elif execution_engine != "python":
     raise ImportError("Unrecognized execution engine: {}.".format(execution_engine))
 
 DEFAULT_NPARTITIONS = max(4, int(num_cpus))

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -96,7 +96,7 @@ elif execution_engine == "Dask":
             num_cpus = sum(client.ncores().values())
     except AssertionError:
         pass
-elif execution_engine != "python":
+elif execution_engine != "Python":
     raise ImportError("Unrecognized execution engine: {}.".format(execution_engine))
 
 DEFAULT_NPARTITIONS = max(4, int(num_cpus))

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -76,8 +76,7 @@ if pandas.__version__ != __pandas_version__:
 os.environ["OMP_NUM_THREADS"] = "1"
 num_cpus = 1
 
-execution_engine = execution_engine.lower()
-if execution_engine == "ray":
+if execution_engine == "Ray":
     try:
         if threading.current_thread().name == "MainThread":
             ray.init(
@@ -89,7 +88,7 @@ if execution_engine == "ray":
             num_cpus = ray.global_state.cluster_resources()["CPU"]
     except AssertionError:
         pass
-elif execution_engine == "dask":
+elif execution_engine == "Dask":
     try:
         if threading.current_thread().name == "MainThread":
             # initialize the dask client

--- a/modin/pandas/test/performance-tests/conftest.py
+++ b/modin/pandas/test/performance-tests/conftest.py
@@ -1,7 +1,9 @@
 import subprocess
+import os
 
 
 def pytest_benchmark_update_commit_info(config, commit_info):
     commit_info["commit_number"] = int(
         subprocess.check_output(["git", "rev-list", "HEAD", "--count"]).strip()
     )
+    commit_info["engine"] = os.environ.get("MODIN_ENGINE", "Ray").title()

--- a/setup.py
+++ b/setup.py
@@ -15,4 +15,9 @@ setup(
     url="https://github.com/modin-project/modin",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=["pandas==0.23.4", "ray==0.6.0"])
+    install_requires=["pandas==0.23.4", "ray==0.6.0"],
+    extras_require={
+        # can be installed by pip install modin[dask]
+        "dask": ["dask==1.0.0", "distributed==1.25.0"]
+    }
+)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

- For Dask 🎉:
   - Add optional dependency in setup.py. So user can `pip install modin[dask]`
- `execution_engine.title()`
  - Allows user to pass in `MODIN_ENGINE=ray` or `MODIN_ENGINE=RAY`
- Add `Dask` and `Python` engine to perf_test for sanity check and basic comparison

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
