### PR TITLE
Fix dtype checking if other is a scalar

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -123,8 +123,11 @@ class BasePandasDataset(object):
                     else len(self._query_compiler.columns)
                 )
             ]
-        # Do dtype checking
-        if numeric_only:
+        # Do dtype checking.
+        if is_scalar(other):
+            # We skip dtype checking if other is a scalar.
+            continue
+        elif numeric_only:
             if not all(
                 is_numeric_dtype(self_dtype) and is_numeric_dtype(other_dtype)
                 for self_dtype, other_dtype in zip(self._get_dtypes(), other_dtypes)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -91,6 +91,9 @@ class BasePandasDataset(object):
         comparison_dtypes_only=False,
     ):
         """Helper method to check validity of other in inter-df operations"""
+        # We skip dtype checking if the other is a scalar.
+        if is_scalar(other):
+            return other
         axis = self._get_axis_number(axis) if axis is not None else 1
         result = other
         if isinstance(other, BasePandasDataset):
@@ -124,10 +127,7 @@ class BasePandasDataset(object):
                 )
             ]
         # Do dtype checking.
-        if is_scalar(other):
-            # We skip dtype checking if other is a scalar.
-            continue
-        elif numeric_only:
+        if numeric_only:
             if not all(
                 is_numeric_dtype(self_dtype) and is_numeric_dtype(other_dtype)
                 for self_dtype, other_dtype in zip(self._get_dtypes(), other_dtypes)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -350,6 +350,15 @@ class TestDFPartOne:
             modin_result = getattr(modin_df, op)(4.0)
             df_equals(modin_result, pandas_result)
 
+        try:
+            pandas_result = getattr(pandas_df, op)("a")
+        except TypeError:
+            with pytest.raises(TypeError):
+                getattr(modin_df, op)("a")
+        else:
+            modin_result = getattr(modin_df, op)("a")
+            df_equals(modin_result, pandas_result)
+
         frame_data = {
             "{}_other".format(modin_df.columns[0]): [0, 2],
             modin_df.columns[0]: [0, 19],


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Removes the dtype checking if one of the objects being compared is a scalar

## Related issue number



- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
