### PR TITLE
Update `Series.map` to support dictionary of operations and support `…

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -683,7 +683,7 @@ class Series(BasePandasDataset):
         return super(Series, new_self).lt(new_other, level=level, axis=axis)
 
     def map(self, arg, na_action=None):
-        if not callable(arg):
+        if not callable(arg) and hasattr(arg, "get"):
             mapper = arg
 
             def arg(s):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -683,7 +683,17 @@ class Series(BasePandasDataset):
         return super(Series, new_self).lt(new_other, level=level, axis=axis)
 
     def map(self, arg, na_action=None):
-        return self.__constructor__(query_compiler=self._query_compiler.applymap(arg))
+        if not callable(arg):
+            mapper = arg
+
+            def arg(s):
+                return mapper.get(s, np.nan)
+
+        return self.__constructor__(
+            query_compiler=self._query_compiler.applymap(
+                lambda s: arg(s) if not pandas.isnull(s) or na_action is None else s
+            )
+        )
 
     def memory_usage(self, index=True, deep=False):
         if index:

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1705,10 +1705,19 @@ def test_mad(data):
         modin_series.mad()
 
 
+@pytest.mark.parametrize("na_values", ["ignore", None], ids=["na_ignore", "na_none"])
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_map(data):
+def test_map(data, na_values):
     modin_series, pandas_series = create_test_series(data)
-    df_equals(modin_series.map(str), pandas_series.map(str))
+    df_equals(
+        modin_series.map(str, na_action=na_values),
+        pandas_series.map(str, na_action=na_values),
+    )
+    mapper = {i: str(i) for i in range(100)}
+    df_equals(
+        modin_series.map(mapper, na_action=na_values),
+        pandas_series.map(mapper, na_action=na_values),
+    )
 
 
 def test_mask():


### PR DESCRIPTION
…na_action`

* Resolves #778
* Creates a callable for the dictionary to match pandas behavior
* Continues to use `applymap` to avoid communication unnecessary data
* Add conditional for the `na_action` to match pandas behavior

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
