### PR TITLE
Adding dtypes to the `exclude` parameter in the remote partition

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1529,13 +1529,14 @@ class PandasQueryCompiler(object):
         # Only describe numeric if there are numeric columns
         # Otherwise, describe all
         new_columns = self.numeric_columns(include_bool=False)
+
         if len(new_columns) != 0:
             numeric = True
             exclude = kwargs.get("exclude", None)
             if is_list_like(exclude):
-                exclude.append([np.timedelta64, np.datetime64])
+                exclude.append([np.timedelta64, np.datetime64, np.object, np.bool])
             else:
-                exclude = [exclude, np.timedelta64, np.datetime64]
+                exclude = [exclude, np.timedelta64, np.datetime64, np.object, np.bool]
             kwargs["exclude"] = exclude
         else:
             numeric = False

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1529,7 +1529,6 @@ class PandasQueryCompiler(object):
         # Only describe numeric if there are numeric columns
         # Otherwise, describe all
         new_columns = self.numeric_columns(include_bool=False)
-
         if len(new_columns) != 0:
             numeric = True
             exclude = kwargs.get("exclude", None)


### PR DESCRIPTION

<!--
Thank you for your contribution!
-->

## What do these changes do?
* This will give the correct result when `df.describe` is called
* Fixes an index mismatch error between the remote and local

<!-- Please give a short brief about these changes. -->

## Related issue number
Resolves #320 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
