### PR TITLE
Correctly match pandas behavior when iteratively updating columns

### DIFF
--- a/modin/data_management/query_compiler/pandas_query_compiler.py
+++ b/modin/data_management/query_compiler/pandas_query_compiler.py
@@ -1730,11 +1730,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 # Describe all columns
                 new_columns = self.columns
 
-        def describe_builder(df, **kwargs):
-            try:
-                return pandas.DataFrame.describe(df, **kwargs)
-            except ValueError:
-                return pandas.DataFrame(index=df.index)
+        def describe_builder(df, internal_indices=[], **kwargs):
+            return df.iloc[:, internal_indices].describe(**kwargs)
 
         # Apply describe and update indices, columns, and dtypes
         func = self._prepare_method(describe_builder, **kwargs)

--- a/modin/engines/base/block_partitions.py
+++ b/modin/engines/base/block_partitions.py
@@ -828,7 +828,7 @@ class BaseBlockPartitions(object):
             A new BaseBlockPartitions object, the type of object that called this.
         """
         if self.partitions.size == 0:
-            return np.array([[]])
+            return self.__constructor__(np.array([[]]))
         if isinstance(indices, dict):
             dict_indices = indices
             indices = list(indices.keys())

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -4723,7 +4723,10 @@ class DataFrame(object):
 
     def __setitem__(self, key, value):
         if not isinstance(key, str):
-            return self._default_to_pandas(pandas.DataFrame.__setitem__, key, value)
+            def setitem_without_string_columns(df):
+                df[key] = value
+                return df
+            return self._update_inplace(self._default_to_pandas(setitem_without_string_columns)._query_compiler)
         if key not in self.columns:
             self.insert(loc=len(self.columns), column=key, value=value)
         elif len(self.index) == 0:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -4726,10 +4726,11 @@ class DataFrame(object):
             return self._default_to_pandas(pandas.DataFrame.__setitem__, key, value)
         if key not in self.columns:
             self.insert(loc=len(self.columns), column=key, value=value)
+        elif len(self.index) == 0:
+            new_self = DataFrame({key: value}, columns=self.columns)
+            self._update_inplace(new_self._query_compiler)
         else:
-            loc = self.columns.get_loc(key)
-            self.__delitem__(key)
-            self.insert(loc=loc, column=key, value=value)
+            self._update_inplace(self._query_compiler.setitem(key, value))
 
     def __len__(self):
         """Gets the length of the DataFrame.

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -4723,10 +4723,14 @@ class DataFrame(object):
 
     def __setitem__(self, key, value):
         if not isinstance(key, str):
+
             def setitem_without_string_columns(df):
                 df[key] = value
                 return df
-            return self._update_inplace(self._default_to_pandas(setitem_without_string_columns)._query_compiler)
+
+            return self._update_inplace(
+                self._default_to_pandas(setitem_without_string_columns)._query_compiler
+            )
         if key not in self.columns:
             self.insert(loc=len(self.columns), column=key, value=value)
         elif len(self.index) == 0:

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4311,14 +4311,32 @@ def test___getattr__(request, data):
         assert isinstance(df2.columns, pandas.Index)
 
 
-@pytest.mark.skip(reason="Defaulting to Pandas")
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test___setitem__(data):
     modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)  # noqa F841
+    pandas_df = pandas.DataFrame(data)
 
-    with pytest.raises(NotImplementedError):
-        modin_df.__setitem__(None, None)
+    modin_df.__setitem__(modin_df.columns[-1], 1)
+    pandas_df.__setitem__(pandas_df.columns[-1], 1)
+    df_equals(modin_df, pandas_df)
+
+    modin_df = pd.DataFrame(data)
+    pandas_df = pandas.DataFrame(data)
+
+    modin_df[modin_df.columns[0]] = np.arange(len(modin_df))
+    pandas_df[pandas_df.columns[0]] = np.arange(len(pandas_df))
+    df_equals(modin_df, pandas_df)
+
+    modin_df = pd.DataFrame(columns=modin_df.columns)
+    pandas_df = pandas.DataFrame(columns=pandas_df.columns)
+
+    for col in modin_df.columns:
+        modin_df[col] = np.arange(1000)
+
+    for col in pandas_df.columns:
+        pandas_df[col] = np.arange(1000)
+
+    df_equals(modin_df, pandas_df)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4338,6 +4338,29 @@ def test___setitem__(data):
 
     df_equals(modin_df, pandas_df)
 
+    # Transpose test
+    modin_df = pd.DataFrame(data).T
+    pandas_df = pandas.DataFrame(data).T
+
+    # We default to pandas on non-string column names
+    if not all(isinstance(c, str) for c in modin_df.columns):
+        with pytest.warns(UserWarning):
+            modin_df[modin_df.columns[0]] = 0
+    else:
+        modin_df[modin_df.columns[0]] = 0
+
+    pandas_df[pandas_df.columns[0]] = 0
+
+    df_equals(modin_df, pandas_df)
+
+    modin_df.columns = [str(i) for i in modin_df.columns]
+    pandas_df.columns = [str(i) for i in pandas_df.columns]
+
+    modin_df[modin_df.columns[0]] = 0
+    pandas_df[pandas_df.columns[0]] = 0
+
+    df_equals(modin_df, pandas_df)
+
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test___len__(data):


### PR DESCRIPTION
* Resolves #474
* Adds `PandasQueryCompiler.setitem` to avoid multiple maps
* Correctly handles the initial insertion when there is no index
* Fix `PandasQueryCompiler._prepare_method` to allow `internal_indices`
  to be used.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
