### PR TITLE
Change `QueryCompiler.view` to use index-based lookup

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2408,9 +2408,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
             np.arange(len(self.columns)), index=self.columns
         )
         if index is not None:
-            index_map_series = index_map_series.reindex(index)
+            index_map_series = index_map_series.iloc[index]
         if columns is not None:
-            column_map_series = column_map_series.reindex(columns)
+            column_map_series = column_map_series.iloc[columns]
         return PandasQueryCompilerView(
             self.data,
             index_map_series.index,

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -326,17 +326,17 @@ class _LocIndexer(_LocationIndexerBase):
                 row_loc = [pandas.to_datetime(row_loc[0])]
 
         if isinstance(row_loc, slice):
-            row_lookup = self.qc.index.to_series().loc[row_loc].values
+            row_lookup = self.qc.index.get_indexer_for(self.qc.index[row_loc])
         elif isinstance(self.qc.index, pandas.MultiIndex):
-            row_lookup = self.qc.index[self.qc.index.get_locs(row_loc)]
+            row_lookup = self.qc.index.get_locs(row_loc)
         else:
-            row_lookup = self.qc.index[self.qc.index.get_indexer_for(row_loc)]
+            row_lookup = self.qc.index.get_indexer_for(row_loc)
         if isinstance(col_loc, slice):
-            col_lookup = self.qc.columns.to_series().loc[col_loc].values
+            col_lookup = self.qc.columns.get_indexer_for(self.qc.columns[col_loc])
         elif isinstance(self.qc.columns, pandas.MultiIndex):
-            col_lookup = self.qc.columns[self.qc.columns.get_locs(col_loc)]
+            col_lookup = self.qc.columns.get_locs(col_loc)
         else:
-            col_lookup = self.qc.columns[self.qc.columns.get_indexer_for(col_loc)]
+            col_lookup = self.qc.columns.get_indexer_for(col_loc)
         return row_lookup, col_lookup
 
 
@@ -361,8 +361,8 @@ class _iLocIndexer(_LocationIndexerBase):
         super(_iLocIndexer, self).__setitem__(row_lookup, col_lookup, item)
 
     def _compute_lookup(self, row_loc, col_loc) -> Tuple[pandas.Index, pandas.Index]:
-        row_lookup = self.qc.index.to_series().iloc[row_loc].index
-        col_lookup = self.qc.columns.to_series().iloc[col_loc].index
+        row_lookup = row_loc
+        col_lookup = col_loc
         return row_lookup, col_lookup
 
     def _check_dtypes(self, locator):

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -224,9 +224,7 @@ class _LocationIndexerBase(object):
     def _write_items(self, row_lookup, col_lookup, item):
         """Perform remote write and replace blocks.
         """
-        row_numeric_idx = self.qc.global_idx_to_numeric_idx("row", row_lookup)
-        col_numeric_idx = self.qc.global_idx_to_numeric_idx("col", col_lookup)
-        self.qc.write_items(row_numeric_idx, col_numeric_idx, item)
+        self.qc.write_items(row_lookup, col_lookup, item)
 
 
 class _LocIndexer(_LocationIndexerBase):
@@ -326,13 +324,13 @@ class _LocIndexer(_LocationIndexerBase):
                 row_loc = [pandas.to_datetime(row_loc[0])]
 
         if isinstance(row_loc, slice):
-            row_lookup = self.qc.index.get_indexer_for(self.qc.index[row_loc])
+            row_lookup = self.qc.index.get_indexer_for(self.qc.index.to_series().loc[row_loc])
         elif isinstance(self.qc.index, pandas.MultiIndex):
             row_lookup = self.qc.index.get_locs(row_loc)
         else:
             row_lookup = self.qc.index.get_indexer_for(row_loc)
         if isinstance(col_loc, slice):
-            col_lookup = self.qc.columns.get_indexer_for(self.qc.columns[col_loc])
+            col_lookup = self.qc.columns.get_indexer_for(self.qc.columns.to_series().loc[col_loc])
         elif isinstance(self.qc.columns, pandas.MultiIndex):
             col_lookup = self.qc.columns.get_locs(col_loc)
         else:
@@ -361,8 +359,8 @@ class _iLocIndexer(_LocationIndexerBase):
         super(_iLocIndexer, self).__setitem__(row_lookup, col_lookup, item)
 
     def _compute_lookup(self, row_loc, col_loc) -> Tuple[pandas.Index, pandas.Index]:
-        row_lookup = row_loc
-        col_lookup = col_loc
+        row_lookup = pandas.RangeIndex(len(self.qc.index)).to_series().iloc[row_loc].index
+        col_lookup = pandas.RangeIndex(len(self.qc.columns)).to_series().iloc[col_loc].index
         return row_lookup, col_lookup
 
     def _check_dtypes(self, locator):

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -324,13 +324,17 @@ class _LocIndexer(_LocationIndexerBase):
                 row_loc = [pandas.to_datetime(row_loc[0])]
 
         if isinstance(row_loc, slice):
-            row_lookup = self.qc.index.get_indexer_for(self.qc.index.to_series().loc[row_loc])
+            row_lookup = self.qc.index.get_indexer_for(
+                self.qc.index.to_series().loc[row_loc]
+            )
         elif isinstance(self.qc.index, pandas.MultiIndex):
             row_lookup = self.qc.index.get_locs(row_loc)
         else:
             row_lookup = self.qc.index.get_indexer_for(row_loc)
         if isinstance(col_loc, slice):
-            col_lookup = self.qc.columns.get_indexer_for(self.qc.columns.to_series().loc[col_loc])
+            col_lookup = self.qc.columns.get_indexer_for(
+                self.qc.columns.to_series().loc[col_loc]
+            )
         elif isinstance(self.qc.columns, pandas.MultiIndex):
             col_lookup = self.qc.columns.get_locs(col_loc)
         else:
@@ -359,8 +363,12 @@ class _iLocIndexer(_LocationIndexerBase):
         super(_iLocIndexer, self).__setitem__(row_lookup, col_lookup, item)
 
     def _compute_lookup(self, row_loc, col_loc) -> Tuple[pandas.Index, pandas.Index]:
-        row_lookup = pandas.RangeIndex(len(self.qc.index)).to_series().iloc[row_loc].index
-        col_lookup = pandas.RangeIndex(len(self.qc.columns)).to_series().iloc[col_loc].index
+        row_lookup = (
+            pandas.RangeIndex(len(self.qc.index)).to_series().iloc[row_loc].index
+        )
+        col_lookup = (
+            pandas.RangeIndex(len(self.qc.columns)).to_series().iloc[col_loc].index
+        )
         return row_lookup, col_lookup
 
     def _check_dtypes(self, locator):

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -2524,6 +2524,19 @@ class TestDFPartOne:
         pandas_df_cp.index = [str(i) for i in pandas_df_cp.index]
         df_equals(modin_df_cp.index, pandas_df_cp.index)
 
+    @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+    def test_indexing_duplicate_axis(self, data):
+        modin_df = pd.DataFrame(data)
+        pandas_df = pandas.DataFrame(data)
+        modin_df.index = pandas_df.index = [i // 3 for i in range(len(modin_df))]
+        assert any(modin_df.index.duplicated())
+        assert any(pandas_df.index.duplicated())
+
+        df_equals(modin_df.iloc[0], pandas_df.iloc[0])
+        df_equals(modin_df.loc[0], pandas_df.loc[0])
+        df_equals(modin_df.iloc[0, 0:4], pandas_df.iloc[0, 0:4])
+        df_equals(modin_df.loc[0, modin_df.columns[0:4]], pandas_df.loc[0, pandas_df.columns[0:4]])
+
     def test_info(self):
         data = test_data_values[0]
         with pytest.warns(UserWarning):

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -2535,7 +2535,10 @@ class TestDFPartOne:
         df_equals(modin_df.iloc[0], pandas_df.iloc[0])
         df_equals(modin_df.loc[0], pandas_df.loc[0])
         df_equals(modin_df.iloc[0, 0:4], pandas_df.iloc[0, 0:4])
-        df_equals(modin_df.loc[0, modin_df.columns[0:4]], pandas_df.loc[0, pandas_df.columns[0:4]])
+        df_equals(
+            modin_df.loc[0, modin_df.columns[0:4]],
+            pandas_df.loc[0, pandas_df.columns[0:4]],
+        )
 
     def test_info(self):
         data = test_data_values[0]


### PR DESCRIPTION
* Resolves #524
* Changes `QueryCompiler.view` to use index-based lookup instead of
  label-based lookup.
* Update tests to include testing for duplicate index

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
