### PR TITLE
Improve the way that Modin filters out empty partitions

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -2082,9 +2082,8 @@ class PandasQueryCompiler(object):
         Returns:
             A new PandasDataManager.
         """
-        numeric_index = self.columns.get_indexer_for([key])
         new_data = self.getitem_column_array([key])
-        if len(numeric_index) > 1:
+        if len(self.columns.get_indexer_for([key])) > 1:
             return new_data
         else:
             # This is the case that we are returning a single Series.
@@ -2304,15 +2303,18 @@ class PandasQueryCompiler(object):
             if (
                 not axis
                 and len(series_result) == len(self.columns)
-                and len(index) != len(series_result)
+                # and len(index) != len(series_result)
             ):
                 index = self.columns
             elif (
                 axis
                 and len(series_result) == len(self.index)
-                and len(index) != len(series_result)
+                # and len(index) != len(series_result)
             ):
                 index = self.index
+            # else:
+            #     print(len(index))
+            #     print(len(series_result))
 
             series_result.index = index
             return series_result

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -2300,21 +2300,10 @@ class PandasQueryCompiler(object):
         # this logic here.
         if len(columns) == 0:
             series_result = result_data.to_pandas(False)
-            if (
-                not axis
-                and len(series_result) == len(self.columns)
-                # and len(index) != len(series_result)
-            ):
+            if not axis and len(series_result) == len(self.columns):
                 index = self.columns
-            elif (
-                axis
-                and len(series_result) == len(self.index)
-                # and len(index) != len(series_result)
-            ):
+            elif axis and len(series_result) == len(self.index):
                 index = self.index
-            # else:
-            #     print(len(index))
-            #     print(len(series_result))
 
             series_result.index = index
             return series_result

--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -668,7 +668,6 @@ class BaseBlockPartitions(object):
             partitions_for_apply = self.partitions.T
         else:
             partitions_for_apply = self.partitions
-
         # We may have a command to perform different functions on different
         # columns at the same time. We attempt to handle this as efficiently as
         # possible here. Functions that use this in the dictionary format must

--- a/modin/engines/ray/pandas_on_ray/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/axis_partition.py
@@ -32,8 +32,6 @@ class PandasOnRayAxisPartition(BaseAxisPartition):
         if num_splits is None:
             num_splits = len(self.list_of_blocks)
 
-        assert len(self.list_of_blocks)
-
         if other_axis_partition is not None:
             return [
                 PandasOnRayRemotePartition(obj)
@@ -105,8 +103,6 @@ def deploy_ray_axis_func(axis, func, num_splits, kwargs, *partitions):
     Returns:
         A list of Pandas DataFrames.
     """
-    if not len(partitions):
-        raise ValueError(partitions, func)
     dataframe = pandas.concat(partitions, axis=axis, copy=False)
     result = func(dataframe, **kwargs)
     if isinstance(result, pandas.Series):

--- a/modin/engines/ray/pandas_on_ray/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/axis_partition.py
@@ -32,6 +32,8 @@ class PandasOnRayAxisPartition(BaseAxisPartition):
         if num_splits is None:
             num_splits = len(self.list_of_blocks)
 
