### PR TITLE
Add parallelism parameter to read_sql() #455

### DIFF
--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -275,6 +275,12 @@ class ExperimentalBaseFactory(BaseFactory):
                         "Distributed read_sql() was only implemented for Ray engine."
                     )
                 del kwargs["upper_bound"]
+            if "max_sessions" in kwargs:
+                if kwargs["max_sessions"] is not None:
+                    warnings.warn(
+                        "Distributed read_sql() was only implemented for Ray engine."
+                    )
+                del kwargs["max_sessions"]
         return cls.io_cls.read_sql(**kwargs)
 
 

--- a/modin/experimental/engines/pandas_on_ray/io_exp.py
+++ b/modin/experimental/engines/pandas_on_ray/io_exp.py
@@ -22,6 +22,7 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
         partition_column=None,
         lower_bound=None,
         upper_bound=None,
+        max_sessions=None,
     ):
         """ Read SQL query or database table into a DataFrame.
 
@@ -49,6 +50,7 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
             partition_column: column used to share the data between the workers (MUST be a INTEGER column)
             lower_bound: the minimum value to be requested from the partition_column
             upper_bound: the maximum value to be requested from the partition_column
+            max_sessions: the maximum number of simultaneous connections allowed to use
 
         Returns:
             Pandas Dataframe
@@ -69,7 +71,7 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
             )
         #  starts the distributed alternative
         cols_names, query = get_query_info(sql, con, partition_column)
-        num_parts = cls.frame_mgr_cls._compute_num_partitions()
+        num_parts = min(cls.frame_mgr_cls._compute_num_partitions(), max_sessions)
         num_splits = min(len(cols_names), num_parts)
         diff = (upper_bound - lower_bound) + 1
         min_size = diff // num_parts

--- a/modin/experimental/pandas/io_exp.py
+++ b/modin/experimental/pandas/io_exp.py
@@ -16,6 +16,7 @@ def read_sql(
     partition_column=None,
     lower_bound=None,
     upper_bound=None,
+    max_sessions=None,
 ):
     """ Read SQL query or database table into a DataFrame.
 
@@ -43,6 +44,7 @@ def read_sql(
         partition_column: column used to share the data between the workers (MUST be a INTEGER column)
         lower_bound: the minimum value to be requested from the partition_column
         upper_bound: the maximum value to be requested from the partition_column
+        max_sessions: the maximum number of simultaneous connections allowed to use
 
     Returns:
         Pandas Dataframe


### PR DESCRIPTION
## What do these changes do?

Add parameter to limit parallel read_sql connections to the minimum of max_sessions, now it is only limited in cpu count.

## Related issue number

#455 

- [X] passes `flake8 modin`
- [X] passes `black --check modin`
- [ ] tests added and passing
