### PR TITLE
ci: upgrade linters (flake8, black)

### DIFF
--- a/ci/travis/install-dependencies.sh
+++ b/ci/travis/install-dependencies.sh
@@ -46,7 +46,7 @@ elif [[ "$LINT" == "1" ]]; then
   bash miniconda.sh -b -p $HOME/miniconda
   export PATH="$HOME/miniconda/bin:$PATH"
   conda install -y python==3.6.5
-  pip install black flake8 flake8-comprehensions
+  pip install --upgrade black flake8 flake8-comprehensions
   
 else
   echo "Unrecognized environment."

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1095,7 +1095,7 @@ class BasePandasDataset(object):
             duplicates = self.duplicated(keep=keep, **kwargs)
         else:
             duplicates = self.duplicated(keep=keep, **kwargs)
-        indices, = duplicates.values.nonzero()
+        (indices,) = duplicates.values.nonzero()
         return self.drop(index=self.index[indices], inplace=inplace)
 
     def duplicated(self, keep="first", **kwargs):


### PR DESCRIPTION
## What do these changes do?

Code in master does not pass formatting checks with
latest black version (19.10b0).

* Reformatted black 19.10b0.
* Ensure that black and flake8 are up to date in CI,
  even if using caching.

## Related issue number: N/A

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- ~[ ] tests added and passing~ (N/A)
