### PR TITLE
Adding try-except block to internal partition computation for describe

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1593,7 +1593,10 @@ class PandasQueryCompiler(object):
                 new_columns = self.columns
 
         def describe_builder(df, **kwargs):
-            return pandas.DataFrame.describe(df, **kwargs)
+            try:
+                return pandas.DataFrame.describe(df, **kwargs)
+            except ValueError:
+                return pandas.DataFrame(index=df.index)
 
         # Apply describe and update indices, columns, and dtypes
         func = self._prepare_method(describe_builder, **kwargs)


### PR DESCRIPTION
* This allows the partition to return a valid DataFrame and not an
  Exception
* In the future, additional post-processing may be needed to throw the
  pandas error that gets thrown if no data of that type exists.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number
Resolves #364 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
