### PR TITLE
Fix issue where partition metadata would be off after insert + window

### DIFF
--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -788,7 +788,7 @@ class BasePandasFrame(object):
             A new dataframe.
         """
         new_partitions = self._frame_mgr_cls.map_axis_partitions(
-            axis, self._partitions, func
+            axis, self._partitions, func, keep_partitioning=True
         )
         if axis == 0:
             new_index = self.index
@@ -835,7 +835,10 @@ class BasePandasFrame(object):
             A new dataframe.
         """
         new_partitions = self._frame_mgr_cls.map_axis_partitions(
-            axis, self._partitions, self._build_mapreduce_func(axis, func)
+            axis,
+            self._partitions,
+            self._build_mapreduce_func(axis, func),
+            keep_partitioning=True,
         )
         # Index objects for new object creation. This is shorter than if..else
         if new_columns is None:

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -111,7 +111,7 @@ class BaseFrameManager(object):
         )
 
     @classmethod
-    def map_axis_partitions(cls, axis, partitions, map_func):
+    def map_axis_partitions(cls, axis, partitions, map_func, keep_partitioning=False):
         """Applies `map_func` to every partition.
 
         Note: This method should be used in the case that `map_func` relies on
@@ -127,10 +127,10 @@ class BaseFrameManager(object):
         # Since we are already splitting the DataFrame back up after an
         # operation, we will just use this time to compute the number of
         # partitions as best we can right now.
-        num_splits = min(
-            cls._compute_num_partitions(),
-            len(partitions) if axis == 0 else len(partitions.T),
-        )
+        if keep_partitioning:
+            num_splits = len(partitions) if axis == 0 else len(partitions.T)
+        else:
+            num_splits = cls._compute_num_partitions()
         preprocessed_map_func = cls.preprocess_func(map_func)
         partitions = (
             cls.column_partitions(partitions)

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -127,7 +127,10 @@ class BaseFrameManager(object):
         # Since we are already splitting the DataFrame back up after an
         # operation, we will just use this time to compute the number of
         # partitions as best we can right now.
-        num_splits = cls._compute_num_partitions()
+        num_splits = min(
+            cls._compute_num_partitions(),
+            len(partitions) if axis == 0 else len(partitions.T),
+        )
         preprocessed_map_func = cls.preprocess_func(map_func)
         partitions = (
             cls.column_partitions(partitions)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -3764,6 +3764,22 @@ class TestDFPartTwo:
             modin_result = modin_df.query(funcs)
             df_equals(modin_result, pandas_result)
 
+    def test_query_after_insert(self):
+        modin_df = pd.DataFrame({"x": [-1, 0, 1, None], "y": [1, 2, None, 3]})
+        modin_df["z"] = modin_df.eval("x / y")
+        modin_df = modin_df.query("z >= 0")
+        modin_result = modin_df.reset_index(drop=True)
+        modin_result.columns = ["a", "b", "c"]
+
+        pandas_df = pd.DataFrame({"x": [-1, 0, 1, None], "y": [1, 2, None, 3]})
+        pandas_df["z"] = pandas_df.eval("x / y")
+        pandas_df = pandas_df.query("z >= 0")
+        pandas_result = pandas_df.reset_index(drop=True)
+        pandas_result.columns = ["a", "b", "c"]
+
+        df_equals(modin_result, pandas_result)
+        df_equals(modin_df, pandas_df)
+
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
     @pytest.mark.parametrize(


### PR DESCRIPTION
* Resolves #865
* Allows repartitioning to only happen if the number of input partitions
  exceed the number of cores.
* Maintain partitioning schema if the number of partitions is less than
  the number of cores.
* Add tests to verify this behavior is corrected.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
