### PR TITLE
 Making Modin more efficient with smaller DataFrames

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1839,9 +1839,7 @@ class PandasQueryCompiler(object):
         # Since we assume no knowledge of internal state, we get the columns
         # from the internal partitions.
         if numeric_only:
-            new_columns = self.columns[
-                [i for i in range(len(self.dtypes)) if is_numeric_dtype(self.dtypes[i])]
-            ]  # self.compute_index(1, new_data, True)
+            new_columns = self.compute_index(1, new_data, True)
         else:
             new_columns = self.columns
         new_dtypes = pandas.Series([np.float64 for _ in new_columns], index=new_columns)

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -691,6 +691,8 @@ class PandasQueryCompiler(object):
         ), "Must have the same DataManager subclass to perform this operation"
 
         def update_builder(df, other, **kwargs):
+            # This is because of a requirement in Arrow
+            df = df.copy()
             df.update(other, **kwargs)
             return df
 
@@ -1782,6 +1784,9 @@ class PandasQueryCompiler(object):
             }
 
             def fillna_dict_builder(df, func_dict={}):
+                # We do this to ensure that no matter the state of the columns we get
+                # the correct ones.
+                func_dict = {df.columns[idx]: func_dict[idx] for idx in func_dict}
                 return df.fillna(value=func_dict, **kwargs)
 
             new_data = self.data.apply_func_to_select_indices(
@@ -1834,7 +1839,7 @@ class PandasQueryCompiler(object):
         # Since we assume no knowledge of internal state, we get the columns
         # from the internal partitions.
         if numeric_only:
-            new_columns = self.compute_index(1, new_data, True)
+            new_columns = self.columns[[i for i in range(len(self.dtypes)) if is_numeric_dtype(self.dtypes[i])]] # self.compute_index(1, new_data, True)
         else:
             new_columns = self.columns
         new_dtypes = pandas.Series([np.float64 for _ in new_columns], index=new_columns)

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1839,7 +1839,9 @@ class PandasQueryCompiler(object):
         # Since we assume no knowledge of internal state, we get the columns
         # from the internal partitions.
         if numeric_only:
-            new_columns = self.columns[[i for i in range(len(self.dtypes)) if is_numeric_dtype(self.dtypes[i])]] # self.compute_index(1, new_data, True)
+            new_columns = self.columns[
+                [i for i in range(len(self.dtypes)) if is_numeric_dtype(self.dtypes[i])]
+            ]  # self.compute_index(1, new_data, True)
         else:
             new_columns = self.columns
         new_dtypes = pandas.Series([np.float64 for _ in new_columns], index=new_columns)

--- a/modin/data_management/utils.py
+++ b/modin/data_management/utils.py
@@ -50,6 +50,8 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
     Returns:
         A list of Pandas DataFrames.
     """
+    if num_splits == 1:
+        return result
     if length_list is not None:
         length_list.insert(0, 0)
         sums = np.cumsum(length_list)
@@ -72,12 +74,12 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
 
 
 def length_fn_pandas(df):
-    assert isinstance(df, (pandas.DataFrame, pandas.Series))
+    assert isinstance(df, (pandas.DataFrame, pandas.Series)), "{}".format(df)
     return len(df)
 
 
 def width_fn_pandas(df):
-    assert isinstance(df, (pandas.DataFrame, pandas.Series))
+    assert isinstance(df, (pandas.DataFrame, pandas.Series)), "{}".format((df))
     if isinstance(df, pandas.DataFrame):
         return len(df.columns)
     else:

--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -5,7 +5,6 @@ from __future__ import print_function
 from typing import Tuple
 
 import numpy as np
-import math
 import pandas
 
 from modin.error_message import ErrorMessage

--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 from typing import Tuple
 
 import numpy as np
+import math
 import pandas
 
 from modin.error_message import ErrorMessage
@@ -466,8 +467,6 @@ class BaseBlockPartitions(object):
         else:
             row_chunksize = max(1, compute_chunksize(len(df), num_splits))
             col_chunksize = max(1, compute_chunksize(len(df.columns), num_splits))
-
-            import math
 
             mem_usage_chunksize = math.sqrt(mem_usage // min_block_size)
             row_chunksize = max(row_chunksize, len(df) // int(mem_usage_chunksize))

--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -457,7 +457,7 @@ class BaseBlockPartitions(object):
 
     @classmethod
     def from_pandas(cls, df):
-        min_block_size = 2**12
+        min_block_size = 2 ** 12
         num_splits = cls._compute_num_partitions()
         put_func = cls._partition_class.put
         mem_usage = df.memory_usage().sum()
@@ -468,12 +468,19 @@ class BaseBlockPartitions(object):
             col_chunksize = max(1, compute_chunksize(len(df.columns), num_splits))
 
             import math
+
             mem_usage_chunksize = math.sqrt(mem_usage // min_block_size)
             row_chunksize = max(row_chunksize, len(df) // int(mem_usage_chunksize))
             # adjust mem_usage_chunksize for non-perfect square roots to have better
             # partitioning
-            mem_usage_chunksize = mem_usage_chunksize if mem_usage_chunksize - int(mem_usage_chunksize) == 0 else mem_usage_chunksize + 1
-            col_chunksize = max(col_chunksize, len(df.columns) // int(mem_usage_chunksize))
+            mem_usage_chunksize = (
+                mem_usage_chunksize
+                if mem_usage_chunksize - int(mem_usage_chunksize) == 0
+                else mem_usage_chunksize + 1
+            )
+            col_chunksize = max(
+                col_chunksize, len(df.columns) // int(mem_usage_chunksize)
+            )
 
             # Each chunk must have a RangeIndex that spans its length and width
             # according to our invariant.
@@ -685,6 +692,7 @@ class BaseBlockPartitions(object):
         # possible here. Functions that use this in the dictionary format must
         # accept a keyword argument `func_dict`.
         if dict_indices is not None:
+
             def local_to_global_idx(partition_id, local_idx):
                 if partition_id == 0:
                     return local_idx
@@ -701,7 +709,9 @@ class BaseBlockPartitions(object):
                             func,
                             partitions_for_apply[i],
                             func_dict={
-                                idx: dict_indices[local_to_global_idx(i, idx)] for idx in partitions_dict[i] if idx >= 0
+                                idx: dict_indices[local_to_global_idx(i, idx)]
+                                for idx in partitions_dict[i]
+                                if idx >= 0
                             },
                         )
                         for i in partitions_dict
@@ -716,7 +726,9 @@ class BaseBlockPartitions(object):
                             func,
                             partitions_for_apply[i],
                             func_dict={
-                                idx: dict_indices[local_to_global_idx(i, idx)] for idx in partitions_dict[i] if idx >= 0
+                                idx: dict_indices[local_to_global_idx(i, idx)]
+                                for idx in partitions_dict[i]
+                                if idx >= 0
                             },
                         )
                         for i in range(len(partitions_for_apply))

--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -685,6 +685,15 @@ class BaseBlockPartitions(object):
         # possible here. Functions that use this in the dictionary format must
         # accept a keyword argument `func_dict`.
         if dict_indices is not None:
+            def local_to_global_idx(partition_id, local_idx):
+                if partition_id == 0:
+                    return local_idx
+                if axis == 0:
+                    cumulative_axis = np.cumsum(self.block_widths)
+                else:
+                    cumulative_axis = np.cumsum(self.block_lengths)
+                return cumulative_axis[partition_id - 1] + local_idx
+
             if not keep_remaining:
                 result = np.array(
                     [
@@ -692,7 +701,7 @@ class BaseBlockPartitions(object):
                             func,
                             partitions_for_apply[i],
                             func_dict={
-                                idx: dict_indices[idx] for idx in partitions_dict[i] if idx >= 0
+                                idx: dict_indices[local_to_global_idx(i, idx)] for idx in partitions_dict[i] if idx >= 0
                             },
                         )
                         for i in partitions_dict
@@ -707,7 +716,7 @@ class BaseBlockPartitions(object):
                             func,
                             partitions_for_apply[i],
                             func_dict={
-                                idx: dict_indices[idx] for idx in partitions_dict[i] if idx >= 0
+                                idx: dict_indices[local_to_global_idx(i, idx)] for idx in partitions_dict[i] if idx >= 0
                             },
                         )
                         for i in range(len(partitions_for_apply))

--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -466,7 +466,7 @@ class BaseBlockPartitions(object):
         # Each chunk must have a RangeIndex that spans its length and width
         # according to our invariant.
         def chunk_builder(i, j):
-            chunk = df.iloc[i: i + row_chunksize, j: j + col_chunksize].copy()
+            chunk = df.iloc[i : i + row_chunksize, j : j + col_chunksize].copy()
             chunk.index = pandas.RangeIndex(len(chunk.index))
             chunk.columns = pandas.RangeIndex(len(chunk.columns))
             return put_func(chunk)

--- a/modin/engines/ray/pandas_on_ray/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/axis_partition.py
@@ -33,15 +33,19 @@ class PandasOnRayAxisPartition(BaseAxisPartition):
             num_splits = len(self.list_of_blocks)
 
         if other_axis_partition is not None:
-            return self._wrap_partitions(deploy_ray_func_between_two_axis_partitions._remote(
+            return self._wrap_partitions(
+                deploy_ray_func_between_two_axis_partitions._remote(
                     args=(self.axis, func, num_splits, len(self.list_of_blocks), kwargs)
                     + tuple(self.list_of_blocks + other_axis_partition.list_of_blocks),
                     num_return_vals=num_splits,
-                ))
+                )
+            )
 
         args = [self.axis, func, num_splits, kwargs]
         args.extend(self.list_of_blocks)
-        return self._wrap_partitions(deploy_ray_axis_func._remote(args, num_return_vals=num_splits))
+        return self._wrap_partitions(
+            deploy_ray_axis_func._remote(args, num_return_vals=num_splits)
+        )
 
     def shuffle(self, func, num_splits=None, **kwargs):
         """Shuffle the order of the data in this axis based on the `func`.
@@ -58,7 +62,9 @@ class PandasOnRayAxisPartition(BaseAxisPartition):
 
         args = [self.axis, func, num_splits, kwargs]
         args.extend(self.list_of_blocks)
-        return self._wrap_partitions(deploy_ray_axis_func._remote(args, num_return_vals=num_splits))
+        return self._wrap_partitions(
+            deploy_ray_axis_func._remote(args, num_return_vals=num_splits)
+        )
 
     def _wrap_partitions(self, partitions):
         if isinstance(partitions, ray.ObjectID):

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -511,6 +511,16 @@ def get_index(index_name, *partition_indices):
 
 
 def _split_result_for_readers(axis, num_splits, df):
+    """Splits the DataFrame read into smaller DataFrames and handles all edge cases.
+
+    Args:
+        axis: Which axis to split over.
+        num_splits: The number of splits to create.
+        df: The DataFrame after it has been read.
+
+    Returns:
+        A list of pandas DataFrames.
+    """
     splits = split_result_of_axis_func_pandas(axis, num_splits, df)
     if not isinstance(splits, list):
         splits = [splits]

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -526,6 +526,7 @@ def _split_result_for_readers(axis, num_splits, df):
         splits = [splits]
     return splits
 
+
 @ray.remote
 def _read_csv_with_offset_pandas_on_ray(fname, num_splits, start, end, kwargs, header):
     """Use a Ray task to read a chunk of a CSV into a Pandas DataFrame.


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
This is not comprehensive, though it is a solid start.

* Initial partitioning can also be determined by size now
* Fixed some internal bugs around having 1x1 partitions (previously an
  extreme edge case -- 1x1 DataFrame)
* Still encountering some edge case bugs
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
