### PR TITLE
Fix `reset_index` when `name` field of the index is set

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -807,7 +807,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 result = self.data.from_pandas(index_data).concat(1, self.data)
                 return self.__constructor__(result, new_index, new_columns)
             else:
-                new_column_name = "index" if "index" not in self.columns else "level_0"
+                new_column_name = (
+                    self.index.name
+                    if self.index.name is not None
+                    else "index"
+                    if "index" not in self.columns
+                    else "level_0"
+                )
                 new_columns = self.columns.insert(0, new_column_name)
                 result = self.insert(0, new_column_name, self.index)
                 return self.__constructor__(result.data, new_index, new_columns)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5015,6 +5015,23 @@ class TestDFPartTwo:
 
             assert modin_cols.equals(pandas_cols)
 
+    def test_reset_index_with_named_index(self):
+        modin_df = pd.DataFrame(test_data_values[0])
+        pandas_df = pandas.DataFrame(test_data_values[0])
+
+        modin_df.index.name = pandas_df.index.name = "NAME_OF_INDEX"
+        df_equals(modin_df, pandas_df)
+        df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
+
+        modin_df.reset_index(drop=True, inplace=True)
+        pandas_df.reset_index(drop=True, inplace=True)
+        df_equals(modin_df, pandas_df)
+
+        modin_df = pd.DataFrame(test_data_values[0])
+        pandas_df = pandas.DataFrame(test_data_values[0])
+        modin_df.index.name = pandas_df.index.name = "NEW_NAME"
+        df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
+
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test_inplace_series_ops(self, data):
         pandas_df = pandas.DataFrame(data)


### PR DESCRIPTION
* Resolves #186
* Corrects the previous behavior by setting the name of the new column
  to the name of the index
* Add tests to verify the behavior

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
