### PR TITLE
Fix pyarrow.parquet import in tests

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -5,6 +5,7 @@ from collections import OrderedDict
 from modin.pandas.utils import to_pandas
 from pathlib import Path
 import pyarrow as pa
+import pyarrow.parquet as pq
 import os
 import shutil
 import sqlalchemy as sa
@@ -80,7 +81,7 @@ def make_parquet_file():
             else:
                 os.mkdir(TEST_PARQUET_FILENAME)
             table = pa.Table.from_pandas(df)
-            pa.parquet.write_to_dataset(table, root_path=TEST_PARQUET_FILENAME)
+            pq.write_to_dataset(table, root_path=TEST_PARQUET_FILENAME)
         elif len(partitioned_columns) > 0:
             df.to_parquet(TEST_PARQUET_FILENAME, partition_cols=partitioned_columns)
         else:


### PR DESCRIPTION
* Resolves #951

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests passing
