### PR TITLE
Add implementation for `droplevel` for `Series` and `DataFrame`

### DIFF
--- a/docs/UsingPandasonRay/dataframe_supported.rst
+++ b/docs/UsingPandasonRay/dataframe_supported.rst
@@ -114,6 +114,8 @@ default to pandas.
 +---------------------------+---------------------------------+----------------------------------------------------+
 | `drop`_                   | Y                               |                                                    |
 +---------------------------+---------------------------------+----------------------------------------------------+
+| `droplevel`_              | Y                               |                                                    |
++---------------------------+---------------------------------+----------------------------------------------------+
 | `drop_duplicates`_        | D                               |                                                    |
 +---------------------------+---------------------------------+----------------------------------------------------+
 | `dropna`_                 | Y                               |                                                    |
@@ -505,6 +507,7 @@ default to pandas.
 .. _`divide`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.divide.html#pandas.DataFrame.divide
 .. _`dot`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.dot.html#pandas.DataFrame.dot
 .. _`drop`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.drop.html#pandas.DataFrame.drop
+.. _`droplevel`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.droplevel.html
 .. _`drop_duplicates`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.drop_duplicates.html#pandas.DataFrame.drop_duplicates
 .. _`dropna`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.dropna.html#pandas.DataFrame.dropna
 .. _`dtypes`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.dtypes.html#pandas.DataFrame.dtypes

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1087,7 +1087,14 @@ class BasePandasDataset(object):
         Returns:
             Index or MultiIndex
         """
-        return self._default_to_pandas("droplevel", level, axis=axis)
+        axis = self._get_axis_number(axis)
+        new_axis = self.axes[axis].droplevel(level)
+        result = self.copy()
+        if axis == 0:
+            result.index = new_axis
+        else:
+            result.columns = new_axis
+        return result
 
     def drop_duplicates(self, keep="first", inplace=False, **kwargs):
         """Return DataFrame with duplicate rows removed, optionally only considering certain columns

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1137,12 +1137,8 @@ class TestDataFrameMapMetadata:
         df.columns = pd.MultiIndex.from_tuples(
             [("c", "e"), ("d", "f")], names=["level_1", "level_2"]
         )
-
-        with pytest.warns(UserWarning):
-            df.droplevel("a")
-
-        with pytest.warns(UserWarning):
-            df.droplevel("level_2", axis=1)
+        df.droplevel("a")
+        df.droplevel("level_2", axis=1)
 
     @pytest.mark.parametrize(
         "data", test_data_with_duplicates_values, ids=test_data_with_duplicates_keys


### PR DESCRIPTION
* Resolves #999
* Adds implementation for `droplevel for `Series` and `DataFrame` by
  creating a copy of the object and assigning the new index/columns to
  the copy.
* Update tests

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
