### PR TITLE
Improve performance of __setitem__ on new column

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -343,7 +343,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
         join = kwargs.get("join", "outer")
         ignore_index = kwargs.get("ignore_index", False)
         new_self, to_append, joined_axis = self.copartition(
-            axis ^ 1, others, join, sort, force_repartition=True
+            axis ^ 1,
+            others,
+            join,
+            sort,
+            force_repartition=any(obj._is_transposed for obj in [self] + others),
         )
         new_data = new_self.concat(axis, to_append)
 
@@ -378,7 +382,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
         lsuffix = kwargs.get("lsuffix", "")
         rsuffix = kwargs.get("rsuffix", "")
         new_self, to_join, joined_index = self.copartition(
-            0, others, how, sort, force_repartition=True
+            0,
+            others,
+            how,
+            sort,
+            force_repartition=any(obj._is_transposed for obj in [self] + others),
         )
         new_data = new_self.concat(1, to_join)
         # This stage is to efficiently get the resulting columns, including the

--- a/modin/data_management/utils.py
+++ b/modin/data_management/utils.py
@@ -119,3 +119,9 @@ def length_fn_pandas(df):
 def width_fn_pandas(df):
     assert isinstance(df, pandas.DataFrame)
     return len(df.columns)
+
+
+def set_indices_for_pandas_concat(df):
+    df.index = pandas.RangeIndex(len(df))
+    df.columns = pandas.RangeIndex(len(df.columns))
+    return df

--- a/modin/engines/base/frame/axis_partition.py
+++ b/modin/engines/base/frame/axis_partition.py
@@ -1,5 +1,8 @@
 import pandas
-from modin.data_management.utils import split_result_of_axis_func_pandas
+from modin.data_management.utils import (
+    split_result_of_axis_func_pandas,
+    set_indices_for_pandas_concat,
+)
 
 
 class BaseFrameAxisPartition(object):  # pragma: no cover
@@ -229,8 +232,22 @@ class PandasFrameAxisPartition(BaseFrameAxisPartition):
         Returns:
             A list of Pandas DataFrames.
         """
-        lt_frame = pandas.concat(list(partitions[:len_of_left]), axis=axis, copy=False)
-        rt_frame = pandas.concat(list(partitions[len_of_left:]), axis=axis, copy=False)
+        lt_frame = pandas.concat(
+            [
+                set_indices_for_pandas_concat(df)
+                for df in list(partitions[:len_of_left])
+            ],
+            axis=axis,
+            copy=False,
+        )
+        rt_frame = pandas.concat(
+            [
+                set_indices_for_pandas_concat(df)
+                for df in list(partitions[len_of_left:])
+            ],
+            axis=axis,
+            copy=False,
+        )
 
         result = func(lt_frame, rt_frame, **kwargs)
         return split_result_of_axis_func_pandas(axis, num_splits, result)

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -8,7 +8,11 @@ from operator import itemgetter
 import pandas
 
 from modin.error_message import ErrorMessage
-from modin.data_management.utils import compute_chunksize, _get_nan_block_id
+from modin.data_management.utils import (
+    compute_chunksize,
+    _get_nan_block_id,
+    set_indices_for_pandas_concat,
+)
 
 
 class BaseFrameManager(object):
@@ -474,7 +478,8 @@ class BaseFrameManager(object):
             return self.transpose().to_pandas(False).T
         else:
             retrieved_objects = [
-                [obj.to_pandas() for obj in part] for part in self.partitions
+                [set_indices_for_pandas_concat(obj.to_pandas()) for obj in part]
+                for part in self.partitions
             ]
             if all(
                 isinstance(part, pandas.Series)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1954,6 +1954,10 @@ class DataFrame(BasePandasDataset):
                 self._create_or_update_from_compiler(
                     self._query_compiler.concat(1, value._query_compiler), inplace=True
                 )
+                # Now that the data is appended, we need to update the column name for
+                # that column to `key`, otherwise the name could be incorrect. Drop the
+                # last column name from the list (the appended value's name and append
+                # the new name.
                 self.columns = self.columns[:-1].append(pandas.Index([key]))
             else:
                 self.insert(loc=len(self.columns), column=key, value=value)


### PR DESCRIPTION
* Resolves #696
* Doesn't require repartitioning every time
* Create a fasttrack for the case where partitioning is already aligned
* Change the concat functionality internally to make all indices align
  * This is possible because we track metadata separately
* Reduce adding new columns from products of old columns take 10's of ms

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
