### PR TITLE
Empty call queue after drain_call_queue for dask backend

### DIFF
--- a/modin/engines/dask/pandas_on_dask_futures/frame/partition.py
+++ b/modin/engines/dask/pandas_on_dask_futures/frame/partition.py
@@ -76,6 +76,7 @@ class PandasOnDaskFramePartition(BaseFramePartition):
         if len(self.call_queue) == 0:
             return
         self.future = self.apply(lambda x: x).future
+        self.call_queue = []
 
     def mask(self, row_indices, col_indices):
         new_obj = self.add_to_apply_calls(


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

This commits empties the `call_queue` after calling `partition.drain_call_queue` for the dask backend.

## Related issue number

#809
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
