### PR TITLE
Add support for level argument in any, all

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -104,7 +104,6 @@ class BasePandasDataset(object):
         """
         if isinstance(level, str):
             level = self.axes[axis].names.index(level)
-
         return getattr(self.groupby(level=level, axis=axis), op)(**kwargs)
 
     def _validate_other(
@@ -427,11 +426,9 @@ class BasePandasDataset(object):
                     raise NotImplementedError(
                         "Option bool_only is not implemented with option level."
                     )
-
                 return self._handle_level_agg(
                     axis, level, "all", skipna=skipna, **kwargs
                 )
-
             return self._reduce_dimension(
                 self._query_compiler.all(
                     axis=axis, bool_only=bool_only, skipna=skipna, level=level, **kwargs
@@ -441,9 +438,7 @@ class BasePandasDataset(object):
             if bool_only:
                 raise ValueError("Axis must be 0 or 1 (got {})".format(axis))
             # Reduce to a scalar if axis is None.
-
             if level is not None:
-
                 return self._handle_level_agg(
                     axis, level, "all", skipna=skipna, **kwargs
                 )
@@ -483,17 +478,14 @@ class BasePandasDataset(object):
                 return data_for_compute.any(
                     axis=axis, bool_only=False, skipna=skipna, level=level, **kwargs
                 )
-
             if level is not None:
                 if bool_only is not None:
                     raise NotImplementedError(
                         "Option bool_only is not implemented with option level."
                     )
-
                 return self._handle_level_agg(
                     axis, level, "any", skipna=skipna, **kwargs
                 )
-
             return self._reduce_dimension(
                 self._query_compiler.any(
                     axis=axis, bool_only=bool_only, skipna=skipna, level=level, **kwargs
@@ -503,7 +495,6 @@ class BasePandasDataset(object):
             if bool_only:
                 raise ValueError("Axis must be 0 or 1 (got {})".format(axis))
             # Reduce to a scalar if axis is None.
-
             if level is not None:
                 return self._handle_level_agg(
                     axis, level, "any", skipna=skipna, **kwargs

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -739,8 +739,7 @@ class BasePandasDataset(object):
                 # error thrown by pandas
                 raise TypeError("Can only count levels on hierarchical columns.")
 
-            return self._handle_level_agg(
-                axis, level, "count")
+            return self._handle_level_agg(axis, level, "count")
 
         return self._reduce_dimension(
             self._query_compiler.count(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -428,8 +428,7 @@ class BasePandasDataset(object):
                         "Option bool_only is not implemented with option level."
                     )
 
-                kwargs["skipna"] = skipna
-                return self._handle_level_agg(axis, level, "all", **kwargs)
+                return self._handle_level_agg(axis, level, "all", skipna=skipna, **kwargs)
 
             return self._reduce_dimension(
                 self._query_compiler.all(
@@ -487,8 +486,7 @@ class BasePandasDataset(object):
                         "Option bool_only is not implemented with option level."
                     )
 
-                kwargs["skipna"] = skipna
-                return self._handle_level_agg(axis, level, "any", **kwargs)
+                return self._handle_level_agg(axis, level, "any", skipna=skipna, **kwargs)
 
             return self._reduce_dimension(
                 self._query_compiler.any(
@@ -743,7 +741,7 @@ class BasePandasDataset(object):
                 # error thrown by pandas
                 raise TypeError("Can only count levels on hierarchical columns.")
 
-            return self._handle_level_agg(axis, level, "count")
+            return self._handle_level_agg(axis, level, "count", numeric_only=numeric_only)
 
         return self._reduce_dimension(
             self._query_compiler.count(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -731,16 +731,16 @@ class BasePandasDataset(object):
         """
 
         axis = self._get_axis_number(axis) if axis is not None else 0
+        if numeric_only is not None and not numeric_only:
+            self._validate_dtypes(numeric_only=True)
 
         if level is not None:
