### PR TITLE
Fix internal indices calculation for non-compute partitions

### DIFF
--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -685,7 +685,7 @@ class BaseFrameManager(object):
             count_for_each_partition = np.array(
                 [(partition_ids == i).sum() for i in range(len(cumulative))]
             ).cumsum()
-            # compute the internal indices and pair those with the partition index.
+            # Compute the internal indices and pair those with the partition index.
             # If the first partition has any values we need to return, compute those
             # first to make the list comprehension easier. Otherwise, just append the
             # rest of the values to an empty list.

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -686,9 +686,16 @@ class BaseFrameManager(object):
                 [(partition_ids == i).sum() for i in range(len(cumulative))]
             ).cumsum()
             # compute the internal indices and pair those with the partition index.
-            partition_ids_with_indices = [
-                (0, internal(0, indices[slice(count_for_each_partition[0])]))
-            ] + [
+            # If the first partition has any values we need to return, compute those
+            # first to make the list comprehension easier. Otherwise, just append the
+            # rest of the values to an empty list.
+            if count_for_each_partition[0] > 0:
+                first_partition_indices = [
+                    (0, internal(0, indices[slice(count_for_each_partition[0])]))
+                ]
+            else:
+                first_partition_indices = []
+            partition_ids_with_indices = first_partition_indices + [
                 (
                     i,
                     internal(


### PR DESCRIPTION
* Resolves #690
* Previously we were always triggering computation on the first
  partition, but now we filter it out if there is nothing to compute.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
