### PR TITLE
Removing is_view from PandasQueryCompilerView and codepath requiring it

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -2712,7 +2712,6 @@ class PandasQueryCompilerView(PandasQueryCompiler):
 
         self.index_map = index_map_series
         self.columns_map = columns_map_series
-        self.is_view = True
 
         PandasQueryCompiler.__init__(
             self, block_partitions_object, index, columns, dtypes

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -147,18 +147,13 @@ class _LocationIndexerBase(object):
     def __init__(self, ray_df: DataFrame):
         self.df = ray_df
         self.qc = ray_df._query_compiler
-        self.is_view = hasattr(self.qc, "is_view")
-
         self.row_scaler = False
         self.col_scaler = False
 
     def __getitem__(
         self, row_lookup: pandas.Index, col_lookup: pandas.Index, ndim: int
     ):
-        if self.is_view:
-            qc_view = self.qc.__constructor__(self.qc.data, row_lookup, col_lookup)
-        else:
-            qc_view = self.qc.view(row_lookup, col_lookup)
+        qc_view = self.qc.view(row_lookup, col_lookup)
 
         if ndim == 2:
             return DataFrame(query_compiler=qc_view)


### PR DESCRIPTION
* Resolves #392
* This creates a view on all objects, even PandasQueryCompilerView
  objects, when using an Indexer (e.g. LocIndexer)
* Allows `df.iloc[...].iloc[...]` to be supported now

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
