### PR TITLE
Fix metadata computation for `get_dummies`

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1233,13 +1233,15 @@ class PandasQueryCompiler(BaseQueryCompiler):
         # efficient if we are mapping over all of the data to do it this way
         # than it would be to reuse the code for specific columns.
         if len(columns) == len(self.columns):
-            new_modin_frame = self._modin_frame._fold(
-                0, lambda df: pandas.get_dummies(df, **kwargs)
+            new_modin_frame = self._modin_frame._apply_full_axis(
+                0, lambda df: pandas.get_dummies(df, **kwargs), new_index=self.index
             )
             untouched_frame = None
         else:
-            new_modin_frame = self._modin_frame.mask(col_indices=columns)._fold(
-                0, lambda df: pandas.get_dummies(df, **kwargs)
+            new_modin_frame = self._modin_frame.mask(
+                col_indices=columns
+            )._apply_full_axis(
+                0, lambda df: pandas.get_dummies(df, **kwargs), new_index=self.index
             )
             untouched_frame = self.drop(columns=columns)
         # If we mapped over all the data we are done. If not, we need to

--- a/modin/pandas/test/test_reshape.py
+++ b/modin/pandas/test/test_reshape.py
@@ -25,12 +25,16 @@ def test_get_dummies():
     modin_result = pd.get_dummies(modin_df, prefix=["col1", "col2"])
     pandas_result = pandas.get_dummies(pandas_df, prefix=["col1", "col2"])
     df_equals(modin_result, pandas_result)
+    assert modin_result._to_pandas().columns.equals(pandas_result.columns)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.get_dummies(pd.DataFrame(pd.Series(list("abcdeabac"))))
     pandas_result = pandas.get_dummies(
         pandas.DataFrame(pandas.Series(list("abcdeabac")))
     )
     df_equals(modin_result, pandas_result)
+    assert modin_result._to_pandas().columns.equals(pandas_result.columns)
+    assert modin_result.shape == pandas_result.shape
 
     with pytest.raises(NotImplementedError):
         pd.get_dummies(modin_df, prefix=["col1", "col2"], sparse=True)


### PR DESCRIPTION
* Resolves #842
* Instead of using `fold`, which maintains metadata from the previous
  object, we must use `apply`, primarily because it will recompute the
  metadata (columns) at the end.
* Added to the tests to verify that the behavior no longer exists.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
