### PR TITLE
Change __constructor__ to return a QueryCompiler instead of a View object.

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -2644,12 +2644,7 @@ class PandasQueryCompilerView(PandasQueryCompiler):
         columns: pandas.Index,
         dtypes=None,
     ):
-        return PandasQueryCompiler(
-            block_partitions_object,
-            index,
-            columns,
-            dtypes,
-        )
+        return PandasQueryCompiler(block_partitions_object, index, columns, dtypes)
 
     def _get_data(self) -> BaseBlockPartitions:
         """Perform the map step

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -2644,15 +2644,11 @@ class PandasQueryCompilerView(PandasQueryCompiler):
         columns: pandas.Index,
         dtypes=None,
     ):
-        new_index_map = self.index_map.reindex(index)
-        new_columns_map = self.columns_map.reindex(columns)
-        return type(self)(
+        return PandasQueryCompiler(
             block_partitions_object,
             index,
             columns,
             dtypes,
-            new_index_map,
-            new_columns_map,
         )
 
     def _get_data(self) -> BaseBlockPartitions:

--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -557,9 +557,10 @@ class BaseBlockPartitions(object):
             A tuple containing (block index and internal index).
         """
         if not axis:
-            assert not index > sum(self.block_widths), \
-                "Internal error: Please email dev@modin.org with the traceback of " \
+            assert not index > sum(self.block_widths), (
+                "Internal error: Please email dev@modin.org with the traceback of "
                 "this error."
+            )
             cumulative_column_widths = np.array(self.block_widths).cumsum()
             block_idx = int(np.digitize(index, cumulative_column_widths))
             if block_idx == len(cumulative_column_widths):
@@ -573,9 +574,10 @@ class BaseBlockPartitions(object):
             )
             return block_idx, internal_idx
         else:
-            assert not index > sum(self.block_lengths), \
-                "Internal error: Please email dev@modin.org with the traceback of " \
+            assert not index > sum(self.block_lengths), (
+                "Internal error: Please email dev@modin.org with the traceback of "
                 "this error."
+            )
             cumulative_row_lengths = np.array(self.block_lengths).cumsum()
             block_idx = int(np.digitize(index, cumulative_row_lengths))
             # See note above about internal index

--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -557,10 +557,6 @@ class BaseBlockPartitions(object):
             A tuple containing (block index and internal index).
         """
         if not axis:
-            assert not index > sum(self.block_widths), (
-                "Internal error: Please email dev@modin.org with the traceback of "
-                "this error."
-            )
             cumulative_column_widths = np.array(self.block_widths).cumsum()
             block_idx = int(np.digitize(index, cumulative_column_widths))
             if block_idx == len(cumulative_column_widths):
@@ -574,10 +570,6 @@ class BaseBlockPartitions(object):
             )
             return block_idx, internal_idx
         else:
-            assert not index > sum(self.block_lengths), (
-                "Internal error: Please email dev@modin.org with the traceback of "
-                "this error."
-            )
             cumulative_row_lengths = np.array(self.block_lengths).cumsum()
             block_idx = int(np.digitize(index, cumulative_row_lengths))
             # See note above about internal index
@@ -614,7 +606,6 @@ class BaseBlockPartitions(object):
                 partitions_dict[part_idx] = [internal_idx]
             else:
                 partitions_dict[part_idx].append(internal_idx)
-
         return partitions_dict
 
     def _apply_func_to_list_of_partitions(self, func, partitions, **kwargs):
@@ -877,6 +868,7 @@ class BaseBlockPartitions(object):
                     item = {"item": item}
                 else:
                     item = {}
+
                 if lazy:
                     result = remote_part.add_to_apply_calls(
                         func,

--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -557,6 +557,9 @@ class BaseBlockPartitions(object):
             A tuple containing (block index and internal index).
         """
         if not axis:
+            assert not index > sum(self.block_widths), \
+                "Internal error: Please email dev@modin.org with the traceback of " \
+                "this error."
             cumulative_column_widths = np.array(self.block_widths).cumsum()
             block_idx = int(np.digitize(index, cumulative_column_widths))
             if block_idx == len(cumulative_column_widths):
@@ -570,6 +573,9 @@ class BaseBlockPartitions(object):
             )
             return block_idx, internal_idx
         else:
+            assert not index > sum(self.block_lengths), \
+                "Internal error: Please email dev@modin.org with the traceback of " \
+                "this error."
             cumulative_row_lengths = np.array(self.block_lengths).cumsum()
             block_idx = int(np.digitize(index, cumulative_row_lengths))
             # See note above about internal index
@@ -606,6 +612,7 @@ class BaseBlockPartitions(object):
                 partitions_dict[part_idx] = [internal_idx]
             else:
                 partitions_dict[part_idx].append(internal_idx)
+
         return partitions_dict
 
     def _apply_func_to_list_of_partitions(self, func, partitions, **kwargs):
@@ -868,7 +875,6 @@ class BaseBlockPartitions(object):
                     item = {"item": item}
                 else:
                     item = {}
-
                 if lazy:
                     result = remote_part.add_to_apply_calls(
                         func,


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Returns a new `QueryCompiler` object instead of a `View` when performing operations on the `View`. The previous problem presented itself when operations resulted in changes in the underlying structure.
<!-- Please give a short brief about these changes. -->

## Related issue number
Resolves #147 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
