### PR TITLE
Ignore numpy version error.

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 
 def get_execution_engine():
@@ -22,6 +23,9 @@ def get_partition_format():
 __version__ = "0.3.0"
 __execution_engine__ = get_execution_engine()
 __partition_format__ = get_partition_format()
+
+# Filter numpy version warnings because they are not relevant
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 
 # We don't want these used outside of this file.
 del get_execution_engine


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
numpy is throwing a warning related to differing numpy dtypes after upgrading. We suppress this because it is harmless.
<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
