### PR TITLE
Temporarily patch s3fs unclosed socket warning issue

### DIFF
--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -32,11 +32,13 @@ def file_exists(file_path):
             from botocore.exceptions import NoCredentialsError
 
             s3fs = S3FS.S3FileSystem(anon=False)
+            exists = False
             try:
-                return s3fs.exists(file_path)
+                exists = s3fs.exists(file_path) or exists
             except NoCredentialsError:
-                s3fs = S3FS.S3FileSystem(anon=True)
-                return s3fs.exists(file_path)
+                pass
+            s3fs = S3FS.S3FileSystem(anon=True)
+            return exists or s3fs.exists(file_path)
     return os.path.exists(file_path)
 
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -838,6 +838,8 @@ def test_from_csv_s3(make_csv_file):
     # This will warn if it defaults to pandas behavior, but it shouldn't
     with pytest.warns(None) as record:
         modin_df = pd.read_csv(dataset_url)
+    
+    print([str(err) for err in record.list])
     assert not any(
         "defaulting to pandas implementation" in str(err) for err in record.list
     )

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -838,7 +838,9 @@ def test_from_csv_s3(make_csv_file):
     # This will warn if it defaults to pandas behavior, but it shouldn't
     with pytest.warns(None) as record:
         modin_df = pd.read_csv(dataset_url)
-    assert not record.list
+    assert not any(
+        "defaulting to pandas implementation" in str(err) for err in record.list
+    )
 
     assert modin_df_equals_pandas(modin_df, pandas_df)
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -839,7 +839,6 @@ def test_from_csv_s3(make_csv_file):
     with pytest.warns(None) as record:
         modin_df = pd.read_csv(dataset_url)
 
-    print([str(err) for err in record.list])
     assert not any(
         "defaulting to pandas implementation" in str(err) for err in record.list
     )

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -838,7 +838,7 @@ def test_from_csv_s3(make_csv_file):
     # This will warn if it defaults to pandas behavior, but it shouldn't
     with pytest.warns(None) as record:
         modin_df = pd.read_csv(dataset_url)
-    
+
     print([str(err) for err in record.list])
     assert not any(
         "defaulting to pandas implementation" in str(err) for err in record.list


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Workaround for unclosed socket warning caused by s3fs during testing.
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
