### PR TITLE
Refactor test_concat.py

### DIFF
--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -46,7 +46,7 @@ def test_modin_concat_with_series(data1, data2):
         random_state.random_integers(RAND_LOW, RAND_HIGH, modin_df1.shape[1])
     )
     df_equals(
-        pd.concat([modin_df1, modin_df2, pandas_series], axis=0),
+        pd.concat([modin_df1, modin_df2, modin_series], axis=0),
         pandas.concat([pandas_df1, pandas_df2, pandas_series], axis=0),
     )
 

--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -35,15 +35,15 @@ def test_modin_concat_with_series(data1, data2):
 
     # Test axis=0
     pandas_series = pandas.Series(random_state.random_integers(RAND_LOW, RAND_HIGH, pandas_df1.shape[1]))
-    modin_series = modin.Series(random_state.random_integers(RAND_LOW, RAND_HIGH, modin_df1.shape[1]))
+    modin_series = pd.Series(random_state.random_integers(RAND_LOW, RAND_HIGH, modin_df1.shape[1]))
     df_equals(
         pd.concat([modin_df1, modin_df2, pandas_series], axis=0),
         pandas.concat([pandas_df1, pandas_df2, pandas_series], axis=0),
     )
 
     # Test axis=1
-    pandas_series = pandas.Series(random_state.random_integers(RAND_LOW, RAND_HIGH, pandas_df1.shape[0]))
-    modin_series = modin.Series(random_state.random_integers(RAND_LOW, RAND_HIGH, modin_df1.shape[0]))
+    pandas_series = pandas.Series(random_state.randint(RAND_LOW, RAND_HIGH, pandas_df1.shape[0]))
+    modin_series = pd.Series(random_state.randint(RAND_LOW, RAND_HIGH, modin_df1.shape[0]))
     df_equals(
         pd.concat([modin_df1, modin_df2, pandas_series], axis=1),
         pandas.concat([pandas_df1, pandas_df2, pandas_series], axis=1),
@@ -65,11 +65,11 @@ def test_modin_concat_on_index(data1, data2):
 
     df_equals(
         pd.concat([modin_df1, modin_df2], axis="rows"),
-        pandas.concat([pandas_df, pandas_df2], axis="rows"),
+        pandas.concat([pandas_df1, pandas_df2], axis="rows"),
     )
 
     df_equals(
-        pd.concat([modin_df1, modin_df2], axis=0), pandas.concat([pandas_df, pandas_df2], axis=0)
+        pd.concat([modin_df1, modin_df2], axis=0), pandas.concat([pandas_df1, pandas_df2], axis=0)
     )
 
 

--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -4,10 +4,15 @@ from __future__ import print_function
 
 import pytest
 import pandas
-import numpy as np
 import modin.pandas as pd
-from modin.pandas.utils import from_pandas, to_pandas
-from .utils import df_equals, test_data_keys, test_data_values, random_state, RAND_LOW, RAND_HIGH
+from .utils import (
+    df_equals,
+    test_data_keys,
+    test_data_values,
+    random_state,
+    RAND_LOW,
+    RAND_HIGH,
+)
 
 pd.DEFAULT_NPARTITIONS = 4
 
@@ -34,18 +39,26 @@ def test_modin_concat_with_series(data1, data2):
     modin_df2 = pd.DataFrame(data2)
 
     # Test axis=0
-    pandas_series = pandas.Series(random_state.random_integers(RAND_LOW, RAND_HIGH, pandas_df1.shape[1]))
-    modin_series = pd.Series(random_state.random_integers(RAND_LOW, RAND_HIGH, modin_df1.shape[1]))
+    pandas_series = pandas.Series(
+        random_state.random_integers(RAND_LOW, RAND_HIGH, pandas_df1.shape[1])
+    )
+    modin_series = pd.Series(
+        random_state.random_integers(RAND_LOW, RAND_HIGH, modin_df1.shape[1])
+    )
     df_equals(
         pd.concat([modin_df1, modin_df2, pandas_series], axis=0),
         pandas.concat([pandas_df1, pandas_df2, pandas_series], axis=0),
     )
 
     # Test axis=1
-    pandas_series = pandas.Series(random_state.randint(RAND_LOW, RAND_HIGH, pandas_df1.shape[0]))
-    modin_series = pd.Series(random_state.randint(RAND_LOW, RAND_HIGH, modin_df1.shape[0]))
+    pandas_series = pandas.Series(
+        random_state.randint(RAND_LOW, RAND_HIGH, pandas_df1.shape[0])
+    )
+    modin_series = pd.Series(
+        random_state.randint(RAND_LOW, RAND_HIGH, modin_df1.shape[0])
+    )
     df_equals(
-        pd.concat([modin_df1, modin_df2, pandas_series], axis=1),
+        pd.concat([modin_df1, modin_df2, modin_series], axis=1),
         pandas.concat([pandas_df1, pandas_df2, pandas_series], axis=1),
     )
 
@@ -69,7 +82,8 @@ def test_modin_concat_on_index(data1, data2):
     )
 
     df_equals(
-        pd.concat([modin_df1, modin_df2], axis=0), pandas.concat([pandas_df1, pandas_df2], axis=0)
+        pd.concat([modin_df1, modin_df2], axis=0),
+        pandas.concat([pandas_df1, pandas_df2], axis=0),
     )
 
 
