### PR TITLE
Simplify Dask import and startup

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -89,11 +89,13 @@ if execution_engine == "Ray":
         pass
 elif execution_engine == "Dask":
     from distributed.client import _get_global_client
+
     if threading.current_thread().name == "MainThread":
         # initialize the dask client
         client = _get_global_client()
         if client is None:
             from distributed import Client
+
             client = Client()
         num_cpus = sum(client.ncores().values())
 elif execution_engine != "Python":

--- a/modin/pandas/dask_client.py
+++ b/modin/pandas/dask_client.py
@@ -1,9 +1,0 @@
-import dask.distributed
-
-
-# TODO add a way to only initalize Client one time
-# Note: functools.lru_cache() is not supported in Python2
-def get_client():
-    """Setup and get dask.distributed client"""
-    # TODO add more parameters or better implement as a Client class
-    return dask.distributed.Client()


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

No longer requires Dask for importing `modin.pandas`. The location of the dask imports has been moved to ensure that we do not depend on it unless it is specifically requested.
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
