### PR TITLE
Fix issue where `repr` was not correct after mapreduce operation

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1848,27 +1848,18 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if self._is_transposed:
             result = self.__constructor__(
                 self.data.transpose().take(1, -n).transpose(),
-                self.index[:-n],
+                self.index[-n:],
                 self.columns,
                 self._dtype_cache,
             )
             result._is_transposed = True
         else:
-            if n == 0:
-                result = self.__constructor__(
-                    self.data.take(0, 0),
-                    self.index[:0],
-                    self.columns,
-                    self._dtype_cache,
-                )
-            else:
-                result = self.__constructor__(
-                    self.data.take(0, -n),
-                    self.index[-n:],
-                    self.columns,
-                    self._dtype_cache,
-                )
-
+            result = self.__constructor__(
+                self.data.take(0, -n),
+                self.index[-n:],
+                self.columns,
+                self._dtype_cache,
+            )
         return result
 
     def front(self, n):

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1855,10 +1855,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             result._is_transposed = True
         else:
             result = self.__constructor__(
-                self.data.take(0, -n),
-                self.index[-n:],
-                self.columns,
-                self._dtype_cache,
+                self.data.take(0, -n), self.index[-n:], self.columns, self._dtype_cache
             )
         return result
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -37,6 +37,8 @@ class BasePandasDataset(object):
         num_rows_for_head = num_rows // 2 + 1
         num_cols_for_front = num_cols // 2 + 1
 
+        if self.empty:
+            return self._query_compiler.to_pandas()
         if len(self.index) <= num_rows:
             head = self._query_compiler
             tail = None

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -659,6 +659,11 @@ class DataFrame(BasePandasDataset):
             other = other._to_pandas()
         return super(DataFrame, self).gt(other, axis=axis, level=level)
 
+    def head(self, n=5):
+        if n == 0:
+            return DataFrame(columns=self.columns)
+        return super(DataFrame, self).head(n)
+
     def hist(
         self,
         column=None,
@@ -1510,6 +1515,11 @@ class DataFrame(BasePandasDataset):
             min_count=min_count,
             **kwargs
         )
+
+    def tail(self, n=5):
+        if n == 0:
+            return DataFrame(columns=self.columns)
+        return super(DataFrame, self).tail(n)
 
     def to_feather(self, fname):  # pragma: no cover
         return self._default_to_pandas(pandas.DataFrame.to_feather, fname)

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -178,8 +178,8 @@ class Series(BasePandasDataset):
 
     def __repr__(self):
         # In the future, we can have this be configurable, just like Pandas.
-        num_rows = 60
-        num_cols = 30
+        num_rows = pandas.get_option("max_rows") or 60
+        num_cols = pandas.get_option("max_columns") or 20
         temp_df = self._build_repr_df(num_rows, num_cols)
         if isinstance(temp_df, pandas.DataFrame):
             temp_df = temp_df.iloc[:, 0]
@@ -550,6 +550,11 @@ class Series(BasePandasDataset):
     def gt(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).gt(new_other, level=level, axis=axis)
+
+    def head(self, n=5):
+        if n == 0:
+            return Series(dtype=self.dtype)
+        return super(Series, self).head(n)
 
     def hist(
         self,
@@ -954,6 +959,11 @@ class Series(BasePandasDataset):
 
     def swaplevel(self, i=-2, j=-1, copy=True):
         return self._default_to_pandas("swaplevel", i=i, j=j, copy=copy)
+
+    def tail(self, n=5):
+        if n == 0:
+            return Series(dtype=self.dtype)
+        return super(Series, self).tail(n)
 
     def to_frame(self, name=None):
         from .dataframe import DataFrame

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4996,6 +4996,12 @@ class TestDFPartTwo:
 
         assert repr(pandas_df) == repr(modin_df)
 
+        # Empty
+        pandas_df = pandas.DataFrame(columns=["col{}".format(i) for i in range(100)])
+        modin_df = pd.DataFrame(columns=["col{}".format(i) for i in range(100)])
+
+        assert repr(pandas_df) == repr(modin_df)
+
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test_reset_index_with_multi_index(self, data):
         modin_df = pd.DataFrame(data)


### PR DESCRIPTION
* Resolves #551
* Add some sanitization from the API layer in `DataFrame` and `Series`
* Fix `df.head(0)` and `df.tail(0)`
* Fix `repr` for empty DataFrames
* Fix `tail` when `transpose` was called

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
