### PR TITLE
Add correct support for `include="all"`

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1117,10 +1117,13 @@ class DataFrame(object):
 
         Returns: Series/DataFrame of summary statistics
         """
-        if include is not None:
+        if include is not None and include != "all":
             if not is_list_like(include):
                 include = [include]
             include = [np.dtype(i) for i in include]
+            if not any(self.dtypes.isin(include)):
+                # This is the error that pandas throws.
+                raise ValueError("No objects to concatenate")
         if exclude is not None:
             if not is_list_like(include):
                 exclude = [exclude]

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1117,17 +1117,41 @@ class DataFrame(object):
 
         Returns: Series/DataFrame of summary statistics
         """
-        if include is not None and include != "all":
+        if include is not None and (isinstance(include, np.dtype) or include != "all"):
             if not is_list_like(include):
                 include = [include]
-            include = [np.dtype(i) for i in include]
-            if not any(self.dtypes.isin(include)):
+            include = [
+                np.dtype(i)
+                if not (isinstance(i, type) and i.__module__ == "numpy")
+                else i
+                for i in include
+            ]
+            if not any(
+                (isinstance(inc, np.dtype) and inc == d)
+                or (
+                    not isinstance(inc, np.dtype)
+                    and inc.__subclasscheck__(getattr(np, d.__str__()))
+                )
+                for d in self.dtypes.values
+                for inc in include
+            ):
                 # This is the error that pandas throws.
                 raise ValueError("No objects to concatenate")
         if exclude is not None:
-            if not is_list_like(include):
+            if not is_list_like(exclude):
                 exclude = [exclude]
             exclude = [np.dtype(e) for e in exclude]
