### PR TITLE
Fix `groupby` + `reduce` for partitions with only 1 row

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1413,7 +1413,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
         def _map(df, other):
             return map_func(
-                df.groupby(by=other.squeeze(axis=axis ^ 1), axis=axis, **groupby_args), **map_args
+                df.groupby(by=other.squeeze(axis=axis ^ 1), axis=axis, **groupby_args),
+                **map_args
             ).reset_index(drop=False)
 
         if reduce_func is not None:

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1413,7 +1413,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
         def _map(df, other):
             return map_func(
-                df.groupby(by=other.squeeze(), axis=axis, **groupby_args), **map_args
+                df.groupby(by=other.squeeze(axis=axis ^ 1), axis=axis, **groupby_args), **map_args
             ).reset_index(drop=False)
 
         if reduce_func is not None:


### PR DESCRIPTION
* Resolves #747
* No longer assume more than one row in the data
* Change the squeeze on the `by` parameter to only squeeze along the
  opposite axis as the groupby.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
