### PR TITLE
Fix support for `level` parameter in groupby

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -40,10 +40,14 @@ class DataFrameGroupBy(object):
         self._index = self._query_compiler.index
         self._columns = self._query_compiler.columns
         self._by = by
-        # This tells us whether or not there are multiple columns/rows in the groupby
-        self._is_multi_by = all(obj in self._df for obj in self._by) and axis == 0
+        if level is None:
+            # This tells us whether or not there are multiple columns/rows in the groupby
+            self._is_multi_by = all(obj in self._df for obj in self._by) and axis == 0
+        else:
+            self._is_multi_by = False
         self._level = level
         self._kwargs = {
+            "level": level,
             "sort": sort,
             "as_index": as_index,
             "group_keys": group_keys,
@@ -410,7 +414,7 @@ class DataFrameGroupBy(object):
         assert callable(f), "'{0}' object is not callable".format(type(f))
         from .dataframe import DataFrame
 
-        if self._is_multi_by:
+        if self._is_multi_by or self._level is not None:
             return self._default_to_pandas(f, **kwargs)
         # For aggregations, pandas behavior does this for the result.
         # For other operations it does not, so we wait until there is an aggregation to

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -804,7 +804,7 @@ def test_groupby_on_index_values_with_loop():
 
 
 def test_groupby_multiindex():
-    frame_data = np.random.randint(0, 100, size=(2**6, 2**4))
+    frame_data = np.random.randint(0, 100, size=(2 ** 6, 2 ** 4))
     modin_df = pd.DataFrame(frame_data)
     new_columns = pandas.MultiIndex.from_tuples(
         [(i // 4, i // 2, i) for i in modin_df.columns]

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -801,3 +801,14 @@ def test_groupby_on_index_values_with_loop():
 
     for k in modin_dict:
         ray_df_equals_pandas(modin_dict[k], pandas_dict[k])
+
+
+def test_groupby_multiindex():
+    frame_data = np.random.randint(0, 100, size=(2**6, 2**4))
+    modin_df = pd.DataFrame(frame_data)
+    new_columns = pandas.MultiIndex.from_tuples(
+        [(i // 4, i // 2, i) for i in modin_df.columns]
+    )
+    modin_df.columns = new_columns
+    with pytest.warns(UserWarning):
+        modin_df.groupby(level=0).sum()


### PR DESCRIPTION
* Resolves #574
* Defaults to pandas for `level` parameter
* Fixes cases where `by` is not set to enable better edge-case handling

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
