### PR TITLE
Removing path and line number from warnings.

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -8,6 +8,8 @@ def custom_formatwarning(msg, category, *args, **kwargs):
 
 
 warnings.formatwarning = custom_formatwarning
+# Filter numpy version warnings because they are not relevant
+warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 
 
 def get_execution_engine():
@@ -31,9 +33,6 @@ def get_partition_format():
 __version__ = "0.3.0"
 __execution_engine__ = get_execution_engine()
 __partition_format__ = get_partition_format()
-
-# Filter numpy version warnings because they are not relevant
-warnings.filterwarnings("ignore", message="numpy.dtype size changed")
 
 # We don't want these used outside of this file.
 del get_execution_engine

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -2,6 +2,14 @@ import os
 import warnings
 
 
+def custom_formatwarning(msg, *args, **kwargs):
+    # ignore everything except the message
+    return "WARN: {}\n".format(msg)
+
+
+warnings.formatwarning = custom_formatwarning
+
+
 def get_execution_engine():
     # In the future, when there are multiple engines and different ways of
     # backing the DataFrame, there will have to be some changed logic here to

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -2,9 +2,9 @@ import os
 import warnings
 
 
-def custom_formatwarning(msg, *args, **kwargs):
+def custom_formatwarning(msg, category, *args, **kwargs):
     # ignore everything except the message
-    return "WARN: {}\n".format(msg)
+    return "{}: {}\n".format(category.__name__, msg)
 
 
 warnings.formatwarning = custom_formatwarning


### PR DESCRIPTION
* Declutters the warning message so the message is easier to see
* Removes the `warnings.warn(message)` from the message as well.
* Difference between old and new shown below:

Previous:
```
/Users/DevinPetersohn/software_builds/modin/modin/error_message.py:32: UserWarning: `cov` defaulting to pandas implementation.
To request implementation, send an email to feature_requests@modin.org.
  warnings.warn(message)
```

This commit:
```
UserWarning: `cov` defaulting to pandas implementation.
To request implementation, send an email to feature_requests@modin.org.
```

<!--
Thank you for your contribution!
-->

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `git diff upstream/master -u -- "*.py" | flake8 --diff`
- [x] passes `black --check modin/`
