### PR TITLE
support for DataFrame().loc when location (row/col) does not exist

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -236,6 +236,18 @@ class _LocIndexer(_LocationIndexerBase):
 
     def __setitem__(self, key, item):
         row_loc, col_loc, _, __, ___ = _parse_tuple(key)
+        if isinstance(row_loc, list) and len(row_loc) == 1:
+            if row_loc[0] not in self.qc.index:
+                index = self.qc.index.insert(len(self.qc.index), row_loc[0])
+                self.qc = self.qc.reindex(labels=index, axis=0)
+                self.df._update_inplace(new_query_compiler=self.qc)
+
+        if isinstance(col_loc, list) and len(col_loc) == 1:
+            if col_loc[0] not in self.qc.columns:
+                columns = self.qc.columns.insert(len(self.qc.columns), col_loc[0])
+                self.qc = self.qc.reindex(labels=columns, axis=1)
+                self.df._update_inplace(new_query_compiler=self.qc)
+
         row_lookup, col_lookup = self._compute_lookup(row_loc, col_loc)
         super(_LocIndexer, self).__setitem__(row_lookup, col_lookup, item)
 


### PR DESCRIPTION
## What do these changes do?
Dataframe().loc will verify row and col locations before setting the item. if these are single locations, one row or one col, and either do not exist, it will be created.
This is to align according to pandas behaviour

## Related issue number
#399 


- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check modin/`
