### PR TITLE
Fix index mismatch for add

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -762,7 +762,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
             new_data = self._map_across_full_axis(
                 axis, self._prepare_method(list_like_op)
             )
-            return self.__constructor__(new_data, self.index, self.columns)
+            if axis == 1 and isinstance(scalar, pandas.Series):
+                new_columns = self.columns.union([label for label in scalar.index if label not in self.columns])
+            else:
+                new_columns = self.columns
+            return self.__constructor__(new_data, self.index, new_columns)
         else:
             return self._map_partitions(self._prepare_method(func))
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -763,7 +763,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 axis, self._prepare_method(list_like_op)
             )
             if axis == 1 and isinstance(scalar, pandas.Series):
-                new_columns = self.columns.union([label for label in scalar.index if label not in self.columns])
+                new_columns = self.columns.union(
+                    [label for label in scalar.index if label not in self.columns]
+                )
             else:
                 new_columns = self.columns
             return self.__constructor__(new_data, self.index, new_columns)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -143,6 +143,18 @@ class TestDFPartOne:
             modin_result = getattr(modin_df, op)(series_test_modin, axis=0)
             df_equals(modin_result, pandas_result)
 
+        # Test dataframe to series with different index
+        series_test_modin = modin_df[modin_df.columns[0]].reset_index(drop=True)
+        series_test_pandas = pandas_df[pandas_df.columns[0]].reset_index(drop=True)
+        try:
+            pandas_result = getattr(pandas_df, op)(series_test_pandas, axis=0)
+        except Exception as e:
+            with pytest.raises(type(e)):
+                getattr(modin_df, op)(series_test_modin, axis=0)
+        else:
+            modin_result = getattr(modin_df, op)(series_test_modin, axis=0)
+            df_equals(modin_result, pandas_result)
+
         # Level test
         new_idx = pandas.MultiIndex.from_tuples(
             [(i // 4, i // 2, i) for i in modin_df.index]


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

The index calculation for `add` did not account for the fact that `add` would increase the number of columns.

## Related issue number

#708 

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
