### PR TITLE
Fix DeprecationWarning: invalid escape sequence \d

### DIFF
--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -10,11 +10,10 @@ from modin.error_message import ErrorMessage
 from modin.engines.base.io import BaseIO
 from modin.data_management.utils import compute_chunksize
 from modin import __execution_engine__
+from modin.pandas.io import PQ_INDEX_REGEX
 
 if __execution_engine__ == "Ray":
     import ray
-
-PQ_INDEX_REGEX = re.compile("__index_level_\d+__")  # noqa W605
 
 
 class RayIO(BaseIO):

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -1,7 +1,6 @@
 import pandas
 
 import os
-import re
 import numpy as np
 import math
 import warnings

--- a/modin/engines/ray/generic/io.py
+++ b/modin/engines/ray/generic/io.py
@@ -9,7 +9,6 @@ from modin.error_message import ErrorMessage
 from modin.engines.base.io import BaseIO
 from modin.data_management.utils import compute_chunksize
 from modin import __execution_engine__
-from modin.pandas.io import PQ_INDEX_REGEX
 
 if __execution_engine__ == "Ray":
     import ray
@@ -86,6 +85,7 @@ class RayIO(BaseIO):
         """
 
         from pyarrow.parquet import ParquetFile, ParquetDataset
+        from modin.pandas.io import PQ_INDEX_REGEX
 
         if cls.read_parquet_remote_task is None:
             return super(RayIO, cls).read_parquet(path, engine, columns, **kwargs)

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -9,7 +9,7 @@ from modin.error_message import ErrorMessage
 from .dataframe import DataFrame
 from modin.data_management.factories import BaseFactory
 
-PQ_INDEX_REGEX = re.compile("__index_level_\d+__")  # noqa W605
+PQ_INDEX_REGEX = re.compile(r"__index_level_\d+__")
 
 
 # Parquet


### PR DESCRIPTION
* Resolves #949
* Removes the duplicated line and fixes in one place

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- ~[ ] tests added and passing~
