### PR TITLE
Initial ray autoscaler support

### DIFF
--- a/docs/using_modin.rst
+++ b/docs/using_modin.rst
@@ -56,11 +56,17 @@ If you would like to request a particular method be implemented, feel free to `o
 issue`_. Before you open an issue please make sure that someone else has not already
 requested that functionality.
 
-Using Modin on a Cluster
-------------------------
+Using Modin on a Cluster (experimental)
+---------------------------------------
 
-Modin can be run on a cluster, but the setup process is quite complex. We are working on
-a solution to make Modin run on a cluster with a simple setup. More on this coming soon!
+Modin is able to utilize Ray's built-in autoscaled cluster. However, this usage
+is still under heavy development. To launch a Ray autoscaled cluster using
+Amazon Web Service (AWS), you can use the file `examples/cluster/aws_example.yaml`
+as the config file when launching an autoscaled Ray cluster. For the commands,
+refer to the `autoscaler documentation`_.
+
+We will provide a sample config file for private servers and other cloud service
+providers as we continue to develop and improve Modin's cluster support.
 
 Advanced usage (experimental)
 -----------------------------
@@ -112,6 +118,7 @@ used to create the blog post.
 .. _`installation page`: http://modin.readthedocs.io/en/latest/installation.html
 .. _`currently supported methods`: http://modin.readthedocs.io/en/latest/pandas_supported.html
 .. _`open an issue`: http://github.com/modin-project/modin/issues
+.. _`autoscaler documentation`: https://ray.readthedocs.io/en/latest/autoscaling.html
 .. _`Ray's documentation`: https://ray.readthedocs.io/en/latest/api.html
 .. _`blog post`: https://rise.cs.berkeley.edu/blog/pandas-on-ray-early-lessons/
 .. _`Jupyter Notebook`: http://gist.github.com/devin-petersohn/f424d9fb5579a96507c709a36d487f24#file-pandas_on_ray_blog_post_0-ipynb

