### PR TITLE
parallel to_sql()

### DIFF
--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -154,6 +154,14 @@ class BaseFactory(object):
     def _read_sql(cls, **kwargs):
         return cls.io_cls.read_sql(**kwargs)
 
+    @classmethod
+    def to_sql(cls, *args, **kwargs):
+        return cls._determine_engine()._to_sql(*args, **kwargs)
+
+    @classmethod
+    def _to_sql(cls, *args, **kwargs):
+        return cls.io_cls.to_sql(*args, **kwargs)
+
 
 class PandasOnRayFactory(BaseFactory):
 

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1113,12 +1113,13 @@ class PandasQueryCompiler(object):
         columns = self.columns
 
         def func(df, **kwargs):
+            raise ValueError(kwargs)
             df.columns = columns
             df.to_sql(**kwargs)
 
         map_func = self._prepare_method(func, **kwargs)
-        new_data = self.map_across_full_axis(1, map_func)
-        return self.__constructor__(new_data, self.index, self.columns)
+        self.map_across_full_axis(1, map_func)
+        # return self.__constructor__(new_data, self.index, self.columns)
 
     def _process_sum_prod(self, func, **kwargs):
         """Calculates the sum or product of the DataFrame.

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1101,26 +1101,6 @@ class PandasQueryCompiler(object):
         """
         return self._process_min_max(pandas.DataFrame.min, **kwargs)
 
-    def to_sql(self, **kwargs):
-        """Write records stored in a DataFrame to a SQL database.
-
-        """
-        empty_df = self.head(1).to_pandas().head(0)
-        # this is to create the full DB table and validate the input against pandas
-        empty_df.to_sql(**kwargs)
-        # so each partition will append its respective DF
-        kwargs["if_exists"] = "append"
-        columns = self.columns
-
-        def func(df, **kwargs):
-            raise ValueError(kwargs)
-            df.columns = columns
-            df.to_sql(**kwargs)
-
-        map_func = self._prepare_method(func, **kwargs)
-        self.map_across_full_axis(1, map_func)
-        # return self.__constructor__(new_data, self.index, self.columns)
-
     def _process_sum_prod(self, func, **kwargs):
         """Calculates the sum or product of the DataFrame.
 

--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1101,6 +1101,25 @@ class PandasQueryCompiler(object):
         """
         return self._process_min_max(pandas.DataFrame.min, **kwargs)
 
+    def to_sql(self, **kwargs):
+        """Write records stored in a DataFrame to a SQL database.
+
+        """
+        empty_df = self.head(1).to_pandas().head(0)
+        # this is to create the full DB table and validate the input against pandas
+        empty_df.to_sql(**kwargs)
+        # so each partition will append its respective DF
+        kwargs["if_exists"] = "append"
+        columns = self.columns
+
+        def func(df, **kwargs):
+            df.columns = columns
+            df.to_sql(**kwargs)
+
+        map_func = self._prepare_method(func, **kwargs)
+        new_data = self.map_across_full_axis(1, map_func)
+        return self.__constructor__(new_data, self.index, self.columns)
+
     def _process_sum_prod(self, func, **kwargs):
         """Calculates the sum or product of the DataFrame.
 

--- a/modin/engines/base/io.py
+++ b/modin/engines/base/io.py
@@ -437,15 +437,14 @@ class BaseIO(object):
         dtype=None,
     ):
         ErrorMessage.default_to_pandas("`to_sql`")
-        return cls.from_pandas(
-            pandas.to_sql(
-                name=name,
-                con=con,
-                schema=schema,
-                if_exists=if_exists,
-                index=index,
-                index_label=index_label,
-                chunksize=chunksize,
-                dtype=dtype,
-            )
+        df = qc.to_pandas()
+        df.to_sql(
+            name=name,
+            con=con,
+            schema=schema,
+            if_exists=if_exists,
+            index=index,
+            index_label=index_label,
+            chunksize=chunksize,
+            dtype=dtype,
         )

--- a/modin/engines/base/io.py
+++ b/modin/engines/base/io.py
@@ -426,6 +426,7 @@ class BaseIO(object):
     @classmethod
     def to_sql(
         cls,
+        qc,
         name,
         con,
         schema=None,

--- a/modin/engines/base/io.py
+++ b/modin/engines/base/io.py
@@ -422,3 +422,29 @@ class BaseIO(object):
                 chunksize=chunksize,
             )
         )
+
+    @classmethod
+    def to_sql(
+        cls,
+        name,
+        con,
+        schema=None,
+        if_exists="fail",
+        index=True,
+        index_label=None,
+        chunksize=None,
+        dtype=None,
+    ):
+        ErrorMessage.default_to_pandas("`to_sql`")
+        return cls.from_pandas(
+            pandas.to_sql(
+                name=name,
+                con=con,
+                schema=schema,
+                if_exists=if_exists,
+                index=index,
+                index_label=index_label,
+                chunksize=chunksize,
+                dtype=dtype,
+            )
+        )

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -541,10 +541,17 @@ class PandasOnRayIO(BaseIO):
     @classmethod
     def to_sql(cls, qc, **kwargs):
         """Write records stored in a DataFrame to a SQL database.
