### PR TITLE
fix for Python 3.7: re._pattern_type no longer exist

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -16,6 +16,14 @@ from .utils import _inherit_docstrings
 from .utils import from_pandas, to_pandas
 
 
+try:
+    # Python >= 3.7
+    from re import Pattern as _pattern_type
+except ImportError:
+    # Python <= 3.6
+    from re import _pattern_type
+
+
 @_inherit_docstrings(pandas.Series, excluded=[pandas.Series, pandas.Series.__init__])
 class Series(BasePandasDataset):
     def __init__(
@@ -1434,9 +1442,7 @@ class StringMethods(object):
         )
 
     def count(self, pat, flags=0, **kwargs):
-        import re
-
-        if not isinstance(pat, (str, re._pattern_type)):
+        if not isinstance(pat, (str, _pattern_type)):
             raise TypeError("first argument must be string or compiled pattern")
         return Series(
             query_compiler=self._query_compiler.str_count(pat, flags=flags, **kwargs)
@@ -1449,18 +1455,14 @@ class StringMethods(object):
         return Series(query_compiler=self._query_compiler.str_endswith(pat, na=na))
 
     def findall(self, pat, flags=0, **kwargs):
-        import re
-
-        if not isinstance(pat, (str, re._pattern_type)):
+        if not isinstance(pat, (str, _pattern_type)):
             raise TypeError("first argument must be string or compiled pattern")
         return Series(
             query_compiler=self._query_compiler.str_findall(pat, flags=flags, **kwargs)
         )
 
     def match(self, pat, case=True, flags=0, na=np.NaN):
-        import re
-
-        if not isinstance(pat, (str, re._pattern_type)):
+        if not isinstance(pat, (str, _pattern_type)):
             raise TypeError("first argument must be string or compiled pattern")
         return Series(
             query_compiler=self._query_compiler.str_match(pat, flags=flags, na=na)

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -15,11 +15,10 @@ from .iterator import PartitionIterator
 from .utils import _inherit_docstrings
 from .utils import from_pandas, to_pandas
 
-
-try:
+if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
     # Python >= 3.7
     from re import Pattern as _pattern_type
-except ImportError:
+else:
     # Python <= 3.6
     from re import _pattern_type
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -5,6 +5,7 @@ import pandas
 import matplotlib
 import modin.pandas as pd
 from numpy.testing import assert_array_equal
+import sys
 
 from modin.pandas.utils import to_pandas
 from .utils import (
@@ -2717,6 +2718,10 @@ def test_str_cat():
 @pytest.mark.parametrize("n", int_arg_values, ids=int_arg_keys)
 @pytest.mark.parametrize("expand", bool_arg_values, ids=bool_arg_keys)
 def test_str_split(data, pat, n, expand):
+    # Empty pattern not supported on Python 3.7+
+    if sys.version_info[0] == 3 and sys.version_info[1] >= 7 and pat == "":
+        return
+
     modin_series, pandas_series = create_test_series(data)
 
     if n >= -1:


### PR DESCRIPTION
## What do these changes do?

* re._pattern_type was removed in Python 3.7. re.Pattern can be used
instead.
* Try re.Pattern first, and fall back to re._pattern_type otherwise.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin` (except for unrelated file)
- ~[ ] tests added and passing:~ Not applicable, tests are present, but they need to run with Python 3.7.
