### PR TITLE
Update numpy version to 1.16

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 pandas==0.24.1
 numpy
-dask[complete]==1.0.0
+dask[complete]==1.1.0
 distributed==1.25.0
 ray==0.6.2
 psutil==5.4.8

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pandas==0.24.1
-numpy <= 1.15.0
+numpy
 dask[complete]==1.0.0
 distributed==1.25.0
 ray==0.6.2

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,6 @@ setup(
     install_requires=["pandas==0.24.1", "ray==0.6.2", "typing"],
     extras_require={
         # can be installed by pip install modin[dask]
-        "dask": ["dask==1.0.0", "distributed==1.25.0"],
+        "dask": ["dask==1.1.0", "distributed==1.25.0"],
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url="https://github.com/modin-project/modin",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=["pandas==0.24.1", "ray==0.6.2", "numpy<=1.15.0", "typing"],
+    install_requires=["pandas==0.24.1", "ray==0.6.2", "numpy<=1.16.0", "typing"],
     extras_require={
         # can be installed by pip install modin[dask]
         "dask": ["dask==1.0.0", "distributed==1.25.0"],

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     url="https://github.com/modin-project/modin",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=["pandas==0.24.1", "ray==0.6.2", "numpy<=1.16.0", "typing"],
+    install_requires=["pandas==0.24.1", "ray==0.6.2", "typing"],
     extras_require={
         # can be installed by pip install modin[dask]
         "dask": ["dask==1.0.0", "distributed==1.25.0"],


### PR DESCRIPTION

## What do these changes do?

Updates modin to be compatible with numpy 1.16.0

## Related issue number

fixes #482 

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
