### PR TITLE
Fixes the setitem read-only error

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1983,6 +1983,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
 
         def setitem(df, internal_indices=[]):
+            df = df.copy()
             if len(internal_indices) == 1:
                 if axis == 0:
                     df[df.columns[internal_indices[0]]] = value

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1983,7 +1983,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
 
         def setitem(df, internal_indices=[]):
-            df = df.copy()
+            # We have this try-except block because there are sometimes that
+            # arrow throws a ValueError that the partitions are read-only while
+            # other times there is no error. Thus, we check with an identity
+            # function to make sure that the partition is not read-only.
+            try:
+                df.iloc[0, 0] = df.iloc[0, 0]
+            except ValueError:
+                df = df.copy()
             if len(internal_indices) == 1:
                 if axis == 0:
                     df[df.columns[internal_indices[0]]] = value


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Makes a copy of the internal partition dataframe so that we do not modify the internal partition in ray when we update the dataframe.

## Related issue number

#525 

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
