### PR TITLE
Fix build issue for documentation

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -11,4 +11,5 @@ sphinx
 sphinx-click
 sphinx_rtd_theme
 pandas
-modin
+modin[all]
+


### PR DESCRIPTION
* Resolves #810
* Adds `[all]` target to modin install from pip

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
