### PR TITLE
 Cleanup `pandas.__init__.py`

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -39,7 +39,6 @@ or for different functionalities of Modin. Here is a list of dependency sets for
 .. code-block:: bash
 
   pip install "modin[dask]" # If you want to use the Dask backend
-  pip install "modin[out_of_core]" # If you want to use Modin's `out of core`_ feature
 
 Installing from the GitHub master branch
 ----------------------------------------

--- a/docs/out_of_core.rst
+++ b/docs/out_of_core.rst
@@ -9,15 +9,8 @@ of Modin. Please let us know what you think!
 Install Modin out of core
 -------------------------
 
-As we mentioned in the `installation page`_, we have set up a select dependency set for
-users who want to use Modin out of core. It can be installed with pip:
-
-.. code-block:: bash
-
-  pip install "modin[out_of_core]"
-
-This will ensure that you have all of the required dependencies for Modin to run out of
-core.
+Modin now comes with all the dependencies for out of core functionality by default! See
+the `installation page`_ for more information on installing Modin.
 
 Starting Modin with out of core enabled
 ---------------------------------------

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,5 @@ setup(
     extras_require={
         # can be installed by pip install modin[dask]
         "dask": ["dask==1.0.0", "distributed==1.25.0"],
-        # can be install by pip install modin[out_of_core]
-        "out_of_core": ["psutil==5.4.8"],
     },
 )


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->
* Cast `MODIN_MEMORY` to `int`
* Remove unreachable code
* No longer require `psutil` to use `OUT_OF_CORE`
* Fix documentation links to installing for out of core
* Remove setup.py target
## What do these changes do?

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