--- a/examples/cluster/aws_example.yaml
+++ b/examples/cluster/aws_example.yaml
@@ -1,0 +1,128 @@
+# An unique identifier for the head node and workers of this cluster.
+cluster_name: default
+
+# The minimum number of workers nodes to launch in addition to the head
+# node. This number should be >= 0.
+min_workers: 0
+
+# The maximum number of workers nodes to launch in addition to the head
+# node. This takes precedence over min_workers.
+max_workers: 5
+
+# The initial number of worker nodes to launch in addition to the head
+# node. When the cluster is first brought up (or when it is refreshed with a
+# subsequent `ray up`) this number of nodes will be started.
+initial_workers: 0
+
+# This executes all commands on all nodes in the docker container,
+# and opens all the necessary ports to support the Ray cluster.
+# Empty string means disabled.
+docker:
+    image: "" # e.g., tensorflow/tensorflow:1.5.0-py3
+    container_name: "" # e.g. ray_docker
+    run_options: []  # Extra options to pass into "docker run"
+
+    # Example of running a GPU head with CPU workers
+    # head_image: "tensorflow/tensorflow:1.13.1-py3"
+    # head_run_options:
+    #     - --runtime=nvidia
+
+    # worker_image: "ubuntu:18.04"
+    # worker_run_options: []
+
+# The autoscaler will scale up the cluster to this target fraction of resource
+# usage. For example, if a cluster of 10 nodes is 100% busy and
+# target_utilization is 0.8, it would resize the cluster to 13. This fraction
+# can be decreased to increase the aggressiveness of upscaling.
+# This value must be less than 1.0 for scaling to happen.
+target_utilization_fraction: 0.8
+
+# If a node is idle for this many minutes, it will be removed.
+idle_timeout_minutes: 5
+
+# Cloud-provider specific configuration.
+provider:
+    type: aws
+    region: us-west-1
+    # Availability zone(s), comma-separated, that nodes may be launched in.
+    # Nodes are currently spread between zones by a round-robin approach,
+    # however this implementation detail should not be relied upon.
+    availability_zone: us-west-1a,us-west-1b
+
+# How Ray will authenticate with newly launched nodes.
+auth:
+    ssh_user: ubuntu
+# By default Ray creates a new private keypair, but you can also use your own.
+# If you do so, make sure to also set "KeyName" in the head and worker node
+# configurations below.
+#    ssh_private_key: /path/to/your/key.pem
+
+# Provider-specific config for the head node, e.g. instance type. By default
+# Ray will auto-configure unspecified fields such as SubnetId and KeyName.
+# For more documentation on available fields, see:
+# http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
+head_node:
+    InstanceType: m5.large
+    ImageId: ami-09c2435df1137686f # Deep Learning AMI
+
+    # You can provision additional disk space with a conf as follows
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+              VolumeSize: 75
+
+    # Additional options in the boto docs.
+
+# Provider-specific config for worker nodes, e.g. instance type. By default
+# Ray will auto-configure unspecified fields such as SubnetId and KeyName.
+# For more documentation on available fields, see:
+# http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
+worker_nodes:
+    InstanceType: m5.large
+    ImageId: ami-09c2435df1137686f # Deep Learning AMI
+
+    # Run workers on spot by default. Comment this out to use on-demand.
+    InstanceMarketOptions:
+        MarketType: spot
+        # Additional options can be found in the boto docs, e.g.
+        #   SpotOptions:
+        #       MaxPrice: MAX_HOURLY_PRICE
+
+    # Additional options in the boto docs.
+
+# Files or directories to copy to the head and worker nodes. The format is a
+# dictionary from REMOTE_PATH: LOCAL_PATH, e.g.
+file_mounts: {
+#    "/path1/on/remote/machine": "/path1/on/local/machine",
+#    "/path2/on/remote/machine": "/path2/on/local/machine",
+}
+
+# List of commands that will be run before `setup_commands`. If docker is
+# enabled, these commands will run outside the container and before docker
+# is setup.
+initialization_commands: []
+
+# List of shell commands to run to set up nodes.
+setup_commands:
+    - pip install modin
+    # Consider uncommenting these if you also want to run apt-get commands during setup
+    # - sudo pkill -9 apt-get || true
+    # - sudo pkill -9 dpkg || true
+    # - sudo dpkg --configure -a
+
+# Custom commands that will be run on the head node after common setup.
+head_setup_commands:
+    - pip install boto3==1.4.8  # 1.4.8 adds InstanceMarketOptions
+
+# Custom commands that will be run on worker nodes after common setup.
+worker_setup_commands: []
+
+# Command to start ray on the head node. You don't need to change this.
+head_start_ray_commands:
+    - ray stop
+    - ulimit -n 65536; ray start --head --redis-port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+
+# Command to start ray on worker nodes. You don't need to change this.
+worker_start_ray_commands:
+    - ray stop
+    - ulimit -n 65536; ray start --redis-address=$RAY_HEAD_IP:6379 --object-manager-port=8076

--- a/examples/cluster/aws_example.yaml
+++ b/examples/cluster/aws_example.yaml
@@ -12,7 +12,7 @@ max_workers: 5
 # The initial number of worker nodes to launch in addition to the head
 # node. When the cluster is first brought up (or when it is refreshed with a
 # subsequent `ray up`) this number of nodes will be started.
-initial_workers: 3
+initial_workers: 2
 
 # This executes all commands on all nodes in the docker container,
 # and opens all the necessary ports to support the Ray cluster.
@@ -106,7 +106,7 @@ initialization_commands: []
 setup_commands:
     - pip install s3fs
     - pip install git+https://github.com/williamma12/modin.git@cluster
-    - echo 'export MODIN_REDIS_ADDRESS="localhost:6379"' >> ~/.bashrc
+    - echo 'export MODIN_RAY_CLUSTER=True' >> ~/.bashrc
     # Consider uncommenting these if you also want to run apt-get commands during setup
     # - sudo pkill -9 apt-get || true
     # - sudo pkill -9 dpkg || true
@@ -115,6 +115,8 @@ setup_commands:
 # Custom commands that will be run on the head node after common setup.
 head_setup_commands:
     - pip install boto3==1.4.8  # 1.4.8 adds InstanceMarketOptions
