### PR TITLE
Remove dtype requirement from `head`, `tail`, etc.

### DIFF
--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1214,7 +1214,7 @@ class BasePandasFrame(object):
             self.columns,
             new_row_lengths,
             self._column_widths,
-            self.dtypes,
+            self._dtypes,
         )
 
     def tail(self, n):
@@ -1239,7 +1239,7 @@ class BasePandasFrame(object):
             self.columns,
             new_row_lengths,
             self._column_widths,
-            self.dtypes,
+            self._dtypes,
         )
 
     def front(self, n):
@@ -1261,7 +1261,7 @@ class BasePandasFrame(object):
             self.columns[:n],
             self._row_lengths,
             new_col_lengths,
-            self.dtypes[:n],
+            self.dtypes[:n] if self._dtypes is not None else None,
         )
 
     def back(self, n):
@@ -1283,7 +1283,7 @@ class BasePandasFrame(object):
             self.columns[-n:],
             self._row_lengths,
             new_col_lengths,
-            self.dtypes[n:],
+            self.dtypes[n:] if self._dtypes is not None else None,
         )
 
     # End Head/Tail/Front/Back


### PR DESCRIPTION
* Resolves #816
* Only passes `dtypes` through if they have been computed
* Several operations that do not have a `dtypes` inferred or passed through
  will be positively affected by this.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
