### PR TITLE
Remove extraneous teardown module for parquet

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -147,11 +147,6 @@ def teardown_test_file(test_path):
         os.remove(test_path)
 
 
-def teardown_parquet_file():
-    if os.path.exists(TEST_PARQUET_FILENAME):
-        os.remove(TEST_PARQUET_FILENAME)
-
-
 @pytest.fixture
 def make_csv_file(delimiter=","):
     """Pytest fixture factory that makes temp csv files for testing.


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Remove extraneous teardown module


- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
