### PR TITLE
Fixup a broken docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Linux or Mac OS, you can install and use either engine.
 
 ### Full Documentation
 
-Visit the complete documentation on readthedocs: http://modin.readthedocs.io
+Visit the complete documentation on readthedocs: https://modin.readthedocs.io
 
 ### Scale your pandas workflow by changing a single line of code.
 

--- a/docs/UsingSQLonRay/index.rst
+++ b/docs/UsingSQLonRay/index.rst
@@ -30,4 +30,4 @@ Modin has a query compiler that acts as an intermediate layer between the query 
    0    1   2.0            A String of information   True
    1    6  17.0  A String of different information  False
 
-.. _architecture: architecture.html
+.. _architecture: https://modin.readthedocs.io/en/latest/architecture.html

--- a/docs/using_modin.rst
+++ b/docs/using_modin.rst
@@ -115,11 +115,11 @@ used to create the blog post.
 
 .. _`DataFrame`: https://pandas.pydata.org/pandas-docs/version/0.23.4/generated/pandas.DataFrame.html
 .. _`pandas`: https://pandas.pydata.org/pandas-docs/stable/
-.. _`installation page`: http://modin.readthedocs.io/en/latest/installation.html
-.. _`currently supported methods`: http://modin.readthedocs.io/en/latest/pandas_supported.html
-.. _`open an issue`: http://github.com/modin-project/modin/issues
+.. _`installation page`: https://modin.readthedocs.io/en/latest/installation.html
+.. _`currently supported methods`: https://modin.readthedocs.io/en/latest/pandas_supported.html
+.. _`open an issue`: https://github.com/modin-project/modin/issues
 .. _`autoscaler documentation`: https://ray.readthedocs.io/en/latest/autoscaling.html
 .. _`Ray's documentation`: https://ray.readthedocs.io/en/latest/api.html
 .. _`blog post`: https://rise.cs.berkeley.edu/blog/pandas-on-ray-early-lessons/
-.. _`Jupyter Notebook`: http://gist.github.com/devin-petersohn/f424d9fb5579a96507c709a36d487f24#file-pandas_on_ray_blog_post_0-ipynb
+.. _`Jupyter Notebook`: https://gist.github.com/devin-petersohn/f424d9fb5579a96507c709a36d487f24#file-pandas_on_ray_blog_post_0-ipynb
 .. _`Out of Core`: out_of_core.html


### PR DESCRIPTION
## What do these changes do?

Fixup broken documentation link and while at it convert http urls to https