### PR TITLE
Parallel parquet reading by row group - third try 

### DIFF
--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -255,13 +255,13 @@ class RayIO(BaseIO):
             ]
 
             # Note: In the nested list comprehnsion below, the expression  j==row_group_partitions[0],
-            #       controls the return of the dtypes array, which for efficiency is only returned 
-            #       from the first remote call for the first row group                      
+            #       controls the return of the dtypes array, which for efficiency is only returned
+            #       from the first remote call for the first row group
             blocks_with_lengths = [
                 [
                     cls.read_parquet_remote_task._remote(
-                        args=(path, col_partitions[i], 1, j, True, True if j==row_group_partitions[0] else False, True, kwargs),
-                        num_return_vals= (len(j) + 3) if j==row_group_partitions[0] else (len(j) + 2),
+                        args=(path, col_partitions[i], 1, j, True, True if j == row_group_partitions[0] else False, True, kwargs),
+                        num_return_vals=(len(j) + 3) if j == row_group_partitions[0] else (len(j) + 2),
                     )
                     for i in range(len(col_partitions))
                 ]
@@ -270,23 +270,22 @@ class RayIO(BaseIO):
 
             blk_partitions = []
             total_count = 0
-            my_data_types = []          
+            my_data_types = []
 
             # process first row group partition
             rowgroup_idx = 0
             for z in range(len(row_group_partitions[rowgroup_idx])):
-                blk_partitions.append([blocks_with_lengths[rowgroup_idx][0][z]])             
+                blk_partitions.append([blocks_with_lengths[rowgroup_idx][0][z]])
             cur_len_index = len(row_group_partitions[rowgroup_idx])
             cur_datatype_index = len(row_group_partitions[rowgroup_idx]) + 1
             cur_split_lengths_index = len(row_group_partitions[rowgroup_idx]) + 2
             row_lengths.extend(ray.get(blocks_with_lengths[rowgroup_idx][0][cur_split_lengths_index]))
             total_count = total_count + ray.get(blocks_with_lengths[rowgroup_idx][0][cur_len_index])
-                                                                                       
-            # prepare metdata                                                                                                                 
-            my_data_types = ray.get(blocks_with_lengths[rowgroup_idx][0][cur_datatype_index])   
-            datatypes_row = ray.put(my_data_types)   
+            # prepare metdata
+            my_data_types = ray.get(blocks_with_lengths[rowgroup_idx][0][cur_datatype_index])
+            datatypes_row = ray.put(my_data_types)
 
-            # process remaining row group partitions  
+            # process remaining row group partitions
             for rowgroup_idx in range(1, len(row_group_partitions)):
               for z in range(len(row_group_partitions[rowgroup_idx])):
                 blk_partitions.append([blocks_with_lengths[rowgroup_idx][0][z]])

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -64,6 +64,11 @@ def _read_parquet_columns(
 
     kwargs["use_pandas_metadata"] = True
 
+    print("In remote read parquet")
+    print("num_splits:" + str(num_splits))
+    print("Columns:" + str(columns))
+    print("Rowgroups:" + str(rowgroups))
+
     if not len(rowgroups) == 0:
         pf = ParquetFile(path)
         df_list = [
@@ -73,6 +78,7 @@ def _read_parquet_columns(
         df_lengths = [len(df.index) for df in df_list]
         total_df_length = sum(df_lengths)
         dtypes = df_list[0].dtypes
+        print("About to return")
         return (
             df_list
             + ([total_df_length] if do_return_length else [])

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -33,7 +33,16 @@ def _split_result_for_readers(axis, num_splits, df):  # pragma: no cover
 
 
 @ray.remote
-def _read_parquet_columns(path, columns, num_splits, rowgroups, do_return_length, do_return_dtypes, do_return_split_lengths, kwargs):  # pragma: no cover
+def _read_parquet_columns(
+    path,
+    columns,
+    num_splits,
+    rowgroups,
+    do_return_length,
+    do_return_dtypes,
+    do_return_split_lengths,
+    kwargs,
+):  # pragma: no cover
     """Use a Ray task to read columns from Parquet into a Pandas DataFrame.
 
     Note: Ray functions are not detected by codecov (thus pragma: no cover)
@@ -64,12 +73,21 @@ def _read_parquet_columns(path, columns, num_splits, rowgroups, do_return_length
         df_lengths = [len(df.index) for df in df_list]
         total_df_length = sum(df_lengths)
         dtypes = df_list[0].dtypes
-        return df_list + ([total_df_length] if do_return_length else []) + ([dtypes] if do_return_dtypes else []) + ([df_lengths] if do_return_split_lengths else [])
+        return (
+            df_list
+            + ([total_df_length] if do_return_length else [])
+            + ([dtypes] if do_return_dtypes else [])
+            + ([df_lengths] if do_return_split_lengths else [])
+        )
     else:
         df = pq.read_table(path, columns=columns, **kwargs).to_pandas()
         df = df[columns]
         # Append the length of the index here to build it externally
-        return _split_result_for_readers(0, num_splits, df) + ([len(df.index)] if do_return_length else []) + ([df.dtypes] if do_return_dtypes else [])
+        return (
+            _split_result_for_readers(0, num_splits, df)
+            + ([len(df.index)] if do_return_length else [])
+            + ([df.dtypes] if do_return_dtypes else [])
+        )
 
 
 @ray.remote

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -33,7 +33,7 @@ def _split_result_for_readers(axis, num_splits, df):  # pragma: no cover
 
 
 @ray.remote
-def _read_parquet_columns(path, columns, num_splits, rowgroups,  do_return_length, do_return_dtypes, do_return_split_lengths, kwargs):  # pragma: no cover
+def _read_parquet_columns(path, columns, num_splits, rowgroups, do_return_length, do_return_dtypes, do_return_split_lengths, kwargs):  # pragma: no cover
     """Use a Ray task to read columns from Parquet into a Pandas DataFrame.
 
     Note: Ray functions are not detected by codecov (thus pragma: no cover)
@@ -64,12 +64,12 @@ def _read_parquet_columns(path, columns, num_splits, rowgroups,  do_return_lengt
         df_lengths = [len(df.index) for df in df_list]
         total_df_length = sum(df_lengths)
         dtypes = df_list[0].dtypes
-        return df_list + ( [total_df_length] if do_return_length else [] ) +  ( [dtypes] if do_return_dtypes else []) + ( [df_lengths] if do_return_split_lengths else []) 
+        return df_list + ([total_df_length] if do_return_length else []) + ([dtypes] if do_return_dtypes else []) + ([df_lengths] if do_return_split_lengths else [])
     else:
         df = pq.read_table(path, columns=columns, **kwargs).to_pandas()
         df = df[columns]
         # Append the length of the index here to build it externally
-        return _split_result_for_readers(0, num_splits, df) + ( [len(df.index)] if do_return_length else [] ) + ( [df.dtypes] if do_return_dtypes else [] )
+        return _split_result_for_readers(0, num_splits, df) + ([len(df.index)] if do_return_length else []) + ([df.dtypes] if do_return_dtypes else [])
 
 
 @ray.remote

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -33,7 +33,7 @@ def _split_result_for_readers(axis, num_splits, df):  # pragma: no cover
 
 
 @ray.remote
-def _read_parquet_columns(path, columns, num_splits, rowgroups, kwargs):  # pragma: no cover
+def _read_parquet_columns(path, columns, num_splits, rowgroups,  do_return_length, do_return_dtypes, kwargs):  # pragma: no cover
     """Use a Ray task to read columns from Parquet into a Pandas DataFrame.
 
     Note: Ray functions are not detected by codecov (thus pragma: no cover)
@@ -62,12 +62,12 @@ def _read_parquet_columns(path, columns, num_splits, rowgroups, kwargs):  # prag
         ]
         total_df_length = sum(len(df.index) for df in df_list)
         dtypes = df_list[0].dtypes
-        return df_list + [total_df_length] + [dtypes]
+        return df_list + ( [total_df_length] if do_return_length else [] ) +  ( [dtypes] if do_return_dtypes else [])
     else:
         df = pq.read_table(path, columns=columns, **kwargs).to_pandas()
         df = df[columns]
         # Append the length of the index here to build it externally
-        return _split_result_for_readers(0, num_splits, df) + [len(df.index), df.dtypes]
+        return _split_result_for_readers(0, num_splits, df) + ( [len(df.index)] if do_return_length else [] ) + ( [df.dtypes] if do_return_dtypes else [] )
 
 
 @ray.remote


### PR DESCRIPTION
Parquet reader parallelized by row group.
In this version the number of row groups is divided by the number of available worker partitions, so that each remote call processes an equal share of the row groups.

Given that Parquet compressed data will have many more rows than columns any time it is of large total size, datasets are not split into columns splits, but read in a single column group.  Thus, each row group will only be scanned once.

The code path updated in this PR only applies to Parquet files that are NOT in a partitioned directory.
Parallelization of partitioned parquet files would be best done based on parallelizing the reading of partitioned bins, not row groups.

Flag parameter have been added to `_read_parquet_columns()` to control the return of lengths, dtypes metadata in order to avoid the superfulous creation of remote objects that would contain redundant data, because these data can be obtained from just the first remote job.

  