### PR TITLE
Fix Travis incompatibility

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,7 @@ s3fs
 pytest==3.9.3
 coverage
 pytest-cov
-pytest-xdist
+pytest-xdist==1.27.0
 feather-format
 lxml
 openpyxl


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
An update to xdist breaks our pin to pytest
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [N/A] tests added and passing
