### PR TITLE
Fix Series.__getitem__ for bool indexers and slices

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 
 import numpy as np
 import pandas
+from pandas.core.common import is_bool_indexer
 from pandas.core.dtypes.common import is_dict_like, is_list_like, is_scalar
 import sys
 import warnings
@@ -154,14 +155,23 @@ class Series(BasePandasDataset):
         return self.floordiv(right)
 
     def __getitem__(self, key):
-        if (
-            key in self.keys()
-            or is_list_like(key)
-            and all(k in self.keys() for k in key)
-        ):
-            return self.loc[key]
+        if isinstance(key, Series) and key.dtype == np.bool:
+            # This ends up being significantly faster than looping through and getting
+            # each item individually.
+            key = key._to_pandas()
+        if is_bool_indexer(key):
+            return self.loc[self.index[key]]
         else:
-            return self.iloc[key]
+            try:
+                if (
+                    key in self.keys()
+                    or is_list_like(key)
+                    and all(k in self.keys() for k in key)
+                ):
+                    return self.loc[key]
+            except TypeError:
+                pass
+        return self.iloc[key]
 
     def __int__(self):
         return int(self.squeeze())

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -162,11 +162,13 @@ class Series(BasePandasDataset):
         if is_bool_indexer(key):
             return self.loc[self.index[key]]
         else:
+            # The check for whether or not `key` is in `keys()` will throw a TypeError
+            # if the object is not hashable. When that happens, we just use the `iloc`.
             try:
                 if (
-                    key in self.keys()
-                    or is_list_like(key)
+                    is_list_like(key)
                     and all(k in self.keys() for k in key)
+                    or key in self.keys()
                 ):
                     return self.loc[key]
             except TypeError:

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -273,6 +273,10 @@ def test___getitem__(data):
     df_equals(
         modin_series[modin_series.index[-1]], pandas_series[pandas_series.index[-1]]
     )
+    modin_series = pd.Series(list(range(1000)))
+    pandas_series = pandas.Series(list(range(1000)))
+    df_equals(modin_series[:30], pandas_series[:30])
+    df_equals(modin_series[modin_series > 500], pandas_series[pandas_series > 500])
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)


### PR DESCRIPTION
* Resolves #590
* For Series boolean indexers, we convert to pandas first because it is
  faster than looping through.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
