### PR TITLE
Replace read_pandas with ParquetDataset to support predicate pushdown

### DIFF
--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -51,7 +51,10 @@ def _read_parquet_columns(path, columns, num_splits, kwargs):  # pragma: no cove
     """
     import pyarrow.parquet as pq
 
-    df = pq.read_pandas(path, columns=columns, **kwargs).to_pandas()
+    df = pq.ParquetDataset(path, **kwargs) \
+           .read(columns=columns) \
+           .to_pandas()
+
     # Append the length of the index here to build it externally
     return _split_result_for_readers(0, num_splits, df) + [len(df.index)]
 

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -51,9 +51,7 @@ def _read_parquet_columns(path, columns, num_splits, kwargs):  # pragma: no cove
     """
     import pyarrow.parquet as pq
 
-    df = pq.ParquetDataset(path, **kwargs) \
-           .read(columns=columns) \
-           .to_pandas()
+    df = pq.ParquetDataset(path, **kwargs).read(columns=columns).to_pandas()
 
     # Append the length of the index here to build it externally
     return _split_result_for_readers(0, num_splits, df) + [len(df.index)]


### PR DESCRIPTION
… on parquet

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The change allows you to use predicate pushdown with parquet with the use of filters kwarg.

## Related issue number
#636 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
