### PR TITLE
Rename `map_full_axis` style functions to `fold`

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -468,9 +468,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             )
         else:
             return self.__constructor__(
-                self._modin_frame._fold_reduce(
-                    axis, lambda df: func(df, **kwargs)
-                )
+                self._modin_frame._fold_reduce(axis, lambda df: func(df, **kwargs))
             )
 
     def prod(self, **kwargs):
@@ -641,9 +639,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
         axis = kwargs.get("axis", 0)
         return self.__constructor__(
-            self._modin_frame._fold_reduce(
-                axis, lambda df: df.idxmax(**kwargs)
-            )
+            self._modin_frame._fold_reduce(axis, lambda df: df.idxmax(**kwargs))
         )
 
     def idxmin(self, **kwargs):
@@ -654,9 +650,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
         axis = kwargs.get("axis", 0)
         return self.__constructor__(
-            self._modin_frame._fold_reduce(
-                axis, lambda df: df.idxmin(**kwargs)
-            )
+            self._modin_frame._fold_reduce(axis, lambda df: df.idxmin(**kwargs))
         )
 
     def last_valid_index(self):
@@ -691,9 +685,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
         # Pandas default is 0 (though not mentioned in docs)
         axis = kwargs.get("axis", 0)
-        return self._modin_frame._fold_reduce(
-            axis, lambda df: df.median(**kwargs)
-        )
+        return self._modin_frame._fold_reduce(axis, lambda df: df.median(**kwargs))
 
     def nunique(self, **kwargs):
         """Returns the number of unique items over each column or row.
@@ -702,9 +694,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             A new QueryCompiler object of ints indexed by column or index names.
         """
         axis = kwargs.get("axis", 0)
-        return self._modin_frame._fold_reduce(
-            axis, lambda df: df.nunique(**kwargs)
-        )
+        return self._modin_frame._fold_reduce(axis, lambda df: df.nunique(**kwargs))
 
     def quantile_for_single_value(self, **kwargs):
         """Returns quantile of each column or row.
@@ -737,9 +727,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
         # Pandas default is 0 (though not mentioned in docs)
         axis = kwargs.get("axis", 0)
-        return self._modin_frame._fold_reduce(
-            axis, lambda df: df.skew(**kwargs)
-        )
+        return self._modin_frame._fold_reduce(axis, lambda df: df.skew(**kwargs))
 
     def std(self, **kwargs):
         """Returns standard deviation of each column or row.
@@ -750,9 +738,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
         # Pandas default is 0 (though not mentioned in docs)
         axis = kwargs.get("axis", 0)
-        return self._modin_frame._fold_reduce(
-            axis, lambda df: df.std(**kwargs)
-        )
+        return self._modin_frame._fold_reduce(axis, lambda df: df.std(**kwargs))
 
     def var(self, **kwargs):
         """Returns variance of each column or row.
@@ -762,9 +748,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
         # Pandas default is 0 (though not mentioned in docs)
         axis = kwargs.get("axis", 0)
-        return self._modin_frame._fold_reduce(
-            axis, lambda df: df.var(**kwargs)
-        )
+        return self._modin_frame._fold_reduce(axis, lambda df: df.var(**kwargs))
 
     # END Column/Row partitions reduce operations
 
@@ -808,9 +792,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     def _cumulative_builder(self, func, **kwargs):
         axis = kwargs.get("axis", 0)
-        new_modin_frame = self._modin_frame._fold(
-            axis, lambda df: func(df, **kwargs)
-        )
+        new_modin_frame = self._modin_frame._fold(axis, lambda df: func(df, **kwargs))
         return self.__constructor__(new_modin_frame)
 
     def cummax(self, **kwargs):
@@ -1524,9 +1506,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
             )
             untouched_frame = None
         else:
-            new_modin_frame = self._modin_frame.mask(
-                col_indices=columns
-            )._fold(0, lambda df: pandas.get_dummies(df, **kwargs))
+            new_modin_frame = self._modin_frame.mask(col_indices=columns)._fold(
+                0, lambda df: pandas.get_dummies(df, **kwargs)
+            )
             untouched_frame = self.drop(columns=columns)
         # If we mapped over all the data we are done. If not, we need to
         # prepend the `new_modin_frame` with the raw data from the columns that were

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -663,7 +663,7 @@ class BasePandasFrame(object):
             new_parts, index, columns, new_lengths, new_widths, new_dtypes
         )
 
-    def _map_reduce_full_axis(self, axis, func):
+    def _fold_reduce(self, axis, func):
         """Applies map that reduce Manager to series but require knowledge of full axis.
 
         Args:
@@ -730,7 +730,7 @@ class BasePandasFrame(object):
             dtypes=dtypes,
         )
 
-    def _map_full_axis(self, axis, func):
+    def _fold(self, axis, func):
         """Perform a function across an entire axis.
 
         Note: The data shape is not changed (length and width of the table).

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -1051,7 +1051,7 @@ class RayIO(BaseIO):
             df.to_sql(**kwargs)
             return pandas.DataFrame()
 
-        result = qc._modin_frame._map_reduce_full_axis(1, func)
+        result = qc._modin_frame._fold_reduce(1, func)
         # blocking operation
         result.to_pandas()
 


### PR DESCRIPTION
* Renaming methods to be more accurate.
* `fold` is a better name than `map_full_axis`.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