-
             if not isinstance(self.axes[axis], pandas.MultiIndex):
                 # error thrown by pandas
                 raise TypeError("Can only count levels on hierarchical columns.")
 
             return self._handle_level_agg(
-                axis, level, "count", numeric_only=numeric_only
-            )
+                axis, level, "count")
 
         return self._reduce_dimension(
             self._query_compiler.count(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -420,7 +420,6 @@ class BasePandasDataset(object):
                 return data_for_compute.all(
                     axis=axis, bool_only=False, skipna=skipna, level=level, **kwargs
                 )
-
             if level is not None:
                 if bool_only is not None:
                     raise NotImplementedError(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -428,7 +428,9 @@ class BasePandasDataset(object):
                         "Option bool_only is not implemented with option level."
                     )
 
-                return self._handle_level_agg(axis, level, "all", skipna=skipna, **kwargs)
+                return self._handle_level_agg(
+                    axis, level, "all", skipna=skipna, **kwargs
+                )
 
             return self._reduce_dimension(
                 self._query_compiler.all(
@@ -441,8 +443,10 @@ class BasePandasDataset(object):
             # Reduce to a scalar if axis is None.
 
             if level is not None:
-                kwargs["skipna"] = skipna
-                return self._handle_level_agg(axis, level, "all", **kwargs)
+
+                return self._handle_level_agg(
+                    axis, level, "all", skipna=skipna, **kwargs
+                )
             else:
                 result = self._reduce_dimension(
                     self._query_compiler.all(
@@ -486,7 +490,9 @@ class BasePandasDataset(object):
                         "Option bool_only is not implemented with option level."
                     )
 
-                return self._handle_level_agg(axis, level, "any", skipna=skipna, **kwargs)
+                return self._handle_level_agg(
+                    axis, level, "any", skipna=skipna, **kwargs
+                )
 
             return self._reduce_dimension(
                 self._query_compiler.any(
@@ -499,8 +505,9 @@ class BasePandasDataset(object):
             # Reduce to a scalar if axis is None.
 
             if level is not None:
-                kwargs["skipna"] = skipna
-                return self._handle_level_agg(axis, level, "any", **kwargs)
+                return self._handle_level_agg(
+                    axis, level, "any", skipna=skipna, **kwargs
+                )
             else:
                 result = self._reduce_dimension(
                     self._query_compiler.any(
@@ -741,7 +748,9 @@ class BasePandasDataset(object):
                 # error thrown by pandas
                 raise TypeError("Can only count levels on hierarchical columns.")
 
-            return self._handle_level_agg(axis, level, "count", numeric_only=numeric_only)
+            return self._handle_level_agg(
+                axis, level, "count", numeric_only=numeric_only
+            )
 
         return self._reduce_dimension(
             self._query_compiler.count(

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -849,6 +849,45 @@ class TestDFPartOne:
             modin_result = modin_df.T.all(axis=None, skipna=skipna, bool_only=bool_only)
             df_equals(modin_result, pandas_result)
 
+        # test level
+        modin_df_multi_level = modin_df.copy()
+        pandas_df_multi_level = pandas_df.copy()
+        axis = modin_df._get_axis_number(axis) if axis is not None else 0
+        levels = 3
+        axis_names = ["a", "b", "c"]
+        if axis == 0:
+            new_idx = pandas.MultiIndex.from_tuples(
+                [(i // 4, i // 2, i) for i in range(len(modin_df.index))],
+                names=axis_names,
+            )
+            modin_df_multi_level.index = new_idx
+            pandas_df_multi_level.index = new_idx
+        else:
+            new_col = pandas.MultiIndex.from_tuples(
+                [(i // 4, i // 2, i) for i in range(len(modin_df.columns))],
+                names=axis_names,
+            )
+            modin_df_multi_level.columns = new_col
+            pandas_df_multi_level.columns = new_col
+
+        for level in list(range(levels)) + axis_names:
+            try:
+                pandas_multi_level_result = pandas_df_multi_level.all(
+                    axis=axis, bool_only=bool_only, level=level, skipna=skipna
+                )
+
+            except Exception as e:
+                with pytest.raises(type(e)):
+                    modin_df_multi_level.all(
+                        axis=axis, bool_only=bool_only, level=level, skipna=skipna
+                    )
+            else:
+                modin_multi_level_result = modin_df_multi_level.all(
+                    axis=axis, bool_only=bool_only, level=level, skipna=skipna
+                )
+
+                df_equals(modin_multi_level_result, pandas_multi_level_result)
+
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
     @pytest.mark.parametrize(
@@ -900,6 +939,45 @@ class TestDFPartOne:
         else:
             modin_result = modin_df.T.any(axis=None, skipna=skipna, bool_only=bool_only)
             df_equals(modin_result, pandas_result)
+
+        # test level
+        modin_df_multi_level = modin_df.copy()
+        pandas_df_multi_level = pandas_df.copy()
+        axis = modin_df._get_axis_number(axis) if axis is not None else 0
+        levels = 3
+        axis_names = ["a", "b", "c"]
+        if axis == 0:
+            new_idx = pandas.MultiIndex.from_tuples(
+                [(i // 4, i // 2, i) for i in range(len(modin_df.index))],
+                names=axis_names,
+            )
+            modin_df_multi_level.index = new_idx
+            pandas_df_multi_level.index = new_idx
+        else:
+            new_col = pandas.MultiIndex.from_tuples(
+                [(i // 4, i // 2, i) for i in range(len(modin_df.columns))],
+                names=axis_names,
+            )
+            modin_df_multi_level.columns = new_col
+            pandas_df_multi_level.columns = new_col
+
+        for level in list(range(levels)) + axis_names:
+            try:
+                pandas_multi_level_result = pandas_df_multi_level.any(
+                    axis=axis, bool_only=bool_only, level=level, skipna=skipna
+                )
+
+            except Exception as e:
+                with pytest.raises(type(e)):
+                    modin_df_multi_level.any(
+                        axis=axis, bool_only=bool_only, level=level, skipna=skipna
+                    )
+            else:
+                modin_multi_level_result = modin_df_multi_level.any(
+                    axis=axis, bool_only=bool_only, level=level, skipna=skipna
+                )
+
+                df_equals(modin_multi_level_result, pandas_multi_level_result)
 
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test_append(self, data):


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Refactored code supporting the `level` argument in `count`.

Added support for the `level` argument for:
* `any`
* `all`


## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
