### PR TITLE
Fix bug where certain encodings were throwing an error

### DIFF
--- a/modin/backends/pandas/parsers.py
+++ b/modin/backends/pandas/parsers.py
@@ -76,7 +76,7 @@ class PandasCSVParser(PandasParser):
         if start is not None and end is not None:
             # pop "compression" from kwargs because bio is uncompressed
             bio = FileReader.file_open(fname, "rb", kwargs.pop("compression", "infer"))
-            if kwargs.pop("encoding", False):
+            if kwargs.get("encoding", None) is not None:
                 header = b"" + bio.readline()
             else:
                 header = b""

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -937,11 +937,14 @@ def test_from_csv_skiprows(make_csv_file):
     df_equals(modin_df, pandas_df)
 
 
-def test_from_csv_encoding(make_csv_file):
-    make_csv_file(encoding="latin8")
+@pytest.mark.parametrize(
+    "encoding", ["latin8", "ISO-8859-1", "latin1", "iso-8859-1", "cp1252", "utf8"]
+)
+def test_from_csv_encoding(make_csv_file, encoding):
+    make_csv_file(encoding=encoding)
 
-    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, encoding="latin8")
-    modin_df = pd.read_csv(TEST_CSV_FILENAME, encoding="latin8")
+    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, encoding=encoding)
+    modin_df = pd.read_csv(TEST_CSV_FILENAME, encoding=encoding)
 
     assert modin_df_equals_pandas(modin_df, pandas_df)
 


### PR DESCRIPTION
* Resolves #976
* Change default value in `kwargs.get` to match pandas
* Add parametrized test for `encoding` with a variety of new encodings

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
