### PR TITLE
Add fastrack for empty mask computation

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1854,7 +1854,12 @@ class DataFrame(BasePandasDataset):
             # of indices, and RangeIndex will give us the exact indices of each boolean
             # requested.
             key = pandas.RangeIndex(len(self.index))[key]
-            return DataFrame(query_compiler=self._query_compiler.getitem_row_array(key))
+            if len(key):
+                return DataFrame(
+                    query_compiler=self._query_compiler.getitem_row_array(key)
+                )
+            else:
+                return DataFrame(columns=self.columns)
         else:
             if any(k not in self.columns for k in key):
                 raise KeyError(

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4670,6 +4670,35 @@ class TestDFPartTwo:
             pd_col = pandas_df[key]
             df_equals(pd_col, modin_col)
 
+    def test_getitem_empty_mask(self):
+        # modin-project/modin#517
+        modin_frames = []
+        pandas_frames = []
+        data1 = np.random.randint(0, 100, size=(100, 4))
+        mdf1 = pd.DataFrame(data1, columns=list("ABCD"))
+        pdf1 = pandas.DataFrame(data1, columns=list("ABCD"))
+        modin_frames.append(mdf1)
+        pandas_frames.append(pdf1)
+
+        data2 = np.random.randint(0, 100, size=(100, 4))
+        mdf2 = pd.DataFrame(data2, columns=list("ABCD"))
+        pdf2 = pandas.DataFrame(data2, columns=list("ABCD"))
+        modin_frames.append(mdf2)
+        pandas_frames.append(pdf2)
+
+        data3 = np.random.randint(0, 100, size=(100, 4))
+        mdf3 = pd.DataFrame(data3, columns=list("ABCD"))
+        pdf3 = pandas.DataFrame(data3, columns=list("ABCD"))
+        modin_frames.append(mdf3)
+        pandas_frames.append(pdf3)
+
+        modin_data = pd.concat(modin_frames)
+        pandas_data = pandas.concat(pandas_frames)
+        df_equals(
+            modin_data[[False for _ in modin_data.index]],
+            pandas_data[[False for _ in modin_data.index]],
+        )
+
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test___getattr__(self, request, data):
         modin_df = pd.DataFrame(data)


### PR DESCRIPTION
* Resolves #517
* No longer trigger compute with an empty mask
* Add tests

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
