### PR TITLE
Add support for concat with empty DataFrames and new Series

### DIFF
--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -8,6 +8,7 @@ import pandas
 
 import modin.pandas as pd
 from modin.pandas.utils import from_pandas, to_pandas
+from .utils import df_equals
 
 pd.DEFAULT_NPARTITIONS = 4
 
@@ -186,3 +187,24 @@ def test_concat_non_subscriptable_keys():
     modin_result = pd.concat(modin_dict.values(), keys=modin_dict.keys())
     pandas_result = pandas.concat(pandas_dict.values(), keys=pandas_dict.keys())
     modin_df_equals_pandas(modin_result, pandas_result)
+
+
+def test_concat_series_only():
+    modin_series = pd.Series(list(range(1000)))
+    pandas_series = pandas.Series(list(range(1000)))
+
+    df_equals(
+        pd.concat([modin_series, modin_series]),
+        pandas.concat([pandas_series, pandas_series]),
+    )
+
+
+def test_concat_with_empty_frame():
+    modin_empty_df = pd.DataFrame()
+    pandas_empty_df = pandas.DataFrame()
+    modin_row = pd.Series({0: "a", 1: "b"})
+    pandas_row = pandas.Series({0: "a", 1: "b"})
+    df_equals(
+        pd.concat([modin_empty_df, modin_row]),
+        pandas.concat([pandas_empty_df, pandas_row]),
+    )


### PR DESCRIPTION
* Resolves #562
* Adds support for empty DataFrames in concat
* Adds support for Modin distributed Series in concat
* Cleans up concat.py
* Add tests for concat

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
