### PR TITLE
Fix `skiprows` logic for `read_csv`

### DIFF
--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -107,8 +107,6 @@ class CSVReader(TextFileReader):
                     skiprows += max(header) + 1
                 for _ in range(skiprows):
                     f.readline()
-            elif skiprows is not None:
-                partition_kwargs["skiprows"] = skiprows
             if kwargs.get("encoding", None) is not None:
                 partition_kwargs["skiprows"] = 1
             # Launch tasks to read partitions

--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -3,7 +3,6 @@ from modin.data_management.utils import compute_chunksize
 from pandas.io.parsers import _validate_usecols_arg
 import pandas
 import py
-import os
 import sys
 
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -915,6 +915,14 @@ def test_from_csv_skiprows(make_csv_file):
     )
     df_equals(modin_df, pandas_df)
 
+    pandas_df = pandas.read_csv(
+        TEST_CSV_FILENAME, names=["c1", "c2", "c3", "c4"], skiprows=lambda x: x % 2
+    )
+    modin_df = pd.read_csv(
+        TEST_CSV_FILENAME, names=["c1", "c2", "c3", "c4"], skiprows=lambda x: x % 2
+    )
+    df_equals(modin_df, pandas_df)
+
 
 def test_from_csv_encoding(make_csv_file):
     make_csv_file(encoding="latin8")

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -905,8 +905,15 @@ def test_from_csv_skiprows(make_csv_file):
 
     pandas_df = pandas.read_csv(TEST_CSV_FILENAME, skiprows=2)
     modin_df = pd.read_csv(TEST_CSV_FILENAME, skiprows=2)
+    df_equals(modin_df, pandas_df)
 
-    assert modin_df_equals_pandas(modin_df, pandas_df)
+    pandas_df = pandas.read_csv(
+        TEST_CSV_FILENAME, names=["c1", "c2", "c3", "c4"], skiprows=2
+    )
+    modin_df = pd.read_csv(
+        TEST_CSV_FILENAME, names=["c1", "c2", "c3", "c4"], skiprows=2
+    )
+    df_equals(modin_df, pandas_df)
 
 
 def test_from_csv_encoding(make_csv_file):


### PR DESCRIPTION
* Resolves #897
* Adds logic to handle `skiprows` for all cases
* Removes unnecessary logic that added to `read_csv` runtime
* Add tests
* Add logic for weird pandas edge case with `names` and `skiprows`

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
