### PR TITLE
Fix `astype` with `"category"` as the type passed

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1103,14 +1103,20 @@ class PandasQueryCompiler(BaseQueryCompiler):
         new_dtypes = self.dtypes.copy()
         for i, column in enumerate(columns):
             dtype = col_dtypes[column]
-            if dtype != self.dtypes[column]:
+            if (
+                not isinstance(dtype, type(self.dtypes[column]))
+                or dtype != self.dtypes[column]
+            ):
                 # Only add dtype only if different
                 if dtype in dtype_indices.keys():
                     dtype_indices[dtype].append(numeric_indices[i])
                 else:
                     dtype_indices[dtype] = [numeric_indices[i]]
                 # Update the new dtype series to the proper pandas dtype
-                new_dtype = np.dtype(dtype)
+                try:
+                    new_dtype = np.dtype(dtype)
+                except TypeError:
+                    new_dtype = dtype
                 if dtype != np.int32 and new_dtype == np.int32:
                     new_dtype = np.dtype("int64")
                 elif dtype != np.float32 and new_dtype == np.float32:

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1063,6 +1063,10 @@ class TestDFPartOne:
         expected_df_casted = expected_df.astype(str)
         df_equals(modin_df_casted, expected_df_casted)
 
+        modin_df_casted = modin_df.astype("category")
+        expected_df_casted = expected_df.astype("category")
+        df_equals(modin_df_casted, expected_df_casted)
+
         dtype_dict = {"A": np.int32, "B": np.int64, "C": str}
         modin_df_casted = modin_df.astype(dtype_dict)
         expected_df_casted = expected_df.astype(dtype_dict)


### PR DESCRIPTION
* Resolves #586
* If it is not a numpy dtype, it will throw a `ValueError`, which is
  caught and we then just use the value passed. We can pass a string to
  the compute kernels.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
