### PR TITLE
Revert "Update Ray version to 0.7.5"

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -12,7 +12,7 @@ omit =
     # Skip Dask until it is fully a part of the testing suite
     modin/engines/dask/*
     # Skip Gandiva because it is experimental
-    modin/experimental/*
+    modin/experimental/engines/pyarrow_on_ray/*
     modin/backends/pyarrow/*
 
 [report]

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,15 +53,15 @@ matrix:
         - export PATH="$HOME/miniconda/bin:$PATH"
         - python -m pytest modin/pandas/test/test_api.py
 
-#    - os: linux
-#      dist: trusty
-#      env:
-#        - PYTHON=3.6
-#        - MODIN_BACKEND=pyarrow
-#        - MODIN_EXPERIMENTAL=True
-#      script:
-#        - export PATH="$HOME/miniconda/bin:$PATH"
-#        - python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_io.py::test_from_csv --cov-append
+    - os: linux
+      dist: trusty
+      env:
+        - PYTHON=3.6
+        - MODIN_BACKEND=pyarrow
+        - MODIN_EXPERIMENTAL=True
+      script:
+        - export PATH="$HOME/miniconda/bin:$PATH"
+        - python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_io.py::test_from_csv --cov-append
 
 install:
   - ./ci/travis/install-dependencies.sh

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -47,7 +47,7 @@ def get_execution_engine():
                             "Please `pip install modin[dask] to install compatible Dask version."
                         )
             else:
-                if ray.__version__ != "0.7.5":
+                if ray.__version__ != "0.7.3":
                     raise ImportError(
                         "Please `pip install modin[ray] to install compatible Ray version."
                     )

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -132,10 +132,6 @@ def initialize_ray():
         plasma_directory = None
         cluster = os.environ.get("MODIN_RAY_CLUSTER", None)
         redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
-        total_mem = ray.utils.get_system_memory()
-        # This is a vile hack.
-        # TODO remove when ray-project/ray#5837 is resolved
-        ray.utils.get_system_memory = lambda: 10 ** 20
         if cluster == "True" and redis_address is not None:
             # We only start ray in a cluster setting for the head node.
             ray.init(
@@ -154,13 +150,15 @@ def initialize_ray():
                 # want to overwrite that value if we have.
                 if object_store_memory is None:
                     # Round down to the nearest Gigabyte.
-                    mem_bytes = total_mem // 10 ** 9 * 10 ** 9
+                    mem_bytes = ray.utils.get_system_memory() // 10 ** 9 * 10 ** 9
                     # Default to 8x memory for out of core
                     object_store_memory = 8 * mem_bytes
             # In case anything failed above, we can still improve the memory for Modin.
             if object_store_memory is None:
                 # Round down to the nearest Gigabyte.
-                object_store_memory = int(0.6 * total_mem // 10 ** 9 * 10 ** 9)
+                object_store_memory = int(
+                    0.6 * ray.utils.get_system_memory() // 10 ** 9 * 10 ** 9
+                )
                 # If the memory pool is smaller than 2GB, just use the default in ray.
                 if object_store_memory == 0:
                     object_store_memory = None
@@ -170,7 +168,6 @@ def initialize_ray():
                 include_webui=False,
                 ignore_reinit_error=True,
                 plasma_directory=plasma_directory,
-                memory=total_mem,
                 object_store_memory=object_store_memory,
                 redis_address=redis_address,
                 logging_level=100,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ pandas==0.25.1
 numpy
 dask[complete]>=2.1.0
 distributed>=2.3.2
-ray==0.7.5
+ray==0.7.3
 psutil==5.4.8
 strip_hints==0.1.1
 xarray

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 dask_deps = ["dask>=2.1.0", "distributed>=2.3.2"]
-ray_deps = ["ray==0.7.5"]
+ray_deps = ["ray==0.7.3"]
 
 setup(
     name="modin",


### PR DESCRIPTION
Reverts modin-project/modin#822.

I ran into several bugs that exist in earlier versions of Ray when using exceptionally large nodes. It appears that Ray is not equipped to deal with these nodes in newer releases, so we are rolling back to a version we have found to be more stable.