### PR TITLE
Fix issue where assigning a column value to overwrite a column

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1149,6 +1149,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 _setitem()
             return df
 
+        if isinstance(value, type(self)):
+            value = value.to_pandas()
         if is_list_like(value):
             new_modin_frame = self._modin_frame._apply_full_axis_select_indices(
                 axis,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1943,6 +1943,8 @@ class DataFrame(BasePandasDataset):
             new_self = DataFrame({key: value}, columns=self.columns)
             self._update_inplace(new_self._query_compiler)
         else:
+            if isinstance(value, Series):
+                value = value._query_compiler
             self._update_inplace(self._query_compiler.setitem(0, key, value))
 
     def __hash__(self):

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4962,6 +4962,13 @@ class TestDFPartTwo:
 
         df_equals(modin_df, pandas_df)
 
+        # Test series assignment to column
+        modin_df = pd.DataFrame(columns=modin_df.columns)
+        pandas_df = pandas.DataFrame(columns=pandas_df.columns)
+        modin_df[modin_df.columns[-1]] = modin_df[modin_df.columns[0]]
+        pandas_df[pandas_df.columns[-1]] = pandas_df[pandas_df.columns[0]]
+        df_equals(modin_df, pandas_df)
+
         # Transpose test
         modin_df = pd.DataFrame(data).T
         pandas_df = pandas.DataFrame(data).T


### PR DESCRIPTION
* Resolves #764
* No longer try to serialize a `Series` object when assigning a new
  column
* Convert the value to a pandas Series to reuse current logic for
  setitem
* In the future we should use the `join` functionality to reduce the
  overhead of `setitem`

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
