### PR TITLE
Correct behavior for `read_table` when `sep=False`

### DIFF
--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -94,6 +94,8 @@ def _make_parser_func(sep):
         float_precision=None,
     ):
         _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
+        if not kwargs.get("sep", sep):
+            kwargs["sep"] = "\t"
         return _read(**kwargs)
 
     return parser_func

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -113,7 +113,7 @@ def teardown_parquet_file():
 
 
 @pytest.fixture
-def make_csv_file():
+def make_csv_file(delimiter=","):
     """Pytest fixture factory that makes temp csv files for testing.
 
     Yields:
@@ -125,7 +125,7 @@ def make_csv_file():
         filename=TEST_CSV_FILENAME,
         row_size=SMALL_ROW_SIZE,
         force=False,
-        delimiter=",",
+        delimiter=delimiter,
         encoding=None,
     ):
         if os.path.exists(filename) and not force:
@@ -524,6 +524,21 @@ def test_from_csv(make_csv_file):
     if not PY2:
         pandas_df = pandas.read_csv(Path(TEST_CSV_FILENAME))
         modin_df = pd.read_csv(Path(TEST_CSV_FILENAME))
+
+        assert modin_df_equals_pandas(modin_df, pandas_df)
+
+
+def test_from_table(make_csv_file):
+    make_csv_file(delimiter="\t")
+
+    pandas_df = pandas.read_table(TEST_CSV_FILENAME)
+    modin_df = pd.read_table(TEST_CSV_FILENAME)
+
+    assert modin_df_equals_pandas(modin_df, pandas_df)
+
+    if not PY2:
+        pandas_df = pandas.read_table(Path(TEST_CSV_FILENAME))
+        modin_df = pd.read_table(Path(TEST_CSV_FILENAME))
 
         assert modin_df_equals_pandas(modin_df, pandas_df)
 


### PR DESCRIPTION
* Resolves #546
* When `sep=False`, adds the sep as `"\t"`, in order to work with the
  internal parser
* Adds test case for `read_table`
* Adds parameter to `make_csv_file` fixture to allow a delimiter to be
  passed

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