+    - echo 'export MODIN_REDIS_ADDRESS="localhost:6379"' >> ~/.bashrc
+    - echo 'export MODIN_OUT_OF_CORE="True"' >> ~/.bashrc
 
 # Custom commands that will be run on worker nodes after common setup.
 worker_setup_commands: []
@@ -122,9 +124,13 @@ worker_setup_commands: []
 # Command to start ray on the head node. You don't need to change this.
 head_start_ray_commands:
     - ray stop
-    - ulimit -n 65536; ray start --head --redis-port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml
+    - echo 'export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024}" /proc/meminfo)' >> ~/.bashrc
+    - echo 'export TMPDIR="$(dirname $(mktemp tmp.XXXXXXXXXX -ut))"' >> ~/.bashrc
+    - ulimit -n 65536; ray start --head --redis-port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml --object-store-memory=$MEMORY_STORE_SIZE --plasma-directory=$TMPDIR
 
 # Command to start ray on worker nodes. You don't need to change this.
 worker_start_ray_commands:
     - ray stop
-    - ulimit -n 65536; ray start --redis-address=$RAY_HEAD_IP:6379 --object-manager-port=8076
+    - echo 'export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024}" /proc/meminfo)' >> ~/.bashrc
+    - echo 'export TMPDIR="$(dirname $(mktemp tmp.XXXXXXXXXX -ut))"' >> ~/.bashrc
+    - ulimit -n 65536; ray start --redis-address=$RAY_HEAD_IP:6379 --object-manager-port=8076 --object-store-memory=$MEMORY_STORE_SIZE --plasma-directory=$TMPDIR

--- a/examples/cluster/aws_example.yaml
+++ b/examples/cluster/aws_example.yaml
@@ -12,7 +12,7 @@ max_workers: 5
 # The initial number of worker nodes to launch in addition to the head
 # node. When the cluster is first brought up (or when it is refreshed with a
 # subsequent `ray up`) this number of nodes will be started.
-initial_workers: 0
+initial_workers: 3
 
 # This executes all commands on all nodes in the docker container,
 # and opens all the necessary ports to support the Ray cluster.
@@ -104,7 +104,9 @@ initialization_commands: []
 
 # List of shell commands to run to set up nodes.
 setup_commands:
-    - pip install modin
+    - pip install s3fs
+    - pip install git+https://github.com/williamma12/modin.git@cluster
+    - echo 'export MODIN_REDIS_ADDRESS="localhost:6379"' >> ~/.bashrc
     # Consider uncommenting these if you also want to run apt-get commands during setup
     # - sudo pkill -9 apt-get || true
     # - sudo pkill -9 dpkg || true

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -966,17 +966,21 @@ class PandasQueryCompiler(BaseQueryCompiler):
         Return:
             A new QueryCompiler object with sum or prod of the object.
         """
+        print("PROCESSOR")
         axis = kwargs.get("axis", 0)
         min_count = kwargs.get("min_count", 0)
+        print("GOT KWARGS")
 
         def sum_prod_builder(df, **kwargs):
             return func(df, **kwargs)
 
-        builder = self._build_mapreduce_func(sum_prod_builder)
+        builder_func = self._build_mapreduce_func(sum_prod_builder, **kwargs)
+        print("FINISHED BUILDER FUNC")
         if min_count <= 1:
-            return self._full_reduce(axis, builder)
+            print("SENDING TO FULL REDUCE")
+            return self._full_reduce(axis, builder_func)
         else:
-            return self._full_axis_reduce(axis, builder)
+            return self._full_axis_reduce(axis, builder_func)
 
     def prod(self, **kwargs):
         """Returns the product of each numerical column or row.
@@ -995,6 +999,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         Return:
             A new QueryCompiler object with the sum of each numerical column or row.
         """
+        print("SUM FUCNTION")
         if self._is_transposed:
             kwargs["axis"] = kwargs.get("axis", 0) ^ 1
             return self.transpose().sum(**kwargs)

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -966,18 +966,15 @@ class PandasQueryCompiler(BaseQueryCompiler):
         Return:
             A new QueryCompiler object with sum or prod of the object.
         """
-        print("PROCESSOR")
         axis = kwargs.get("axis", 0)
         min_count = kwargs.get("min_count", 0)
