### PR TITLE
Remove `__array_prepare__` from Series API

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -128,6 +128,7 @@ class Series(BasePandasDataset):
 
     def __array__(self, dtype=None):
         return super(Series, self).__array__(dtype).flatten()
+
     @property
     def __array_priority__(self):  # pragma: no cover
         return self._to_pandas().__array_priority__

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -128,12 +128,6 @@ class Series(BasePandasDataset):
 
     def __array__(self, dtype=None):
         return super(Series, self).__array__(dtype).flatten()
-
-    def __array_prepare__(self, result, context=None):  # pragma: no cover
-        return self._default_to_pandas(
-            pandas.Series.__array_prepare__, result, context=context
-        )
-
     @property
     def __array_priority__(self):  # pragma: no cover
         return self._to_pandas().__array_priority__


### PR DESCRIPTION
* Resolves #885
* Get rid of deprecated functionality

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- ~[ ] tests added and passing~
