### PR TITLE
Add to_numpy to Frame Manager, Query Compiler, and BaseDataFrame

### DIFF
--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -158,6 +158,17 @@ class BaseQueryCompiler(object):
 
     # END To/From Pandas
 
+    # To NumPy
+    def to_numpy(self):
+        """Converts Modin DataFrame to NumPy DataFrame.
+
+        Returns:
+            NumPy Array of the QueryCompiler.
+        """
+        raise NotImplementedError("Must be implemented in children classes")
+
+    # END To NumPy
+
     # Abstract copartition
     def copartition(self, axis, other, how_to_join, sort, force_repartition=False):
         """Copartition two QueryCompiler objects.

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -532,6 +532,21 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # END To/From Pandas
 
+    # To NumPy
+    def to_numpy(self):
+        """Converts Modin DataFrame to NumPy Array.
+
+        Returns:
+            NumPy Array of the QueryCompiler.
+        """
+        arr = self.data.to_numpy(is_transposed=self._is_transposed)
+        ErrorMessage.catch_bugs_and_request_email(
+            len(arr) != len(self.index) or len(arr[0]) != len(self.columns)
+        )
+        return arr
+
+    # END To NumPy
+
     # Inter-Data operations (e.g. add, sub)
     # These operations require two DataFrames and will change the shape of the
     # data if the index objects don't match. An outer join + op is performed,

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -543,8 +543,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
         ErrorMessage.catch_bugs_and_request_email(
             len(arr) != len(self.index) or len(arr[0]) != len(self.columns)
         )
-        if len(self.columns) == 1 and self.columns[0] == "__reduced__":
-            arr = arr.flatten()
         return arr
 
     # END To NumPy

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -543,6 +543,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         ErrorMessage.catch_bugs_and_request_email(
             len(arr) != len(self.index) or len(arr[0]) != len(self.columns)
         )
+        if len(self.columns) == 1 and self.columns[0] == "__reduced__":
+            arr = arr.flatten()
         return arr
 
     # END To NumPy

--- a/modin/backends/pyarrow/query_compiler.py
+++ b/modin/backends/pyarrow/query_compiler.py
@@ -191,3 +191,15 @@ class PyarrowQueryCompiler(PandasQueryCompiler):
             df.index = self.index
             df.columns = self.columns
         return df
+
+    def to_numpy(self):
+        """Converts Modin DataFrame to NumPy Array.
+
+        Returns:
+            NumPy Array of the QueryCompiler.
+        """
+        arr = self.data.to_numpy(is_transposed=self._is_transposed)
+        ErrorMessage.catch_bugs_and_request_email(
+            len(arr) != len(self.index) or len(arr[0]) != len(self.columns)
+        )
+        return arr

--- a/modin/backends/pyarrow/query_compiler.py
+++ b/modin/backends/pyarrow/query_compiler.py
@@ -202,6 +202,4 @@ class PyarrowQueryCompiler(PandasQueryCompiler):
         ErrorMessage.catch_bugs_and_request_email(
             len(arr) != len(self.index) or len(arr[0]) != len(self.columns)
         )
-        if len(self.columns) == 1 and self.columns[0] == "__reduced__":
-            arr = arr.flatten()
         return arr

--- a/modin/backends/pyarrow/query_compiler.py
+++ b/modin/backends/pyarrow/query_compiler.py
@@ -202,4 +202,6 @@ class PyarrowQueryCompiler(PandasQueryCompiler):
         ErrorMessage.catch_bugs_and_request_email(
             len(arr) != len(self.index) or len(arr[0]) != len(self.columns)
         )
+        if len(self.columns) == 1 and self.columns[0] == "__reduced__":
+            arr = arr.flatten()
         return arr

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -57,8 +57,6 @@ class BaseFrameManager(object):
     _row_partition_class = None
     # Whether or not we have already filtered out the empty partitions.
     _filtered_empties = False
-    # Vectorized function to convert array of row partitions into a partitioned NumPy array.
-    _vec_to_numpy = np.vectorize(lambda row: row.to_numpy(), otypes=[np.ndarray])
 
     def _get_partitions(self):
         if not self._filtered_empties or (
@@ -529,7 +527,9 @@ class BaseFrameManager(object):
         Returns:
             A NumPy Array
         """
