### PR TITLE
Fix sorting for MultiIndex

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2546,7 +2546,10 @@ class BasePandasDataset(object):
             A sorted DataFrame
         """
         axis = self._get_axis_number(axis)
-        if level is not None:
+        if level is not None or (
+            (axis == 0 and isinstance(self.index, pandas.MultiIndex))
+            or (axis == 1 and isinstance(self.columns, pandas.MultiIndex))
+        ):
             new_query_compiler = self._default_to_pandas(
                 "sort_index",
                 axis=axis,
@@ -2556,7 +2559,7 @@ class BasePandasDataset(object):
                 kind=kind,
                 na_position=na_position,
                 sort_remaining=sort_remaining,
-            )
+            )._query_compiler
             return self._create_or_update_from_compiler(new_query_compiler, inplace)
         if by is not None:
             warnings.warn(

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4257,6 +4257,21 @@ class TestDFPartTwo:
         )
         df_equals(modin_df_cp, pandas_df_cp)
 
+        # MultiIndex
+        modin_df = pd.DataFrame(data)
+        pandas_df = pandas.DataFrame(data)
+        modin_df.index = pd.MultiIndex.from_tuples(
+            [(i // 10, i // 5, i) for i in range(len(modin_df))]
+        )
+        pandas_df.index = pandas.MultiIndex.from_tuples(
+            [(i // 10, i // 5, i) for i in range(len(pandas_df))]
+        )
+
+        with pytest.warns(UserWarning):
+            df_equals(modin_df.sort_index(level=0), pandas_df.sort_index(level=0))
+        with pytest.warns(UserWarning):
+            df_equals(modin_df.sort_index(axis=0), pandas_df.sort_index(axis=0))
+
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
     @pytest.mark.parametrize(


### PR DESCRIPTION
* Resolves #698
* Correctly creates a new DataFrame based on the QueryCompiler instead of the DataFrame object itself
* Adds conditional checking for MultiIndex when `axis=0` and `axis=1`.
* Add tests

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
