### PR TITLE
Fix drop after transpose

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2012,6 +2012,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         Returns:
             A new QueryCompiler.
         """
+        if self._is_transposed:
+            return self.transpose().drop(index=columns, columns=index).transpose()
         if index is None:
             new_data = self.data
             new_index = self.index

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1618,6 +1618,22 @@ class TestDFPartOne:
         with pytest.raises(ValueError):
             modin_df.drop(axis=1)
 
+    @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+    def test_drop_transpose(self, data):
+        modin_df = pd.DataFrame(data)
+        pandas_df = pandas.DataFrame(data)
+        modin_result = modin_df.T.drop(columns=[0, 1, 2])
+        pandas_result = pandas_df.T.drop(columns=[0, 1, 2])
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.T.drop(index=["col3", "col1"])
+        pandas_result = pandas_df.T.drop(index=["col3", "col1"])
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.T.drop(columns=[0, 1, 2], index=["col3", "col1"])
+        pandas_result = pandas_df.T.drop(columns=[0, 1, 2], index=["col3", "col1"])
+        df_equals(modin_result, pandas_result)
+
     def test_droplevel(self):
         df = (
             pd.DataFrame([[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]])


### PR DESCRIPTION
* Resolves #581
* Adds a clause that avoids extra computation by transposing back and swapping
  `columns` and `index` parameters, then transposing back

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
