### PR TITLE
Add fast path for `concat` when the axes and partitioning is aligned

### DIFF
--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1037,18 +1037,30 @@ class BasePandasFrame(object):
             A new dataframe.
         """
         # Fast path for equivalent columns and partitioning
-        if axis == 0 and all(o.columns.equals(self.columns) for o in others) and all(o._column_widths == self._column_widths for o in others):
+        if (
+            axis == 0
+            and all(o.columns.equals(self.columns) for o in others)
+            and all(o._column_widths == self._column_widths for o in others)
+        ):
             joined_index = self.columns
             left_parts = self._partitions
             right_parts = [o._partitions for o in others]
-            new_lengths = self._row_lengths + [l for o in others for l in o._row_lengths]
+            new_lengths = self._row_lengths + [
+                l for o in others for l in o._row_lengths
+            ]
             new_widths = self._column_widths
-        elif axis == 1 and all(o.index.equals(self.index) for o in others) and all(o._row_lengths == self._row_lengths for o in others):
+        elif (
+            axis == 1
+            and all(o.index.equals(self.index) for o in others)
+            and all(o._row_lengths == self._row_lengths for o in others)
+        ):
             joined_index = self.index
             left_parts = self._partitions
             right_parts = [o._partitions for o in others]
             new_lengths = self._row_lengths
-            new_widths = self._column_widths + [l for o in others for l in o._column_widths]
+            new_widths = self._column_widths + [
+                l for o in others for l in o._column_widths
+            ]
         else:
             left_parts, right_parts, joined_index = self._copartition(
                 axis ^ 1, others, how, sort, force_repartition=True
@@ -1062,7 +1074,9 @@ class BasePandasFrame(object):
         else:
             new_columns = self.columns.append([other.columns for other in others])
             new_index = joined_index
-        return self.__constructor__(new_partitions, new_index, new_columns, new_lengths, new_widths)
+        return self.__constructor__(
+            new_partitions, new_index, new_columns, new_lengths, new_widths
+        )
 
     def groupby_reduce(
         self, axis, by, map_func, reduce_func, new_index=None, new_columns=None

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1036,11 +1036,25 @@ class BasePandasFrame(object):
         Returns:
             A new dataframe.
         """
-        # TODO Update to no longer force repartition
-        # Requires pruning of the partitions after they have been changed
-        left_parts, right_parts, joined_index = self._copartition(
-            axis ^ 1, others, how, sort, force_repartition=True
-        )
+        # Fast path for equivalent columns and partitioning
+        if axis == 0 and all(o.columns.equals(self.columns) for o in others) and all(o._column_widths == self._column_widths for o in others):
+            joined_index = self.columns
+            left_parts = self._partitions
+            right_parts = [o._partitions for o in others]
+            new_lengths = self._row_lengths + [l for o in others for l in o._row_lengths]
+            new_widths = self._column_widths
+        elif axis == 1 and all(o.index.equals(self.index) for o in others) and all(o._row_lengths == self._row_lengths for o in others):
+            joined_index = self.index
+            left_parts = self._partitions
+            right_parts = [o._partitions for o in others]
+            new_lengths = self._row_lengths
+            new_widths = self._column_widths + [l for o in others for l in o._column_widths]
+        else:
+            left_parts, right_parts, joined_index = self._copartition(
+                axis ^ 1, others, how, sort, force_repartition=True
+            )
+            new_lengths = None
+            new_widths = None
         new_partitions = self._frame_mgr_cls.concat(axis, left_parts, right_parts)
         if axis == 0:
             new_index = self.index.append([other.index for other in others])
@@ -1048,7 +1062,7 @@ class BasePandasFrame(object):
         else:
             new_columns = self.columns.append([other.columns for other in others])
             new_index = joined_index
-        return self.__constructor__(new_partitions, new_index, new_columns)
+        return self.__constructor__(new_partitions, new_index, new_columns, new_lengths, new_widths)
 
     def groupby_reduce(
         self, axis, by, map_func, reduce_func, new_index=None, new_columns=None


### PR DESCRIPTION
* Resolves #817
* This is a common usecase, where the partitioning is already aligned
* Performance is improved significantly, operations that took O(10s) are taking 300ms
* Properly propagate metadata to further improve performance

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
