### PR TITLE
Refactor Pandas Axis Partition objects to avoid duplicate code

### DIFF
--- a/modin/engines/base/axis_partition.py
+++ b/modin/engines/base/axis_partition.py
@@ -18,7 +18,9 @@ class BaseAxisPartition(object):
             there will always be `BaseRemotePartition` object stored and structures
             itself accordingly.
 
-        The only abstract method needed to implement is the `apply` method.
+        The abstract methods that need implemented are `apply` and `shuffle`.
+        The children classes must also implement `instance_type` and `partition_type`
+        (see below).
     """
 
     def apply(
@@ -58,15 +60,14 @@ class BaseAxisPartition(object):
         raise NotImplementedError("Must be implemented in children classes")
 
     def shuffle(self, func, lengths, **kwargs):
-        """Shuffle the order of the data in this axis based on the `func`.
+        """Shuffle the order of the data in this axis based on the `lengths`.
 
         Args:
-            func:
-            num_splits:
-            kwargs:
+            func: The function to apply before splitting.
+            lengths: The list of partition lengths to split the result into.
 
         Returns:
-             A list of `BaseRemotePartition` objects.
+            A list of RemotePartition objects split by `lengths`.
         """
         raise NotImplementedError("Must be implemented in children classes")
 
@@ -82,6 +83,18 @@ class BaseAxisPartition(object):
 
 
 class PandasOnXAxisPartition(BaseAxisPartition):
