### PR TITLE
parallel read_sql() using limit and offset

### DIFF
--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -601,8 +601,6 @@ class PandasOnRayIO(BaseIO):
         row_cnt_query = "SELECT COUNT(*) FROM ({})".format(sql)
         row_cnt = pandas.read_sql(row_cnt_query, con).squeeze()
         cols_names_df = pandas.read_sql("SELECT * FROM ({}) LIMIT 0".format(sql), con, index_col=index_col)
-        if index_col is not None:
-            cols_names_df = cols_names_df.drop(columns=index_col)
         cols_names = cols_names_df.columns
         num_parts = cls.block_partitions_cls._compute_num_partitions()
         partition_ids = []

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -589,6 +589,49 @@ class PandasOnRayIO(BaseIO):
         # blocking operation
         result.to_pandas()
 
+    @classmethod
+    def read_sql(cls, sql, con, index_col=None, **kwargs):
+        """Reads a SQL query or database table into a DataFrame.
+        Args:
+            sql: string or SQLAlchemy Selectable (select or text object) SQL query to be executed or a table name.
+            con: SQLAlchemy connectable (engine/connection) or database string URI or DBAPI2 connection (fallback mode)
+            index_col: Column(s) to set as index(MultiIndex).
+            kwargs: Pass into pandas.read_sql function.
+        """
+        row_cnt_query = "SELECT COUNT(*) FROM ({})".format(sql)
+        row_cnt = pandas.read_sql(row_cnt_query, con).iloc[0][0]
+        cols_names_df = pandas.read_sql("SELECT * FROM ({}) LIMIT 0".format(sql), con)
+        if index_col is not None:
+            cols_names_df = cols_names_df.drop(columns=index_col)
+        cols_names = cols_names_df.columns
+        num_parts = cls.block_partitions_cls._compute_num_partitions()
+        partition_ids = []
+        index_ids = []
+        limit = int(round(row_cnt / num_parts))
+        for part in range(num_parts):
+            offset = part * limit
+            query = "SELECT * FROM ({}) LIMIT {} OFFSET {}".format(sql, limit, offset)
+            partition_id = _read_sql_with_limit_offset._remote(
+                args=(num_parts, query, con, index_col, kwargs),
+                num_return_vals=num_parts + 1,
+            )
+            partition_ids.append(
+                [PandasOnRayRemotePartition(obj) for obj in partition_id[:-1]]
+            )
+            index_ids.append(partition_id[-1])
+
+        if index_col is None:  # sum all lens returned from partitions
+            index_lens = ray.get(index_ids)
+            new_index = pandas.RangeIndex(sum(index_lens))
+        else:  # concat index returned from partitions
+            index_lst = [x for part_index in ray.get(index_ids) for x in part_index]
+            new_index = pandas.Index(index_lst).set_names(index_col)
+
+        new_query_compiler = cls.query_compiler_cls(
+            cls.block_partitions_cls(np.array(partition_ids)), new_index, cols_names
+        )
+        return new_query_compiler
+
 
 @ray.remote
 def get_index(index_name, *partition_indices):  # pragma: no cover
@@ -726,3 +769,19 @@ def _read_feather_columns(path, columns, num_splits):  # pragma: no cover
     df = feather.read_feather(path, columns=columns)
     # Append the length of the index here to build it externally
     return _split_result_for_readers(0, num_splits, df) + [len(df.index)]
+
+
+@ray.remote
+def _read_sql_with_limit_offset(
+    num_splits, sql, con, index_col, kwargs
+):  # pragma: no cover
+    """Use a Ray task to read a chunk of SQL source.
+
+    Note: Ray functions are not detected by codecov (thus pragma: no cover)
+    """
+    pandas_df = pandas.read_sql(sql, con, index_col=index_col, **kwargs)
+    if index_col is None:
+        index = len(pandas_df)
+    else:
+        index = pandas_df.index
+    return _split_result_for_readers(1, num_splits, pandas_df) + [index]

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -12,6 +12,7 @@ import py
 import ray
 import re
 import numpy as np
+import math
 
 from modin.error_message import ErrorMessage
 from modin.data_management.utils import split_result_of_axis_func_pandas
@@ -605,7 +606,7 @@ class PandasOnRayIO(BaseIO):
         num_parts = cls.block_partitions_cls._compute_num_partitions()
         partition_ids = []
         index_ids = []
