### PR TITLE
Correctly merge `CategoricalDtype` dtypes

### DIFF
--- a/modin/backends/pandas/parsers.py
+++ b/modin/backends/pandas/parsers.py
@@ -28,7 +28,10 @@ def _split_result_for_readers(axis, num_splits, df):  # pragma: no cover
 
 def find_common_type_cat(types):
     if all(isinstance(t, pandas.CategoricalDtype) for t in types):
-        return pandas.CategoricalDtype(reduce(np.union1d, [t.categories for t in types]), ordered=all(t.ordered for t in types))
+        return pandas.CategoricalDtype(
+            reduce(np.union1d, [t.categories for t in types]),
+            ordered=all(t.ordered for t in types),
+        )
     else:
         find_common_type(types)
 

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -112,7 +112,6 @@ class BasePandasFrame(object):
         """
 
         def dtype_builder(df):
-            print(df)
             return df.apply(lambda col: find_common_type(col.values), axis=0)
 
         map_func = self._build_mapreduce_func(0, lambda df: df.dtypes)

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -2,12 +2,12 @@ from itertools import groupby
 import numpy as np
 from operator import itemgetter
 import pandas
-from pandas.core.dtypes.cast import find_common_type
 from pandas.core.index import ensure_index
 from pandas.core.dtypes.common import is_numeric_dtype
 
 from modin.backends.pandas.query_compiler import PandasQueryCompiler
 from modin.error_message import ErrorMessage
+from modin.backends.pandas.parsers import find_common_type_cat as find_common_type
 
 
 class BasePandasFrame(object):
@@ -112,7 +112,8 @@ class BasePandasFrame(object):
         """
 
         def dtype_builder(df):
-            return df.apply(lambda row: find_common_type(row.values), axis=0)
+            print(df)
+            return df.apply(lambda col: find_common_type(col.values), axis=0)
 
         map_func = self._build_mapreduce_func(0, lambda df: df.dtypes)
         reduce_func = self._build_mapreduce_func(0, dtype_builder)

--- a/modin/engines/ray/pandas_on_ray/frame/data.py
+++ b/modin/engines/ray/pandas_on_ray/frame/data.py
@@ -1,9 +1,9 @@
 import pandas
-from pandas.core.dtypes.cast import find_common_type
 
 from .partition_manager import PandasOnRayFrameManager
 from modin.engines.base.frame.data import BasePandasFrame
 from modin import __execution_engine__
+from modin.backends.pandas.parsers import find_common_type_cat as find_common_type
 
 if __execution_engine__ == "Ray":
     import ray


### PR DESCRIPTION
* Resolves #874
* Creates a new utility in the pandas parsers that overrides the default
  behavior
* Union the values in the `categories` field of `CategoricalDtype` list
  to merge the values
* Set `ordered` to `True` if all are ordered, else `False`
* Issue created in pandas to fix the behavior in pandas:
  pandas-dev/pandas#29980

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
