### PR TITLE
Add a way to skip the initial reindex phase for left and right

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -422,10 +422,8 @@ class PandasQueryCompiler(object):
 
         for i in range(len(other)):
 
-            # TODO: If we don't need to reindex, don't. It is expensive.
-            # The challenge with avoiding reindexing is that we need to make sure that
-            # the internal indices line up (i.e. if a drop or a select was just
-            # performed, the internal indices may not match).
+            # If the indices are equal we can skip partitioning so long as we are not
+            # forced to repartition. See note above about `force_repartition`.
             if i != 0 or (left_old_idx.equals(joined_index) and not force_repartition):
                 reindex_left = None
             else:


### PR DESCRIPTION
* Skips reindexing if there is already a match
* Since some operations always need the reindex, add a flag for that
* Add docs
* Lint

<!--
Thank you for your contribution!
-->

## What do these changes do?
(Above)
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