-        arr = np.block(self._vec_to_numpy(self.partitions).tolist())
+        arr = np.block(
+            [[block.to_pandas().values for block in row] for row in self.partitions]
+        )
         if is_transposed:
             return arr.T
         return arr

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -527,9 +527,7 @@ class BaseFrameManager(object):
         Returns:
             A NumPy Array
         """
-        arr = np.block(
-            [[block.to_pandas().values for block in row] for row in self.partitions]
-        )
+        arr = np.block([[block.to_numpy() for block in row] for row in self.partitions])
         if is_transposed:
             return arr.T
         return arr

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -57,6 +57,8 @@ class BaseFrameManager(object):
     _row_partition_class = None
     # Whether or not we have already filtered out the empty partitions.
     _filtered_empties = False
+    # Vectorized function to convert array of row partitions into a partitioned NumPy array.
+    _vec_to_numpy = np.vectorize(lambda row: row.to_numpy(), otypes=[np.ndarray])
 
     def _get_partitions(self):
         if not self._filtered_empties or (
@@ -520,6 +522,17 @@ class BaseFrameManager(object):
                 return pandas.DataFrame()
             else:
                 return pandas.concat(df_rows)
+
+    def to_numpy(self, is_transposed=False):
+        """Convert this object into a NumPy Array from the partitions.
+
+        Returns:
+            A NumPy Array
+        """
+        arr = np.block(self._vec_to_numpy(self.partitions).tolist())
+        if is_transposed:
+            return arr.T
+        return arr
 
     @classmethod
     def from_pandas(cls, df):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2964,7 +2964,7 @@ class BasePandasDataset(object):
             A numpy array.
         """
         arr = self._query_compiler.to_numpy()
-        if dtype != None:
+        if dtype is not None:
             return np.asarray(arr, dtype)
         return arr
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3162,7 +3162,8 @@ class BasePandasDataset(object):
         return self._binary_op("__and__", other, axis=0)
 
     def __array__(self, dtype=None):
-        return self.to_numpy(dtype)
+        arr = self.to_numpy(dtype)
+        return arr
 
     def __array_wrap__(self, result, context=None):
         """TODO: This is very inefficient. __array__ and as_matrix have been

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -532,7 +532,9 @@ class BasePandasDataset(object):
         Returns:
             values: ndarray
         """
