### PR TITLE
[WIP] add GitHub Actions workflow for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,118 @@
+name: Continuous Integration
+on: [push, pull_request]
+jobs:
+  lint-black:
+    name: lint (black)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.7.x'
+          architecture: 'x64'
+      - run: pip install black
+      - run: black --check modin/
+  lint-flake8:
+    name: lint (flake8)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: '3.7.x'
+          architecture: 'x64'
+      - run: pip install flake8
+      - run: flake8 .
+  test-all:
+    needs: [lint-flake8, lint-black]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.6.x', '3.7.x' ]
+        engine: [ 'debug', 'ray']
+        part: [ 1, 2, 3 ]
+    name: test (${{ matrix.engine }}, part ${{ matrix.part }}, python ${{ matrix.python-version }})
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+      - run: sudo apt install -y libhdf5-dev
+      - run: pip install -r requirements.txt
+      - run: |
+          if [[ ${{ matrix.engine}} = debug ]]; then
+            export MODIN_DEBUG=1
+          else
+            export MODIN_ENGINE=${{ matrix.engine }}
+          fi
+      - run: python -m pytest -n auto --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_dataframe.py::TestDFPartOne --cov-append
+        if: matrix.part == 1
+      - run: python -m pytest -n auto --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_dataframe.py::TestDFPartTwo --cov-append
+        if: matrix.part == 2
+      - run: python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_series.py --cov-append
+        if: matrix.part == 3
+      - run: python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_concat.py --cov-append
+        if: matrix.part == 3
+      - run: python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_groupby.py --cov-append
+        if: matrix.part == 3
+      - run: python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_reshape.py --cov-append
+        if: matrix.part == 3
+      - run: python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_general.py --cov-append
+        if: matrix.part == 3
+      - run: pip install numexpr
+        if: matrix.part == 3
+      - run: python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_io.py --cov-append
+        if: matrix.part == 3
+      - run: python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/experimental/pandas/test/test_io_exp.py --cov-append
+        if: matrix.part == 3
+      - run: bash <(curl -s https://codecov.io/bash)
+  test-pyarrow:
+    needs: [lint-flake8, lint-black]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.6.x', '3.7.x' ]
+    env:
+      MODIN_BACKEND: pyarrow
+      MODIN_EXPERIMENTAL: "True"
+    name: test (pyarrow, python ${{ matrix.python-version }})
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+      - run: sudo apt install -y libhdf5-dev
+      - run: pip install -r requirements.txt
+      - run: python -m pytest --disable-pytest-warnings --cov-config=.coveragerc --cov=modin modin/pandas/test/test_io.py::test_from_csv --cov-append
+      - run: bash <(curl -s https://codecov.io/bash)
+  test-api:
+    needs: [lint-flake8, lint-black]
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.7.x' ]
+    env:
+      MODIN_BACKEND: pyarrow
+      MODIN_EXPERIMENTAL: "True"
+    name: test (api, python ${{ matrix.python-version }})
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+          architecture: 'x64'
+      - run: sudo apt install -y libhdf5-dev
+      - run: pip install -r requirements.txt
+      - run: python -m pytest modin/pandas/test/test_api.py


### PR DESCRIPTION
Adds [GitHub Actions](https://help.github.com/en/github/automating-your-workflow-with-github-actions/about-github-actions) support.

It currently runs everything that is setup with `.travis.yml`, and adds Python 3.7.x to the build matrix.

See an example run here: https://github.com/smola/modin/commit/391596d961039cdf4358c675de424b80fa54ae6c/checks?check_suite_id=290849650

## Benefits
* Higher [usage limits](https://help.github.com/en/github/automating-your-workflow-with-github-actions/workflow-syntax-for-github-actions#usage-limits) than Travis: 20 concurrent jobs with 6 hours timeout per job. This allows to finish a full run in less than 40 minutes, even adding an additional Python version to the build matrix.
* Integration of results right in GitHub.
* Apparently better performance per worker.

## Downsides
* Codecov has no proper GitHub Actions integration yet, so it needs `CODECOV_TOKEN`. Setting up the token as a GitHub Actions secret makes it work only for branches in the main repository, not forks (as in external pull requests).

## To Do
* Speed up dependency install with cache. See: [actions/cache](https://github.com/actions/cache).
* Add macOS support.
* Add Windows support.
* Add Dask tests.