### PR TITLE
Fix level parameter for aggregations when names are `None`

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -102,8 +102,6 @@ class BasePandasDataset(object):
             level: The level of the axis to apply the operation on
             op: String representation of the operation to be performed on the level
         """
-        if isinstance(level, str):
-            level = self.axes[axis].names.index(level)
         return getattr(self.groupby(level=level, axis=axis), op)(**kwargs)
 
     def _validate_other(

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -378,13 +378,6 @@ class DataFrame(BasePandasDataset):
             elif mismatch:
                 raise KeyError(next(x for x in by if x not in self))
 
-        if by is None and level is not None and axis == 0:
-            if not isinstance(level, str):
-                by = self.axes[axis].names[level]
-                level = None
-            else:
-                by = level
-                level = None
         from .groupby import DataFrameGroupBy
 
         return DataFrameGroupBy(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -36,7 +36,11 @@ class DataFrameGroupBy(object):
         self._columns = self._query_compiler.columns
         self._by = by
 
-        if level is None and not isinstance(by, type(self._query_compiler)):
+        if (
+            level is None
+            and not isinstance(by, type(self._query_compiler))
+            and is_list_like(by)
+        ):
             # This tells us whether or not there are multiple columns/rows in the groupby
             self._is_multi_by = all(obj in self._df for obj in self._by) and axis == 0
         else:
@@ -410,7 +414,7 @@ class DataFrameGroupBy(object):
     def _groupby_reduce(
         self, map_func, reduce_func, drop=True, numeric_only=True, **kwargs
     ):
-        if self._is_multi_by or self._level is not None:
+        if self._is_multi_by:
             return self._default_to_pandas(map_func, **kwargs)
         if not isinstance(self._by, type(self._query_compiler)):
             return self._apply_agg_function(map_func, drop=drop, **kwargs)
@@ -455,7 +459,7 @@ class DataFrameGroupBy(object):
         else:
             by = self._by
 
-        if self._is_multi_by or self._level is not None:
+        if self._is_multi_by:
             return self._default_to_pandas(f, **kwargs)
         # For aggregations, pandas behavior does this for the result.
         # For other operations it does not, so we wait until there is an aggregation to

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -854,39 +854,40 @@ class TestDFPartOne:
         pandas_df_multi_level = pandas_df.copy()
         axis = modin_df._get_axis_number(axis) if axis is not None else 0
         levels = 3
-        axis_names = ["a", "b", "c"]
-        if axis == 0:
-            new_idx = pandas.MultiIndex.from_tuples(
-                [(i // 4, i // 2, i) for i in range(len(modin_df.index))],
-                names=axis_names,
-            )
-            modin_df_multi_level.index = new_idx
-            pandas_df_multi_level.index = new_idx
-        else:
-            new_col = pandas.MultiIndex.from_tuples(
-                [(i // 4, i // 2, i) for i in range(len(modin_df.columns))],
-                names=axis_names,
-            )
-            modin_df_multi_level.columns = new_col
-            pandas_df_multi_level.columns = new_col
-
-        for level in list(range(levels)) + axis_names:
-            try:
-                pandas_multi_level_result = pandas_df_multi_level.all(
-                    axis=axis, bool_only=bool_only, level=level, skipna=skipna
+        axis_names_list = [["a", "b", "c"], None]
+        for axis_names in axis_names_list:
+            if axis == 0:
+                new_idx = pandas.MultiIndex.from_tuples(
+                    [(i // 4, i // 2, i) for i in range(len(modin_df.index))],
+                    names=axis_names,
                 )
+                modin_df_multi_level.index = new_idx
+                pandas_df_multi_level.index = new_idx
+            else:
+                new_col = pandas.MultiIndex.from_tuples(
+                    [(i // 4, i // 2, i) for i in range(len(modin_df.columns))],
+                    names=axis_names,
+                )
+                modin_df_multi_level.columns = new_col
+                pandas_df_multi_level.columns = new_col
 
-            except Exception as e:
-                with pytest.raises(type(e)):
-                    modin_df_multi_level.all(
+            for level in list(range(levels)) + (axis_names if axis_names else []):
+                try:
+                    pandas_multi_level_result = pandas_df_multi_level.all(
                         axis=axis, bool_only=bool_only, level=level, skipna=skipna
                     )
-            else:
-                modin_multi_level_result = modin_df_multi_level.all(
-                    axis=axis, bool_only=bool_only, level=level, skipna=skipna
-                )
 
-                df_equals(modin_multi_level_result, pandas_multi_level_result)
+                except Exception as e:
+                    with pytest.raises(type(e)):
+                        modin_df_multi_level.all(
+                            axis=axis, bool_only=bool_only, level=level, skipna=skipna
+                        )
+                else:
+                    modin_multi_level_result = modin_df_multi_level.all(
+                        axis=axis, bool_only=bool_only, level=level, skipna=skipna
+                    )
+
+                    df_equals(modin_multi_level_result, pandas_multi_level_result)
 
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
@@ -945,39 +946,40 @@ class TestDFPartOne:
         pandas_df_multi_level = pandas_df.copy()
         axis = modin_df._get_axis_number(axis) if axis is not None else 0
         levels = 3
-        axis_names = ["a", "b", "c"]
-        if axis == 0:
-            new_idx = pandas.MultiIndex.from_tuples(
-                [(i // 4, i // 2, i) for i in range(len(modin_df.index))],
-                names=axis_names,
-            )
-            modin_df_multi_level.index = new_idx
-            pandas_df_multi_level.index = new_idx
-        else:
-            new_col = pandas.MultiIndex.from_tuples(
-                [(i // 4, i // 2, i) for i in range(len(modin_df.columns))],
-                names=axis_names,
-            )
-            modin_df_multi_level.columns = new_col
-            pandas_df_multi_level.columns = new_col
-
-        for level in list(range(levels)) + axis_names:
-            try:
-                pandas_multi_level_result = pandas_df_multi_level.any(
-                    axis=axis, bool_only=bool_only, level=level, skipna=skipna
+        axis_names_list = [["a", "b", "c"], None]
+        for axis_names in axis_names_list:
+            if axis == 0:
+                new_idx = pandas.MultiIndex.from_tuples(
+                    [(i // 4, i // 2, i) for i in range(len(modin_df.index))],
+                    names=axis_names,
                 )
+                modin_df_multi_level.index = new_idx
+                pandas_df_multi_level.index = new_idx
+            else:
+                new_col = pandas.MultiIndex.from_tuples(
+                    [(i // 4, i // 2, i) for i in range(len(modin_df.columns))],
+                    names=axis_names,
+                )
+                modin_df_multi_level.columns = new_col
+                pandas_df_multi_level.columns = new_col
 
-            except Exception as e:
-                with pytest.raises(type(e)):
-                    modin_df_multi_level.any(
+            for level in list(range(levels)) + (axis_names if axis_names else []):
+                try:
+                    pandas_multi_level_result = pandas_df_multi_level.any(
                         axis=axis, bool_only=bool_only, level=level, skipna=skipna
                     )
-            else:
-                modin_multi_level_result = modin_df_multi_level.any(
-                    axis=axis, bool_only=bool_only, level=level, skipna=skipna
-                )
 
-                df_equals(modin_multi_level_result, pandas_multi_level_result)
+                except Exception as e:
+                    with pytest.raises(type(e)):
+                        modin_df_multi_level.any(
+                            axis=axis, bool_only=bool_only, level=level, skipna=skipna
+                        )
+                else:
+                    modin_multi_level_result = modin_df_multi_level.any(
+                        axis=axis, bool_only=bool_only, level=level, skipna=skipna
+                    )
+
+                    df_equals(modin_multi_level_result, pandas_multi_level_result)
 
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test_append(self, data):
@@ -1412,44 +1414,49 @@ class TestDFPartOne:
         pandas_df_multi_level = pandas_df.copy()
         axis = modin_df._get_axis_number(axis) if axis is not None else 0
         levels = 3
-        axis_names = ["a", "b", "c"]
-        if axis == 0:
-            new_idx = pandas.MultiIndex.from_tuples(
-                [(i // 4, i // 2, i) for i in range(len(modin_df.index))],
-                names=axis_names,
-            )
-            modin_df_multi_level.index = new_idx
-            pandas_df_multi_level.index = new_idx
-            try:  # test error
-                pandas_df_multi_level.count(axis=1, numeric_only=numeric_only, level=0)
-            except Exception as e:
-                with pytest.raises(type(e)):
-                    modin_df_multi_level.count(
+        axis_names_list = [["a", "b", "c"], None]
+        for axis_names in axis_names_list:
+            if axis == 0:
+                new_idx = pandas.MultiIndex.from_tuples(
+                    [(i // 4, i // 2, i) for i in range(len(modin_df.index))],
+                    names=axis_names,
+                )
+                modin_df_multi_level.index = new_idx
+                pandas_df_multi_level.index = new_idx
+                try:  # test error
+                    pandas_df_multi_level.count(
                         axis=1, numeric_only=numeric_only, level=0
                     )
-        else:
-            new_col = pandas.MultiIndex.from_tuples(
-                [(i // 4, i // 2, i) for i in range(len(modin_df.columns))],
-                names=axis_names,
-            )
-            modin_df_multi_level.columns = new_col
-            pandas_df_multi_level.columns = new_col
-            try:  # test error
-                pandas_df_multi_level.count(axis=0, numeric_only=numeric_only, level=0)
-            except Exception as e:
-                with pytest.raises(type(e)):
-                    modin_df_multi_level.count(
+                except Exception as e:
+                    with pytest.raises(type(e)):
+                        modin_df_multi_level.count(
+                            axis=1, numeric_only=numeric_only, level=0
+                        )
+            else:
+                new_col = pandas.MultiIndex.from_tuples(
+                    [(i // 4, i // 2, i) for i in range(len(modin_df.columns))],
+                    names=axis_names,
+                )
+                modin_df_multi_level.columns = new_col
+                pandas_df_multi_level.columns = new_col
+                try:  # test error
+                    pandas_df_multi_level.count(
                         axis=0, numeric_only=numeric_only, level=0
                     )
+                except Exception as e:
+                    with pytest.raises(type(e)):
+                        modin_df_multi_level.count(
+                            axis=0, numeric_only=numeric_only, level=0
+                        )
 
-        for level in list(range(levels)) + axis_names:
-            modin_multi_level_result = modin_df_multi_level.count(
-                axis=axis, numeric_only=numeric_only, level=level
-            )
-            pandas_multi_level_result = pandas_df_multi_level.count(
-                axis=axis, numeric_only=numeric_only, level=level
-            )
-            df_equals(modin_multi_level_result, pandas_multi_level_result)
+            for level in list(range(levels)) + (axis_names if axis_names else []):
+                modin_multi_level_result = modin_df_multi_level.count(
+                    axis=axis, numeric_only=numeric_only, level=level
+                )
+                pandas_multi_level_result = pandas_df_multi_level.count(
+                    axis=axis, numeric_only=numeric_only, level=level
+                )
+                df_equals(modin_multi_level_result, pandas_multi_level_result)
 
     def test_cov(self):
         data = test_data_values[0]

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -808,8 +808,7 @@ def test_groupby_multiindex():
     )
     modin_df.columns = new_columns
     pandas_df.columns = new_columns
-    with pytest.warns(UserWarning):
-        modin_df.groupby(level=1, axis=1).sum()
+    modin_df.groupby(level=1, axis=1).sum()
 
     modin_df = modin_df.T
     pandas_df = pandas_df.T


### PR DESCRIPTION
* Resolves #837
* Add logic for handling unnamed levels for both aggregations and `groupby`
* Clean up some of the implementations.
  * It should be possible to drop the `DataFrame._handle_level_agg` now.
  * Remove unnecessary logic in `DataFrame.groupby` that deals with `level`
  * Add additional check for `DataFrameGroupby._is_multi_by` with `is_list_like`
  * Remove defaulting to pandas logic if `level` is set. We no longer need this.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
