### PR TITLE
Add metadata to be returned by operations along entire axis

### DIFF
--- a/modin/engines/ray/pandas_on_ray/frame/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/axis_partition.py
@@ -54,9 +54,7 @@ class PandasOnRayFrameAxisPartition(PandasFrameAxisPartition):
         )
 
     def _wrap_partitions(self, partitions):
-        if isinstance(partitions, self.instance_type):
-            return [self.partition_type(partitions)]
-        else:
+        if not isinstance(partitions, self.instance_type):
             return [
                 self.partition_type(
                     partitions[i],
@@ -65,6 +63,7 @@ class PandasOnRayFrameAxisPartition(PandasFrameAxisPartition):
                 )
                 for i in range(0, len(partitions), 3)
             ]
+        return super(PandasOnRayFrameAxisPartition, self)._wrap_partitions(partitions)
 
 
 class PandasOnRayFrameColumnPartition(PandasOnRayFrameAxisPartition):

--- a/modin/engines/ray/pandas_on_ray/frame/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/axis_partition.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 
+import pandas
 import ray
 
 from modin.engines.base.frame.axis_partition import PandasFrameAxisPartition
@@ -97,4 +98,9 @@ def deploy_ray_func(func, *args):  # pragma: no cover
         The result of the function `func`.
     """
     result = func(*args)
-    return [i for r in result for i in [r, len(r), len(r.columns)]]
+    if isinstance(result, pandas.DataFrame):
+        return result, len(result), len(result.columns)
+    elif all(isinstance(r, pandas.DataFrame) for r in result):
+        return [i for r in result for i in [r, len(r), len(r.columns)]]
+    else:
+        return [i for r in result for i in [r, None, None]]

--- a/modin/engines/ray/pandas_on_ray/frame/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/axis_partition.py
@@ -54,16 +54,14 @@ class PandasOnRayFrameAxisPartition(PandasFrameAxisPartition):
         )
 
     def _wrap_partitions(self, partitions):
-        if not isinstance(partitions, self.instance_type):
-            return [
-                self.partition_type(
-                    partitions[i],
-                    self.partition_type(partitions[i + 1]),
-                    self.partition_type(partitions[i + 2]),
-                )
-                for i in range(0, len(partitions), 3)
-            ]
-        return super(PandasOnRayFrameAxisPartition, self)._wrap_partitions(partitions)
+        return [
+            self.partition_type(
+                partitions[i],
+                self.partition_type(partitions[i + 1]),
+                self.partition_type(partitions[i + 2]),
+            )
+            for i in range(0, len(partitions), 3)
+        ]
 
 
 class PandasOnRayFrameColumnPartition(PandasOnRayFrameAxisPartition):


### PR DESCRIPTION
* Returns the length and width of each partition to the partition so it
  doesn't have to be recomputed
* Reduces the overhead of 2 additional tasks to compute this data

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
