### PR TITLE
Send full path to workers on `read_csv`

### DIFF
--- a/modin/engines/base/io/file_reader.py
+++ b/modin/engines/base/io/file_reader.py
@@ -11,6 +11,13 @@ class FileReader:
     query_compiler_cls = None
 
     @classmethod
+    def get_path(cls, file_path):
+        if S3_ADDRESS_REGEX.search(file_path):
+            return file_path
+        else:
+            return os.path.abspath(file_path)
+
+    @classmethod
     def file_open(cls, file_path, mode="rb", compression="infer"):
         if isinstance(file_path, str):
             match = S3_ADDRESS_REGEX.search(file_path)

--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -59,9 +59,9 @@ class CSVReader(TextFileReader):
     @classmethod
     def read(cls, filepath_or_buffer, **kwargs):
         if isinstance(filepath_or_buffer, str):
-            filepath_or_buffer = os.path.abspath(filepath_or_buffer)
             if not cls.file_exists(filepath_or_buffer):
                 return cls.single_worker_read(filepath_or_buffer, **kwargs)
+            filepath_or_buffer = cls.get_path(filepath_or_buffer)
         elif not isinstance(filepath_or_buffer, py.path.local):
             read_from_pandas = True
             # Pandas read_csv supports pathlib.Path

--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -59,6 +59,7 @@ class CSVReader(TextFileReader):
     @classmethod
     def read(cls, filepath_or_buffer, **kwargs):
         if isinstance(filepath_or_buffer, str):
+            filepath_or_buffer = os.path.abspath(filepath_or_buffer)
             if not cls.file_exists(filepath_or_buffer):
                 return cls.single_worker_read(filepath_or_buffer, **kwargs)
         elif not isinstance(filepath_or_buffer, py.path.local):

--- a/modin/engines/base/io/text/json_reader.py
+++ b/modin/engines/base/io/text/json_reader.py
@@ -8,6 +8,7 @@ import numpy as np
 class JSONReader(TextFileReader):
     @classmethod
     def read(cls, path_or_buf, **kwargs):
+        path_or_buf = cls.get_path(path_or_buf)
         if not kwargs.get("lines", False):
             return cls.single_worker_read(path_or_buf, **kwargs)
         columns = pandas.read_json(


### PR DESCRIPTION
* Resolves #882
* Extracts full path and sends that to workers to avoid issues where
  the driver process changed directories but the children had not.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
