### PR TITLE
Remove unneeded duplicate code in child class of PandasQueryCompiler

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2523,24 +2523,6 @@ class PandasQueryCompilerView(PandasQueryCompiler):
         """Return parent object when getting the constructor."""
         return PandasQueryCompiler
 
-    _dtype_cache = None
-
-    def _get_dtype(self):
-        """Override the parent on this to avoid getting the wrong dtypes"""
-        if self._dtype_cache is None:
-            map_func = self._prepare_method(lambda df: df.dtypes)
-
-            def dtype_builder(df):
-                return df.apply(lambda row: find_common_type(row.values), axis=0)
-
-            self._dtype_cache = self._full_reduce(0, map_func, dtype_builder)
-            self._dtype_cache.index = self.columns
-        elif not self._dtype_cache.index.equals(self.columns):
-            self._dtype_cache = self._dtype_cache.reindex(self.columns)
-        return self._dtype_cache
-
-    dtypes = property(_get_dtype)
-
     def _get_data(self) -> BaseFrameManager:
         """Perform the map step
 


### PR DESCRIPTION
* Resolves #592
* PandasQueryCompilerView does not need a different way of determining
  the `dtypes` of a View object, the code was duplicated

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
