### PR TITLE
Fix indexing on empty_series

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3147,6 +3147,12 @@ class BasePandasDataset(object):
     def __ge__(self, other):
         return self.ge(other)
 
+    def __getitem__(self, key):
+        if len(self) == 0:
+            return self._default_to_pandas("__getitem__", key)
+        else:
+            return self.getitem(key)
+
     def __getstate__(self):
         return self._default_to_pandas("__getstate__")
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3151,7 +3151,7 @@ class BasePandasDataset(object):
         if len(self) == 0:
             return self._default_to_pandas("__getitem__", key)
         else:
-            return self.getitem(key)
+            return self._getitem(key)
 
     def __getstate__(self):
         return self._default_to_pandas("__getstate__")

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1796,7 +1796,7 @@ class DataFrame(BasePandasDataset):
             pandas.DataFrame.xs, key, axis=axis, level=level, drop_level=drop_level
         )
 
-    def getitem(self, key):
+    def _getitem(self, key):
         """Get the column specified by key for this DataFrame.
 
         Args:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1796,7 +1796,7 @@ class DataFrame(BasePandasDataset):
             pandas.DataFrame.xs, key, axis=axis, level=level, drop_level=drop_level
         )
 
-    def __getitem__(self, key):
+    def getitem(self, key):
         """Get the column specified by key for this DataFrame.
 
         Args:

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -154,7 +154,7 @@ class Series(BasePandasDataset):
     def __floordiv__(self, right):
         return self.floordiv(right)
 
-    def getitem(self, key):
+    def _getitem(self, key):
         if isinstance(key, Series) and key.dtype == np.bool:
             # This ends up being significantly faster than looping through and getting
             # each item individually.

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -154,7 +154,7 @@ class Series(BasePandasDataset):
     def __floordiv__(self, right):
         return self.floordiv(right)
 
-    def __getitem__(self, key):
+    def getitem(self, key):
         if isinstance(key, Series) and key.dtype == np.bool:
             # This ends up being significantly faster than looping through and getting
             # each item individually.

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4718,17 +4718,19 @@ class TestDFPartTwo:
             df.xs("mammal")
 
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-    def test___getitem__(self, request, data):
+    def test___getitem__(self, data):
         modin_df = pd.DataFrame(data)
         pandas_df = pandas.DataFrame(data)
 
-        if "empty_data" not in request.node.name:
-            key = modin_df.columns[0]
-            modin_col = modin_df.__getitem__(key)
-            assert isinstance(modin_col, pd.Series)
+        key = modin_df.columns[0]
+        modin_col = modin_df.__getitem__(key)
+        assert isinstance(modin_col, pd.Series)
 
-            pd_col = pandas_df[key]
-            df_equals(pd_col, modin_col)
+        pd_col = pandas_df[key]
+        df_equals(pd_col, modin_col)
+
+        # Test empty
+        df_equals(pd.DataFrame([])[:10], pandas.DataFrame([])[:10])
 
     def test_getitem_empty_mask(self):
         # modin-project/modin#517

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -281,6 +281,7 @@ def test___getitem__(data):
     # Test empty series
     df_equals(pd.Series([])[:30], pandas.Series([])[:30])
 
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test___gt__(data):
     modin_series, pandas_series = create_test_series(data)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -278,6 +278,8 @@ def test___getitem__(data):
     df_equals(modin_series[:30], pandas_series[:30])
     df_equals(modin_series[modin_series > 500], pandas_series[pandas_series > 500])
 
+    # Test empty series
+    df_equals(pd.Series([])[:30], pandas.Series([])[:30])
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test___gt__(data):


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Sets `__getitem__` to default to pandas if the dataframe is empty

## Related issue number

#595 

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
