### PR TITLE
Support multiple `names` values for groupby on MultiLevelIndex

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -361,10 +361,12 @@ class DataFrame(BasePandasDataset):
             if isinstance(by, Series):
                 idx_name = by.name
                 by = by.values
-            mismatch = (
-                len(by) != len(self) if axis == 0 else len(by) != len(self.columns)
-            )
-            if mismatch and all(obj in self for obj in by):
+            mismatch = len(by) != len(self.axes[axis])
+            if mismatch and all(
+                obj in self
+                or (hasattr(self.index, "names") and obj in self.index.names)
+                for obj in by
+            ):
                 # In the future, we will need to add logic to handle this, but for now
                 # we default to pandas in this case.
                 pass

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -819,3 +819,8 @@ def test_groupby_multiindex():
     ray_df_equals_pandas(
         modin_df.groupby(by="four").count(), pandas_df.groupby(by="four").count()
     )
+
+    by = ["one", "two"]
+    ray_df_equals_pandas(
+        modin_df.groupby(by=by).count(), pandas_df.groupby(by=by).count()
+    )


### PR DESCRIPTION
* Resolves #783
* Updates error checking to allow multiple level values to be passed
  for the `by` parameter as long as they are included in `names`.
* Add tests for checking this behavior matches pandas

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
