### PR TITLE
Fix mode when axis=1 and remove a reindex

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1742,28 +1742,20 @@ class PandasQueryCompiler(object):
                     columns=result.columns, index=range(len(result), len(df))
                 )
                 result = pandas.concat([result, append_values], ignore_index=True)
-            elif axis:
+            elif axis and len(df.columns) != len(result.columns):
                 # Pad rows
                 append_vals = pandas.DataFrame(
-                    columns=range(len(result.columns), len(df)), index=result.index
+                    columns=range(len(result.columns), len(df.columns)), index=result.index
                 )
                 result = pandas.concat([result, append_vals], axis=1)
             return result
 
         func = self._prepare_method(mode_builder, **kwargs)
         new_data = self.map_across_full_axis(axis, func)
+
         new_index = pandas.RangeIndex(len(self.index)) if not axis else self.index
         new_columns = self.columns if not axis else pandas.RangeIndex(len(self.columns))
-        # We have to reindex the DataFrame so that all of the partitions are
-        # matching in shape. The next steps ensure this happens.
-        final_labels = new_index if not axis else new_columns
-        # We build these intermediate objects to avoid depending directly on
-        # the underlying implementation.
-        return (
-            self.__constructor__(new_data, new_index, new_columns, self._dtype_cache)
-            .reindex(axis=axis, labels=final_labels)
-            .dropna(axis=axis, how="all")
-        )
+        return self.__constructor__(new_data, new_index, new_columns, self._dtype_cache).dropna(axis=axis, how="all")
 
     def fillna(self, **kwargs):
         """Replaces NaN values with the method provided.

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1745,7 +1745,8 @@ class PandasQueryCompiler(object):
             elif axis and len(df.columns) != len(result.columns):
                 # Pad rows
                 append_vals = pandas.DataFrame(
-                    columns=range(len(result.columns), len(df.columns)), index=result.index
+                    columns=range(len(result.columns), len(df.columns)),
+                    index=result.index,
                 )
                 result = pandas.concat([result, append_vals], axis=1)
             return result
@@ -1755,7 +1756,9 @@ class PandasQueryCompiler(object):
 
         new_index = pandas.RangeIndex(len(self.index)) if not axis else self.index
         new_columns = self.columns if not axis else pandas.RangeIndex(len(self.columns))
-        return self.__constructor__(new_data, new_index, new_columns, self._dtype_cache).dropna(axis=axis, how="all")
+        return self.__constructor__(
+            new_data, new_index, new_columns, self._dtype_cache
+        ).dropna(axis=axis, how="all")
 
     def fillna(self, **kwargs):
         """Replaces NaN values with the method provided.


### PR DESCRIPTION
## What do these changes do?

Removes a reindex and `mode` works properly when `axis=1`

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
