### PR TITLE
read_excel(sheet_name=None) not working  (#512)

### DIFF
--- a/modin/engines/base/io.py
+++ b/modin/engines/base/io.py
@@ -3,6 +3,7 @@ from __future__ import division
 from __future__ import print_function
 
 import pandas
+from collections import OrderedDict
 from modin.error_message import ErrorMessage
 from modin.backends.base.query_compiler import BaseQueryCompiler
 
@@ -310,36 +311,38 @@ class BaseIO(object):
         if skip_footer != 0:
             skipfooter = skip_footer
         ErrorMessage.default_to_pandas("`read_excel`")
-        return cls.from_pandas(
-            pandas.read_excel(
-                io,
-                sheet_name=sheet_name,
-                header=header,
-                names=names,
-                index_col=index_col,
-                parse_cols=parse_cols,
-                usecols=usecols,
-                squeeze=squeeze,
-                dtype=dtype,
-                engine=engine,
-                converters=converters,
-                true_values=true_values,
-                false_values=false_values,
-                skiprows=skiprows,
-                nrows=nrows,
-                na_values=na_values,
-                keep_default_na=keep_default_na,
-                verbose=verbose,
-                parse_dates=parse_dates,
-                date_parser=date_parser,
-                thousands=thousands,
-                comment=comment,
-                skipfooter=skipfooter,
-                convert_float=convert_float,
-                mangle_dupe_cols=mangle_dupe_cols,
-                **kwds
-            )
+        parsed = pandas.read_excel(
+            io,
+            sheet_name=sheet_name,
+            header=header,
+            names=names,
+            index_col=index_col,
+            parse_cols=parse_cols,
+            usecols=usecols,
+            squeeze=squeeze,
+            dtype=dtype,
+            engine=engine,
+            converters=converters,
+            true_values=true_values,
+            false_values=false_values,
+            skiprows=skiprows,
+            nrows=nrows,
+            na_values=na_values,
+            keep_default_na=keep_default_na,
+            verbose=verbose,
+            parse_dates=parse_dates,
+            date_parser=date_parser,
+            thousands=thousands,
+            comment=comment,
+            skipfooter=skipfooter,
+            convert_float=convert_float,
+            mangle_dupe_cols=mangle_dupe_cols,
+            **kwds
         )
+        if isinstance(parsed, OrderedDict):
+            return parsed
+        else:
+            return cls.from_pandas(parsed)
 
     @classmethod
     def read_hdf(cls, path_or_buf, key=None, mode="r", columns=None):

--- a/modin/engines/base/io.py
+++ b/modin/engines/base/io.py
@@ -311,7 +311,7 @@ class BaseIO(object):
         if skip_footer != 0:
             skipfooter = skip_footer
         ErrorMessage.default_to_pandas("`read_excel`")
-        parsed = pandas.read_excel(
+        intermediate = pandas.read_excel(
             io,
             sheet_name=sheet_name,
             header=header,
@@ -339,10 +339,13 @@ class BaseIO(object):
             mangle_dupe_cols=mangle_dupe_cols,
             **kwds
         )
-        if isinstance(parsed, OrderedDict):
+        if isinstance(intermediate, OrderedDict):
+            parsed = OrderedDict()
+            for key in intermediate.keys():
+                parsed[key] = cls.from_pandas(intermediate.get(key))
             return parsed
         else:
-            return cls.from_pandas(parsed)
+            return cls.from_pandas(intermediate)
 
     @classmethod
     def read_hdf(cls, path_or_buf, key=None, mode="r", columns=None):

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import inspect
 import pandas
 import re
+from collections import OrderedDict
 
 from modin.error_message import ErrorMessage
 from .dataframe import DataFrame
@@ -219,7 +220,11 @@ def read_excel(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwds", {}))
-    return DataFrame(query_compiler=BaseFactory.read_excel(**kwargs))
+    parsed = BaseFactory.read_excel(**kwargs)
+    if isinstance(parsed, OrderedDict):
+        return parsed
+    else:
+        return DataFrame(query_compiler=parsed)
 
 
 def read_hdf(path_or_buf, key=None, mode="r", **kwargs):

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -220,11 +220,14 @@ def read_excel(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwds", {}))
-    parsed = BaseFactory.read_excel(**kwargs)
-    if isinstance(parsed, OrderedDict):
+    intermediate = BaseFactory.read_excel(**kwargs)
+    if isinstance(intermediate, OrderedDict):
+        parsed = OrderedDict()
+        for key in intermediate.keys():
+            parsed[key] = DataFrame(query_compiler=intermediate.get(key))
         return parsed
     else:
-        return DataFrame(query_compiler=parsed)
+        return DataFrame(query_compiler=intermediate)
 
 
 def read_hdf(path_or_buf, key=None, mode="r", **kwargs):

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -5,6 +5,7 @@ from __future__ import print_function
 import pytest
 import numpy as np
 import pandas
+from collections import OrderedDict
 from modin.pandas.utils import to_pandas
 from pathlib import Path
 import pyarrow as pa
@@ -393,6 +394,23 @@ def test_from_excel():
     modin_df = pd.read_excel(TEST_EXCEL_FILENAME)
 
     assert modin_df_equals_pandas(modin_df, pandas_df)
+
+    teardown_excel_file()
+
+
+def test_from_excel_all_sheets():
+    setup_excel_file(SMALL_ROW_SIZE)
+
+    pandas_df = pandas.read_excel(TEST_EXCEL_FILENAME, sheet_name=None)
+    modin_df = pd.read_excel(TEST_EXCEL_FILENAME, sheet_name=None)
+
+    assert isinstance(pandas_df, OrderedDict)
+    assert isinstance(modin_df, OrderedDict)
+
+    assert pandas_df.keys() == modin_df.keys()
+
+    for key in pandas_df.keys():
+        assert modin_df.get(key).equals(pandas_df.get(key))
 
     teardown_excel_file()
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -410,7 +410,7 @@ def test_from_excel_all_sheets():
     assert pandas_df.keys() == modin_df.keys()
 
     for key in pandas_df.keys():
-        assert modin_df.get(key).equals(pandas_df.get(key))
+        assert modin_df_equals_pandas(modin_df.get(key), pandas_df.get(key))
 
     teardown_excel_file()
 


### PR DESCRIPTION
## What do these changes do?

Fix read_excel when sheet_name=None, return corrected type (OrderedDict) 

#512 

- [X] passes `flake8 modin`
- [X] passes `black --check modin`
- [X] tests added and passing
