### PR TITLE
Add better defaulting to pandas message for `groupby`

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -491,6 +491,6 @@ class DataFrameGroupBy(object):
             by = self._by
 
         def groupby_on_multiple_columns(df):
-            f(df.groupby(by=by, axis=self._axis, **self._kwargs), **kwargs)
+            return f(df.groupby(by=by, axis=self._axis, **self._kwargs), **kwargs)
 
         return self._df._default_to_pandas(groupby_on_multiple_columns)

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -490,6 +490,7 @@ class DataFrameGroupBy(object):
         else:
             by = self._by
 
-        return self._df._default_to_pandas(
-            lambda df: f(df.groupby(by=by, axis=self._axis, **self._kwargs)), **kwargs
-        )
+        def groupby_on_multiple_columns(df):
+            f(df.groupby(by=by, axis=self._axis, **self._kwargs), **kwargs)
+
+        return self._df._default_to_pandas(groupby_on_multiple_columns)


### PR DESCRIPTION
* Resolves #734
* Adds a function that contains the correct name instead of using an
  anonymous lambda.
* User will now see:
```
UserWarning: `DataFrame.groupby_on_multiple_columns` defaulting to pandas implementation.
```

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
