### PR TITLE
Fix `apply` when `args` is set

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -561,7 +561,7 @@ class BasePandasDataset(object):
                 )
         elif not callable(func) and not is_list_like(func):
             raise TypeError("{} object is not callable".format(type(func)))
-        query_compiler = self._query_compiler.apply(func, axis, *args, **kwds)
+        query_compiler = self._query_compiler.apply(func, axis, args=args, **kwds)
         return query_compiler
 
     def as_blocks(self, copy=True):

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1070,6 +1070,26 @@ class TestDFPartOne:
             modin_result = modin_df.apply(func, axis)
             df_equals(modin_result, pandas_result)
 
+    @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+    @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
+    def test_apply_args(self, data, axis):
+        modin_df = pd.DataFrame(data)
+        pandas_df = pandas.DataFrame(data)
+
+        def apply_func(series, y):
+            try:
+                return series + y
+            except TypeError:
+                return series.map(str) + str(y)
+
+        modin_result = modin_df.apply(apply_func, axis=axis, args=(1,))
+        pandas_result = pandas_df.apply(apply_func, axis=axis, args=(1,))
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.apply(apply_func, axis=axis, args=("_A",))
+        pandas_result = pandas_df.apply(apply_func, axis=axis, args=("_A",))
+        df_equals(modin_result, pandas_result)
+
     def test_apply_metadata(self):
         def add(a, b, c):
             return a + b + c


### PR DESCRIPTION
* Resolves #915
* Send `args` as another keyword argument instead of unpacking the tuple
* Add tests to verify correctness of fixed functionality

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
