### PR TITLE
Fix inplace operations without inplace keyword on emtpy dataframes

### DIFF
--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -575,6 +575,18 @@ class TestDataFrameMapMetadata:
         assert len(df.index) == 0
         assert len(df.columns) == 0
 
+        df = pd.DataFrame()
+        pd_df = pandas.DataFrame()
+        df["a"] = [1, 2, 3, 4, 5]
+        pd_df["a"] = [1, 2, 3, 4, 5]
+        df_equals(df, pd_df)
+
+        df = pd.DataFrame()
+        pd_df = pandas.DataFrame()
+        df["a"] = list("ABCDEF")
+        pd_df["a"] = list("ABCDEF")
+        df_equals(df, pd_df)
+
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test_abs(self, request, data):
         modin_df = pd.DataFrame(data)


### PR DESCRIPTION
* Resolves #982
* Adds clause for operations that default to pandas that do not return
  any value
  * In these cases, we build the object based on the class name of the
    object in pandas
* Add some error checking cases to the default code
* Add more test cases for the emtpy dataframe case.

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
