### PR TITLE
Fix how we compute the block_widths/lengths after single update

### DIFF
--- a/modin/engines/ray/generic/frame/partition_manager.py
+++ b/modin/engines/ray/generic/frame/partition_manager.py
@@ -53,7 +53,12 @@ class RayFrameManager(BaseFrameManager):
                     )
             else:
                 self._lengths_cache = np.array(
-                    [obj.length() for obj in self._partitions_cache.T[0]]
+                    [
+                        obj.length()
+                        if isinstance(obj.length(), int)
+                        else ray.get(obj.length().oid)
+                        for obj in self._partitions_cache.T[0]
+                    ]
                 )
         return self._lengths_cache
 
@@ -88,6 +93,11 @@ class RayFrameManager(BaseFrameManager):
                     )
             else:
                 self._widths_cache = np.array(
-                    [obj.width() for obj in self._partitions_cache[0]]
+                    [
+                        obj.width()
+                        if isinstance(obj.width(), int)
+                        else ray.get(obj.width().oid)
+                        for obj in self._partitions_cache[0]
+                    ]
                 )
         return self._widths_cache


### PR DESCRIPTION
* Resolves #692
* Checks that each object is an integer for `width()` or `length()`
* If not, calls `ray.get` on it.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
