### PR TITLE
Create SeriesGroupBy wrapper to default to pandas and return to Modin

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -572,17 +572,21 @@ class Series(BasePandasDataset):
         observed=False,
         **kwargs
     ):
-        return self._default_to_pandas(
-            pandas.Series.groupby,
-            by=by,
-            axis=axis,
-            level=level,
-            as_index=as_index,
-            sort=sort,
-            group_keys=group_keys,
-            squeeze=squeeze,
-            observed=observed,
-            **kwargs
+        from .groupby import SeriesGroupBy
+
+        return SeriesGroupBy(
+            self._default_to_pandas(
+                pandas.Series.groupby,
+                by=by,
+                axis=axis,
+                level=level,
+                as_index=as_index,
+                sort=sort,
+                group_keys=group_keys,
+                squeeze=squeeze,
+                observed=observed,
+                **kwargs
+            )
         )
 
     def gt(self, other, level=None, fill_value=None, axis=0):

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1430,13 +1430,14 @@ def test_get_values(data):
     with pytest.warns(UserWarning):
         modin_series.get_values()
 
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_groupby(data):
+    modin_series, _ = create_test_series(data)
 
-@pytest.mark.skip(reason="Using pandas Series.")
-def test_groupby():
-    modin_series = create_test_series()
+    with pytest.warns(UserWarning):
+        result = modin_series.groupby(modin_series).count()
 
-    with pytest.raises(NotImplementedError):
-        modin_series.groupby(None, None, None, None, None, None, None)
+    assert isinstance(result, pd.Series)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1430,6 +1430,7 @@ def test_get_values(data):
     with pytest.warns(UserWarning):
         modin_series.get_values()
 
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_groupby(data):
     modin_series, _ = create_test_series(data)


### PR DESCRIPTION
* Resolves #878
* Create a `SeriesGroupBy` object that intercepts every call to the
  `SeriesGroupBy` object, applies it to the pandas object, then
  re-distributes the object if it is a `pandas.Series` or a
  `pandas.DataFrame`. This is a temporary measure until we can implement
  a `SeriesGroupBy` object with all of the methods.
* This issue originally surfaced with issues handling interactions
  between pandas and modin Series objects.
* A further pass is required to remove other cases where Modin can
  return a pandas object.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
