### PR TITLE
Allow `concat` to accept non-subscriptable objects as `keys` parameter

### DIFF
--- a/modin/pandas/concat.py
+++ b/modin/pandas/concat.py
@@ -96,10 +96,8 @@ def concat(
     if keys is not None:
         objs = [objs[i] for i in range(min(len(objs), len(keys)))]
         new_idx_labels = {
-            keys[i]: objs[i].index if axis == 0 else objs[i].columns
-            for i in range(len(objs))
+            k: v.index if axis == 0 else v.columns for k, v in zip(keys, objs)
         }
-        print(new_idx_labels)
         tuples = [(k, o) for k, obj in new_idx_labels.items() for o in obj]
         new_idx = pandas.MultiIndex.from_tuples(tuples)
     else:

--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -2,8 +2,10 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import numpy as np
 import pytest
 import pandas
+
 import modin.pandas as pd
 from modin.pandas.utils import from_pandas, to_pandas
 
@@ -172,3 +174,15 @@ def test_ignore_index_concat():
         pd.concat([df, df2], ignore_index=True),
         pandas.concat([df, df2], ignore_index=True),
     )
+
+
+def test_concat_non_subscriptable_keys():
+    frame_data = np.random.randint(0, 100, size=(2 ** 10, 2 ** 6))
+    df = pd.DataFrame(frame_data).add_prefix("col")
+    pdf = pandas.DataFrame(frame_data).add_prefix("col")
+
+    modin_dict = {"c": df.copy(), "b": df.copy()}
+    pandas_dict = {"c": pdf.copy(), "b": pdf.copy()}
+    modin_result = pd.concat(modin_dict.values(), keys=modin_dict.keys())
+    pandas_result = pandas.concat(pandas_dict.values(), keys=pandas_dict.keys())
+    modin_df_equals_pandas(modin_result, pandas_result)


### PR DESCRIPTION
* Resolves #557
* Zips the `keys` and `objs` parameters together to determine index instead of accessing via index
* Adds test to validate new behavior

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
