### PR TITLE
Add to_numpy method

### DIFF
--- a/modin/engines/base/frame/partition.py
+++ b/modin/engines/base/frame/partition.py
@@ -62,7 +62,7 @@ class BaseFramePartition(object):  # pragma: no cover
             A Pandas DataFrame.
         """
         raise NotImplementedError("Must be implemented in child class")
-    
+
     def to_numpy(self):
         """Convert the object stored in this partition to a Numpy Array.
 

--- a/modin/engines/base/frame/partition.py
+++ b/modin/engines/base/frame/partition.py
@@ -62,6 +62,17 @@ class BaseFramePartition(object):  # pragma: no cover
             A Pandas DataFrame.
         """
         raise NotImplementedError("Must be implemented in child class")
+    
+    def to_numpy(self):
+        """Convert the object stored in this partition to a Numpy Array.
+
+        Note: If the underlying object is a Pandas DataFrame, this will return
+            a 2D array.
+
+        Returns:
+            A Numpy Array.
+        """
+        raise NotImplementedError("Must be implemented in child class")
 
     def mask(self, row_indices, col_indices):
         """Lazily create a mask that extracts the indices provided.

--- a/modin/engines/python/pandas_on_python/frame/partition.py
+++ b/modin/engines/python/pandas_on_python/frame/partition.py
@@ -93,6 +93,14 @@ class PandasOnPythonFramePartition(BaseFramePartition):
 
         return dataframe
 
+    def to_numpy(self):
+        """Convert the object stored in this partition to a NumPy Array.
+
+        Returns:
+            A NumPy Array.
+        """
+        return self.apply(lambda df: df.values).get()
+
     @classmethod
     def put(cls, obj):
         """A factory classmethod to format a given object.

--- a/modin/engines/ray/pandas_on_ray/frame/partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition.py
@@ -88,6 +88,14 @@ class PandasOnRayFramePartition(BaseFramePartition):
         assert type(dataframe) is pandas.DataFrame or type(dataframe) is pandas.Series
         return dataframe
 
+    def to_numpy(self):
+        """Convert the object stored in this parition to a Numpy Array.
+
+        Returns:
+            A Numpy Array.
+        """
+        return self.apply(lambda df: df.values).get()
+
     def mask(self, row_indices, col_indices):
         new_obj = self.add_to_apply_calls(
             lambda df: pandas.DataFrame(df.iloc[row_indices, col_indices])

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1060,6 +1060,12 @@ class TestDFPartOne:
         with pytest.warns(UserWarning):
             pd.DataFrame({"A": [1, 2], "B": [3, 4]}).to_numpy()
 
+    def test_partition_to_numpy(self):
+        test_data = TestData()
+        frame = pd.DataFrame(test_data.frame)
+        for partition in frame._query_compiler.data.partitions.flatten().tolist():
+            assert np.array_equal(partition.to_pandas().values, partition.to_numpy())
+            
     def test_asfreq(self):
         index = pd.date_range("1/1/2000", periods=4, freq="T")
         series = pd.Series([0.0, None, 2.0, 3.0], index=index)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1065,7 +1065,7 @@ class TestDFPartOne:
         frame = pd.DataFrame(test_data.frame)
         for partition in frame._query_compiler.data.partitions.flatten().tolist():
             assert np.array_equal(partition.to_pandas().values, partition.to_numpy())
-            
+
     def test_asfreq(self):
         index = pd.date_range("1/1/2000", periods=4, freq="T")
         series = pd.Series([0.0, None, 2.0, 3.0], index=index)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

These changes add an abstract `to_numpy` method to the `BaseFramePartition` class and implement it in the `PandasOnRayFramePartition` class. 

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
