### PR TITLE
Fix `df.squeeze` when `axis=0` on a 1x1 dataframe

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1532,7 +1532,7 @@ class DataFrame(BasePandasDataset):
         if axis == 1 and len(self.columns) == 1:
             return Series(query_compiler=self._query_compiler)
         if axis == 0 and len(self.index) == 1:
-            return Series(query_compiler=self._query_compiler)
+            return Series(query_compiler=self.T._query_compiler)
         else:
             return self.copy()
 

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4635,6 +4635,21 @@ class TestDFPartTwo:
         ray_df_5 = pd.DataFrame(frame_data_5).squeeze()
         df_equals(ray_df_5, pandas_df_5)
 
+        data = [
+            [
+                pd.Timestamp("2019-01-02"),
+                pd.Timestamp("2019-01-03"),
+                pd.Timestamp("2019-01-04"),
+                pd.Timestamp("2019-01-05"),
+            ],
+            [1, 1, 1, 2],
+        ]
+        df = pd.DataFrame(data, index=["date", "value"]).T
+        pf = pandas.DataFrame(data, index=["date", "value"]).T
+        df.set_index("date", inplace=True)
+        pf.set_index("date", inplace=True)
+        df_equals(df.iloc[0], pf.iloc[0])
+
     def test_stack(self):
         data = test_data_values[0]
         with pytest.warns(UserWarning):


### PR DESCRIPTION
* Resolves #891
* Force transposes a DataFrame before it is passed to the Series constructor
  when `axis=0`.
* Previous implementation assumed that there would be >1 row and that
  the Series constructor logic could handle the transpose if necessary.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
