### PR TITLE
Re-enable test for `Series.view` on Dask

### DIFF
--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2672,7 +2672,6 @@ def test_var(data, skipna, ddof):
         df_equals(modin_result, pandas_result)
 
 
-@pytest.mark.skipif(sys.platform == "win32", reason="Windows memory issue #960")
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_view(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
* Resolves #960

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [ ] tests added and passing
