### PR TITLE
Fix __repr__ bug

### DIFF
--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -304,9 +304,7 @@ class BaseBlockPartitions(object):
             partitions = self.partitions.T
             bin_lengths = self.block_widths
         if n < 0:
-            reversed_bins = bin_lengths
-            reversed_bins.reverse()
-            length_bins = np.cumsum(reversed_bins)
+            length_bins = np.cumsum(bin_lengths[::-1])
             n *= -1
             idx = int(np.digitize(n, length_bins))
             if idx > 0:


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Previously, during `__repr__` the `bin_lenghts` were getting reversed which was modifying the metadata of the object directly. Now, we create a view of the object's reverse

## Related issue number

Resolves #298 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
