### PR TITLE
Add `-v` pytest flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,12 @@ script:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - if [[ "$PYTHON" == "2.7" ]]; then python .travis/strip-type-hints.py; fi
   - curl -s https://codecov.io/bash > codecov.sh
-  - python -m pytest -v -n auto --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/ --cov-append
-  - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/experimental/pandas/test/ --cov-append
+  - python -m pytest -v -n auto --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_dataframe.py --cov-append
+  - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_concat.py --cov-append
+  - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_groupby.py --cov-append
+  - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_reshape.py --cov-append
+  - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_general.py --cov-append
+  - pip install numexpr
+  - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_io.py --cov-append
+  - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/experimental/pandas/test/test_io_exp.py --cov-append
   - bash codecov.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,6 +56,6 @@ script:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - if [[ "$PYTHON" == "2.7" ]]; then python .travis/strip-type-hints.py; fi
   - curl -s https://codecov.io/bash > codecov.sh
-  - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/ --cov-append
+  - python -m pytest -v -n auto --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/ --cov-append
   - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/experimental/pandas/test/ --cov-append
   - bash codecov.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -56,12 +56,6 @@ script:
   - export PATH="$HOME/miniconda/bin:$PATH"
   - if [[ "$PYTHON" == "2.7" ]]; then python .travis/strip-type-hints.py; fi
   - curl -s https://codecov.io/bash > codecov.sh
-  - python -m pytest -n auto --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_dataframe.py --cov-append
-  - python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_concat.py --cov-append
-  - python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_groupby.py --cov-append
-  - python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_reshape.py --cov-append
-  - python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_general.py --cov-append
-  - pip install numexpr
-  - python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_io.py --cov-append
-  - python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/experimental/pandas/test/test_io_exp.py --cov-append
+  - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/ --cov-append
+  - python -m pytest -v --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/experimental/pandas/test/ --cov-append
   - bash codecov.sh


### PR DESCRIPTION
## What do these changes do?

Adds a `-v` flag to the `pytest` commands in `.travis.yml` to have it print the test names as it runs. Doing so will make it easier to see which test, if any, that travis hangs on. However, this also increases the length of the logs significantly and we may want to undo this later.

## Related issue number

N/A

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