+    """This abstract class is created to simplify and consolidate the code for
+        AxisPartitions that run pandas. Because much of the code is similar, this allows
+        us to reuse this code.
+
+        Subclasses must implement `list_of_blocks` which unwraps the `RemotePartition`
+        objects and creates something interpretable as a pandas DataFrame.
+
+        See `modin.engines.ray.pandas_on_ray.axis_partition.PandasOnRayAxisPartition`
+        for an example on how to override/use this class when the implementation needs
+        to be augmented.
+    """
+
     def apply(
         self,
         func,

--- a/modin/engines/base/axis_partition.py
+++ b/modin/engines/base/axis_partition.py
@@ -1,3 +1,7 @@
+import pandas
+from modin.data_management.utils import split_result_of_axis_func_pandas
+
+
 class BaseAxisPartition(object):
     """This abstract class represents the Parent class for any
         `ColumnPartition` or `RowPartition` class. This class is intended to
@@ -17,7 +21,14 @@ class BaseAxisPartition(object):
         The only abstract method needed to implement is the `apply` method.
     """
 
-    def apply(self, func, num_splits=None, other_axis_partition=None, **kwargs):
+    def apply(
+        self,
+        func,
+        num_splits=None,
+        other_axis_partition=None,
+        maintain_partitioning=True,
+        **kwargs
+    ):
         """Applies a function to a full axis.
 
         Note: The procedures that invoke this method assume full axis
@@ -34,6 +45,12 @@ class BaseAxisPartition(object):
                 splitting at this time.
             other_axis_partition: Another `BaseAxisPartition` object to be applied
                 to func. This is for operations that are between datasets.
+            maintain_partitioning: Whether or not to keep the partitioning in the same
+                orientation as it was previously. This is important because we may be
+                operating on an individual AxisPartition and not touching the rest.
+                In this case, we have to return the partitioning to its previous
+                orientation (the lengths will remain the same). This is ignored between
+                two axis partitions.
 
         Returns:
             A list of `BaseRemotePartition` objects.
@@ -62,3 +79,145 @@ class BaseAxisPartition(object):
             return [self.partition_type(partitions)]
         else:
             return [self.partition_type(obj) for obj in partitions]
+
+
+class PandasOnXAxisPartition(BaseAxisPartition):
+    def apply(
+        self,
+        func,
+        num_splits=None,
+        other_axis_partition=None,
+        maintain_partitioning=True,
+        **kwargs
+    ):
+        """Applies func to the object in the plasma store.
+
+        See notes in Parent class about this method.
+
+        Args:
+            func: The function to apply.
+            num_splits: The number of times to split the result object.
+            other_axis_partition: Another `PandasOnRayAxisPartition` object to apply to
+                func with this one.
+            maintain_partitioning: Whether or not to keep the partitioning in the same
+                orientation as it was previously. This is important because we may be
+                operating on an individual AxisPartition and not touching the rest.
+                In this case, we have to return the partitioning to its previous
+                orientation (the lengths will remain the same). This is ignored between
+                two axis partitions.
+
+        Returns:
+            A list of `RayRemotePartition` objects.
+        """
+        if num_splits is None:
+            num_splits = len(self.list_of_blocks)
+
+        if other_axis_partition is not None:
+            return self._wrap_partitions(
+                self.deploy_func_between_two_axis_partitions(
+                    self.axis,
+                    func,
+                    num_splits,
+                    len(self.list_of_blocks),
+                    kwargs,
+                    *tuple(self.list_of_blocks + other_axis_partition.list_of_blocks)
+                )
+            )
+        args = [self.axis, func, num_splits, kwargs, maintain_partitioning]
+        args.extend(self.list_of_blocks)
+        return self._wrap_partitions(self.deploy_axis_func(*args))
+
+    def shuffle(self, func, lengths, **kwargs):
+        """Shuffle the order of the data in this axis based on the `lengths`.
+
+        Extends `BaseAxisPartition.shuffle`.
+
+        Args:
+            func: The function to apply before splitting.
+            lengths: The list of partition lengths to split the result into.
+
+        Returns:
+            A list of RemotePartition objects split by `lengths`.
+        """
+        num_splits = len(lengths)
+        # We add these to kwargs and will pop them off before performing the operation.
+        kwargs["manual_partition"] = True
+        kwargs["_lengths"] = lengths
+        args = [self.axis, func, num_splits, kwargs, False]
+        args.extend(self.list_of_blocks)
+        return self._wrap_partitions(self.deploy_axis_func(*args))
+
+    @classmethod
+    def deploy_axis_func(
+        cls, axis, func, num_splits, kwargs, maintain_partitioning, *partitions
+    ):
+        """Deploy a function along a full axis in Ray.
+
+            Args:
+                axis: The axis to perform the function along.
+                func: The function to perform.
+                num_splits: The number of splits to return
+                    (see `split_result_of_axis_func_pandas`)
+                kwargs: A dictionary of keyword arguments.
+                maintain_partitioning: If True, keep the old partitioning if possible.
+                    If False, create a new partition layout.
+                partitions: All partitions that make up the full axis (row or column)
+
+            Returns:
+                A list of Pandas DataFrames.
+            """
+        # Pop these off first because they aren't expected by the function.
+        manual_partition = kwargs.pop("manual_partition", False)
+        lengths = kwargs.pop("_lengths", None)
+
+        dataframe = pandas.concat(partitions, axis=axis, copy=False)
+        result = func(dataframe, **kwargs)
+        if isinstance(result, pandas.Series):
+            if num_splits == 1:
+                return result
+            return [result] + [pandas.Series([]) for _ in range(num_splits - 1)]
+
+        if manual_partition:
+            # The split function is expecting a list
+            lengths = list(lengths)
+        # We set lengths to None so we don't use the old lengths for the resulting partition
+        # layout. This is done if the number of splits is changing or we are told not to
+        # keep the old partitioning.
+        elif num_splits != len(partitions) or not maintain_partitioning:
+            lengths = None
+        else:
+            if axis == 0:
+                lengths = [len(part) for part in partitions]
+                if sum(lengths) != len(result):
+                    lengths = None
+            else:
+                lengths = [len(part.columns) for part in partitions]
+                if sum(lengths) != len(result.columns):
+                    lengths = None
+        return split_result_of_axis_func_pandas(axis, num_splits, result, lengths)
+
+    @classmethod
+    def deploy_func_between_two_axis_partitions(
+        cls, axis, func, num_splits, len_of_left, kwargs, *partitions
+    ):
+        """Deploy a function along a full axis between two data sets in Ray.
+
+        Args:
+            axis: The axis to perform the function along.
+            func: The function to perform.
+            num_splits: The number of splits to return
+                (see `split_result_of_axis_func_pandas`).
+            len_of_left: The number of values in `partitions` that belong to the
+                left data set.
+            kwargs: A dictionary of keyword arguments.
+            partitions: All partitions that make up the full axis (row or column)
+                for both data sets.
+
+        Returns:
+            A list of Pandas DataFrames.
+        """
+        lt_frame = pandas.concat(list(partitions[:len_of_left]), axis=axis, copy=False)
+        rt_frame = pandas.concat(list(partitions[len_of_left:]), axis=axis, copy=False)
+
+        result = func(lt_frame, rt_frame, **kwargs)
+        return split_result_of_axis_func_pandas(axis, num_splits, result)

--- a/modin/engines/python/pandas_on_python/axis_partition.py
+++ b/modin/engines/python/pandas_on_python/axis_partition.py
@@ -4,75 +4,17 @@ from __future__ import print_function
 
 import pandas
 
-from modin.engines.base.axis_partition import BaseAxisPartition
-from modin.data_management.utils import split_result_of_axis_func_pandas
+from modin.engines.base.axis_partition import PandasOnXAxisPartition
 from .remote_partition import PandasOnPythonRemotePartition
 
 
-class PandasOnPythonAxisPartition(BaseAxisPartition):
+class PandasOnPythonAxisPartition(PandasOnXAxisPartition):
     def __init__(self, list_of_blocks):
         # Unwrap from BaseRemotePartition object for ease of use
         self.list_of_blocks = [obj.data for obj in list_of_blocks]
 
     partition_type = PandasOnPythonRemotePartition
     instance_type = pandas.DataFrame
-
-    def apply(
-        self,
-        func,
-        num_splits=None,
-        other_axis_partition=None,
-        maintain_partitioning=True,
-        **kwargs
-    ):
-        """Applies func to the object in the plasma store.
-
-        See notes in Parent class about this method.
-
-        Args:
-            func: The function to apply.
-            num_splits: The number of times to split the result object.
-            other_axis_partition: Another `PandasOnRayAxisPartition` object to apply to
-                func with this one.
-
-        Returns:
-            A list of `RayRemotePartition` objects.
-        """
-        if num_splits is None:
-            num_splits = len(self.list_of_blocks)
-
-        if other_axis_partition is not None:
-            return self._wrap_partitions(
-                deploy_python_func_between_two_axis_partitions(
-                    self.axis,
-                    func,
-                    num_splits,
-                    len(self.list_of_blocks),
-                    kwargs,
-                    *tuple(self.list_of_blocks + other_axis_partition.list_of_blocks)
-                )
-            )
-        args = [self.axis, func, num_splits, kwargs, maintain_partitioning]
-        args.extend(self.list_of_blocks)
-        return self._wrap_partitions(deploy_python_axis_func(*args))
-
-    def shuffle(self, func, lengths, **kwargs):
-        """Shuffle the order of the data in this axis based on the `func`.
-
-        Extends `BaseAxisPartition.shuffle`.
-
-        :param func:
-        :param num_splits:
-        :param kwargs:
-        :return:
-        """
-        num_splits = len(lengths)
-        # We add these to kwargs and will pop them off before performing the operation.
-        kwargs["manual_partition"] = True
-        kwargs["_lengths"] = lengths
-        args = [self.axis, func, num_splits, kwargs, False]
-        args.extend(self.list_of_blocks)
-        return self._wrap_partitions(deploy_python_axis_func(*args))
 
 
 class PandasOnPythonColumnPartition(PandasOnPythonAxisPartition):
@@ -91,96 +33,3 @@ class PandasOnPythonRowPartition(PandasOnPythonAxisPartition):
     """
 
     axis = 1
-
-
-def deploy_python_axis_func(
-    axis, func, num_splits, kwargs, maintain_partitioning, *partitions
-):
-    """Deploy a function along a full axis in Ray.
-
-    Args:
-        axis: The axis to perform the function along.
-        func: The function to perform.
-        num_splits: The number of splits to return
-            (see `split_result_of_axis_func_pandas`)
-        kwargs: A dictionary of keyword arguments.
-        partitions: All partitions that make up the full axis (row or column)
-
-    Returns:
-        A list of Pandas DataFrames.
-    """
-    # Pop these off first because they aren't expected by the function.
-    manual_partition = kwargs.pop("manual_partition", False)
-    lengths = kwargs.pop("_lengths", None)
-
-    dataframe = pandas.concat(partitions, axis=axis, copy=False)
-    result = func(dataframe, **kwargs)
-
-    if isinstance(result, pandas.Series):
-        return [result] + [pandas.Series([]) for _ in range(num_splits - 1)]
-    if manual_partition:
-        # The split function is expecting a list
-        lengths = list(lengths)
-    # We set lengths to None so we don't use the old lengths for the resulting partition
-    # layout. This is done if the number of splits is changing or we are told not to
-    # keep the old partitioning.
-    elif num_splits != len(partitions) or not maintain_partitioning:
-        lengths = None
-    else:
-        if axis == 0:
-            lengths = [len(part) for part in partitions]
-            if sum(lengths) != len(result):
-                lengths = None
-        else:
-            lengths = [len(part.columns) for part in partitions]
-            if sum(lengths) != len(result.columns):
-                lengths = None
-    return split_result_of_axis_func_pandas(axis, num_splits, result, lengths)
-
-
-def deploy_python_func_between_two_axis_partitions(
-    axis, func, num_splits, len_of_left, kwargs, *partitions
-):
-    """Deploy a function along a full axis between two data sets in Ray.
-
-    Args:
-        axis: The axis to perform the function along.
-        func: The function to perform.
-        num_splits: The number of splits to return
-            (see `split_result_of_axis_func_pandas`).
-        len_of_left: The number of values in `partitions` that belong to the
-            left data set.
-        kwargs: A dictionary of keyword arguments.
-        partitions: All partitions that make up the full axis (row or column)
-            for both data sets.
-
-    Returns:
-        A list of Pandas DataFrames.
-    """
-    lt_frame = pandas.concat(list(partitions[:len_of_left]), axis=axis, copy=False)
-    rt_frame = pandas.concat(list(partitions[len_of_left:]), axis=axis, copy=False)
-
-    result = func(lt_frame, rt_frame, **kwargs)
-    return [
-        df.copy() for df in split_result_of_axis_func_pandas(axis, num_splits, result)
-    ]
-
-
-def deploy_python_shuffle_func(axis, func, numsplits, kwargs, *partitions):
-    """Deploy a function that defines the partitions along this axis.
-
-    Args:
-        axis:
-        func:
-        numsplits:
-        kwargs:
-        partitions:
-
-    Returns:
-        A list of Pandas DataFrames.
-    """
-    dataframe = pandas.concat(partitions, axis=axis, copy=False)
-    result = func(dataframe, numsplits=numsplits, **kwargs)
-
-    assert isinstance(result, list)
-    return result

--- a/modin/engines/ray/pandas_on_ray/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/axis_partition.py
@@ -35,7 +35,7 @@ class PandasOnRayAxisPartition(PandasOnXAxisPartition):
 
     @classmethod
     def deploy_func_between_two_axis_partitions(
-            cls, axis, func, num_splits, len_of_left, kwargs, *partitions
+        cls, axis, func, num_splits, len_of_left, kwargs, *partitions
     ):
         return deploy_ray_func._remote(
             args=(
@@ -45,7 +45,7 @@ class PandasOnRayAxisPartition(PandasOnXAxisPartition):
                 num_splits,
                 len_of_left,
                 kwargs,
-                *partitions
+                *partitions,
             ),
             num_return_vals=num_splits,
         )

--- a/modin/engines/ray/pandas_on_ray/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/axis_partition.py
@@ -2,15 +2,13 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
-import pandas
 import ray
 
-from modin.engines.base.axis_partition import BaseAxisPartition
-from modin.data_management.utils import split_result_of_axis_func_pandas
+from modin.engines.base.axis_partition import PandasOnXAxisPartition
 from .remote_partition import PandasOnRayRemotePartition
 
 
-class PandasOnRayAxisPartition(BaseAxisPartition):
+class PandasOnRayAxisPartition(PandasOnXAxisPartition):
     def __init__(self, list_of_blocks):
         # Unwrap from BaseRemotePartition object for ease of use
         self.list_of_blocks = [obj.oid for obj in list_of_blocks]
@@ -18,71 +16,38 @@ class PandasOnRayAxisPartition(BaseAxisPartition):
     partition_type = PandasOnRayRemotePartition
     instance_type = ray.ObjectID
 
-    def apply(
-        self,
-        func,
-        num_splits=None,
-        other_axis_partition=None,
-        maintain_partitioning=True,
-        **kwargs
+    @classmethod
+    def deploy_axis_func(
+        cls, axis, func, num_splits, kwargs, maintain_partitioning, *partitions
     ):
-        """Applies func to the object in the plasma store.
-
-        See notes in Parent class about this method.
-
-        Args:
-            func: The function to apply.
-            num_splits: The number of times to split the result object.
-            other_axis_partition: Another `PandasOnRayAxisPartition` object to apply to
-                func with this one.
-            maintain_partitioning: Whether or not to keep the partitioning in the same
-                orientation as it was previously. This is important because we may be
-                operating on an individual AxisPartition and not touching the rest.
-                In this case, we have to return the partitioning to its previous
-                orientation (the lengths will remain the same). This is ignored between
-                two axis partitions.
-
-        Returns:
-            A list of `RayRemotePartition` objects.
-        """
-        if num_splits is None:
-            num_splits = len(self.list_of_blocks)
-
-        if other_axis_partition is not None:
-            return self._wrap_partitions(
-                deploy_ray_func_between_two_axis_partitions._remote(
-                    args=(self.axis, func, num_splits, len(self.list_of_blocks), kwargs)
-                    + tuple(self.list_of_blocks + other_axis_partition.list_of_blocks),
-                    num_return_vals=num_splits,
-                )
-            )
-
-        args = [self.axis, func, num_splits, kwargs, maintain_partitioning]
-        args.extend(self.list_of_blocks)
-        return self._wrap_partitions(
-            deploy_ray_axis_func._remote(args, num_return_vals=num_splits)
+        return deploy_ray_func._remote(
+            args=(
+                PandasOnXAxisPartition.deploy_axis_func,
+                axis,
+                func,
+                num_splits,
+                kwargs,
+                maintain_partitioning,
+                *partitions,
+            ),
+            num_return_vals=num_splits,
         )
 
-    def shuffle(self, func, lengths, **kwargs):
-        """Shuffle the order of the data in this axis based on the `lengths`.
-
-        Extends `BaseAxisPartition.shuffle`.
-
-        Args:
-            func: The function to apply before splitting.
-            lengths: The list of partition lengths to split the result into.
-
-        Returns:
-            A list of RemotePartition objects split by `lengths`.
-        """
-        num_splits = len(lengths)
-        # We add these to kwargs and will pop them off before performing the operation.
-        kwargs["manual_partition"] = True
-        kwargs["_lengths"] = lengths
-        args = [self.axis, func, num_splits, kwargs, False]
-        args.extend(self.list_of_blocks)
-        return self._wrap_partitions(
-            deploy_ray_axis_func._remote(args, num_return_vals=num_splits)
+    @classmethod
+    def deploy_func_between_two_axis_partitions(
+            cls, axis, func, num_splits, len_of_left, kwargs, *partitions
+    ):
+        return deploy_ray_func._remote(
+            args=(
+                PandasOnXAxisPartition.deploy_func_between_two_axis_partitions,
+                axis,
+                func,
+                num_splits,
+                len_of_left,
+                kwargs,
+                *partitions
+            ),
+            num_return_vals=num_splits,
         )
 
 
@@ -105,98 +70,5 @@ class PandasOnRayRowPartition(PandasOnRayAxisPartition):
 
 
 @ray.remote
-def deploy_ray_axis_func(
-    axis, func, num_splits, kwargs, maintain_partitioning, *partitions
-):
-    """Deploy a function along a full axis in Ray.
-
-    Args:
-        axis: The axis to perform the function along.
-        func: The function to perform.
-        num_splits: The number of splits to return
-            (see `split_result_of_axis_func_pandas`)
-        kwargs: A dictionary of keyword arguments.
-        maintain_partitioning: If True, keep the old partitioning if possible.
-            If False, create a new partition layout.
-        partitions: All partitions that make up the full axis (row or column)
-
-    Returns:
-        A list of Pandas DataFrames.
-    """
-    # Pop these off first because they aren't expected by the function.
-    manual_partition = kwargs.pop("manual_partition", False)
-    lengths = kwargs.pop("_lengths", None)
-
-    dataframe = pandas.concat(partitions, axis=axis, copy=False)
-    result = func(dataframe, **kwargs)
-    if isinstance(result, pandas.Series):
-        if num_splits == 1:
-            return result
-        return [result] + [pandas.Series([]) for _ in range(num_splits - 1)]
-
-    if manual_partition:
-        # The split function is expecting a list
-        lengths = list(lengths)
-    # We set lengths to None so we don't use the old lengths for the resulting partition
-    # layout. This is done if the number of splits is changing or we are told not to
-    # keep the old partitioning.
-    elif num_splits != len(partitions) or not maintain_partitioning:
-        lengths = None
-    else:
-        if axis == 0:
-            lengths = [len(part) for part in partitions]
-            if sum(lengths) != len(result):
-                lengths = None
-        else:
-            lengths = [len(part.columns) for part in partitions]
-            if sum(lengths) != len(result.columns):
-                lengths = None
-    return split_result_of_axis_func_pandas(axis, num_splits, result, lengths)
-
-
-@ray.remote
-def deploy_ray_func_between_two_axis_partitions(
-    axis, func, num_splits, len_of_left, kwargs, *partitions
-):
-    """Deploy a function along a full axis between two data sets in Ray.
-
-    Args:
-        axis: The axis to perform the function along.
-        func: The function to perform.
-        num_splits: The number of splits to return
-            (see `split_result_of_axis_func_pandas`).
-        len_of_left: The number of values in `partitions` that belong to the
-            left data set.
-        kwargs: A dictionary of keyword arguments.
-        partitions: All partitions that make up the full axis (row or column)
-            for both data sets.
-
-    Returns:
-        A list of Pandas DataFrames.
-    """
-    lt_frame = pandas.concat(list(partitions[:len_of_left]), axis=axis, copy=False)
-    rt_frame = pandas.concat(list(partitions[len_of_left:]), axis=axis, copy=False)
-
-    result = func(lt_frame, rt_frame, **kwargs)
-    return split_result_of_axis_func_pandas(axis, num_splits, result)
-
-
-@ray.remote
-def deploy_ray_shuffle_func(axis, func, numsplits, kwargs, *partitions):
-    """Deploy a function that defines the partitions along this axis.
-
-    Args:
-        axis:
-        func:
-        numsplits:
-        kwargs:
-        partitions:
-
-    Returns:
-        A list of Pandas DataFrames.
-    """
-    dataframe = pandas.concat(partitions, axis=axis, copy=False)
-    result = func(dataframe, numsplits=numsplits, **kwargs)
-
-    assert isinstance(result, list)
-    return result
+def deploy_ray_func(func, *args):
+    return func(*args)

--- a/modin/engines/ray/pandas_on_ray/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/axis_partition.py
@@ -28,8 +28,8 @@ class PandasOnRayAxisPartition(PandasOnXAxisPartition):
                 num_splits,
                 kwargs,
                 maintain_partitioning,
-                *partitions,
-            ),
+            )
+            + tuple(partitions),
             num_return_vals=num_splits,
         )
 
@@ -45,8 +45,8 @@ class PandasOnRayAxisPartition(PandasOnXAxisPartition):
                 num_splits,
                 len_of_left,
                 kwargs,
-                *partitions,
-            ),
+            )
+            + tuple(partitions),
             num_return_vals=num_splits,
         )
 

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -36,6 +36,7 @@ from pandas import (
 import threading
 import os
 import ray
+import types
 
 from .. import __version__
 from .concat import concat
@@ -131,6 +132,9 @@ def initialize_ray():
             plasma_directory=plasma_directory,
             object_store_memory=object_store_memory,
         )
+        # Register custom serializer for method objects to avoid warning message.
+        # We serialize `MethodType` objects when we use AxisPartition operations.
+        ray.register_custom_serializer(types.MethodType, use_pickle=True)
 
 
 if execution_engine == "Ray":


### PR DESCRIPTION
* Create PandasOnXAxisPartition abstract class to contain common code
* Remove common code between `PandasOnRay` and `PandasOnPython` `AxisPartitions`
* Register a custom serializer for Ray to fit with the new code

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
