### PR TITLE
Fix `concat` with all Series and axis=1

### DIFF
--- a/modin/pandas/concat.py
+++ b/modin/pandas/concat.py
@@ -90,12 +90,15 @@ def concat(
     ]
     objs = [obj._query_compiler for obj in objs if len(obj.index) or len(obj.columns)]
     if keys is not None:
-        objs = [objs[i] for i in range(min(len(objs), len(keys)))]
-        new_idx_labels = {
-            k: v.index if axis == 0 else v.columns for k, v in zip(keys, objs)
-        }
-        tuples = [(k, o) for k, obj in new_idx_labels.items() for o in obj]
-        new_idx = pandas.MultiIndex.from_tuples(tuples)
+        if all_series:
+            new_idx = keys
+        else:
+            objs = [objs[i] for i in range(min(len(objs), len(keys)))]
+            new_idx_labels = {
+                k: v.index if axis == 0 else v.columns for k, v in zip(keys, objs)
+            }
+            tuples = [(k, o) for k, obj in new_idx_labels.items() for o in obj]
+            new_idx = pandas.MultiIndex.from_tuples(tuples)
     else:
         new_idx = None
     new_query_compiler = objs[0].concat(


### PR DESCRIPTION
* Resolves #683
* Adds logic to handle edge case where keys is not None and all objects
  are Series.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
