### PR TITLE
Reduce the amount of data we deserialize to match pandas

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -83,7 +83,7 @@ class DataFrame(BasePandasDataset):
             self._query_compiler = query_compiler
 
     def __repr__(self):
-        num_rows = pandas.get_option("max_rows") or 60
+        num_rows = pandas.get_option("max_rows") or 10
         num_cols = pandas.get_option("max_columns") or 20
 
         result = repr(self._build_repr_df(num_rows, num_cols))


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
Pandas changed the default to 10 lines in the most recent release. We don't need to fetch so much data anymore
<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
