### PR TITLE
support for duplicated() and drop_duplicates()

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -949,6 +949,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
             )
         )
 
+    def duplicated(self, **kwargs):
+        return self.__constructor__(
+            self._modin_frame._apply_full_axis(
+                1, lambda df: pandas.DataFrame.duplicated(df, **kwargs),
+            )
+        )
+
     def drop(self, index=None, columns=None):
         """Remove row data for target index and columns.
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -949,13 +949,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
             )
         )
 
-    def duplicated(self, **kwargs):
-        return self.__constructor__(
-            self._modin_frame._apply_full_axis(
-                1, lambda df: pandas.DataFrame.duplicated(df, **kwargs),
-            )
-        )
-
     def drop(self, index=None, columns=None):
         """Remove row data for target index and columns.
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1091,15 +1091,15 @@ class BasePandasDataset(object):
                 deduplicated : DataFrame
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        if kwargs.get("subset", None) is not None:
-            duplicates = self.duplicated(keep=keep, **kwargs)
-        else:
-            duplicates = self.duplicated(keep=keep, **kwargs)
-        (indices,) = duplicates.values.nonzero()
+        duplicates = self.duplicated(keep=keep, **kwargs)
+        indices = duplicates.values.nonzero()[0]
         return self.drop(index=self.index[indices], inplace=inplace)
 
-    def duplicated(self, keep="first", **kwargs):
-        return self._default_to_pandas("duplicated", keep=keep, **kwargs)
+    def duplicated(self, subset=None, keep="first", **kwargs):
+        new_query_compiler = self._query_compiler.duplicated(
+            subset=subset, keep=keep, **kwargs
+        )
+        return self._create_or_update_from_compiler(new_query_compiler)
 
     def eq(self, other, axis="columns", level=None):
         """Checks element-wise that this is equal to other.

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1095,9 +1095,9 @@ class BasePandasDataset(object):
         indices = duplicates.values.nonzero()[0]
         return self.drop(index=self.index[indices], inplace=inplace)
 
-    def duplicated(self, subset=None, keep="first", **kwargs):
+    def duplicated(self, keep="first", **kwargs):
         new_query_compiler = self._query_compiler.duplicated(
-            subset=subset, keep=keep, **kwargs
+            keep=keep, **kwargs
         )
         return self._create_or_update_from_compiler(new_query_compiler)
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1091,7 +1091,10 @@ class BasePandasDataset(object):
                 deduplicated : DataFrame
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        duplicates = self.duplicated(keep=keep)
+        if kwargs.get("subset", None) is not None:
+            duplicates = self.duplicated(keep=keep, subset=kwargs.get("subset"))
+        else:
+            duplicates = self.duplicated(keep=keep)
         indices = duplicates.values.nonzero()[0]
         return self.drop(index=self.index[indices], inplace=inplace)
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1095,11 +1095,10 @@ class BasePandasDataset(object):
         indices = duplicates.values.nonzero()[0]
         return self.drop(index=self.index[indices], inplace=inplace)
 
-    def duplicated(self, keep="first", **kwargs):
-        new_query_compiler = self._query_compiler.duplicated(
-            keep=keep, **kwargs
-        )
-        return self._create_or_update_from_compiler(new_query_compiler)
+    def duplicated(self, keep="first"):
+        duplicates = self.apply(lambda s: s.duplicated(keep=keep))[0]
+        duplicates.name = None
+        return duplicates
 
     def eq(self, other, axis="columns", level=None):
         """Checks element-wise that this is equal to other.

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1091,14 +1091,9 @@ class BasePandasDataset(object):
                 deduplicated : DataFrame
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        duplicates = self.duplicated(keep=keep, **kwargs)
+        duplicates = self.duplicated(keep=keep)
         indices = duplicates.values.nonzero()[0]
         return self.drop(index=self.index[indices], inplace=inplace)
