### PR TITLE
Adding hooks to be able to custom distribute non-pandas objects

### DIFF
--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -32,6 +32,14 @@ class BaseFactory(object):
         return cls.io_cls.from_pandas(df)
 
     @classmethod
+    def from_non_pandas(cls, *args, **kwargs):
+        return cls._determine_engine()._from_non_pandas(*args, **kwargs)
+
+    @classmethod
+    def _from_non_pandas(cls, *args, **kwargs):
+        return cls.io_cls.from_non_pandas(*args, **kwargs)
+
+    @classmethod
     def read_parquet(cls, **kwargs):
         return cls._determine_engine()._read_parquet(**kwargs)
 

--- a/modin/engines/base/io.py
+++ b/modin/engines/base/io.py
@@ -6,6 +6,10 @@ from modin.backends.base.query_compiler import BaseQueryCompiler
 
 class BaseIO(object):
     @classmethod
+    def from_non_pandas(cls, *args, **kwargs):
+        return None
+
+    @classmethod
     def from_pandas(cls, df):
         return cls.query_compiler_cls.from_pandas(df, cls.frame_cls)
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -18,7 +18,7 @@ from typing import Tuple, Union
 import warnings
 
 from modin.error_message import ErrorMessage
-from .utils import from_pandas, to_pandas, _inherit_docstrings
+from .utils import from_pandas, from_non_pandas, to_pandas, _inherit_docstrings
 from .iterator import PartitionIterator
 from .series import Series
 from .base import BasePandasDataset
@@ -61,6 +61,11 @@ class DataFrame(BasePandasDataset):
                 data._add_sibling(self)
         # Check type of data and use appropriate constructor
         elif query_compiler is None:
+            distributed_frame = from_non_pandas(data, index, columns, dtype)
+            if distributed_frame is not None:
+                self._query_compiler = distributed_frame._query_compiler
+                return
+
             warnings.warn(
                 "Distributing {} object. This may take some time.".format(type(data))
             )

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -1,6 +1,15 @@
 from ..data_management.factories import BaseFactory
 
 
+def from_non_pandas(df, index, columns, dtype):
+    new_qc = BaseFactory.from_non_pandas(df, index, columns, dtype)
+    if new_qc is not None:
+        from .dataframe import DataFrame
+
+        return DataFrame(query_compiler=new_qc)
+    return new_qc
+
+
 def from_pandas(df):
     """Converts a pandas DataFrame to a Ray DataFrame.
     Args:


### PR DESCRIPTION
* Resolves #807
* Adds a BaseFactory method to create a DataFrame from a non-pandas object
* New query compilers are free to override the BaseIO functionality, which only returns None
* If the query compiler only has certain types of data customized, it can still return None
  for the not-yet-implemented types.
* If there is no custom way of handling the type provided, we just default back to the pandas
  DataFrame behavior and use `from_pandas`

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
