### PR TITLE
Update components of groupby when level is being used

### DIFF
--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -784,7 +784,7 @@ class BasePandasFrame(object):
             )
         if new_index is None:
             new_index = self._frame_mgr_cls.get_indices(
-                1, new_partitions, lambda df: df.index
+                0, new_partitions, lambda df: df.index
             )
         # Length objects for new object creation. This is shorter than if..else
         # This object determines the lengths and widths based on the given parameters

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -695,19 +695,7 @@ class BasePandasDataset(object):
 
             if isinstance(level, str):
                 level = self.axes[axis].names.index(level)
-
-            new_names = dict(
-                zip(
-                    range(len(self.axes[axis].levels[level])),
-                    self.axes[axis].levels[level],
-                )
-            )
-            return (
-                self.groupby(self.axes[axis].codes[level], axis=axis)
-                .count()
-                .rename(new_names, axis=axis)
-                .rename_axis(self.axes[axis].names[level], axis=axis)
-            )
+            return self.groupby(level=level, axis=axis).count()
 
         return self._reduce_dimension(
             self._query_compiler.count(

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -348,7 +348,10 @@ class DataFrame(BasePandasDataset):
             by = self.index.map(by)
         elif isinstance(by, str):
             idx_name = by
-            if isinstance(self.axes[axis], pandas.MultiIndex) and by in self.axes[axis].names:
+            if (
+                isinstance(self.axes[axis], pandas.MultiIndex)
+                and by in self.axes[axis].names
+            ):
                 # In this case we pass the string value of the name through to the
                 # partitions. This is more efficient than broadcasting the values.
                 pass

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -411,10 +411,8 @@ class DataFrameGroupBy(object):
         if (
             self._is_multi_by
             or self._level is not None
-            or isinstance(self._df.axes[self._axis], pandas.MultiIndex)
         ):
             return self._default_to_pandas(map_func, **kwargs)
-
         if not isinstance(self._by, type(self._query_compiler)):
             return self._apply_agg_function(map_func, drop=drop, **kwargs)
 
@@ -461,7 +459,6 @@ class DataFrameGroupBy(object):
         if (
             self._is_multi_by
             or self._level is not None
-            or isinstance(self._index, pandas.MultiIndex)
         ):
             return self._default_to_pandas(f, **kwargs)
         # For aggregations, pandas behavior does this for the result.

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -408,10 +408,7 @@ class DataFrameGroupBy(object):
     def _groupby_reduce(
         self, map_func, reduce_func, drop=True, numeric_only=True, **kwargs
     ):
-        if (
-            self._is_multi_by
-            or self._level is not None
-        ):
+        if self._is_multi_by or self._level is not None:
             return self._default_to_pandas(map_func, **kwargs)
         if not isinstance(self._by, type(self._query_compiler)):
             return self._apply_agg_function(map_func, drop=drop, **kwargs)
@@ -456,10 +453,7 @@ class DataFrameGroupBy(object):
         else:
             by = self._by
 
-        if (
-            self._is_multi_by
-            or self._level is not None
-        ):
+        if self._is_multi_by or self._level is not None:
             return self._default_to_pandas(f, **kwargs)
         # For aggregations, pandas behavior does this for the result.
         # For other operations it does not, so we wait until there is an aggregation to

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -801,9 +801,17 @@ def test_groupby_on_index_values_with_loop():
 def test_groupby_multiindex():
     frame_data = np.random.randint(0, 100, size=(2 ** 6, 2 ** 4))
     modin_df = pd.DataFrame(frame_data)
+    pandas_df = pandas.DataFrame(frame_data)
+
     new_columns = pandas.MultiIndex.from_tuples(
-        [(i // 4, i // 2, i) for i in modin_df.columns]
+        [(i // 4, i // 2, i) for i in modin_df.columns], names=["four", "two", "one"]
     )
     modin_df.columns = new_columns
+    pandas_df.columns = new_columns
     with pytest.warns(UserWarning):
-        modin_df.groupby(level=0).sum()
+        modin_df.groupby(level=1, axis=1).sum()
+
+    modin_df = modin_df.T
+    pandas_df = pandas_df.T
+    ray_df_equals_pandas(modin_df.groupby(level=1).count(), pandas_df.groupby(level=1).count())
+    ray_df_equals_pandas(modin_df.groupby(by="four").count(), pandas_df.groupby(by="four").count())

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -813,5 +813,9 @@ def test_groupby_multiindex():
 
     modin_df = modin_df.T
     pandas_df = pandas_df.T
-    ray_df_equals_pandas(modin_df.groupby(level=1).count(), pandas_df.groupby(level=1).count())
-    ray_df_equals_pandas(modin_df.groupby(by="four").count(), pandas_df.groupby(by="four").count())
+    ray_df_equals_pandas(
+        modin_df.groupby(level=1).count(), pandas_df.groupby(level=1).count()
+    )
+    ray_df_equals_pandas(
+        modin_df.groupby(by="four").count(), pandas_df.groupby(by="four").count()
+    )


### PR DESCRIPTION
* Resolves #758
* Update the index extraction to be correct (bug: axis=1 -> 0)
* Send the level name to the partitions if it is specified
* Don't always default to pandas when a MultiIndex is the grouping axis

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