+            if all(
+                (isinstance(exc, np.dtype) and exc == d)
+                or (
+                    not isinstance(exc, np.dtype)
+                    and exc.__subclasscheck__(getattr(np, d.__str__()))
+                )
+                for d in self.dtypes.values
+                for exc in exclude
+            ):
+                # This is the error that pandas throws.
+                raise ValueError("No objects to concatenate")
         if percentiles is not None:
             pandas.DataFrame()._check_percentile(percentiles)
         return DataFrame(

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1382,12 +1382,18 @@ def test_describe(data):
     df_equals(modin_df.describe(), pandas_df.describe())
 
     try:
-        pandas_result = pandas_df.describe(include=[np.timedelta64, np.datetime64, np.object, np.bool])
+        pandas_result = pandas_df.describe(
+            include=[np.timedelta64, np.datetime64, np.object, np.bool]
+        )
     except Exception as e:
         with pytest.raises(type(e)):
-            modin_df.describe(include=[np.timedelta64, np.datetime64, np.object, np.bool])
+            modin_df.describe(
+                include=[np.timedelta64, np.datetime64, np.object, np.bool]
+            )
     else:
-        modin_result = modin_df.describe(include=[np.timedelta64, np.datetime64, np.object, np.bool])
+        modin_result = modin_df.describe(
+            include=[np.timedelta64, np.datetime64, np.object, np.bool]
+        )
         df_equals(modin_result, pandas_result)
 
     df_equals(modin_df.describe(include="all"), pandas_df.describe(include="all"))

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1381,6 +1381,17 @@ def test_describe(data):
 
     df_equals(modin_df.describe(), pandas_df.describe())
 
+    try:
+        pandas_result = pandas_df.describe(include=[np.timedelta64, np.datetime64, np.object, np.bool])
+    except Exception as e:
+        with pytest.raises(type(e)):
+            modin_df.describe(include=[np.timedelta64, np.datetime64, np.object, np.bool])
+    else:
+        modin_result = modin_df.describe(include=[np.timedelta64, np.datetime64, np.object, np.bool])
+        df_equals(modin_result, pandas_result)
+
+    df_equals(modin_df.describe(include="all"), pandas_df.describe(include="all"))
+
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1381,7 +1381,10 @@ def test_describe(data):
 
     df_equals(modin_df.describe(), pandas_df.describe())
     percentiles = [0.10, 0.11, 0.44, 0.78, 0.99]
-    df_equals(modin_df.describe(percentiles=percentiles), pandas_df.describe(percentiles=percentiles))
+    df_equals(
+        modin_df.describe(percentiles=percentiles),
+        pandas_df.describe(percentiles=percentiles),
+    )
 
     try:
         pandas_result = pandas_df.describe(exclude=[np.float64])
@@ -1435,7 +1438,10 @@ def test_describe(data):
         # We have to do this because we choose the highest count slightly differently
         # than pandas. Because there is no true guarantee which one will be first,
         # If they don't match, make sure that the `freq` is the same at least.
-        df_equals(modin_df.describe().loc[["count", "unique", "freq"]], pandas_df.describe().loc[["count", "unique", "freq"]])
+        df_equals(
+            modin_df.describe().loc[["count", "unique", "freq"]],
+            pandas_df.describe().loc[["count", "unique", "freq"]],
+        )
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1380,6 +1380,26 @@ def test_describe(data):
     pandas_df = pandas.DataFrame(data)
 
     df_equals(modin_df.describe(), pandas_df.describe())
+    percentiles = [0.10, 0.11, 0.44, 0.78, 0.99]
+    df_equals(modin_df.describe(percentiles=percentiles), pandas_df.describe(percentiles=percentiles))
+
+    try:
+        pandas_result = pandas_df.describe(exclude=[np.float64])
+    except Exception as e:
+        with pytest.raises(type(e)):
+            modin_df.describe(exclude=[np.float64])
+    else:
+        modin_result = modin_df.describe(exclude=[np.float64])
+        df_equals(modin_result, pandas_result)
+
+    try:
+        pandas_result = pandas_df.describe(exclude=np.float64)
+    except Exception as e:
+        with pytest.raises(type(e)):
+            modin_df.describe(exclude=np.float64)
+    else:
+        modin_result = modin_df.describe(exclude=np.float64)
+        df_equals(modin_result, pandas_result)
 
     try:
         pandas_result = pandas_df.describe(
@@ -1396,7 +1416,26 @@ def test_describe(data):
         )
         df_equals(modin_result, pandas_result)
 
+    modin_result = modin_df.describe(include=str(modin_df.dtypes.values[0]))
+    pandas_result = pandas_df.describe(include=str(pandas_df.dtypes.values[0]))
+    df_equals(modin_result, pandas_result)
+
+    modin_result = modin_df.describe(include=[np.number])
+    pandas_result = pandas_df.describe(include=[np.number])
+    df_equals(modin_result, pandas_result)
+
     df_equals(modin_df.describe(include="all"), pandas_df.describe(include="all"))
+
+    modin_df = pd.DataFrame(data).applymap(str)
+    pandas_df = pandas.DataFrame(data).applymap(str)
+
+    try:
+        df_equals(modin_df.describe(), pandas_df.describe())
+    except AssertionError:
+        # We have to do this because we choose the highest count slightly differently
+        # than pandas. Because there is no true guarantee which one will be first,
+        # If they don't match, make sure that the `freq` is the same at least.
+        df_equals(modin_df.describe().loc[["count", "unique", "freq"]], pandas_df.describe().loc[["count", "unique", "freq"]])
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)


### PR DESCRIPTION
* Resolves $484
* Adds correct support for all `include` values passed
  * Previously, the behavior was to use `include` to compute `exclude`
  * The correct behavior is that `include` is strictly inclusive, such
    that only types in the `include` list are included, rather than
    those being included in addition to the default types.
* Also correctly throws the same error type as pandas (with the same
  message, though the message is not informative
* Add tests for `include="all"` and `include=[np.timedelta64, np.datetime64, np.object, np.bool]`

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
