### PR TITLE
Parallel parquet reading by row group - second try 

### DIFF
--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -216,25 +216,48 @@ class RayIO(BaseIO):
             columns[i : i + column_splits]
             for i in range(0, len(columns), column_splits)
         ]
-        # Each item in this list will be a list of columns of original df
-        # partitioned to smaller pieces along rows.
-        # We need to transpose the oids array to fit our schema.
-        # TODO (williamma12): This part can be parallelized even more if we
-        # separate the partitioned parquet file code path from the default one.
-        blk_partitions = np.array(
-            [
-                cls.read_parquet_remote_task._remote(
-                    args=(path, cols + partitioned_columns, num_splits, kwargs),
-                    num_return_vals=num_splits + 1,
-                )
-                if directory and cols == col_partitions[len(col_partitions) - 1]
-                else cls.read_parquet_remote_task._remote(
-                    args=(path, cols, num_splits, kwargs),
-                    num_return_vals=num_splits + 1,
-                )
-                for cols in col_partitions
-            ]
-        ).T
+
+        if(not directory):
+          pf = ParquetFile(path, memory_map=False)
+          num_row_groups = pf.metadata.num_row_groups
+          blocks_with_lengths = [ 
+                 [
+                   cls.read_parquet_remote_task._remote(args=(path,col_partitions[i], 1, j, kwargs),num_return_vals=2) for i in range(len(col_partitions))
+                 ]       
+                 for j in range(num_row_groups)
+          ]
+
+          blk_partitions = [
+                    [
+                      blocks_with_lengths[i][j][0] for j in range(len(col_partitions))
+                    ]
+                    for i in range(num_row_groups)
+          ]
+
+          row_total = ray.put(sum([ ray.get(blocks_with_lengths[j][0][1]) for j in range(num_row_groups) ]))
+          blk_partitions.append( [row_total for c in columns] )
+        else:
+    
+          # Each item in this list will be a list of columns of original df
+          # partitioned to smaller pieces along rows.
+          # We need to transpose the oids array to fit our schema.
+          # TODO (williamma12): This part can be parallelized even more if we
+          # separate the partitioned parquet file code path from the default one.
+          blk_partitions = np.array(
+              [
+                  cls.read_parquet_remote_task._remote(
+                      args=(path, cols + partitioned_columns, num_splits, -1, kwargs),
+                      num_return_vals=num_splits + 1,
+                  )
+                  if directory and cols == col_partitions[len(col_partitions) - 1]
+                  else cls.read_parquet_remote_task._remote(
+                      args=(path, cols, num_splits, -1, kwargs),
+                      num_return_vals=num_splits + 1,
+                  )
+                  for cols in col_partitions
+              ]
+          ).T
+
         remote_partitions = np.array(
             [
                 [cls.frame_partition_cls(obj) for obj in row]

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -217,46 +217,53 @@ class RayIO(BaseIO):
             for i in range(0, len(columns), column_splits)
         ]
 
+        # Only read row groups in parallel if parquet files are not in a partitioned within a directory
         if(not directory):
-          pf = ParquetFile(path, memory_map=False)
-          num_row_groups = pf.metadata.num_row_groups
-          blocks_with_lengths = [ 
-                 [
-                   cls.read_parquet_remote_task._remote(args=(path,col_partitions[i], 1, j, kwargs),num_return_vals=2) for i in range(len(col_partitions))
-                 ]       
-                 for j in range(num_row_groups)
-          ]
+            pf = ParquetFile(path, memory_map=False)
+            num_row_groups = pf.metadata.num_row_groups
+            blocks_with_lengths = [
+                [
+                    cls.read_parquet_remote_task._remote(
+                        args=(path, col_partitions[i], 1, j, kwargs),
+                        num_return_vals=2)
+                    for i in range(len(col_partitions))
+                ]
+                for j in range(num_row_groups)
+            ]
 
-          blk_partitions = [
-                    [
-                      blocks_with_lengths[i][j][0] for j in range(len(col_partitions))
-                    ]
-                    for i in range(num_row_groups)
-          ]
+            blk_partitions = [
+                [
+                    blocks_with_lengths[i][j][0] for j in range(len(col_partitions))
+                ]
+                for i in range(num_row_groups)
+            ]
 
-          row_total = ray.put(sum([ ray.get(blocks_with_lengths[j][0][1]) for j in range(num_row_groups) ]))
-          blk_partitions.append( [row_total for c in columns] )
+            row_total = ray.put(
+                sum([ray.get(blocks_with_lengths[j][0][1])
+                    for j in range(num_row_groups)])
+            )
+
+            blk_partitions.append([row_total for c in columns])
         else:
-    
-          # Each item in this list will be a list of columns of original df
-          # partitioned to smaller pieces along rows.
-          # We need to transpose the oids array to fit our schema.
-          # TODO (williamma12): This part can be parallelized even more if we
-          # separate the partitioned parquet file code path from the default one.
-          blk_partitions = np.array(
-              [
-                  cls.read_parquet_remote_task._remote(
-                      args=(path, cols + partitioned_columns, num_splits, -1, kwargs),
-                      num_return_vals=num_splits + 1,
-                  )
-                  if directory and cols == col_partitions[len(col_partitions) - 1]
-                  else cls.read_parquet_remote_task._remote(
-                      args=(path, cols, num_splits, -1, kwargs),
-                      num_return_vals=num_splits + 1,
-                  )
-                  for cols in col_partitions
-              ]
-          ).T
+            # Each item in this list will be a list of columns of original df
+            # partitioned to smaller pieces along rows.
+            # We need to transpose the oids array to fit our schema.
+            # TODO (williamma12): This part can be parallelized even more if we
+            # separate the partitioned parquet file code path from the default one.
+            blk_partitions = np.array(
+                [
+                    cls.read_parquet_remote_task._remote(
+                        args=(path, cols + partitioned_columns, num_splits, -1, kwargs),
+                        num_return_vals=num_splits + 1,
+                    )
+                    if directory and cols == col_partitions[len(col_partitions) - 1]
+                    else cls.read_parquet_remote_task._remote(
+                        args=(path, cols, num_splits, -1, kwargs),
+                        num_return_vals=num_splits + 1,
+                    )
+                    for cols in col_partitions
+                ]
+            ).T
 
         remote_partitions = np.array(
             [

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -222,7 +222,7 @@ class RayIO(BaseIO):
                 for i in range(0, len(columns), column_splits)
             ]
 
-            pf = ParquetFile(path, memory_map=False)
+            pf = ParquetFile(path)
             num_row_groups = pf.metadata.num_row_groups
 
             row_group_splits = (

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -36,7 +36,9 @@ def _split_result_for_readers(axis, num_splits, df):  # pragma: no cover
 
 
 @ray.remote
-def _read_parquet_columns(path, columns, num_splits, rowgroup, kwargs):  # pragma: no cover
+def _read_parquet_columns(
+    path, columns, num_splits, rowgroup, kwargs
+):  # pragma: no cover
     """Use a Ray task to read columns from Parquet into a Pandas DataFrame.
 
     Note: Ray functions are not detected by codecov (thus pragma: no cover)
@@ -57,7 +59,7 @@ def _read_parquet_columns(path, columns, num_splits, rowgroup, kwargs):  # pragm
 
     kwargs["use_pandas_metadata"] = True
 
-    if(rowgroup >= 0):
+    if rowgroup >= 0:
         pf = ParquetFile(path, memory_map=False)
         df = pf.read_row_group(rowgroup, columns, **kwargs).to_pandas()
         return _split_result_for_readers(0, 1, df) + [len(df.index)]

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -65,7 +65,7 @@ def _read_parquet_columns(
             pf.read_row_group(rowgroup, columns, **kwargs).to_pandas()
             for rowgroup in rowgroups
         ]
-        total_df_length = sum([len(df.index) for df in df_list])
+        total_df_length = sum(len(df.index) for df in df_list)
         return df_list + [total_df_length]
     else:
         df = pq.read_table(path, columns=columns, **kwargs).to_pandas()


### PR DESCRIPTION
Ready now for review.  The one test that is failing I don't think is related to my code given its related to `pyopenssl.py`

it does pass locally `pytest  modin/pandas/test/test_io.py ` except for one boto permission error that is likely unique to my dev environment.   

Notes: 
1) Parallel parquet reading including varying number of column splits appear to be working now.

2) At the moment only non-partitioned parquet datasets are read in a row-group parallel way.   I think that that for partitioned datasets we will parallelize by partitioned chunk, and not by row group, so we may  permanently keep this rowgroup code only on the non-partitioned codepath - thoughts?

3) I had initial problems with segmentation faults in my test dataset, related to pyarrow, not modin.  These errors went away when I wrote the test parquet dataset with fewer numbers of rows per row group, this seems to be a current limitation to pyarrow which some users may also encounter but that we can't do anything about right now on our end except warn users to keep row-groups smaller than default.  I'll try to determine where the cutoff is and if it is rows, columns, bytes, or elements specifically.


