### PR TITLE
Fix integer overflow when doing a mask for Windows users

### DIFF
--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -544,15 +544,11 @@ class BasePandasFrame(object):
         else:
             indices = np.array(indices)
         if not axis:
-            # INT_MAX to make sure we don't try to compute on partitions that don't
-            # exist.
-            cumulative = np.array(
-                np.append(self._column_widths[:-1], np.iinfo(np.int32).max)
-            ).cumsum()
+            bins = np.array(self._column_widths)
         else:
-            cumulative = np.array(
-                np.append(self._row_lengths[:-1], np.iinfo(np.int32).max)
-            ).cumsum()
+            bins = np.array(self._row_lengths)
+        # INT_MAX to make sure we don't try to compute on partitions that don't exist.
+        cumulative = np.append(bins[:-1].cumsum(), np.iinfo(bins.dtype).max)
 
         def internal(block_idx, global_index):
             return (


### PR DESCRIPTION
* Resolves #852
* Changes where we do the cumulative sum, no longer incorporating INT_MAX into the sum result

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- ~[ ] tests added and passing~
