### PR TITLE
removing axis from replace signature and validation of insert when value is an instance of pandas.Series 

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1958,7 +1958,7 @@ class DataFrame(object):
         else:
             if not is_list_like(value):
                 value = np.full(len(self.index), value)
-            if len(value) != len(self.index):
+            if not isinstance(value, pandas.Series) and len(value) != len(self.index):
                 raise ValueError("Length of values does not match length of index")
             if not allow_duplicates and column in self.columns:
                 raise ValueError("cannot insert {0}, already exists".format(column))
@@ -3107,7 +3107,6 @@ class DataFrame(object):
         limit=None,
         regex=False,
         method="pad",
-        axis=None,
     ):
         return self._default_to_pandas(
             pandas.DataFrame.replace,
@@ -3117,7 +3116,6 @@ class DataFrame(object):
             limit=limit,
             regex=regex,
             method=method,
-            axis=axis,
         )
 
     def resample(


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Remove the `axis` arg from DataFrame.replace signature (to fit pandas)
When using `DataFrame.insert()` with an instance of `pandas.Series`, validation of index length will be skipped as Series have index and can be inserted into the data frame as is  
<!-- Please give a short brief about these changes. -->

## Related issue number
#410 #411 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [ ] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [ ] passes `black --check modin/`
