### PR TITLE
Support console with __repr__ like pandas

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -92,7 +92,9 @@ class DataFrame(BasePandasDataset):
 
         num_rows = pandas.get_option("display.max_rows") or 10
         num_cols = pandas.get_option("display.max_columns") or 20
-        if pandas.get_option("display.expand_frame_repr"):
+        if pandas.get_option("display.max_columns") is None and pandas.get_option(
+            "display.expand_frame_repr"
+        ):
             width, _ = console.get_console_size()
             col_counter = 0
             i = 0

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -88,9 +88,26 @@ class DataFrame(BasePandasDataset):
             self._query_compiler = query_compiler
 
     def __repr__(self):
-        num_rows = pandas.get_option("max_rows") or 10
-        num_cols = pandas.get_option("max_columns") or 20
+        from pandas.io.formats import console
 
+        num_rows = pandas.get_option("display.max_rows") or 10
+        num_cols = pandas.get_option("display.max_columns") or 20
+        if pandas.get_option("display.expand_frame_repr"):
+            width, _ = console.get_console_size()
+            col_counter = 0
+            i = 0
+            while col_counter < width:
+                col_counter += len(str(self.columns[i])) + 1
+                i += 1
+
+            num_cols = i
+            i = len(self.columns) - 1
+            col_counter = 0
+            while col_counter < width:
+                col_counter += len(str(self.columns[i])) + 1
+                i -= 1
+
+            num_cols += len(self.columns) - i
         result = repr(self._build_repr_df(num_rows, num_cols))
         if len(self.index) > num_rows or len(self.columns) > num_cols:
             # The split here is so that we don't repr pandas row lengths.


### PR DESCRIPTION
* Resolves #898
* Pre-compute the number of columns based on the width of the column
  names
  * This guarantees that we will get at least as many columns from the
    partitions as we need.
  * Compute width using pandas utility to match the behavior
* Tested locally to verify behavior

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests ~added and~ passing
