### PR TITLE
Fix bug in concat where keys were improperly assigned

### DIFF
--- a/modin/pandas/concat.py
+++ b/modin/pandas/concat.py
@@ -97,7 +97,7 @@ def concat(
         new_idx = pandas.MultiIndex.from_tuples(tuples)
     else:
         new_idx = None
-    new_manager = df._query_compiler.concat(
+    new_query_compiler = df._query_compiler.concat(
         axis,
         objs[1:],
         join=join,
@@ -110,7 +110,7 @@ def concat(
         copy=True,
         sort=False,
     )
-    result_df = DataFrame(query_compiler=new_manager)
+    result_df = DataFrame(query_compiler=new_query_compiler)
     if new_idx is not None:
         if axis == 0:
             result_df.index = new_idx

--- a/modin/pandas/concat.py
+++ b/modin/pandas/concat.py
@@ -20,10 +20,14 @@ def concat(
     sort=None,
     copy=True,
 ):
-    if isinstance(objs, (pandas.Series, DataFrame, compat.string_types, pandas.DataFrame)):
-        raise TypeError('first argument must be an iterable of pandas '
-                        'objects, you passed an object of type '
-                        '"{name}"'.format(name=type(objs).__name__))
+    if isinstance(
+        objs, (pandas.Series, DataFrame, compat.string_types, pandas.DataFrame)
+    ):
+        raise TypeError(
+            "first argument must be an iterable of pandas "
+            "objects, you passed an object of type "
+            '"{name}"'.format(name=type(objs).__name__)
+        )
     objs = list(objs)
     if len(objs) == 0:
         raise ValueError("No objects to concatenate")
@@ -91,7 +95,10 @@ def concat(
     objs = [obj._query_compiler for obj in objs]
     if keys is not None:
         objs = [objs[i] for i in range(min(len(objs), len(keys)))]
-        new_idx_labels = {keys[i]: objs[i].index if axis == 0 else objs[i].columns for i in range(len(objs))}
+        new_idx_labels = {
+            keys[i]: objs[i].index if axis == 0 else objs[i].columns
+            for i in range(len(objs))
+        }
         print(new_idx_labels)
         tuples = [(k, o) for k, obj in new_idx_labels.items() for o in obj]
         new_idx = pandas.MultiIndex.from_tuples(tuples)

--- a/modin/pandas/concat.py
+++ b/modin/pandas/concat.py
@@ -3,7 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import pandas
-
+from pandas import compat
 from .dataframe import DataFrame
 
 
@@ -17,13 +17,14 @@ def concat(
     levels=None,
     names=None,
     verify_integrity=False,
+    sort=None,
     copy=True,
-    sort=False,
 ):
-    if keys is not None:
-        objs = [objs[k] for k in keys]
-    else:
-        objs = list(objs)
+    if isinstance(objs, (pandas.Series, DataFrame, compat.string_types, pandas.DataFrame)):
+        raise TypeError('first argument must be an iterable of pandas '
+                        'objects, you passed an object of type '
+                        '"{name}"'.format(name=type(objs).__name__))
+    objs = list(objs)
     if len(objs) == 0:
         raise ValueError("No objects to concatenate")
 
@@ -31,7 +32,6 @@ def concat(
 
     if len(objs) == 0:
         raise ValueError("All objects passed were None")
-
     try:
         type_check = next(
             obj
@@ -61,8 +61,8 @@ def concat(
                 levels,
                 names,
                 verify_integrity,
-                copy,
                 sort,
+                copy,
             )
         )
     if isinstance(objs, dict):
@@ -89,6 +89,14 @@ def concat(
     ]
     df = objs[0]
     objs = [obj._query_compiler for obj in objs]
+    if keys is not None:
+        objs = [objs[i] for i in range(min(len(objs), len(keys)))]
+        new_idx_labels = {keys[i]: objs[i].index if axis == 0 else objs[i].columns for i in range(len(objs))}
+        print(new_idx_labels)
+        tuples = [(k, o) for k, obj in new_idx_labels.items() for o in obj]
+        new_idx = pandas.MultiIndex.from_tuples(tuples)
+    else:
+        new_idx = None
     new_manager = df._query_compiler.concat(
         axis,
         objs[1:],
@@ -102,4 +110,10 @@ def concat(
         copy=True,
         sort=False,
     )
-    return DataFrame(query_compiler=new_manager)
+    result_df = DataFrame(query_compiler=new_manager)
+    if new_idx is not None:
+        if axis == 0:
+            result_df.index = new_idx
+        else:
+            result_df.columns = new_idx
+    return result_df


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

* Now creates a MultiIndex correctly from the keys provided
* Better error checking (closer to pandas)
* Correct order of keyword arguments
* Minor refactor
<!-- Please give a short brief about these changes. -->

## Related issue number
Resovles 316
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
