### PR TITLE
Fixed block lengths error

### DIFF
--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -578,7 +578,6 @@ class BaseBlockPartitions(object):
                 if not block_idx
                 else index - cumulative_column_widths[block_idx - 1]
             )
-            return block_idx, internal_idx
         else:
             ErrorMessage.catch_bugs_and_request_email(index > sum(self.block_lengths))
             cumulative_row_lengths = np.array(self.block_lengths).cumsum()
@@ -589,7 +588,7 @@ class BaseBlockPartitions(object):
                 if not block_idx
                 else index - cumulative_row_lengths[block_idx - 1]
             )
-            return block_idx, internal_idx
+        return block_idx, internal_idx
 
     def _get_dict_of_block_index(self, axis, indices):
         """Convert indices to a dict of block index to internal index mapping.

--- a/modin/engines/python/pandas_on_python/remote_partition.py
+++ b/modin/engines/python/pandas_on_python/remote_partition.py
@@ -137,7 +137,7 @@ class PandasOnPythonRemotePartition(object):
 
     def length(self):
         if self._length_cache is None:
-            self._length_cache = type(self).width_extraction_fn()(self.data)
+            self._length_cache = type(self).length_extraction_fn()(self.data)
         return self._length_cache
 
     def width(self):


### PR DESCRIPTION
## What do these changes do?

Fixed typo that was causing the `lengths` in `PandasOnPythonRemotePartition` to be calculated with `width_extraction_fn` instead of `length_extraction_fn`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check modin/`
