### PR TITLE
Fix memory_usage() for transposed dataframes

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1284,9 +1284,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
             if axis:
                 df = df.T
             result = df.memory_usage(**kwargs)
-            # We add back in the axis kwarg for the sum_memory_usage reduction
-            # function.
-            kwargs["axis"] = axis
             return result
 
         def sum_memory_usage(df, **kwargs):
@@ -1296,9 +1293,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         # Even though memory_usage does not take in an axis argument, we have to
         # pass in an axis kwargs for _build_mapreduce_func to properly arrange
         # the results.
-        kwargs["axis"] = axis
-        map_func = self._build_mapreduce_func(memory_usage_builder, **kwargs)
-        reduce_func = self._build_mapreduce_func(sum_memory_usage, **kwargs)
+        map_func = self._build_mapreduce_func(memory_usage_builder, axis=axis, **kwargs)
+        reduce_func = self._build_mapreduce_func(sum_memory_usage, axis=axis, **kwargs)
         return self._full_reduce(axis, map_func, reduce_func)
 
     def nunique(self, **kwargs):

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1278,9 +1278,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
         def memory_usage_builder(df, **kwargs):
             axis = kwargs.pop("axis")
+            # We have to manually change the orientation of the data within the
+            # partitions because memory_usage does not take in an axis argument
+            # and always does it along columns.
             if axis:
                 df = df.T
             result = df.memory_usage(**kwargs)
+            # We add back in the axis kwarg for the sum_memory_usage reduction
+            # function.
             kwargs["axis"] = axis
             return result
 
@@ -1288,11 +1293,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
             axis = kwargs.pop("axis")
             return df.sum(axis=axis)
 
+        # Even though memory_usage does not take in an axis argument, we have to
+        # pass in an axis kwargs for _build_mapreduce_func to properly arrange
+        # the results.
         kwargs["axis"] = axis
         map_func = self._build_mapreduce_func(memory_usage_builder, **kwargs)
         reduce_func = self._build_mapreduce_func(sum_memory_usage, **kwargs)
-        result = self._full_reduce(axis, map_func, reduce_func)
-        return result
+        return self._full_reduce(axis, map_func, reduce_func)
 
     def nunique(self, **kwargs):
         """Returns the number of unique items over each column or row.

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1277,19 +1277,20 @@ class PandasQueryCompiler(BaseQueryCompiler):
             return self.transpose().memory_usage(axis=1, **kwargs)
 
         def memory_usage_builder(df, **kwargs):
+            axis = kwargs.pop("axis")
             if axis:
-                return df.T.memory_usage(**kwargs).to_frame()
-            else:
-                return df.memory_usage(**kwargs)
+                df = df.T
+            result = df.memory_usage(**kwargs)
+            kwargs["axis"] = axis
+            return result
 
-        def sum_memory_usage(df):
-            if axis:
-                return df.sum(axis=axis).to_frame()
-            else:
-                return df.sum()
+        def sum_memory_usage(df, **kwargs):
+            axis = kwargs.pop("axis")
+            return df.sum(axis=axis)
 
+        kwargs["axis"] = axis
         map_func = self._build_mapreduce_func(memory_usage_builder, **kwargs)
-        reduce_func = self._build_mapreduce_func(sum_memory_usage)
+        reduce_func = self._build_mapreduce_func(sum_memory_usage, **kwargs)
         result = self._full_reduce(axis, map_func, reduce_func)
         return result
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1267,22 +1267,31 @@ class PandasQueryCompiler(BaseQueryCompiler):
         func = self._build_mapreduce_func(pandas.DataFrame.median, **kwargs)
         return self._full_axis_reduce(axis, func)
 
-    def memory_usage(self, **kwargs):
+    def memory_usage(self, axis=0, **kwargs):
         """Returns the memory usage of each column.
 
         Returns:
             A new QueryCompiler object containing the memory usage of each column.
         """
+        if self._is_transposed:
+            return self.transpose().memory_usage(axis=1, **kwargs)
 
         def memory_usage_builder(df, **kwargs):
-            return df.memory_usage(**kwargs)
+            if axis:
+                return df.T.memory_usage(**kwargs).to_frame()
+            else:
+                return df.memory_usage(**kwargs)
 
         def sum_memory_usage(df):
-            return df.sum()
+            if axis:
+                return df.sum(axis=axis).to_frame()
+            else:
+                return df.sum()
 
         map_func = self._build_mapreduce_func(memory_usage_builder, **kwargs)
         reduce_func = self._build_mapreduce_func(sum_memory_usage)
-        return self._full_reduce(0, map_func, reduce_func)
+        result = self._full_reduce(axis, map_func, reduce_func)
+        return result
 
     def nunique(self, **kwargs):
         """Returns the number of unique items over each column or row.

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -3070,6 +3070,19 @@ class TestDFPartTwo:
 
         modin_result = modin_df.memory_usage(index=index)
         pandas_result = pandas_df.memory_usage(index=index)
+        # We do not compare the indicies because pandas and modin handles the
+        # indicies slightly differently
+        if index:
+            modin_result = modin_result[1:]
+            pandas_result = pandas_result[1:]
+
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.T.memory_usage(index=index)
+        pandas_result = pandas_df.T.memory_usage(index=index)
+        if index:
+            modin_result = modin_result[1:]
+            pandas_result = pandas_result[1:]
 
         df_equals(modin_result, pandas_result)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

`memory_usage()` for transposed dataframes was broken. This fixes the error

## Related issue number



- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
