### PR TITLE
Add a warning message when passing a SQLAlchemy connection object to read_sql

### DIFF
--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -1078,7 +1078,7 @@ class RayIO(BaseIO):
         if isinstance(con, (sa.engine.Engine, sa.engine.Connection)):
             warnings.warn(
                 "To use parallel implementation of `read_sql`, pass the "
-                "connection string as `con` instead of {}.".format(type(con))
+                "connection string instead of {}.".format(type(con))
             )
             return super(RayIO, cls).read_sql(sql, con, index_col=index_col, **kwargs)
         row_cnt_query = "SELECT COUNT(*) FROM ({}) as foo".format(sql)

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -1076,8 +1076,10 @@ class RayIO(BaseIO):
         # are not pickleable. We have to convert it to the URL string and connect from
         # each of the workers.
         if isinstance(con, (sa.engine.Engine, sa.engine.Connection)):
-            warnings.warn("To use parallel implementation of `read_sql`, pass the "
-                          "connection string as `con` instead of {}.".format(type(con)))
+            warnings.warn(
+                "To use parallel implementation of `read_sql`, pass the "
+                "connection string as `con` instead of {}.".format(type(con))
+            )
             return super(RayIO, cls).read_sql(sql, con, index_col=index_col, **kwargs)
         row_cnt_query = "SELECT COUNT(*) FROM ({}) as foo".format(sql)
         row_cnt = pandas.read_sql(row_cnt_query, con).squeeze()

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -11,6 +11,7 @@ import re
 import sys
 import numpy as np
 import math
+import warnings
 
 from modin.error_message import ErrorMessage
 from modin.engines.base.io import BaseIO
@@ -1075,7 +1076,9 @@ class RayIO(BaseIO):
         # are not pickleable. We have to convert it to the URL string and connect from
         # each of the workers.
         if isinstance(con, (sa.engine.Engine, sa.engine.Connection)):
-            con = repr(con.engine.url)
+            warnings.warn("To use parallel implementation of `read_sql`, pass the "
+                          "connection string as `con` instead of {}.".format(type(con)))
+            return super(RayIO, cls).read_sql(sql, con, index_col=index_col, **kwargs)
         row_cnt_query = "SELECT COUNT(*) FROM ({}) as foo".format(sql)
         row_cnt = pandas.read_sql(row_cnt_query, con).squeeze()
         cols_names_df = pandas.read_sql(


### PR DESCRIPTION


* Resolves #741
* Add a warning to users to let them know that the parallel
  implementation requires the string so Modin can create the connections
  to the database.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