-
+        Args:
+            qc: the query compiler of the DF that we want to run to_sql on
+            kwargs: parameters for pandas.to_sql(**kwargs)
         """
+        # we first insert an empty DF in order to create the full table in the database
+        # This also helps to validate the input against pandas
+        # we would like to_sql() to complete only when all rows have been inserted into the database
+        # since the mapping operation is non-blocking, each partition will return an empty DF
+        # so at the end, the blocking operation will be this empty DF to_pandas
+
         empty_df = qc.head(1).to_pandas().head(0)
-        # this is to create the full DB table and validate the input against pandas
         empty_df.to_sql(**kwargs)
         # so each partition will append its respective DF
         kwargs["if_exists"] = "append"
@@ -557,6 +564,7 @@ class PandasOnRayIO(BaseIO):
 
         map_func = qc._prepare_method(func, **kwargs)
         result = qc.map_across_full_axis(1, map_func)
+        # blocking operation
         result.to_pandas()
 
 

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -538,6 +538,27 @@ class PandasOnRayIO(BaseIO):
         )
         return new_query_compiler
 
+    @classmethod
+    def to_sql(cls, qc, **kwargs):
+        """Write records stored in a DataFrame to a SQL database.
+
+        """
+        empty_df = qc.head(1).to_pandas().head(0)
+        # this is to create the full DB table and validate the input against pandas
+        empty_df.to_sql(**kwargs)
+        # so each partition will append its respective DF
+        kwargs["if_exists"] = "append"
+        columns = qc.columns
+
+        def func(df, **kwargs):
+            df.columns = columns
+            df.to_sql(**kwargs)
+            return pandas.DataFrame()
+
+        map_func = qc._prepare_method(func, **kwargs)
+        result = qc.map_across_full_axis(1, map_func)
+        result.to_pandas()
+
 
 @ray.remote
 def get_index(index_name, *partition_indices):  # pragma: no cover

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -2,53 +2,42 @@ import os
 import pandas
 import pytest
 import modin.experimental.pandas as pd
-
-
 from modin.pandas.test.test_io import (
-    setup_sql_file,
-    teardown_sql_file,
     modin_df_equals_pandas,
-)
+    make_sql_connection,
+)  # noqa: F401
 
 
-def test_from_sql_distributed():
+def test_from_sql_distributed(make_sql_connection):  # noqa: F811
     if os.environ.get("MODIN_ENGINE", "") == "Ray":
         filename = "test_from_sql_distributed.db"
-        teardown_sql_file(filename)
         table = "test_from_sql_distributed"
-        db_uri = "sqlite:///" + filename
-        setup_sql_file(db_uri, filename, table, True)
+        conn = make_sql_connection(filename, table)
         query = "select * from {0}".format(table)
 
-        pandas_df = pandas.read_sql(query, db_uri)
+        pandas_df = pandas.read_sql(query, conn)
         modin_df_from_query = pd.read_sql(
-            query, db_uri, partition_column="col1", lower_bound=0, upper_bound=6
+            query, conn, partition_column="col1", lower_bound=0, upper_bound=6
         )
         modin_df_from_table = pd.read_sql(
-            table, db_uri, partition_column="col1", lower_bound=0, upper_bound=6
+            table, conn, partition_column="col1", lower_bound=0, upper_bound=6
         )
 
         assert modin_df_equals_pandas(modin_df_from_query, pandas_df)
         assert modin_df_equals_pandas(modin_df_from_table, pandas_df)
 
-        teardown_sql_file(filename)
 
-
-def test_from_sql_defaults():
+def test_from_sql_defaults(make_sql_connection):  # noqa: F811
     filename = "test_from_sql_distributed.db"
-    teardown_sql_file(filename)
     table = "test_from_sql_distributed"
-    db_uri = "sqlite:///" + filename
-    setup_sql_file(db_uri, filename, table, True)
+    conn = make_sql_connection(filename, table)
     query = "select * from {0}".format(table)
 
-    pandas_df = pandas.read_sql(query, db_uri)
+    pandas_df = pandas.read_sql(query, conn)
     with pytest.warns(UserWarning):
-        modin_df_from_query = pd.read_sql(query, db_uri)
+        modin_df_from_query = pd.read_sql(query, conn)
     with pytest.warns(UserWarning):
-        modin_df_from_table = pd.read_sql(table, db_uri)
+        modin_df_from_table = pd.read_sql(table, conn)
 
     assert modin_df_equals_pandas(modin_df_from_query, pandas_df)
     assert modin_df_equals_pandas(modin_df_from_table, pandas_df)
-
-    teardown_sql_file(filename)

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -2,10 +2,10 @@ import os
 import pandas
 import pytest
 import modin.experimental.pandas as pd
-from modin.pandas.test.test_io import (
+from modin.pandas.test.test_io import (  # noqa: F401
     modin_df_equals_pandas,
     make_sql_connection,
-)  # noqa: F401
+)
 
 
 def test_from_sql_distributed(make_sql_connection):  # noqa: F811

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -47,7 +47,6 @@ def setup_parquet_file(row_size, force=False):
         ).to_parquet(TEST_PARQUET_FILENAME)
 
 
-@pytest.fixture
 def create_test_ray_dataframe():
     df = pd.DataFrame(
         {
@@ -62,7 +61,6 @@ def create_test_ray_dataframe():
     return df
 
 
-@pytest.fixture
 def create_test_pandas_dataframe():
     df = pandas.DataFrame(
         {


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Implementation of `Dataframe.to_sql()`

The major challenge was writing the index to the database, as the partitions don't hold the original index. The solution was to add the index as a column if needed.
One remaining issue,  when saving the index, the resulting DB file is not of the same size as the one that is saved by `pandas`. other than that, loading from a DB table which was saved by `pandas.Dataframe.to_sql()` or by  `modin.Dataframe.to_sql()` will result in the same Dataframe (verified in the unit tests).

## Related issue number

#453 

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] tests added and passing
