### PR TITLE
Correctly handling empty DataFrames for selective operations

### DIFF
--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -688,6 +688,8 @@ class BaseBlockPartitions(object):
         Returns:
             A new BaseBlockPartitions object, the type of object that called this.
         """
+        if self.partitions.size == 0:
+            return np.array([[]])
         # Handling dictionaries has to be done differently, but we still want
         # to figure out the partitions that need to be applied to, so we will
         # store the dictionary in a separate variable and assign `indices` to
@@ -811,6 +813,8 @@ class BaseBlockPartitions(object):
         Returns:
             A new BaseBlockPartitions object, the type of object that called this.
         """
+        if self.partitions.size == 0:
+            return np.array([[]])
         if isinstance(indices, dict):
             dict_indices = indices
             indices = list(indices.keys())


### PR DESCRIPTION
* Adding a condition for selective apply operations that will simply
  return an empty 2D numpy array for partitions if there are no
  partitions.
* This is added to both `apply_func_to_select_indices` and
  `apply_func_to_select_indices_along_full_axis`

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number
Resolves #368 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
