### PR TITLE
Fix `map` and `apply` over a `Series` that contains list values

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -691,7 +691,9 @@ class Series(BasePandasDataset):
 
         return self.__constructor__(
             query_compiler=self._query_compiler.applymap(
-                lambda s: arg(s) if not pandas.isnull(s) or na_action is None else s
+                lambda s: arg(s)
+                if pandas.isnull(s) is not True or na_action is None
+                else s
             )
         )
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1720,6 +1720,16 @@ def test_map(data, na_values):
         pandas_series.map(mapper, na_action=na_values),
     )
 
+    # Return list objects
+    modin_series_lists = modin_series.map(lambda s: [s, s, s])
+    pandas_series_lists = pandas_series.map(lambda s: [s, s, s])
+    df_equals(modin_series_lists, pandas_series_lists)
+
+    # Index into list objects
+    df_equals(
+        modin_series_lists.map(lambda l: l[0]), pandas_series_lists.map(lambda l: l[0])
+    )
+
 
 def test_mask():
     modin_series = pd.Series(np.arange(10))


### PR DESCRIPTION
* Resolves #839
* Adds additional syntax for checking that the value returned by
  `pandas.isnull` is `True`. This is because list values are unpacked
  by `pandas.isnull` and will be returned as a list. The fix is to just
  add `is not True` instead of just `not`.
* Add tests to avoid regressions.
* Additional test for creating a list from a non-list object.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
