### PR TITLE
Fix `groupby` with `by=pandas.Grouper` object

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -41,7 +41,11 @@ class DataFrameGroupBy(object):
         self._columns = self._query_compiler.columns
         self._by = by
         # This tells us whether or not there are multiple columns/rows in the groupby
-        self._is_multi_by = all(obj in self._df for obj in self._by) and axis == 0
+        self._is_multi_by = (
+            is_list_like(self._by)
+            and all(obj in self._df for obj in self._by)
+            and axis == 0
+        )
         self._level = level
         self._kwargs = {
             "sort": sort,
@@ -80,17 +84,19 @@ class DataFrameGroupBy(object):
     @property
     def _index_grouped(self):
         if self._index_grouped_cache is None:
-            if self._is_multi_by:
+            if self._is_multi_by or isinstance(self._by, pandas.Grouper):
                 # Because we are doing a collect (to_pandas) here and then groupby, we
                 # end up using pandas implementation. Add the warning so the user is
                 # aware.
                 ErrorMessage.catch_bugs_and_request_email(self._axis == 1)
-                ErrorMessage.default_to_pandas("Groupby with multiple columns")
+                ErrorMessage.default_to_pandas(
+                    "Groupby with multiple columns or Grouper object"
+                )
                 self._index_grouped_cache = {
                     k: v.index
-                    for k, v in self._df._query_compiler.getitem_column_array(self._by)
-                    .to_pandas()
-                    .groupby(by=self._by)
+                    for k, v in self._df._query_compiler.to_pandas().groupby(
+                        by=self._by
+                    )
                 }
             else:
                 if self._axis == 0:
@@ -323,6 +329,13 @@ class DataFrameGroupBy(object):
         )
 
     def ngroup(self, ascending=True):
+        if self._is_multi_by or isinstance(self._by, pandas.Grouper):
+            ErrorMessage.default_to_pandas(
+                "Gropuby with multiple columns or Grouper object"
+            )
+            return self._df._default_to_pandas(
+                lambda df: df.groupby(by=self._by).ngroup()
+            )
         index = self._index if not self._axis else self._columns
         return (
             pandas.Series(index=index)
@@ -410,7 +423,7 @@ class DataFrameGroupBy(object):
         assert callable(f), "'{0}' object is not callable".format(type(f))
         from .dataframe import DataFrame
 
-        if self._is_multi_by:
+        if self._is_multi_by or isinstance(self._by, pandas.Grouper):
             return self._default_to_pandas(f, **kwargs)
         # For aggregations, pandas behavior does this for the result.
         # For other operations it does not, so we wait until there is an aggregation to

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -75,11 +75,16 @@ def test_mixed_dtypes_groupby():
 
     n = 1
 
-    by_values = ["col1", lambda x: x % 2, pandas_df.col1]
+    by_values = [
+        ("col1", "col1"),
+        (lambda x: x % 2, lambda x: x % 2),
+        (ray_df.col1, pandas_df.col1),
+        (pd.Grouper("col1", sort=True), pandas.Grouper("col1", sort=True)),
+    ]
 
     for by in by_values:
-        ray_groupby = ray_df.groupby(by=by)
-        pandas_groupby = pandas_df.groupby(by=by)
+        ray_groupby = ray_df.groupby(by=by[0])
+        pandas_groupby = pandas_df.groupby(by=by[1])
 
         ray_groupby_equals_pandas(ray_groupby, pandas_groupby)
         test_ngroups(ray_groupby, pandas_groupby)


### PR DESCRIPTION
* Resolves #533
* Defaults to pandas until we implement a way to be compatible with
  the `Grouper`

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
