### PR TITLE
Fix `DataFrame.apply` when the result of the `apply` is a `Series`

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1381,13 +1381,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
         if isinstance(pandas.DataFrame().apply(func), pandas.Series):
             new_modin_frame = self._modin_frame._fold_reduce(
-                axis,
-                lambda df: pandas.DataFrame(df.apply(func, axis=axis, *args, **kwargs)),
+                axis, lambda df: df.apply(func, axis=axis, *args, **kwargs)
             )
         else:
             new_modin_frame = self._modin_frame._apply_full_axis(
-                axis,
-                lambda df: pandas.DataFrame(df.apply(func, axis=axis, *args, **kwargs)),
+                axis, lambda df: df.apply(func, axis=axis, *args, **kwargs)
             )
         return self.__constructor__(new_modin_frame)
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1381,11 +1381,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
         if isinstance(pandas.DataFrame().apply(func), pandas.Series):
             new_modin_frame = self._modin_frame._fold_reduce(
-                axis, lambda df: pandas.DataFrame(df.apply(func, axis=axis, *args, **kwargs))
+                axis,
+                lambda df: pandas.DataFrame(df.apply(func, axis=axis, *args, **kwargs)),
             )
         else:
             new_modin_frame = self._modin_frame._apply_full_axis(
-                axis, lambda df: pandas.DataFrame(df.apply(func, axis=axis, *args, **kwargs))
+                axis,
+                lambda df: pandas.DataFrame(df.apply(func, axis=axis, *args, **kwargs)),
             )
         return self.__constructor__(new_modin_frame)
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1381,11 +1381,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
         if isinstance(pandas.DataFrame().apply(func), pandas.Series):
             new_modin_frame = self._modin_frame._fold_reduce(
-                axis, lambda df: df.apply(func, axis=axis, *args, **kwargs)
+                axis, lambda df: pandas.DataFrame(df.apply(func, axis=axis, *args, **kwargs))
             )
         else:
             new_modin_frame = self._modin_frame._apply_full_axis(
-                axis, lambda df: df.apply(func, axis=axis, *args, **kwargs)
+                axis, lambda df: pandas.DataFrame(df.apply(func, axis=axis, *args, **kwargs))
             )
         return self.__constructor__(new_modin_frame)
 

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -775,7 +775,7 @@ class BasePandasFrame(object):
             A new dataframe.
         """
         new_partitions = self._frame_mgr_cls.map_axis_partitions(
-            axis, self._partitions, func
+            axis, self._partitions, self._build_mapreduce_func(axis, func)
         )
         # Index objects for new object creation. This is shorter than if..else
         if new_columns is None:

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -988,6 +988,23 @@ class TestDFPartOne:
             modin_result = modin_df.apply(func, axis)
             df_equals(modin_result, pandas_result)
 
+    def test_apply_metadata(self):
+        def add(a, b, c):
+            return a + b + c
+
+        data = {"A": [1, 2, 3], "B": [4, 5, 6], "C": [7, 8, 9]}
+
+        modin_df = pd.DataFrame(data)
+        modin_df["add"] = modin_df.apply(
+            lambda row: add(row["A"], row["B"], row["C"]), axis=1
+        )
+
+        pandas_df = pandas.DataFrame(data)
+        pandas_df["add"] = pandas_df.apply(
+            lambda row: add(row["A"], row["B"], row["C"]), axis=1
+        )
+        df_equals(modin_df, pandas_df)
+
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     @pytest.mark.parametrize("func", agg_func_values, ids=agg_func_keys)
     @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)


### PR DESCRIPTION
* Resolves #790
* Wrap the result of `apply` in a `pandas.DataFrame` to correctly use
  the results to compute metadata

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
