### PR TITLE
Fix Parquet reader for partitioned files

### DIFF
--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -159,7 +159,11 @@ class RayIO(BaseIO):
                 if dir_names:
                     partitioned_columns.add(dir_names[0].split("=")[0])
                 if files:
+                    # Metadata files, git files, .DSStore
+                    if files[0][0] == ".":
+                        continue
                     file_path = os.path.join(root, files[0])
+                    break
             partitioned_columns = list(partitioned_columns)
         else:
             directory = False

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -631,7 +631,11 @@ class RayIO(BaseIO):
 
         columns = kwargs.get("columns", None)
         if not columns:
-            empty_pd_df = pandas.read_hdf(path_or_buf, start=0, stop=0)
+            start = kwargs.pop("start", None)
+            stop = kwargs.pop("stop", None)
+            empty_pd_df = pandas.read_hdf(path_or_buf, start=0, stop=0, **kwargs)
+            kwargs["start"] = start
+            kwargs["stop"] = stop
             columns = empty_pd_df.columns
 
         num_partitions = cls.frame_mgr_cls._compute_num_partitions()

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -169,7 +169,12 @@ class RayIO(BaseIO):
             if directory:
                 # Path of the sample file that we will read to get the remaining
                 # columns.
-                pd = ParquetDataset(file_path)
+                from pyarrow import ArrowIOError
+
+                try:
+                    pd = ParquetDataset(file_path)
+                except ArrowIOError:
+                    pd = ParquetDataset(path)
                 column_names = pd.schema.names
             else:
                 pf = ParquetFile(path)

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -160,7 +160,6 @@ class RayIO(BaseIO):
                     partitioned_columns.add(dir_names[0].split("=")[0])
                 if files:
                     file_path = os.path.join(root, files[0])
-                    break
             partitioned_columns = list(partitioned_columns)
         else:
             directory = False

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -149,18 +149,22 @@ class RayIO(BaseIO):
 
         if os.path.isdir(path):
             directory = True
-            partitioned_columns = list(
-                set(  # noqa: C401
-                    column_value.split("=")[0]
-                    for (_, dir_names, _) in os.walk(path)
-                    for column_value in dir_names
-                )
-            )
+            partitioned_columns = set()
+            # We do a tree walk of the path directory because partitioned
+            # parquet directories have a unique column at each directory level.
+            # Thus, we can use os.walk(), which does a dfs search, to walk
+            # through the different columns that the data is partitioned on
+            for (root, dir_names, files) in os.walk(path):
+                if dir_names:
+                    partitioned_columns.add(dir_names[0].split("=")[0])
+            partitioned_columns = list(partitioned_columns)
         else:
             directory = False
 
         if not columns:
-            if os.path.isdir(path):
+            if directory:
+                # Path of the sample file that we will read to get the remaining
+                # columns.
                 pd = ParquetDataset(path)
                 column_names = pd.schema.names
             else:

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -50,9 +50,9 @@ def _read_parquet_columns(path, columns, num_splits, kwargs):  # pragma: no cove
             default Index.
     """
     import pyarrow.parquet as pq
+
     kwargs["use_pandas_metadata"] = True
     df = pq.read_table(path, columns=columns, **kwargs).to_pandas()
-
     # Append the length of the index here to build it externally
     return _split_result_for_readers(0, num_splits, df) + [len(df.index)]
 

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -50,8 +50,8 @@ def _read_parquet_columns(path, columns, num_splits, kwargs):  # pragma: no cove
             default Index.
     """
     import pyarrow.parquet as pq
-
-    df = pq.ParquetDataset(path, **kwargs).read(columns=columns).to_pandas()
+    kwargs["use_pandas_metadata"] = True
+    df = pq.read_table(path, columns=columns, **kwargs).to_pandas()
 
     # Append the length of the index here to build it externally
     return _split_result_for_readers(0, num_splits, df) + [len(df.index)]

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -53,6 +53,7 @@ def _read_parquet_columns(path, columns, num_splits, kwargs):  # pragma: no cove
 
     kwargs["use_pandas_metadata"] = True
     df = pq.read_table(path, columns=columns, **kwargs).to_pandas()
+    df = df[columns]
     # Append the length of the index here to build it externally
     return _split_result_for_readers(0, num_splits, df) + [len(df.index)]
 

--- a/modin/experimental/engines/pandas_on_ray/io_exp.py
+++ b/modin/experimental/engines/pandas_on_ray/io_exp.py
@@ -26,9 +26,15 @@ def _read_parquet_columns(path, columns, num_splits, kwargs):  # pragma: no cove
     """
     import pyarrow.parquet as pq
 
-    df = pq.ParquetDataset(path, **kwargs).read(columns=columns, use_pandas_metadata=True).to_pandas()
+    df = (
+        pq.ParquetDataset(path, **kwargs)
+        .read(columns=columns, use_pandas_metadata=True)
+        .to_pandas()
+    )
+    df = df[columns]
     # Append the length of the index here to build it externally
     return _split_result_for_readers(0, num_splits, df) + [len(df.index)]
+
 
 class ExperimentalPandasOnRayIO(PandasOnRayIO):
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
* Move `ParquetDataset` functionality to experimental
* Filter columns read in the partitions when there is at least one partition column
<!-- Please give a short brief about these changes. -->

## Related issue number
* Resolves #642 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
