### PR TITLE
Default to pandas on MultiLevelIndex `reset_index`

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2187,14 +2187,14 @@ class BasePandasDataset(object):
         inplace = validate_bool_kwarg(inplace, "inplace")
         # TODO Implement level
         if level is not None or isinstance(self.index, pandas.MultiIndex):
-            return self._default_to_pandas(
+            new_query_compiler = self._default_to_pandas(
                 "reset_index",
                 level=level,
                 drop=drop,
-                inplace=inplace,
+                inplace=False,
                 col_level=col_level,
                 col_fill=col_fill,
-            )
+            )._query_compiler
         # Error checking for matching Pandas. Pandas does not allow you to
         # insert a dropped index into a DataFrame if these columns already
         # exist.

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2186,8 +2186,8 @@ class BasePandasDataset(object):
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
         # TODO Implement level
-        if level is not None:
-            new_query_compiler = self._default_to_pandas(
+        if level is not None or isinstance(self.index, pandas.MultiIndex):
+            return self._default_to_pandas(
                 "reset_index",
                 level=level,
                 drop=drop,


### PR DESCRIPTION
* Resolves #738
* Fixes the default behavior to return the correct object and not
  error

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] tests added and passing
