### PR TITLE
Converting PandasQueryCompiler.getitem_array to accept numeric indices

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1665,7 +1665,7 @@ class PandasQueryCompiler(object):
             if not axis:
                 compute_na = self.getitem_column_array(subset)
             else:
-                compute_na = self.getitem_row_array(subset)
+                compute_na = self.getitem_row_array(self.index.get_indexer_for(subset))
         else:
             compute_na = self
 
@@ -2202,23 +2202,23 @@ class PandasQueryCompiler(object):
         """Get row data for target labels.
 
         Args:
-            key: Target labels by which to retrieve data.
+            key: Target numeric indices by which to retrieve data.
 
         Returns:
             A new PandasDataManager.
         """
         # Convert to list for type checking
-        numeric_indices = list(self.index.get_indexer_for(key))
+        key = list(key)
 
         def getitem(df, internal_indices=[]):
             return df.iloc[internal_indices]
 
         result = self.data.apply_func_to_select_indices(
-            1, getitem, numeric_indices, keep_remaining=False
+            1, getitem, key, keep_remaining=False
         )
         # We can't just set the index to key here because there may be multiple
         # instances of a key.
-        new_index = self.index[numeric_indices]
+        new_index = self.index[key]
         return self.__constructor__(result, new_index, self.columns, self._dtype_cache)
 
     # END __getitem__ methods

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -3371,8 +3371,8 @@ class DataFrame(object):
             axis_labels = self.columns
             axis_length = len(axis_labels)
         else:
-            # Getting rows requires indices instead of labels
-            axis_labels = range(len(self.index))
+            # Getting rows requires indices instead of labels. RangeIndex provides this.
+            axis_labels = pandas.RangeIndex(len(self.index))
             axis_length = len(axis_labels)
         if weights is not None:
             # Index of the weights Series should correspond to the index of the

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -3371,7 +3371,8 @@ class DataFrame(object):
             axis_labels = self.columns
             axis_length = len(axis_labels)
         else:
-            axis_labels = self.index
+            # Getting rows requires indices instead of labels
+            axis_labels = range(len(self.index))
             axis_length = len(axis_labels)
         if weights is not None:
             # Index of the weights Series should correspond to the index of the
@@ -4552,9 +4553,10 @@ class DataFrame(object):
                     )
                 )
             key = check_bool_indexer(self.index, key)
-            # We convert here because the query_compiler assumes it is a list of
-            # indices. This greatly decreases the complexity of the code.
-            key = self.index[key]
+            # We convert to a RangeIndex because getitem_row_array is expecting a list
+            # of indices, and RangeIndex will give us the exact indices of each boolean
+            # requested.
+            key = pandas.RangeIndex(len(self.index))[key]
             return DataFrame(query_compiler=self._query_compiler.getitem_row_array(key))
         else:
             if any(k not in self.columns for k in key):
@@ -4568,9 +4570,10 @@ class DataFrame(object):
             )
 
     def _getitem_slice(self, key):
-        # We convert here because the query_compiler assumes it is a list of
-        # indices. This greatly decreases the complexity of the code.
-        key = self.index[key]
+        # We convert to a RangeIndex because getitem_row_array is expecting a list
+        # of indices, and RangeIndex will give us the exact indices of each boolean
+        # requested.
+        key = pandas.RangeIndex(len(self.index))[key]
         return DataFrame(query_compiler=self._query_compiler.getitem_row_array(key))
 
     def __getattr__(self, key):

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -89,7 +89,9 @@ class DataFrameGroupBy(object):
                 else:
                     self._index_grouped_cache = {
                         k: v.index
-                        for k, v in self._df._query_compiler.getitem_row_array(self._by)
+                        for k, v in self._df._query_compiler.getitem_row_array(
+                            self._index.get_indexer_for(self._by)
+                        )
                         .to_pandas()
                         .groupby(by=self._by)
                     }
@@ -120,7 +122,7 @@ class DataFrameGroupBy(object):
                     k,
                     DataFrame(
                         query_compiler=self._query_compiler.getitem_row_array(
-                            self._index_grouped[k]
+                            self._index.get_indexer_for(self._index_grouped[k])
                         )
                     ),
                 )

--- a/modin/pandas/iterator.py
+++ b/modin/pandas/iterator.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pandas
 from collections import Iterator
 
 

--- a/modin/pandas/iterator.py
+++ b/modin/pandas/iterator.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import pandas
 from collections import Iterator
 
 
@@ -18,10 +19,11 @@ class PartitionIterator(Iterator):
         self.data_manager = data_manager
         self.axis = axis
         self.index_iter = (
-            iter(self.data_manager.columns) if axis else iter(self.data_manager.index)
+            iter(self.data_manager.columns)
+            if axis
+            else iter(range(len(self.data_manager.index)))
         )
         self.func = func
-        self.index_within_rows = 0
 
     def __iter__(self):
         return self
@@ -30,11 +32,9 @@ class PartitionIterator(Iterator):
         return self.next()
 
     def next(self):
+        key = next(self.index_iter)
         if self.axis:
-            key = next(self.index_iter)
             df = self.data_manager.getitem_column_array([key]).to_pandas()
         else:
-            key = self.index_within_rows
-            self.index_within_rows += 1
             df = self.data_manager.getitem_row_array([key]).to_pandas()
         return next(self.func(df))

--- a/modin/pandas/iterator.py
+++ b/modin/pandas/iterator.py
@@ -21,6 +21,7 @@ class PartitionIterator(Iterator):
             iter(self.data_manager.columns) if axis else iter(self.data_manager.index)
         )
         self.func = func
+        self.index_within_rows = 0
 
     def __iter__(self):
         return self
@@ -33,6 +34,7 @@ class PartitionIterator(Iterator):
             key = next(self.index_iter)
             df = self.data_manager.getitem_column_array([key]).to_pandas()
         else:
-            key = next(self.index_iter)
+            key = self.index_within_rows
+            self.index_within_rows += 1
             df = self.data_manager.getitem_row_array([key]).to_pandas()
         return next(self.func(df))


### PR DESCRIPTION
* Resolves #384
* Make changes to the functions that use getitem_array to now use
  indices instead

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