@@ -82,7 +96,8 @@ def test_ray_concat_on_column(data1, data2):
     modin_df2 = pd.DataFrame(data2)
 
     df_equals(
-        pd.concat([modin_df1, modin_df2], axis=1), pandas.concat([pandas_df1, pandas_df2], axis=1)
+        pd.concat([modin_df1, modin_df2], axis=1),
+        pandas.concat([pandas_df1, pandas_df2], axis=1),
     )
 
     df_equals(
@@ -94,8 +109,6 @@ def test_ray_concat_on_column(data1, data2):
 @pytest.mark.parametrize("data1", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("data2", test_data_values, ids=test_data_keys)
 def test_invalid_axis_errors(data1, data2):
-    pandas_df1 = pandas.DataFrame(data1)
-    pandas_df2 = pandas.DataFrame(data2)
     modin_df1 = pd.DataFrame(data1)
     modin_df2 = pd.DataFrame(data2)
 
@@ -114,7 +127,10 @@ def test_mixed_concat(data1, data2, data3):
     modin_df2 = pd.DataFrame(data2)
     modin_df3 = pd.DataFrame(data3)
 
-    df_equals(pd.concat([modin_df1, modin_df2, modin_df3]), pandas.concat([pandas_df1, pandas_df2, pandas_df3]))
+    df_equals(
+        pd.concat([modin_df1, modin_df2, modin_df3]),
+        pandas.concat([pandas_df1, pandas_df2, pandas_df3]),
+    )
 
 
 @pytest.mark.parametrize("data1", test_data_values, ids=test_data_keys)
@@ -128,4 +144,7 @@ def test_mixed_inner_concat(data1, data2, data3):
     modin_df2 = pd.DataFrame(data2)
     modin_df3 = pd.DataFrame(data3)
 
-    df_equals(pd.concat([modin_df1, modin_df2, modin_df3], join='inner'), pandas.concat([pandas_df1, pandas_df2, pandas_df3], join='inner'))
+    df_equals(
+        pd.concat([modin_df1, modin_df2, modin_df3], join="inner"),
+        pandas.concat([pandas_df1, pandas_df2, pandas_df3], join="inner"),
+    )

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1021,9 +1021,9 @@ def test_clip(request, data, axis):
             else len(modin_df.columns)
         )
         # set bounds
-        lower, upper = np.sort(random_state.random_integers(RAND_LOW, RAND_HIGH, 2))
-        lower_list = random_state.random_integers(RAND_LOW, RAND_HIGH, ind_len)
-        upper_list = random_state.random_integers(RAND_LOW, RAND_HIGH, ind_len)
+        lower, upper = np.sort(random_state.randint(RAND_LOW, RAND_HIGH, 2))
+        lower_list = random_state.randint(RAND_LOW, RAND_HIGH, ind_len)
+        upper_list = random_state.randint(RAND_LOW, RAND_HIGH, ind_len)
 
         # test only upper scalar bound
         modin_result = modin_df.clip(None, upper, axis=axis)
@@ -1059,8 +1059,8 @@ def test_clip_lower(request, data, axis):
             else len(modin_df.columns)
         )
         # set bounds
-        lower = random_state.random_integers(RAND_LOW, RAND_HIGH, 1)[0]
-        lower_list = random_state.random_integers(RAND_LOW, RAND_HIGH, ind_len)
+        lower = random_state.randint(RAND_LOW, RAND_HIGH, 1)[0]
+        lower_list = random_state.randint(RAND_LOW, RAND_HIGH, ind_len)
 
         # test lower scalar bound
         pandas_result = pandas_df.clip_lower(lower, axis=axis)
@@ -1086,8 +1086,8 @@ def test_clip_upper(request, data, axis):
             else len(modin_df.columns)
         )
         # set bounds
-        upper = random_state.random_integers(RAND_LOW, RAND_HIGH, 1)[0]
-        upper_list = random_state.random_integers(RAND_LOW, RAND_HIGH, ind_len)
+        upper = random_state.randint(RAND_LOW, RAND_HIGH, 1)[0]
+        upper_list = random_state.randint(RAND_LOW, RAND_HIGH, ind_len)
 
         # test upper scalar bound
         modin_result = modin_df.clip_upper(upper, axis=axis)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Refactor `modin/pandas/tests/test_concat.py` to use the test data that is used by `test_dataframe.py`. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
