### PR TITLE
count with level defaults to pandas

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -683,6 +683,11 @@ class BasePandasDataset(object):
         Returns:
             The count, in a Series (or DataFrame if level is specified).
         """
+        if level is not None:
+            return self._default_to_pandas(
+                "count", axis=axis, level=level, numeric_only=numeric_only
+            )
+
         axis = self._get_axis_number(axis) if axis is not None else 0
         return self._reduce_dimension(
             self._query_compiler.count(

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1331,10 +1331,16 @@ class TestDFPartOne:
         # multi-index count test
         levels = 2
         modin_multiindex_df = modin_df.groupby(list(modin_df.columns[:levels])).count()
-        pandas_multiindex_df = pandas_df.groupby(list(pandas_df.columns[:levels])).count()
+        pandas_multiindex_df = pandas_df.groupby(
+            list(pandas_df.columns[:levels])
+        ).count()
         for level in range(levels):
-            modin_result = modin_multiindex_df.count(axis="index", numeric_only=numeric_only, level=level)
-            pandas_result = pandas_multiindex_df.count(axis="index", numeric_only=numeric_only, level=level)
+            modin_result = modin_multiindex_df.count(
+                axis="index", numeric_only=numeric_only, level=level
+            )
+            pandas_result = pandas_multiindex_df.count(
+                axis="index", numeric_only=numeric_only, level=level
+            )
             df_equals(modin_result, pandas_result)
 
     def test_cov(self):

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1328,6 +1328,15 @@ class TestDFPartOne:
         pandas_result = pandas_df.T.count(axis=axis, numeric_only=numeric_only)
         df_equals(modin_result, pandas_result)
 
+        # multi-index count test
+        levels = 2
+        modin_multiindex_df = modin_df.groupby(list(modin_df.columns[:levels])).count()
+        pandas_multiindex_df = pandas_df.groupby(list(pandas_df.columns[:levels])).count()
+        for level in range(levels):
+            modin_result = modin_multiindex_df.count(axis="index", numeric_only=numeric_only, level=level)
+            pandas_result = pandas_multiindex_df.count(axis="index", numeric_only=numeric_only, level=level)
+            df_equals(modin_result, pandas_result)
+
     def test_cov(self):
         data = test_data_values[0]
         with pytest.warns(UserWarning):


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

Calling `df.count()` with specified level on a MultiIndex DataFrame will default to the Pandas implementation instead of raising an error. 

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] tests added and passing