-        print("GOT KWARGS")
 
         def sum_prod_builder(df, **kwargs):
+            print("GOT HERE")
             return func(df, **kwargs)
 
         builder_func = self._build_mapreduce_func(sum_prod_builder, **kwargs)
-        print("FINISHED BUILDER FUNC")
         if min_count <= 1:
-            print("SENDING TO FULL REDUCE")
             return self._full_reduce(axis, builder_func)
         else:
             return self._full_axis_reduce(axis, builder_func)
@@ -999,7 +996,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
         Return:
             A new QueryCompiler object with the sum of each numerical column or row.
         """
-        print("SUM FUCNTION")
         if self._is_transposed:
             kwargs["axis"] = kwargs.get("axis", 0) ^ 1
             return self.transpose().sum(**kwargs)

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -970,7 +970,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         min_count = kwargs.get("min_count", 0)
 
         def sum_prod_builder(df, **kwargs):
-            print("GOT HERE")
+            import time
+            print(time.ctime())
             return func(df, **kwargs)
 
         builder_func = self._build_mapreduce_func(sum_prod_builder, **kwargs)

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -869,7 +869,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
             reduce_func = map_func
 
         mapped_parts = self.data.map_across_blocks(map_func)
+        print("FINISHED MAPPING")
         full_frame = mapped_parts.map_across_full_axis(axis, reduce_func)
+        print("FINISHED REDUCING")
         if axis == 0:
             columns = self.columns
             return self.__constructor__(
@@ -970,8 +972,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
         min_count = kwargs.get("min_count", 0)
 
         def sum_prod_builder(df, **kwargs):
-            import time
-            print(time.ctime())
             return func(df, **kwargs)
 
         builder_func = self._build_mapreduce_func(sum_prod_builder, **kwargs)

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -972,10 +972,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
         def sum_prod_builder(df, **kwargs):
             return func(df, **kwargs)
 
+        builder = self._build_mapreduce_func(sum_prod_builder)
         if min_count <= 1:
-            return self._full_reduce(axis, sum_prod_builder)
+            return self._full_reduce(axis, builder)
         else:
-            return self._full_axis_reduce(axis, sum_prod_builder)
+            return self._full_axis_reduce(axis, builder)
 
     def prod(self, **kwargs):
         """Returns the product of each numerical column or row.
@@ -986,9 +987,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if self._is_transposed:
             kwargs["axis"] = kwargs.get("axis", 0) ^ 1
             return self.transpose().prod(**kwargs)
-        return self._process_sum_prod(
-            self._build_mapreduce_func(pandas.DataFrame.prod, **kwargs), **kwargs
-        )
+        return self._process_sum_prod(pandas.DataFrame.prod, **kwargs)
 
     def sum(self, **kwargs):
         """Returns the sum of each numerical column or row.
@@ -999,9 +998,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if self._is_transposed:
             kwargs["axis"] = kwargs.get("axis", 0) ^ 1
             return self.transpose().sum(**kwargs)
-        return self._process_sum_prod(
-            self._build_mapreduce_func(pandas.DataFrame.sum, **kwargs), **kwargs
-        )
+        return self._process_sum_prod(pandas.DataFrame.sum, **kwargs)
 
     def _process_all_any(self, func, **kwargs):
         """Calculates if any or all the values are true.

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -476,17 +476,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
         Returns:
             Pandas DataFrame of the DataManager.
         """
-        print("STARTED TO_PANDAS")
         df = self.data.to_pandas(is_transposed=self._is_transposed)
-        print("CONVERTED TO PANDAS")
         if df.empty:
-            print("EMPTY")
             if len(self.columns) != 0:
                 df = pandas.DataFrame(columns=self.columns).astype(self.dtypes)
             else:
                 df = pandas.DataFrame(columns=self.columns, index=self.index)
         else:
-            print("NOT EMPTY")
             ErrorMessage.catch_bugs_and_request_email(
                 len(df.index) != len(self.index) or len(df.columns) != len(self.columns)
             )

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -476,13 +476,17 @@ class PandasQueryCompiler(BaseQueryCompiler):
         Returns:
             Pandas DataFrame of the DataManager.
         """