-
-    def duplicated(self, keep="first"):
-        duplicates = self.apply(lambda s: s.duplicated(keep=keep))[0]
-        duplicates.name = None
-        return duplicates
 
     def eq(self, other, axis="columns", level=None):
         """Checks element-wise that this is equal to other.

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -199,7 +199,11 @@ class DataFrame(BasePandasDataset):
         return self._query_compiler.dtypes
 
     def duplicated(self, subset=None, keep="first"):
-        return super(DataFrame, self).duplicated(subset=subset, keep=keep)
+        df = self[subset] if subset is not None else self
+        return super(
+            DataFrame,
+            DataFrame(df.apply(lambda s: hash(s.to_numpy().data.tobytes()), axis=1)),
+        ).duplicated(keep=keep)
 
     @property
     def empty(self):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -524,9 +524,7 @@ class Series(BasePandasDataset):
         return super(Series, self).dropna(axis=axis, inplace=inplace)
 
     def duplicated(self, keep="first"):
-        from .dataframe import DataFrame
-
-        return super(DataFrame, DataFrame(self)).duplicated(keep=keep)
+        return self.to_frame().duplicated(keep=keep)
 
     def eq(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -524,7 +524,9 @@ class Series(BasePandasDataset):
         return super(Series, self).dropna(axis=axis, inplace=inplace)
 
     def duplicated(self, keep="first"):
-        return super(Series, self).duplicated(keep=keep)
+        from .dataframe import DataFrame
+
+        return super(DataFrame, DataFrame(self)).duplicated(keep=keep)
 
     def eq(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1867,17 +1867,18 @@ class TestDFPartOne:
 
         df_equals(
             modin_df.drop_duplicates(keep=keep, inplace=inplace),
-            pandas_df.drop_duplicates(keep=keep, inplace=inplace),
+            pandas_df.drop_duplicates(keep=keep, inplace=inplace)
         )
 
-        frame_data = {
-            "A": list(range(3)) * 2,
-            "B": list(range(1, 4)) * 2,
-            "C": list(range(6)),
-        }
-        modin_df = pd.DataFrame(frame_data)
-        modin_df.drop_duplicates(subset=["A", "B"], keep=keep, inplace=inplace)
-        df_equals(modin_df, pandas.DataFrame({"A": [], "B": [], "C": []}))
+        import random
+
+        subset = random.sample(
+            list(pandas_df.columns), random.randint(1, len(pandas_df.columns))
+        )
+        df_equals(
+            modin_df.drop_duplicates(keep=keep, subset=subset, inplace=inplace),
+            pandas_df.drop_duplicates(keep=keep, subset=subset, inplace=inplace)
+        )
 
     def test_drop_duplicates_with_missing_index_values(self):
         data = {

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1867,7 +1867,7 @@ class TestDFPartOne:
 
         df_equals(
             modin_df.drop_duplicates(keep=keep, inplace=inplace),
-            pandas_df.drop_duplicates(keep=keep, inplace=inplace)
+            pandas_df.drop_duplicates(keep=keep, inplace=inplace),
         )
 
         import random
@@ -1877,7 +1877,7 @@ class TestDFPartOne:
         )
         df_equals(
             modin_df.drop_duplicates(keep=keep, subset=subset, inplace=inplace),
-            pandas_df.drop_duplicates(keep=keep, subset=subset, inplace=inplace)
+            pandas_df.drop_duplicates(keep=keep, subset=subset, inplace=inplace),
         )
 
     def test_drop_duplicates_with_missing_index_values(self):

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1200,26 +1200,16 @@ def test_drop():
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_drop_duplicates(data):
+@pytest.mark.parametrize(
+    "keep", ["last", "first", False], ids=["last", "first", "False"]
+)
+@pytest.mark.parametrize("inplace", [True, False], ids=["True", "False"])
+def test_drop_duplicates(data, keep, inplace):
     modin_series, pandas_series = create_test_series(data)
     df_equals(
-        modin_series.drop_duplicates(keep="first", inplace=False),
-        pandas_series.drop_duplicates(keep="first", inplace=False),
+        modin_series.drop_duplicates(keep=keep, inplace=inplace),
+        pandas_series.drop_duplicates(keep=keep, inplace=inplace),
     )
-    df_equals(
-        modin_series.drop_duplicates(keep="last", inplace=False),
-        pandas_series.drop_duplicates(keep="last", inplace=False),
-    )
-    df_equals(
-        modin_series.drop_duplicates(keep=False, inplace=False),
-        pandas_series.drop_duplicates(keep=False, inplace=False),
-    )
-    df_equals(
-        modin_series.drop_duplicates(inplace=False),
-        pandas_series.drop_duplicates(inplace=False),
-    )
-    modin_series.drop_duplicates(inplace=True)
-    df_equals(modin_series, pandas_series.drop_duplicates(inplace=False))
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
@@ -1261,7 +1251,9 @@ def test_dtype(data):
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-@pytest.mark.parametrize("keep", ["last", "first"], ids=["last", "first"])
+@pytest.mark.parametrize(
+    "keep", ["last", "first", False], ids=["last", "first", "False"]
+)
 def test_duplicated(data, keep):
     modin_series, pandas_series = create_test_series(data)
     modin_result = modin_series.duplicated(keep=keep)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1264,8 +1264,7 @@ def test_dtype(data):
 @pytest.mark.parametrize("keep", ["last", "first"], ids=["last", "first"])
 def test_duplicated(data, keep):
     modin_series, pandas_series = create_test_series(data)
-    with pytest.warns(UserWarning):
-        modin_result = modin_series.duplicated(keep=keep)
+    modin_result = modin_series.duplicated(keep=keep)
     df_equals(modin_result, pandas_series.duplicated(keep=keep))
 
 

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -99,6 +99,35 @@ test_data = {
 test_data_values = list(test_data.values())
 test_data_keys = list(test_data.keys())
 
+test_data_with_duplicates = {
+    "no_duplicates": {
+        "col{}".format(int((i - NCOLS / 2) % NCOLS + 1)): range(NROWS)
+        for i in range(NCOLS)
+    },
+    "all_duplicates": {
+        "col{}".format(int((i - NCOLS / 2) % NCOLS + 1)): [
+            float(i) for _ in range(NROWS)
+        ]
+        for i in range(NCOLS)
+    },
+    "some_duplicates": {
+        "col{}".format(int((i - NCOLS / 2) % NCOLS + 1)): [
+            i if j % 7 == 0 else x for j, x in enumerate(range(NROWS))
+        ]
+        for i in range(NCOLS)
+    },
+    "subset_duplicates": {
+        "col{}".format(i): [
+            i if j % 7 == 0 and i in [1, 3, 7] else x
+            for j, x in enumerate(range(NROWS))
+        ]
+        for i in range(NCOLS)
+    },
+}
+
+test_data_with_duplicates_values = list(test_data_with_duplicates.values())
+test_data_with_duplicates_keys = list(test_data_with_duplicates.keys())
+
 numeric_dfs = [
     "empty_data",
     "columns_only",


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?
this is an implementation of `Dataframe.duplicated()` that also adds support for `Series.drop_duplicates()` and `Dataframe.drop_duplicates()`.
It transformes either one to a single column `Dataframe` and checks for duplicates using `Dataframe.apply()`

## Related issue number
#634 
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
