### PR TITLE
Add `datetime` to top level API. issue: #542

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -75,6 +75,7 @@ from pandas import (
     SparseArray,
     SparseSeries,
     SparseDataFrame,
+    datetime,
 )
 import threading
 import os
@@ -288,6 +289,7 @@ __all__ = [
     "SparseArray",
     "SparseSeries",
     "SparseDataFrame",
+    "datetime",
 ]
 
 del pandas

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -26,7 +26,6 @@ def test_top_level_api_equality():
         "get_option",
         "option_context",
         "reset_option",
-        "options",
     ]
 
     assert not len(
@@ -34,7 +33,7 @@ def test_top_level_api_equality():
     ), "Differences found in API: {}".format(missing_from_modin - set(ignore))
 
     difference = []
-    allowed_different = ["Interval"]
+    allowed_different = ["Interval", "datetime"]
 
     for m in set(pandas_dir) - set(ignore):
         if m in allowed_different:


### PR DESCRIPTION
## What do these changes do?

Add datetime attribute from pandas, tryied to remove "datetime" from ignored in test_top_level_api_equality test, but pandas doesn't have a signature for datetime so the test breaks (maybe test it in another place, i try running some examples to check the attribute)

## Related issue number

#542 

- [X] passes `flake8 modin`
- [X] passes `black --check modin`
