### PR TITLE
Fix issue for updating to Categorical Dtypes from `astype`

### DIFF
--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -450,12 +450,15 @@ class BasePandasFrame(object):
                     new_dtype = np.dtype(dtype)
                 except TypeError:
                     new_dtype = dtype
+
                 if dtype != np.int32 and new_dtype == np.int32:
-                    new_dtype = np.dtype("int64")
+                    new_dtypes[column] = np.dtype("int64")
                 elif dtype != np.float32 and new_dtype == np.float32:
-                    new_dtype = np.dtype("float64")
-                new_dtypes[column] = new_dtype
-        # Update partitions for each dtype that is updated
+                    new_dtypes[column] = np.dtype("float64")
+                # We cannot infer without computing the dtype if
+                elif isinstance(new_dtype, str) and new_dtype == "category":
+                    new_dtypes = None
+                    break
 
         def astype_builder(df):
             return df.astype({k: v for k, v in col_dtypes.items() if k in df})

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1222,6 +1222,24 @@ class TestDFPartOne:
         with pytest.raises(KeyError):
             modin_df.astype({"not_exists": np.uint8})
 
+    def test_astype_category(self):
+        modin_df = pd.DataFrame(
+            {"col1": ["A", "A", "B", "B", "A"], "col2": [1, 2, 3, 4, 5]}
+        )
+        pandas_df = pandas.DataFrame(
+            {"col1": ["A", "A", "B", "B", "A"], "col2": [1, 2, 3, 4, 5]}
+        )
+
+        modin_result = modin_df.astype({"col1": "category"})
+        pandas_result = pandas_df.astype({"col1": "category"})
+        df_equals(modin_result, pandas_result)
+        assert modin_result.dtypes.equals(pandas_result.dtypes)
+
+        modin_result = modin_df.astype("category")
+        pandas_result = pandas_df.astype("category")
+        df_equals(modin_result, pandas_result)
+        assert modin_result.dtypes.equals(pandas_result.dtypes)
+
     def test_at_time(self):
         i = pd.date_range("2018-04-09", periods=4, freq="12H")
         ts = pd.DataFrame({"A": [1, 2, 3, 4]}, index=i)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -794,6 +794,21 @@ def test_astype(data):
         df_equals(modin_series.astype(np.float64), pandas_result)
 
 
+def test_astype_categorical():
+    modin_df = pd.Series(["A", "A", "B", "B", "A"])
+    pandas_df = pandas.Series(["A", "A", "B", "B", "A"])
+
+    modin_result = modin_df.astype("category")
+    pandas_result = pandas_df.astype("category")
+    df_equals(modin_result, pandas_result)
+    assert modin_result.dtype == pandas_result.dtype
+
+    modin_df = pd.Series([1, 1, 2, 1, 2, 2, 3, 1, 2, 1, 2])
+    pandas_df = pandas.Series([1, 1, 2, 1, 2, 2, 3, 1, 2, 1, 2])
+    df_equals(modin_result, pandas_result)
+    assert modin_result.dtype == pandas_result.dtype
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_at(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
* Resolves #864
* Forces Modin to compute the dtypes in the case of categorical in
  `astype`. It is not currently possible (and may never be) to determine
  what the categories would be before computing the `astype` in the
  partitions.
* Adds tests specific to the `CategoricalDtype` for `astype`.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
