### PR TITLE
Fix dtypes on empty dataframes calls to to_pandas

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -49,9 +49,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
             )
             reduce_func = self._build_mapreduce_func(dtype_builder)
             # For now we will use a pandas Series for the dtypes.
-            self._dtype_cache = (
-                self._full_reduce(0, map_func, reduce_func).to_pandas().iloc[0]
-            )
+            if len(self.data.partitions) > 0:
+                self._dtype_cache = (
+                    self._full_reduce(0, map_func, reduce_func).to_pandas().iloc[0]
+                )
+            else:
+                self._dtype_cache = pandas.Series([])
             # reset name to None because we use "__reduced__" internally
             self._dtype_cache.name = None
         return self._dtype_cache

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -49,7 +49,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             )
             reduce_func = self._build_mapreduce_func(dtype_builder)
             # For now we will use a pandas Series for the dtypes.
-            if len(self.data.partitions) > 0:
+            if len(self.columns) > 0:
                 self._dtype_cache = (
                     self._full_reduce(0, map_func, reduce_func).to_pandas().iloc[0]
                 )


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Checks to make sure that the calls are not empty

## Related issue number

Resolves #685
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
