### PR TITLE
Correctly apply Series functions element-wise for correct cases

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -299,11 +299,9 @@ class BasePandasDataset(object):
                 result = self._aggregate(func, _axis=axis, *args, **kwargs)
             except TypeError:
                 pass
-
         if result is None:
             kwargs.pop("is_transform", None)
             return self.apply(func, axis=axis, args=args, **kwargs)
-
         return result
 
     def _aggregate(self, arg, *args, **kwargs):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -385,7 +385,7 @@ class Series(BasePandasDataset):
         # type.
         return_type = type(
             getattr(getattr(pandas, self.__name__)(index=self.index), apply_func)(
-                func, convert_dtype=convert_dtype, *args, **kwds
+                func, *args, **kwds
             )
         ).__name__
         if return_type not in ["DataFrame", "Series"]:

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -44,6 +44,10 @@ from .utils import (
     int_arg_values,
 )
 
+# TODO remove once modin-project/modin#469 is resolved
+agg_func_keys.remove("str")
+agg_func_values.remove(str)
+
 pd.DEFAULT_NPARTITIONS = 4
 
 # Force matplotlib to not use any Xwindows backend.

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -138,6 +138,7 @@ query_func_values = list(query_func.values())
 agg_func = {
     "sum": "sum",
     "df sum": lambda df: df.sum(),
+    "str": str,
     "sum mean": ["sum", "mean"],
     "sum sum": ["sum", "sum"],
     "sum df sum": ["sum", lambda df: df.sum()],


### PR DESCRIPTION
* Resolves #597
* Mimic the error handling/cases of pandas
* Add checks for UDFs which use args/kwargs
* Add `str` to the tests for `apply`
* Remove those from `DataFrame.apply` tests because of #469

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
