### PR TITLE
A little cleanup of Dask Delayed implementation

### DIFF
--- a/modin/engines/dask/pandas_on_dask_delayed/axis_partition.py
+++ b/modin/engines/dask/pandas_on_dask_delayed/axis_partition.py
@@ -56,10 +56,6 @@ class DaskAxisPartition(BaseAxisPartition):
         args = [self.axis, func, num_splits, kwargs, maintain_partitioning]
 
         args.extend(dask.compute(*self.list_of_blocks))
-        # return [
-        #     DaskRemotePartition(dask.delayed(obj)) for obj in deploy_axis_func(*args)
-        # ]
-        # args = [self.axis, func, num_splits, kwargs] + self.list_of_blocks
         delayed_call = dask.delayed(deploy_axis_func, nout=num_splits)(*args)
         return [DaskRemotePartition(delayed_call[i]) for i in range(num_splits)]
 
@@ -109,7 +105,7 @@ def deploy_axis_func(
             if sum(lengths) != len(result.columns):
                 lengths = None
     return [
-        df.copy()
+        df.copy() if isinstance(df, pandas.DataFrame) else pandas.DataFrame(df)
         for df in split_result_of_axis_func_pandas(axis, num_splits, result, lengths)
     ]
 

--- a/modin/engines/dask/pandas_on_dask_delayed/axis_partition.py
+++ b/modin/engines/dask/pandas_on_dask_delayed/axis_partition.py
@@ -47,10 +47,8 @@ class DaskAxisPartition(BaseAxisPartition):
                     num_splits,
                     len(self.list_of_blocks),
                     kwargs,
-                    *dask.compute(
-                        *tuple(
-                            self.list_of_blocks + other_axis_partition.list_of_blocks
-                        )
+                    *tuple(
+                        self.list_of_blocks + other_axis_partition.list_of_blocks
                     )
                 )
             ]

