### PR TITLE
Fixing strange partitioning-related iloc bug

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -2669,7 +2669,7 @@ class PandasQueryCompilerView(PandasQueryCompiler):
             func=iloc,
             row_indices=self.index_map.values,
             col_indices=self.columns_map.values,
-            lazy=True,
+            lazy=False,
             keep_remaining=False,
         )
         return masked_data


### PR DESCRIPTION
* Only occurs when a `set_index` is called, followed by a `drop`
* Only fails the first time, resulting the a `call_queue` that is not
  empty
* Fails differently on `df.iloc[[0]]` and `df.iloc[0]` but cause is the
  same
* The failure is a result of some partitions not filtering out the data:
  e.g. The first column of block partitions in the affected partitions
  does not properly remove all of the data.
* Only fails when a certain number of partitions are present. No error on
  4x4, but error occurs on 8x8.
* Fixed by removing lazy operator.
* Creating a new issue to track #293

<!--
Thank you for your contribution!
-->

## What do these changes do?

Disable lazy operation for correctness until root of bug is discovered.
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
