### PR TITLE
Correctly compute `reindex` after a transpose

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1712,7 +1712,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
         kwargs["ascending"] = ascending
 
         def sort_index_builder(df, **kwargs):
-            print(df)
             if axis:
                 df.columns = index
             else:

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2586,7 +2586,7 @@ class BasePandasDataset(object):
         # Currently, sort_values will just reindex based on the sorted values.
         # TODO create a more efficient way to sort
         if axis == 0:
-            broadcast_value_dict = {col: self[col] for col in by}
+            broadcast_value_dict = {col: self[col]._to_pandas() for col in by}
             broadcast_values = pandas.DataFrame(broadcast_value_dict, index=self.index)
             new_index = broadcast_values.sort_values(
                 by=by,

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -3565,24 +3565,24 @@ class TestDFPartTwo:
         modin_df = pd.DataFrame(frame_data)
 
         df_equals(modin_df.reindex([0, 3, 2, 1]), pandas_df.reindex([0, 3, 2, 1]))
-
         df_equals(modin_df.reindex([0, 6, 2]), pandas_df.reindex([0, 6, 2]))
-
         df_equals(
             modin_df.reindex(["col1", "col3", "col4", "col2"], axis=1),
             pandas_df.reindex(["col1", "col3", "col4", "col2"], axis=1),
         )
-
         df_equals(
             modin_df.reindex(["col1", "col7", "col4", "col8"], axis=1),
             pandas_df.reindex(["col1", "col7", "col4", "col8"], axis=1),
         )
-
         df_equals(
             modin_df.reindex(index=[0, 1, 5], columns=["col1", "col7", "col4", "col8"]),
             pandas_df.reindex(
                 index=[0, 1, 5], columns=["col1", "col7", "col4", "col8"]
             ),
+        )
+        df_equals(
+            modin_df.T.reindex(["col1", "col7", "col4", "col8"], axis=0),
+            pandas_df.T.reindex(["col1", "col7", "col4", "col8"], axis=0),
         )
 
     def test_reindex_axis(self):


### PR DESCRIPTION
* Resolves #599
* Adds a clause similar to other functions to perform the operation
  across the opposite axis
* Create a parameter for `_is_transposed` flag in the constructor
* Simplify `transpose` logic internally

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
