### PR TITLE
Fix index of the result of get_dtype_counts

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1672,7 +1672,6 @@ class DataFrame(object):
         """
         result = self.dtypes.value_counts()
         result.index = result.index.map(lambda x: str(x))
-        result = result.sort_index()
         return result
 
     def get_ftype_counts(self):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1673,7 +1673,6 @@ class DataFrame(object):
         result = self.dtypes.value_counts()
         result.index = result.index.map(lambda x: str(x))
         result = result.sort_index()
-        result.index = result.index.map(lambda x: np.dtype(getattr(np, x)))
         return result
 
     def get_ftype_counts(self):

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -993,7 +993,9 @@ def test_get(ray_df, pandas_df, key):
 
 @pytest.fixture
 def test_get_dtype_counts(ray_df, pandas_df):
-    assert ray_df.get_dtype_counts().equals(pandas_df.get_dtype_counts())
+    ray_result = ray_df.get_dtype_counts().sort_index()
+    pandas_result = pandas_df.get_dtype_counts().sort_index()
+    assert ray_result.equals(pandas_result)
 
 
 @pytest.fixture


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Fixes `get_dtype_counts` error of the resulting index having mixed dtypes and issues with handling the conversion from pandas datetime[ns] to numpy 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