-        limit = int(round(row_cnt / num_parts))
+        limit = math.ceil(row_cnt / num_parts)
         for part in range(num_parts):
             offset = part * limit
             query = "SELECT * FROM ({}) LIMIT {} OFFSET {}".format(sql, limit, offset)

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -600,7 +600,7 @@ class PandasOnRayIO(BaseIO):
         """
         row_cnt_query = "SELECT COUNT(*) FROM ({})".format(sql)
         row_cnt = pandas.read_sql(row_cnt_query, con).squeeze()
-        cols_names_df = pandas.read_sql("SELECT * FROM ({}) LIMIT 0".format(sql), con)
+        cols_names_df = pandas.read_sql("SELECT * FROM ({}) LIMIT 0".format(sql), con, index_col=index_col)
         if index_col is not None:
             cols_names_df = cols_names_df.drop(columns=index_col)
         cols_names = cols_names_df.columns

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -601,7 +601,9 @@ class PandasOnRayIO(BaseIO):
         """
         row_cnt_query = "SELECT COUNT(*) FROM ({})".format(sql)
         row_cnt = pandas.read_sql(row_cnt_query, con).squeeze()
-        cols_names_df = pandas.read_sql("SELECT * FROM ({}) LIMIT 0".format(sql), con, index_col=index_col)
+        cols_names_df = pandas.read_sql(
+            "SELECT * FROM ({}) LIMIT 0".format(sql), con, index_col=index_col
+        )
         cols_names = cols_names_df.columns
         num_parts = cls.block_partitions_cls._compute_num_partitions()
         partition_ids = []

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -599,7 +599,7 @@ class PandasOnRayIO(BaseIO):
             kwargs: Pass into pandas.read_sql function.
         """
         row_cnt_query = "SELECT COUNT(*) FROM ({})".format(sql)
-        row_cnt = pandas.read_sql(row_cnt_query, con).iloc[0][0]
+        row_cnt = pandas.read_sql(row_cnt_query, con).squeeze()
         cols_names_df = pandas.read_sql("SELECT * FROM ({}) LIMIT 0".format(sql), con)
         if index_col is not None:
             cols_names_df = cols_names_df.drop(columns=index_col)

--- a/modin/experimental/engines/pandas_on_ray/io_exp.py
+++ b/modin/experimental/engines/pandas_on_ray/io_exp.py
@@ -61,11 +61,11 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
                 sql,
                 con,
                 index_col,
-                coerce_float,
-                params,
-                parse_dates,
-                columns,
-                chunksize,
+                coerce_float=coerce_float,
+                params=params,
+                parse_dates=parse_dates,
+                columns=columns,
+                chunksize=chunksize,
             )
         #  starts the distributed alternative
         cols_names, query = get_query_info(sql, con, partition_column)

--- a/modin/experimental/engines/pandas_on_ray/io_exp.py
+++ b/modin/experimental/engines/pandas_on_ray/io_exp.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas
 import ray
+import warnings
 
 from modin.engines.ray.pandas_on_ray.io import PandasOnRayIO, _split_result_for_readers
 from modin.engines.ray.pandas_on_ray.remote_partition import PandasOnRayRemotePartition
@@ -55,8 +56,7 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
         from .sql import is_distributed, get_query_info
 
         if not is_distributed(partition_column, lower_bound, upper_bound):
-            # Change this so that when `PandasOnRayIO` has a parallel `read_sql` we can
-            # still use it.
+            warnings.warn("defaulting to modin core implementation")
             return PandasOnRayIO.read_sql(
                 sql,
                 con,

--- a/modin/experimental/engines/pandas_on_ray/io_exp.py
+++ b/modin/experimental/engines/pandas_on_ray/io_exp.py
@@ -56,7 +56,7 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
         from .sql import is_distributed, get_query_info
 
         if not is_distributed(partition_column, lower_bound, upper_bound):
-            warnings.warn("defaulting to modin core implementation")
+            warnings.warn("Defaulting to Modin core implementation")
             return PandasOnRayIO.read_sql(
                 sql,
                 con,

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -464,6 +464,11 @@ def test_from_sql(make_sql_connection):
 
     assert modin_df_equals_pandas(modin_df, pandas_df)
 
+    pandas_df = pandas.read_sql(query, conn, index_col="index")
+    modin_df = pd.read_sql(query, conn, index_col="index")
+
+    assert modin_df_equals_pandas(modin_df, pandas_df)
+
     with pytest.warns(UserWarning):
         pd.read_sql_query(query, conn)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Implementation of parallel read_sql(). Partitioning the data with `LIMIT` and `OFFSET`. 
There is an initial query that gets the number of expected rows, using `COUNT`. Then, divid the query with limit and offset for each partition accordingly.

## Related issue number
#418 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] tests added and passing
