### PR TITLE
Increase `n_workers` for Dask from default to number of cores

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -223,9 +223,10 @@ elif execution_engine == "Dask":  # pragma: no cover
         client = _get_global_client()
         if client is None:
             from distributed import Client
+            import multiprocessing
 
-            client = Client()
-        num_cpus = sum(client.ncores().values())
+            num_cpus = multiprocessing.cpu_count()
+            client = Client(n_workers=num_cpus)
 elif execution_engine != "Python":
     raise ImportError("Unrecognized execution engine: {}.".format(execution_engine))
 


### PR DESCRIPTION
* Resolves #954
* Increases the number of workers for Dask to the number of cores

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests passing