-        return self.to_numpy()
+        if columns is None:
+            return self.to_numpy()
+        return self.__getitem__(columns).to_numpy()
 
     def asfreq(self, freq, method=None, how=None, normalize=False, fill_value=None):
         return self._default_to_pandas(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -532,7 +532,6 @@ class BasePandasDataset(object):
         Returns:
             values: ndarray
         """
-        # TODO this is very inefficient, also see __array__
         return self.to_numpy()
 
     def asfreq(self, freq, method=None, how=None, normalize=False, fill_value=None):
@@ -3161,11 +3160,13 @@ class BasePandasDataset(object):
         return self._binary_op("__and__", other, axis=0)
 
     def __array__(self, dtype=None):
-        # TODO: This is very inefficient and needs fix, also see as_matrix
         return self.to_numpy(dtype)
 
     def __array_wrap__(self, result, context=None):
-        # TODO: This is very inefficient, see also __array__ and as_matrix
+        """TODO: This is very inefficient. __array__ and as_matrix have been
+        changed to call the more efficient to_numpy, but this has been left
+        unchanged since we are not sure of its purpose.
+        """
         return self._default_to_pandas("__array_wrap__", result, context=context)
 
     def __copy__(self, deep=True):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -533,7 +533,7 @@ class BasePandasDataset(object):
             values: ndarray
         """
         # TODO this is very inefficient, also see __array__
-        return self._default_to_pandas("as_matrix", columns=columns)
+        return self.to_numpy()
 
     def asfreq(self, freq, method=None, how=None, normalize=False, fill_value=None):
         return self._default_to_pandas(
@@ -3162,7 +3162,7 @@ class BasePandasDataset(object):
 
     def __array__(self, dtype=None):
         # TODO: This is very inefficient and needs fix, also see as_matrix
-        return self._default_to_pandas("__array__", dtype=dtype)
+        return self.to_numpy(dtype)
 
     def __array_wrap__(self, result, context=None):
         # TODO: This is very inefficient, see also __array__ and as_matrix

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2963,7 +2963,10 @@ class BasePandasDataset(object):
         Returns:
             A numpy array.
         """
-        return self._default_to_pandas("to_numpy", dtype=dtype, copy=copy)
+        arr = self._query_compiler.to_numpy()
+        if dtype != None:
+            return np.asarray(arr, dtype)
+        return arr
 
     # TODO(williamma12): When this gets implemented, have the series one call this.
     def to_period(self, freq=None, axis=0, copy=True):  # pragma: no cover
@@ -3335,7 +3338,7 @@ class BasePandasDataset(object):
         Returns:
             The numpy representation of this object.
         """
-        return self._to_pandas().values
+        return self.to_numpy()
 
     @property
     def __name__(self):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -124,6 +124,9 @@ class Series(BasePandasDataset):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).__and__(new_other)
 
+    def __array__(self, dtype=None):
+        return super(Series, self).__array__(dtype).flatten()
+
     def __array_prepare__(self, result, context=None):  # pragma: no cover
         return self._default_to_pandas(
             pandas.Series.__array_prepare__, result, context=context
@@ -261,6 +264,15 @@ class Series(BasePandasDataset):
     __ipow__ = __pow__
     __isub__ = __sub__
     __itruediv__ = __truediv__
+
+    @property
+    def values(self):
+        """Create a numpy array with the values from this Series.
+
+        Returns:
+            The numpy representation of this object.
+        """
+        return super(Series, self).to_numpy().flatten()
 
     def __xor__(self, other):
         new_self, new_other = self._prepare_inter_op(other)
@@ -1038,6 +1050,19 @@ class Series(BasePandasDataset):
 
     def to_list(self):
         return self._default_to_pandas(pandas.Series.to_list)
+
+    def to_numpy(self, dtype=None, copy=False):
+        """Convert the Series to a NumPy array.
+
+        Args:
+            dtype: The dtype to pass to numpy.asarray()
+            copy: Whether to ensure that the returned value is a not a view on another
+                array.
+
+        Returns:
+            A numpy array.
+        """
+        return super(Series, self).to_numpy(dtype, copy).flatten()
 
     tolist = to_list
 

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1065,9 +1065,7 @@ class TestDFPartOne:
         test_data = TestData()
         frame = pd.DataFrame(test_data.frame)
         for partition in frame._query_compiler.data.partitions.flatten().tolist():
-            assert_array_equal(
-                partition.to_pandas().values, partition.to_numpy()
-            )
+            assert_array_equal(partition.to_pandas().values, partition.to_numpy())
 
     def test_asfreq(self):
         index = pd.date_range("1/1/2000", periods=4, freq="T")

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1059,13 +1059,13 @@ class TestDFPartOne:
     def test_to_numpy(self):
         test_data = TestData()
         frame = pd.DataFrame(test_data.frame)
-        assert assert_array_equal(frame.values, test_data.frame.values)
+        assert_array_equal(frame.values, test_data.frame.values)
 
     def test_partition_to_numpy(self):
         test_data = TestData()
         frame = pd.DataFrame(test_data.frame)
         for partition in frame._query_compiler.data.partitions.flatten().tolist():
-            assert assert_array_equal(
+            assert_array_equal(
                 partition.to_pandas().values, partition.to_numpy()
             )
 

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1059,13 +1059,15 @@ class TestDFPartOne:
     def test_to_numpy(self):
         test_data = TestData()
         frame = pd.DataFrame(test_data.frame)
-        assert np.array_equiv(frame.values, test_data.frame.values)
+        assert assert_array_equal(frame.values, test_data.frame.values)
 
     def test_partition_to_numpy(self):
         test_data = TestData()
         frame = pd.DataFrame(test_data.frame)
         for partition in frame._query_compiler.data.partitions.flatten().tolist():
-            assert np.array_equal(partition.to_pandas().values, partition.to_numpy())
+            assert assert_array_equal(
+                partition.to_pandas().values, partition.to_numpy()
+            )
 
     def test_asfreq(self):
         index = pd.date_range("1/1/2000", periods=4, freq="T")

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1057,8 +1057,9 @@ class TestDFPartOne:
         tm.assert_almost_equal(mat, expected)
 
     def test_to_numpy(self):
-        with pytest.warns(UserWarning):
-            pd.DataFrame({"A": [1, 2], "B": [3, 4]}).to_numpy()
+        test_data = TestData()
+        frame = pd.DataFrame(test_data.frame)
+        assert np.array_equiv(frame.values, test_data.frame.values)
 
     def test_partition_to_numpy(self):
         test_data = TestData()

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2487,7 +2487,7 @@ def test_to_period():
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_to_numpy(data):
     modin_series, pandas_series = create_test_series(data)
-    assert np.array_equiv(modin_series.values, pandas_series.values)
+    assert assert_array_equal(modin_series.values, pandas_series.values)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2485,6 +2485,12 @@ def test_to_period():
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_to_numpy(data):
+    modin_series, pandas_series = create_test_series(data)
+    assert np.array_equiv(modin_series.values, pandas_series.values)
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_to_sparse(data):
     modin_series, _ = create_test_series(data)  # noqa: F841
     with pytest.warns(UserWarning):

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -177,8 +177,7 @@ def test___and__(data):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test___array__(data):
     modin_series, pandas_series = create_test_series(data)
-    with pytest.warns(UserWarning):
-        modin_result = modin_series.__array__()
+    modin_result = modin_series.__array__()
     assert_array_equal(modin_result, pandas_series.__array__())
 
 
@@ -741,8 +740,7 @@ def test_as_blocks(data):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_as_matrix(data):
     modin_series, _ = create_test_series(data)  # noqa: F841
-    with pytest.warns(UserWarning):
-        modin_series.as_matrix()
+    modin_series.as_matrix()
 
 
 def test_asfreq():
@@ -2487,7 +2485,7 @@ def test_to_period():
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_to_numpy(data):
     modin_series, pandas_series = create_test_series(data)
-    assert assert_array_equal(modin_series.values, pandas_series.values)
+    assert_array_equal(modin_series.values, pandas_series.values)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Add the to_numpy method to the BaseFrameManager, Python and PyArrow QueryCompiler and the BaseDataFrame.
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
