### PR TITLE
Improve fillna performance depending on arguments passed in

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1599,9 +1599,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         value = kwargs.get("value")
         method = kwargs.get("method", None)
         limit = kwargs.get("limit", None)
-        downcast = kwargs.get("downcast", None)
         full_axis = method is not None or limit is not None
-        new_dtype = self.dtypes if downcast is None else None
         if isinstance(value, dict):
             value = kwargs.pop("value")
 
@@ -1627,14 +1625,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 new_data = self.data.apply_func_to_select_indices(
                     axis, fillna_dict_builder, value, keep_remaining=True
                 )
-            return self.__constructor__(new_data, self.index, self.columns, new_dtypes)
+            return self.__constructor__(new_data, self.index, self.columns)
         else:
             func = self._prepare_method(pandas.DataFrame.fillna, **kwargs)
             if full_axis:
                 new_data = self._map_across_full_axis(axis, func)
-                return self.__constructor__(new_data, self.index, self.columns, new_dtypes)
+                return self.__constructor__(new_data, self.index, self.columns)
             else:
-                return self._map_partitions(axis, func, new_dtypes)
+                return self._map_partitions(axis, func)
 
     def quantile_for_list_of_values(self, **kwargs):
         """Returns Manager containing quantiles along an axis for numeric columns.

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1632,7 +1632,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 new_data = self._map_across_full_axis(axis, func)
                 return self.__constructor__(new_data, self.index, self.columns)
             else:
-                return self._map_partitions(axis, func)
+                return self._map_partitions(func)
 
     def quantile_for_list_of_values(self, **kwargs):
         """Returns Manager containing quantiles along an axis for numeric columns.

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1141,6 +1141,11 @@ class BasePandasDataset(object):
                 expecting=expecting, method=method
             )
             raise ValueError(msg)
+        if limit is not None:
+            if not isinstance(limit, int):
+                raise ValueError("Limit must be an integer")
+            elif limit <= 0:
+                raise ValueError("Limit must be greater than 0")
 
         new_query_compiler = self._query_compiler.fillna(
             value=value,

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -2068,6 +2068,26 @@ class TestDFPartOne:
 
         df_equals(modin_df.ffill(), test_data.tsframe.ffill())
 
+    @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+    @pytest.mark.parametrize("method", ["backfill", "bfill", "pad", "ffill", None], ids=["backfill", "bfill", "pad", "ffill", "None"])
+    @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
+    @pytest.mark.parametrize("limit", int_arg_values, ids=int_arg_keys)
+    def test_fillna(self, data, method, axis, limit):
+        # We are not testing when limit is not positive until pandas-27042 gets fixed.
+        # We are not testing when axis is over rows until pandas-17399 gets fixed.
+        if limit > 0 and axis != 1 and axis != "columns":
+            modin_df = pd.DataFrame(data)
+            pandas_df = pandas.DataFrame(data)
+
+            try:
+                pandas_result = pandas_df.fillna(0, method=method, axis=axis, limit=limit)
+            except Exception as e:
+                with pytest.raises(type(e)):
+                    modin_df.fillna(0, method=method, axis=axis, limit=limit)
+            else:
+                modin_result = modin_df.fillna(0, method=method, axis=axis, limit=limit)
+                df_equals(modin_result, pandas_result)
+
     def test_fillna_sanity(self):
         test_data = TestData()
         tf = test_data.tsframe

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -2069,7 +2069,11 @@ class TestDFPartOne:
         df_equals(modin_df.ffill(), test_data.tsframe.ffill())
 
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-    @pytest.mark.parametrize("method", ["backfill", "bfill", "pad", "ffill", None], ids=["backfill", "bfill", "pad", "ffill", "None"])
+    @pytest.mark.parametrize(
+        "method",
+        ["backfill", "bfill", "pad", "ffill", None],
+        ids=["backfill", "bfill", "pad", "ffill", "None"],
+    )
     @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
     @pytest.mark.parametrize("limit", int_arg_values, ids=int_arg_keys)
     def test_fillna(self, data, method, axis, limit):
@@ -2080,7 +2084,9 @@ class TestDFPartOne:
             pandas_df = pandas.DataFrame(data)
 
             try:
-                pandas_result = pandas_df.fillna(0, method=method, axis=axis, limit=limit)
+                pandas_result = pandas_df.fillna(
+                    0, method=method, axis=axis, limit=limit
+                )
             except Exception as e:
                 with pytest.raises(type(e)):
                     modin_df.fillna(0, method=method, axis=axis, limit=limit)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Changes how `fillna` is applied to the partitions depending on the arguments being passed in

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