--- a/modin/engines/dask/pandas_on_dask_delayed/axis_partition.py
+++ b/modin/engines/dask/pandas_on_dask_delayed/axis_partition.py
@@ -41,15 +41,15 @@ class DaskAxisPartition(BaseAxisPartition):
         if other_axis_partition is not None:
             return [
                 DaskRemotePartition(obj)
-                for obj in dask.delayed(deploy_func_between_two_axis_partitions, nout=num_splits)(
+                for obj in dask.delayed(
+                    deploy_func_between_two_axis_partitions, nout=num_splits
+                )(
                     self.axis,
                     func,
                     num_splits,
                     len(self.list_of_blocks),
                     kwargs,
-                    *tuple(
-                        self.list_of_blocks + other_axis_partition.list_of_blocks
-                    )
+                    *tuple(self.list_of_blocks + other_axis_partition.list_of_blocks)
                 )
             ]
 

--- a/modin/engines/dask/pandas_on_dask_delayed/axis_partition.py
+++ b/modin/engines/dask/pandas_on_dask_delayed/axis_partition.py
@@ -40,8 +40,8 @@ class DaskAxisPartition(BaseAxisPartition):
 
         if other_axis_partition is not None:
             return [
-                DaskRemotePartition(dask.delayed(obj))
-                for obj in deploy_func_between_two_axis_partitions(
+                DaskRemotePartition(obj)
+                for obj in dask.delayed(deploy_func_between_two_axis_partitions, nout=num_splits)(
                     self.axis,
                     func,
                     num_splits,
@@ -91,16 +91,11 @@ def deploy_axis_func(
     """
     dataframe = pandas.concat(partitions, axis=axis, copy=False)
     result = func(dataframe, **kwargs)
-    # XXX pandas_on_python.py is slightly different here but that implementation seems wrong as
-    # uncovered by test_var
+
     if isinstance(result, pandas.Series):
         return [result] + [pandas.Series([]) for _ in range(num_splits - 1)]
     if num_splits != len(partitions) or not maintain_partitioning:
         lengths = None
-
-    #    if num_splits != len(partitions) or isinstance(result, pandas.Series):
-    #        import pdb; pdb.set_trace()
-    #        lengths = None
     else:
         if axis == 0:
             lengths = [len(part) for part in partitions]

--- a/modin/engines/dask/pandas_on_dask_delayed/axis_partition.py
+++ b/modin/engines/dask/pandas_on_dask_delayed/axis_partition.py
@@ -56,9 +56,12 @@ class DaskAxisPartition(BaseAxisPartition):
         args = [self.axis, func, num_splits, kwargs, maintain_partitioning]
 
         args.extend(dask.compute(*self.list_of_blocks))
-        return [
-            DaskRemotePartition(dask.delayed(obj)) for obj in deploy_axis_func(*args)
-        ]
+        # return [
+        #     DaskRemotePartition(dask.delayed(obj)) for obj in deploy_axis_func(*args)
+        # ]
+        # args = [self.axis, func, num_splits, kwargs] + self.list_of_blocks
+        delayed_call = dask.delayed(deploy_axis_func, nout=num_splits)(*args)
+        return [DaskRemotePartition(delayed_call[i]) for i in range(num_splits)]
 
 
 class DaskColumnPartition(DaskAxisPartition):

--- a/modin/engines/dask/pandas_on_dask_delayed/block_partitions.py
+++ b/modin/engines/dask/pandas_on_dask_delayed/block_partitions.py
@@ -1,4 +1,8 @@
+import pandas
+import dask
+
 from modin.engines.base.block_partitions import BaseBlockPartitions
+from modin.error_message import ErrorMessage
 from .axis_partition import DaskColumnPartition, DaskRowPartition
 from .remote_partition import DaskRemotePartition
 
@@ -13,3 +17,56 @@ class DaskBlockPartitions(BaseBlockPartitions):
 
     def __init__(self, partitions):
         self.partitions = partitions
+
+    def _get_partitions(self):
+        # We don't filter fot the laziness of Dask Delayed
+        return self._partitions_cache
+
+    def _set_partitions(self, new_partitions):
+        self._partitions_cache = new_partitions
+
+    partitions = property(_get_partitions, _set_partitions)
+
+    def to_pandas(self, is_transposed=False):
+        """Convert this object into a Pandas DataFrame from the partitions.
+
+        Args:
+            is_transposed: A flag for telling this object that the external
+                representation is transposed, but not the internal.
+
+        Returns:
+            A Pandas DataFrame
+        """
+        # In the case this is transposed, it is easier to just temporarily
+        # transpose back then transpose after the conversion. The performance
+        # is the same as if we individually transposed the blocks and
+        # concatenated them, but the code is much smaller.
+        if is_transposed:
+            return self.transpose().to_pandas(False).T
+        else:
+            retrieved_objects = [
+                list(dask.compute(*[obj.dask_obj for obj in part])) for part in self.partitions
+            ]
+            if all(
+                isinstance(part, pandas.Series)
+                for row in retrieved_objects
+                for part in row
+            ):
+                axis = 0
+            elif all(
+                isinstance(part, pandas.DataFrame)
+                for row in retrieved_objects
+                for part in row
+            ):
+                axis = 1
+            else:
+                ErrorMessage.catch_bugs_and_request_email(True)
+            df_rows = [
+                pandas.concat([part for part in row], axis=axis)
+                for row in retrieved_objects
+                if not all(part.empty for part in row)
+            ]
+            if len(df_rows) == 0:
+                return pandas.DataFrame()
+            else:
+                return pandas.concat(df_rows)

--- a/modin/engines/dask/pandas_on_dask_delayed/block_partitions.py
+++ b/modin/engines/dask/pandas_on_dask_delayed/block_partitions.py
@@ -45,7 +45,8 @@ class DaskBlockPartitions(BaseBlockPartitions):
             return self.transpose().to_pandas(False).T
         else:
             retrieved_objects = [
-                list(dask.compute(*[obj.dask_obj for obj in part])) for part in self.partitions
+                list(dask.compute(*[obj.dask_obj for obj in part]))
+                for part in self.partitions
             ]
             if all(
                 isinstance(part, pandas.Series)

--- a/modin/engines/dask/pandas_on_dask_delayed/block_partitions.py
+++ b/modin/engines/dask/pandas_on_dask_delayed/block_partitions.py
@@ -44,12 +44,8 @@ class DaskBlockPartitions(BaseBlockPartitions):
         if is_transposed:
             return self.transpose().to_pandas(False).T
         else:
-            # retrieved_objects = [
-            #     list(dask.compute(*[obj.dask_obj for obj in part]))
-            #     for part in self.partitions
-            # ]
-            retreived_objects = dask.compute(
-                [obj.dask_obj for obj in part for part in self.partitions]
+            retrieved_objects = dask.compute(
+                [obj.dask_obj for part in self.partitions for obj in part]
             )
             if all(
                 isinstance(part, pandas.Series)

--- a/modin/engines/dask/pandas_on_dask_delayed/block_partitions.py
+++ b/modin/engines/dask/pandas_on_dask_delayed/block_partitions.py
@@ -44,10 +44,13 @@ class DaskBlockPartitions(BaseBlockPartitions):
         if is_transposed:
             return self.transpose().to_pandas(False).T
         else:
-            retrieved_objects = [
-                list(dask.compute(*[obj.dask_obj for obj in part]))
-                for part in self.partitions
-            ]
+            # retrieved_objects = [
+            #     list(dask.compute(*[obj.dask_obj for obj in part]))
+            #     for part in self.partitions
+            # ]
+            retreived_objects = dask.compute(
+                [obj.dask_obj for obj in part for part in self.partitions]
+            )
             if all(
                 isinstance(part, pandas.Series)
                 for row in retrieved_objects


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
This does not fully make everything 100% lazy, but it does help make more lazy.

* Override partitions to avoid pruning empty partitions
  * This is not necessary because there is nothing to prune until
    computation begins
  * In the future we may lazily prune empty partitions
* Override to_pandas to use dask.compute instead of blocking each
  partition's execution individually
* Take dask.compute out of a couple of places in DaskAxisPartition
<!-- Please give a short brief about these changes. -->

## Related issue number
#289 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
