### PR TITLE
Fix dropna when axis argument is a string

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -503,12 +503,12 @@ class DataFrame(object):
                 result = result.dropna(axis=ax, how=how, thresh=thresh, subset=subset)
             return self._create_dataframe_from_compiler(result._query_compiler, inplace)
 
+        axis = pandas.DataFrame()._get_axis_number(axis)
         if how is not None and how not in ["any", "all"]:
             raise ValueError("invalid how option: %s" % how)
         if how is None and thresh is None:
             raise TypeError("must specify how or thresh")
         if subset is not None:
-            axis = pandas.DataFrame()._get_axis_number(axis)
             if axis == 1:
                 indices = self.index.get_indexer_for(subset)
                 check = indices == -1


### PR DESCRIPTION
## What do these changes do?

Always converts `dropna`'s `axis` argument from a string to an integer before passing to `self.query_compiler`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
