### PR TITLE
Adding `quantile` to list of Reductions

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -388,6 +388,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     sum_min_count = ReductionFunction.register(pandas.DataFrame.sum)
     prod_min_count = ReductionFunction.register(pandas.DataFrame.prod)
     mean = ReductionFunction.register(pandas.DataFrame.mean)
+    quantile_for_single_value = ReductionFunction.register(pandas.DataFrame.quantile)
 
     # END Reduction operations
 
@@ -515,29 +516,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
             .squeeze()
         )
         return self.index[first_result]
-
-    def quantile_for_single_value(self, **kwargs):
-        """Returns quantile of each column or row.
-
-        Returns:
-            A new QueryCompiler object containing the quantile of each column or row.
-        """
-        axis = kwargs.get("axis", 0)
-        q = kwargs.get("q", 0.5)
-        assert type(q) is float
-
-        def quantile_builder(df):
-            try:
-                return pandas.DataFrame.quantile(df, **kwargs)
-            except ValueError:
-                return pandas.Series()
-
-        result = self._modin_frame._fold_reduce(axis, quantile_builder)
-        if axis == 0:
-            result.index = [q]
-        else:
-            result.columns = [q]
-        return self.__constructor__(result)
 
     # END Column/Row partitions reduce operations
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1894,7 +1894,7 @@ class BasePandasDataset(object):
                 )
             )
         else:
-            return self._reduce_dimension(
+            result = self._reduce_dimension(
                 self._query_compiler.quantile_for_single_value(
                     q=q,
                     axis=axis,
@@ -1902,6 +1902,9 @@ class BasePandasDataset(object):
                     interpolation=interpolation,
                 )
             )
+            if isinstance(result, BasePandasDataset):
+                result.name = q
+            return result
 
     def rank(
         self,


### PR DESCRIPTION
* Removes a lot of unneeded code from implementation
* Moves some of the pandas-specific metadata changes to the API layer
  * Names the result if it is a `Series`

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
