### PR TITLE
pin pytables version in tests to avoid dependency mismatches

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ typing
 xarray
 Jinja2
 pathlib
-tables
+tables==3.4.4
 scipy
 pytest==3.9.3
 coverage


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
