### PR TITLE
Support parameters with run-tests.sh

### DIFF
--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
-arg=$arg
+arg=$1
+shift
 
 if [ "$arg" == "" ]; then
     arg="all"
@@ -10,23 +11,23 @@ if [ "$arg" == "ray" ] || [ "$arg" == "all" ]; then
     echo "Running Ray tests"
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_ray .
     mv testmondata_ray .testmondata
-    MODIN_ENGINE=ray pytest modin/pandas/test/
+    MODIN_ENGINE=ray pytest modin/pandas/test/ $@
 fi
 if [ "$arg" == "python" ] || [ "$arg" == "all" ]; then
     echo "Running Python tests"
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_python .
     mv testmondata_python .testmondata
-    MODIN_ENGINE=python pytest modin/pandas/test/
+    MODIN_ENGINE=python pytest modin/pandas/test/ $@
 fi
 if [ "$arg" == "dask" ] || [ "$arg" == "all" ]; then
     echo "Running Dask tests"
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_dask .
     mv testmondata_dask .testmondata
-    MODIN_ENGINE=dask pytest modin/pandas/test/test_io.py
+    MODIN_ENGINE=dask pytest modin/pandas/test/test_io.py $@
 fi
 if [ "$arg" == "pyarrow" ] || [ "$arg" == "all" ]; then
     echo "Running Pyarrow tests"
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_pyarrow .
     mv testmondata_pyarrow .testmondata
-    MODIN_BACKEND=pyarrow MODIN_EXPERIMENTAL=1 pytest modin/pandas/test/test_io.py::test_from_csv
+    MODIN_BACKEND=pyarrow MODIN_EXPERIMENTAL=1 pytest modin/pandas/test/test_io.py::test_from_csv $@
 fi


### PR DESCRIPTION
* Resolves #958
* Support passing in an engine/test suite
* Also supports parameters to be passed to pytest e.g. -k, -v, -x, etc.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- ~[ ] tests added and passing~