+        assert len(self.list_of_blocks)
+
         if other_axis_partition is not None:
             return [
                 PandasOnRayRemotePartition(obj)
@@ -103,6 +105,8 @@ def deploy_ray_axis_func(axis, func, num_splits, kwargs, *partitions):
     Returns:
         A list of Pandas DataFrames.
     """
+    if not len(partitions):
+        raise ValueError(partitions, func)
     dataframe = pandas.concat(partitions, axis=axis, copy=False)
     result = func(dataframe, **kwargs)
     if isinstance(result, pandas.Series):

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -27,9 +27,7 @@ else:
 
 @pytest.fixture
 def ray_df_equals_pandas(ray_df, pandas_df):
-    return to_pandas(ray_df).equals(pandas_df) or to_pandas(ray_df).eq(pandas_df).all(
-        axis=None
-    )
+    return to_pandas(ray_df).equals(pandas_df)
 
 
 @pytest.fixture
@@ -1076,9 +1074,7 @@ def test_apply(ray_df, pandas_df, func, axis):
     if isinstance(ray_result, pd.DataFrame):
         assert ray_df_equals_pandas(ray_result, pandas_result)
     else:
-        assert ray_result.equals(pandas_result) or ray_result.eq(pandas_result).all(
-            axis=None
-        )
+        assert ray_result.equals(pandas_result)
 
 
 @pytest.mark.skip(reason="Defaulting to Pandas")

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -27,7 +27,8 @@ else:
 
 @pytest.fixture
 def ray_df_equals_pandas(ray_df, pandas_df):
-    return to_pandas(ray_df).equals(pandas_df)
+    return to_pandas(ray_df).equals(pandas_df) or \
+           to_pandas(ray_df).eq(pandas_df).all(axis=None)
 
 
 @pytest.fixture
@@ -108,7 +109,7 @@ def test_int_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
-    test_query(ray_df, pandas_df, query_funcs)
+    # test_query(ray_df, pandas_df, query_funcs)
 
     test_mean(ray_df, pandas_df)
     test_var(ray_df, pandas_df)
@@ -285,7 +286,7 @@ def test_float_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
-    test_query(ray_df, pandas_df, query_funcs)
+    # test_query(ray_df, pandas_df, query_funcs)
 
     test_mean(ray_df, pandas_df)
     test_var(ray_df, pandas_df)
@@ -452,7 +453,7 @@ def test_mixed_dtype_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
-    test_query(ray_df, pandas_df, query_funcs)
+    # test_query(ray_df, pandas_df, query_funcs)
 
     test_mean(ray_df, pandas_df)
     test_var(ray_df, pandas_df)
@@ -615,7 +616,7 @@ def test_nan_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
-    test_query(ray_df, pandas_df, query_funcs)
+    # test_query(ray_df, pandas_df, query_funcs)
 
     test_mean(ray_df, pandas_df)
     test_var(ray_df, pandas_df)
@@ -1074,7 +1075,8 @@ def test_apply(ray_df, pandas_df, func, axis):
     if isinstance(ray_result, pd.DataFrame):
         assert ray_df_equals_pandas(ray_result, pandas_result)
     else:
-        assert ray_result.equals(pandas_result)
+        assert ray_result.equals(pandas_result) or \
+               ray_result.eq(pandas_result).all(axis=None)
 
 
 @pytest.mark.skip(reason="Defaulting to Pandas")
@@ -1495,18 +1497,17 @@ def test_dropna(ray_df, pd_df):
 
 @pytest.fixture
 def test_dropna_inplace(ray_df, pd_df):
-    ray_df = ray_df.copy()
-    pd_df = pd_df.copy()
+    ray_df_cp = ray_df.copy()
+    pd_df_cp = pd_df.copy()
+    ray_df_cp.dropna(thresh=2, inplace=True)
+    pd_df_cp.dropna(thresh=2, inplace=True)
+    assert ray_df_equals_pandas(ray_df_cp, pd_df_cp)
 
-    ray_df.dropna(thresh=2, inplace=True)
-    pd_df.dropna(thresh=2, inplace=True)
-
-    assert ray_df_equals_pandas(ray_df, pd_df)
-
-    ray_df.dropna(axis=1, how="any", inplace=True)
-    pd_df.dropna(axis=1, how="any", inplace=True)
-
-    assert ray_df_equals_pandas(ray_df, pd_df)
+    ray_df_cp = ray_df.copy()
+    pd_df_cp = pd_df.copy()
+    ray_df_cp.dropna(axis=1, how="any", inplace=True)
+    pd_df_cp.dropna(axis=1, how="any", inplace=True)
+    assert ray_df_equals_pandas(ray_df_cp, pd_df_cp)
 
 
 @pytest.fixture

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -27,8 +27,9 @@ else:
 
 @pytest.fixture
 def ray_df_equals_pandas(ray_df, pandas_df):
-    return to_pandas(ray_df).equals(pandas_df) or \
-           to_pandas(ray_df).eq(pandas_df).all(axis=None)
+    return to_pandas(ray_df).equals(pandas_df) or to_pandas(ray_df).eq(pandas_df).all(
+        axis=None
+    )
 
 
 @pytest.fixture
@@ -109,7 +110,7 @@ def test_int_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
-    # test_query(ray_df, pandas_df, query_funcs)
+    test_query(ray_df, pandas_df, query_funcs)
 
     test_mean(ray_df, pandas_df)
     test_var(ray_df, pandas_df)
@@ -286,7 +287,7 @@ def test_float_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
-    # test_query(ray_df, pandas_df, query_funcs)
+    test_query(ray_df, pandas_df, query_funcs)
 
     test_mean(ray_df, pandas_df)
     test_var(ray_df, pandas_df)
@@ -453,7 +454,7 @@ def test_mixed_dtype_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
-    # test_query(ray_df, pandas_df, query_funcs)
+    test_query(ray_df, pandas_df, query_funcs)
 
     test_mean(ray_df, pandas_df)
     test_var(ray_df, pandas_df)
@@ -616,7 +617,7 @@ def test_nan_dataframe():
     test_keys(ray_df, pandas_df)
     test_transpose(ray_df, pandas_df)
     test_round(ray_df, pandas_df)
-    # test_query(ray_df, pandas_df, query_funcs)
+    test_query(ray_df, pandas_df, query_funcs)
 
     test_mean(ray_df, pandas_df)
     test_var(ray_df, pandas_df)
@@ -1075,8 +1076,9 @@ def test_apply(ray_df, pandas_df, func, axis):
     if isinstance(ray_result, pd.DataFrame):
         assert ray_df_equals_pandas(ray_result, pandas_result)
     else:
-        assert ray_result.equals(pandas_result) or \
-               ray_result.eq(pandas_result).all(axis=None)
+        assert ray_result.equals(pandas_result) or ray_result.eq(pandas_result).all(
+            axis=None
+        )
 
 
 @pytest.mark.skip(reason="Defaulting to Pandas")


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Sometimes we keep around extra partitions. This PR fully filters out those partitions. 

When we keep empty partitions around, there can be mismatches between how things are represented and how they are. e.g. A `drop` followed by indexing into the frame can result in errors getting thrown from the remote partitions.
<!-- Please give a short brief about these changes. -->

## Related issue number

N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
