### PR TITLE
Fix `concat` when QueryCompiler is transposed

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -321,8 +321,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def _append_list_of_managers(self, others, axis, **kwargs):
         if not isinstance(others, list):
             others = [others]
-
         if self._is_transposed:
+            # If others are transposed, we handle that behavior correctly in
+            # `copartition`, but it is not handled correctly in the case that `self` is
+            # transposed.
             return (
                 self.transpose()
                 ._append_list_of_managers(

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -321,6 +321,15 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def _append_list_of_managers(self, others, axis, **kwargs):
         if not isinstance(others, list):
             others = [others]
+
+        if self._is_transposed:
+            return (
+                self.transpose()
+                ._append_list_of_managers(
+                    [o.transpose() for o in others], axis ^ 1, **kwargs
+                )
+                .transpose()
+            )
         assert all(
             isinstance(other, type(self)) for other in others
         ), "Different Manager objects are being used. This is not allowed"


### PR DESCRIPTION
* Resolves #680
* Adds a condition similar to other transpose handling that changes the
  axis

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
