### PR TITLE
Fix single-column DataFrame index on MapReduce operations

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -49,7 +49,9 @@ class Series(BasePandasDataset):
                     )
                 )
             )._query_compiler
-        if len(query_compiler.index) == 1 and query_compiler.index[0] == "__reduced__":
+        if len(query_compiler.columns) != 1 or (
+            len(query_compiler.index) == 1 and query_compiler.index[0] == "__reduced__"
+        ):
             query_compiler = query_compiler.transpose()
         self._query_compiler = query_compiler
 

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -45,7 +45,7 @@ class Series(BasePandasDataset):
                     )
                 )
             )._query_compiler
-        if len(query_compiler.columns) != 1:
+        if len(query_compiler.index) == 1 and query_compiler.index[0] == "__reduced__":
             query_compiler = query_compiler.transpose()
         self._query_compiler = query_compiler
 

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4415,6 +4415,13 @@ class TestDFPartTwo:
             )
             df_equals(modin_result, pandas_result)
 
+    @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+    def test_sum_single_column(self, data):
+        modin_df = pd.DataFrame(data).iloc[:, [0]]
+        pandas_df = pandas.DataFrame(data).iloc[:, [0]]
+        df_equals(modin_df.sum(), pandas_df.sum())
+        df_equals(modin_df.sum(axis=1), pandas_df.sum(axis=1))
+
     def test_swapaxes(self):
         data = test_data_values[0]
         with pytest.warns(UserWarning):


### PR DESCRIPTION
* Resolves #579
* Adds a check in the constructor for the index
* Sometimes when we pass a QueryCompiler object to the constructor, it's
  not oriented correctly. We have to transpose the data if we want to
  ensure it is correct. This corrects the check for whether or not we
  need to transpose to be more correct and robust.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
