### PR TITLE
Add warning when using the constructor of DataFrame and Series

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -61,7 +61,10 @@ class DataFrame(BasePandasDataset):
             if isinstance(data, Series) and data.name is None:
                 self.columns = [0]
         # Check type of data and use appropriate constructor
-        elif data is not None or query_compiler is None:
+        elif query_compiler is None:
+            warnings.warn(
+                "Distributing {} object. This may take some time.".format(type(data))
+            )
             pandas_df = pandas.DataFrame(
                 data=data, index=index, columns=columns, dtype=dtype, copy=copy
             )

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas
 from pandas.core.dtypes.common import is_dict_like, is_list_like, is_scalar
 import sys
+import warnings
 
 from .base import BasePandasDataset
 from .iterator import PartitionIterator
@@ -31,6 +32,9 @@ class Series(BasePandasDataset):
             series_oids ([ObjectID]): The list of remote Series objects.
         """
         if query_compiler is None:
+            warnings.warn(
+                "Distributing {} object. This may take some time.".format(type(data))
+            )
             if name is None:
                 name = "__reduced__"
             query_compiler = from_pandas(


### PR DESCRIPTION
* Warns user that using the constructor to distribute a large object can
  take some time.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