+        print("STARTED TO_PANDAS")
         df = self.data.to_pandas(is_transposed=self._is_transposed)
+        print("CONVERTED TO PANDAS")
         if df.empty:
+            print("EMPTY")
             if len(self.columns) != 0:
                 df = pandas.DataFrame(columns=self.columns).astype(self.dtypes)
             else:
                 df = pandas.DataFrame(columns=self.columns, index=self.index)
         else:
+            print("NOT EMPTY")
             ErrorMessage.catch_bugs_and_request_email(
                 len(df.index) != len(self.index) or len(df.columns) != len(self.columns)
             )
@@ -869,9 +873,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             reduce_func = map_func
 
         mapped_parts = self.data.map_across_blocks(map_func)
-        print("FINISHED MAPPING")
         full_frame = mapped_parts.map_across_full_axis(axis, reduce_func)
-        print("FINISHED REDUCING")
         if axis == 0:
             columns = self.columns
             return self.__constructor__(

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -135,6 +135,7 @@ def initialize_ray():
     if threading.current_thread().name == "MainThread":
         plasma_directory = None
         object_store_memory = os.environ.get("MODIN_MEMORY", None)
+        cluster = os.environ.get("MODIN_CLUSTER", None)
         redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
         if os.environ.get("MODIN_OUT_OF_CORE", "False").title() == "True":
             from tempfile import gettempdir
@@ -148,14 +149,14 @@ def initialize_ray():
                 # Default to 8x memory for out of core
                 object_store_memory = 8 * mem_bytes
         # In case anything failed above, we can still improve the memory for Modin.
-        if redis_address is not None:
+        if cluster == "1" and redis_address is not None:
             ray.init(
                 include_webui=False,
                 ignore_reinit_error=True,
                 plasma_directory=plasma_directory,
                 redis_address=redis_address,
             )
-        else:
+        elif cluster is None:
             if object_store_memory is None:
                 # Round down to the nearest Gigabyte.
                 object_store_memory = int(

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -149,32 +149,31 @@ def initialize_ray():
                 # Default to 8x memory for out of core
                 object_store_memory = 8 * mem_bytes
         # In case anything failed above, we can still improve the memory for Modin.
-        print(cluster)
-        if cluster == "1" and redis_address is not None:
-            ray.init(
-                include_webui=False,
-                ignore_reinit_error=True,
-                plasma_directory=plasma_directory,
-                redis_address=redis_address,
-            )
-        elif cluster is None:
-            if object_store_memory is None:
-                # Round down to the nearest Gigabyte.
-                object_store_memory = int(
-                    0.6 * ray.utils.get_system_memory() // 10 ** 9 * 10 ** 9
-                )
-                # If the memory pool is smaller than 2GB, just use the default in ray.
-                if object_store_memory == 0:
-                    object_store_memory = None
-            else:
-                object_store_memory = int(object_store_memory)
-            ray.init(
-                include_webui=False,
-                ignore_reinit_error=True,
-                plasma_directory=plasma_directory,
-                object_store_memory=object_store_memory,
-                redis_address=redis_address,
-            )
+        # if cluster == "1" and redis_address is not None:
+        #     ray.init(
+        #         include_webui=False,
+        #         ignore_reinit_error=True,
+        #         plasma_directory=plasma_directory,
+        #         redis_address=redis_address,
+        #     )
+        # elif cluster is None:
+        #     if object_store_memory is None:
+        #         # Round down to the nearest Gigabyte.
+        #         object_store_memory = int(
+        #             0.6 * ray.utils.get_system_memory() // 10 ** 9 * 10 ** 9
+        #         )
+        #         # If the memory pool is smaller than 2GB, just use the default in ray.
+        #         if object_store_memory == 0:
+        #             object_store_memory = None
+        #     else:
+        #         object_store_memory = int(object_store_memory)
+        #     ray.init(
+        #         include_webui=False,
+        #         ignore_reinit_error=True,
+        #         plasma_directory=plasma_directory,
+        #         object_store_memory=object_store_memory,
+        #         redis_address=redis_address,
+        #     )
         # Register custom serializer for method objects to avoid warning message.
         # We serialize `MethodType` objects when we use AxisPartition operations.
         ray.register_custom_serializer(types.MethodType, use_pickle=True)

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -195,7 +195,8 @@ elif execution_engine == "Dask":  # pragma: no cover
 elif execution_engine != "Python":
     raise ImportError("Unrecognized execution engine: {}.".format(execution_engine))
 
-DEFAULT_NPARTITIONS = max(4, int(num_cpus))
+# DEFAULT_NPARTITIONS = max(4, int(num_cpus))
+DEFAULT_NPARTITIONS = 16
 
 __all__ = [
     "DataFrame",

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -148,24 +148,31 @@ def initialize_ray():
                 # Default to 8x memory for out of core
                 object_store_memory = 8 * mem_bytes
         # In case anything failed above, we can still improve the memory for Modin.
-        if object_store_memory is None:
-            # Round down to the nearest Gigabyte.
-            object_store_memory = int(
-                0.6 * ray.utils.get_system_memory() // 10 ** 9 * 10 ** 9
+        if redis_address is not None:
+            ray.init(
+                include_webui=False,
+                ignore_reinit_error=True,
+                plasma_directory=plasma_directory,
+                redis_address=redis_address,
             )
-            # If the memory pool is smaller than 2GB, just use the default in ray.
-            if object_store_memory == 0:
-                object_store_memory = None
         else:
-            object_store_memory = int(object_store_memory)
-        print(redis_address)
-        ray.init(
-            include_webui=False,
-            ignore_reinit_error=True,
-            plasma_directory=plasma_directory,
-            object_store_memory=object_store_memory,
-            redis_address=redis_address,
-        )
+            if object_store_memory is None:
+                # Round down to the nearest Gigabyte.
+                object_store_memory = int(
+                    0.6 * ray.utils.get_system_memory() // 10 ** 9 * 10 ** 9
+                )
+                # If the memory pool is smaller than 2GB, just use the default in ray.
+                if object_store_memory == 0:
+                    object_store_memory = None
+            else:
+                object_store_memory = int(object_store_memory)
+            ray.init(
+                include_webui=False,
+                ignore_reinit_error=True,
+                plasma_directory=plasma_directory,
+                object_store_memory=object_store_memory,
+                redis_address=redis_address,
+            )
         # Register custom serializer for method objects to avoid warning message.
         # We serialize `MethodType` objects when we use AxisPartition operations.
         ray.register_custom_serializer(types.MethodType, use_pickle=True)

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -135,6 +135,7 @@ def initialize_ray():
     if threading.current_thread().name == "MainThread":
         plasma_directory = None
         object_store_memory = os.environ.get("MODIN_MEMORY", None)
+        redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
         if os.environ.get("MODIN_OUT_OF_CORE", "False").title() == "True":
             from tempfile import gettempdir
 
@@ -162,6 +163,7 @@ def initialize_ray():
             ignore_reinit_error=True,
             plasma_directory=plasma_directory,
             object_store_memory=object_store_memory,
+            redis_address=redis_address,
         )
         # Register custom serializer for method objects to avoid warning message.
         # We serialize `MethodType` objects when we use AxisPartition operations.

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -135,7 +135,7 @@ def initialize_ray():
     if threading.current_thread().name == "MainThread":
         plasma_directory = None
         object_store_memory = os.environ.get("MODIN_MEMORY", None)
-        cluster = os.environ.get("MODIN_RAY_CLUSTER_HEAD", None)
+        cluster = os.environ.get("MODIN_RAY_CLUSTER", None)
         redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
         if os.environ.get("MODIN_OUT_OF_CORE", "False").title() == "True":
             from tempfile import gettempdir

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -158,6 +158,7 @@ def initialize_ray():
                 object_store_memory = None
         else:
             object_store_memory = int(object_store_memory)
+        print(redis_address)
         ray.init(
             include_webui=False,
             ignore_reinit_error=True,

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -134,9 +134,7 @@ def initialize_ray():
     """Initializes ray based on environment variables and internal defaults."""
     if threading.current_thread().name == "MainThread":
         plasma_directory = None
-        object_store_memory = os.environ.get("MODIN_MEMORY", None)
         cluster = os.environ.get("MODIN_RAY_CLUSTER", None)
-        redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
         if cluster == "True" and redis_address is not None:
             # We only start ray in a cluster setting for the head node.
             ray.init(
@@ -145,6 +143,8 @@ def initialize_ray():
                 redis_address=redis_address,
             )
         elif cluster is None:
+            object_store_memory = os.environ.get("MODIN_MEMORY", None)
+            redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
             if os.environ.get("MODIN_OUT_OF_CORE", "False").title() == "True":
                 from tempfile import gettempdir
 
@@ -196,8 +196,7 @@ elif execution_engine == "Dask":  # pragma: no cover
 elif execution_engine != "Python":
     raise ImportError("Unrecognized execution engine: {}.".format(execution_engine))
 
-# DEFAULT_NPARTITIONS = max(4, int(num_cpus))
-DEFAULT_NPARTITIONS = 16
+DEFAULT_NPARTITIONS = max(4, int(num_cpus))
 
 __all__ = [
     "DataFrame",

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -149,38 +149,38 @@ def initialize_ray():
                 # Default to 8x memory for out of core
                 object_store_memory = 8 * mem_bytes
         # In case anything failed above, we can still improve the memory for Modin.
-        # if cluster == "1" and redis_address is not None:
-        #     ray.init(
-        #         include_webui=False,
-        #         ignore_reinit_error=True,
-        #         plasma_directory=plasma_directory,
-        #         redis_address=redis_address,
-        #     )
-        # elif cluster is None:
-        #     if object_store_memory is None:
-        #         # Round down to the nearest Gigabyte.
-        #         object_store_memory = int(
-        #             0.6 * ray.utils.get_system_memory() // 10 ** 9 * 10 ** 9
-        #         )
-        #         # If the memory pool is smaller than 2GB, just use the default in ray.
-        #         if object_store_memory == 0:
-        #             object_store_memory = None
-        #     else:
-        #         object_store_memory = int(object_store_memory)
-        #     ray.init(
-        #         include_webui=False,
-        #         ignore_reinit_error=True,
-        #         plasma_directory=plasma_directory,
-        #         object_store_memory=object_store_memory,
-        #         redis_address=redis_address,
-        #     )
+        if cluster == "1" and redis_address is not None:
+            ray.init(
+                include_webui=False,
+                ignore_reinit_error=True,
+                plasma_directory=plasma_directory,
+                redis_address=redis_address,
+            )
+        elif cluster is None:
+            if object_store_memory is None:
+                # Round down to the nearest Gigabyte.
+                object_store_memory = int(
+                    0.6 * ray.utils.get_system_memory() // 10 ** 9 * 10 ** 9
+                )
+                # If the memory pool is smaller than 2GB, just use the default in ray.
+                if object_store_memory == 0:
+                    object_store_memory = None
+            else:
+                object_store_memory = int(object_store_memory)
+            ray.init(
+                include_webui=False,
+                ignore_reinit_error=True,
+                plasma_directory=plasma_directory,
+                object_store_memory=object_store_memory,
+                redis_address=redis_address,
+            )
         # Register custom serializer for method objects to avoid warning message.
         # We serialize `MethodType` objects when we use AxisPartition operations.
         ray.register_custom_serializer(types.MethodType, use_pickle=True)
 
 
 if execution_engine == "Ray":
-    initialize_ray()
+    # initialize_ray()
     num_cpus = ray.global_state.cluster_resources()["CPU"]
 elif execution_engine == "Dask":  # pragma: no cover
     from distributed.client import _get_global_client

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -135,7 +135,7 @@ def initialize_ray():
     if threading.current_thread().name == "MainThread":
         plasma_directory = None
         object_store_memory = os.environ.get("MODIN_MEMORY", None)
-        cluster = os.environ.get("MODIN_CLUSTER", None)
+        cluster = os.environ.get("MODIN_RAY_CLUSTER", None)
         redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
         if os.environ.get("MODIN_OUT_OF_CORE", "False").title() == "True":
             from tempfile import gettempdir
@@ -149,6 +149,7 @@ def initialize_ray():
                 # Default to 8x memory for out of core
                 object_store_memory = 8 * mem_bytes
         # In case anything failed above, we can still improve the memory for Modin.
+        print(cluster)
         if cluster == "1" and redis_address is not None:
             ray.init(
                 include_webui=False,

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -196,7 +196,7 @@ elif execution_engine != "Python":
     raise ImportError("Unrecognized execution engine: {}.".format(execution_engine))
 
 # DEFAULT_NPARTITIONS = max(4, int(num_cpus))
-DEFAULT_NPARTITIONS = 8
+DEFAULT_NPARTITIONS = 16
 
 __all__ = [
     "DataFrame",

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -154,6 +154,7 @@ def initialize_ray():
                 ignore_reinit_error=True,
                 plasma_directory=plasma_directory,
                 redis_address=redis_address,
+                redis_max_memory=20 * 10 ** 9
             )
         else:
             if object_store_memory is None:

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -135,6 +135,7 @@ def initialize_ray():
     if threading.current_thread().name == "MainThread":
         plasma_directory = None
         cluster = os.environ.get("MODIN_RAY_CLUSTER", None)
+        redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
         if cluster == "True" and redis_address is not None:
             # We only start ray in a cluster setting for the head node.
             ray.init(
@@ -144,7 +145,6 @@ def initialize_ray():
             )
         elif cluster is None:
             object_store_memory = os.environ.get("MODIN_MEMORY", None)
-            redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
             if os.environ.get("MODIN_OUT_OF_CORE", "False").title() == "True":
                 from tempfile import gettempdir
 

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -154,7 +154,6 @@ def initialize_ray():
                 ignore_reinit_error=True,
                 plasma_directory=plasma_directory,
                 redis_address=redis_address,
-                redis_max_memory=20 * 10 ** 9
             )
         else:
             if object_store_memory is None:

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -196,7 +196,7 @@ elif execution_engine != "Python":
     raise ImportError("Unrecognized execution engine: {}.".format(execution_engine))
 
 # DEFAULT_NPARTITIONS = max(4, int(num_cpus))
-DEFAULT_NPARTITIONS = 16
+DEFAULT_NPARTITIONS = 8
 
 __all__ = [
     "DataFrame",

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -137,26 +137,25 @@ def initialize_ray():
         object_store_memory = os.environ.get("MODIN_MEMORY", None)
         cluster = os.environ.get("MODIN_RAY_CLUSTER", None)
         redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
-        if os.environ.get("MODIN_OUT_OF_CORE", "False").title() == "True":
-            from tempfile import gettempdir
-
-            plasma_directory = gettempdir()
-            # We may have already set the memory from the environment variable, we don't
-            # want to overwrite that value if we have.
-            if object_store_memory is None:
-                # Round down to the nearest Gigabyte.
-                mem_bytes = ray.utils.get_system_memory() // 10 ** 9 * 10 ** 9
-                # Default to 8x memory for out of core
-                object_store_memory = 8 * mem_bytes
-        if cluster == "1" and redis_address is not None:
+        if cluster == "True" and redis_address is not None:
             # We only start ray in a cluster setting for the head node.
             ray.init(
                 include_webui=False,
                 ignore_reinit_error=True,
-                plasma_directory=plasma_directory,
                 redis_address=redis_address,
             )
         elif cluster is None:
+            if os.environ.get("MODIN_OUT_OF_CORE", "False").title() == "True":
+                from tempfile import gettempdir
+
+                plasma_directory = gettempdir()
+                # We may have already set the memory from the environment variable, we don't
+                # want to overwrite that value if we have.
+                if object_store_memory is None:
+                    # Round down to the nearest Gigabyte.
+                    mem_bytes = ray.utils.get_system_memory() // 10 ** 9 * 10 ** 9
+                    # Default to 8x memory for out of core
+                    object_store_memory = 8 * mem_bytes
             # In case anything failed above, we can still improve the memory for Modin.
             if object_store_memory is None:
                 # Round down to the nearest Gigabyte.


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Changes how modin is initialized in a cluster environment and provides a sample script for launching a ray autoscaled cluster in aws. 

This is a first pass so there are still lots of work needed to be done before this is ready for proper workloads but it is in a working state.

## Related Issues

#660 

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
