### PR TITLE
Add implementation for `first` for `Series` and `DataFrame`

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1301,7 +1301,7 @@ class BasePandasDataset(object):
         return self[self.columns[bool_arr]]
 
     def first(self, offset):
-        return self._default_to_pandas("first", offset)
+        return self.loc[pandas.Series(index=self.index).first(offset).index]
 
     def first_valid_index(self):
         """Return index for first non-NA/null value.

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -2317,10 +2317,13 @@ class TestDataFrameDefault:
             modin_df.explode(modin_df.columns[0])
 
     def test_first(self):
-        i = pd.date_range("2018-04-09", periods=4, freq="2D")
-        ts = pd.DataFrame({"A": [1, 2, 3, 4]}, index=i)
-        with pytest.warns(UserWarning):
-            ts.first("3D")
+        i = pd.date_range("2010-04-09", periods=400, freq="2D")
+        modin_df = pd.DataFrame({"A": list(range(400)), "B": list(range(400))}, index=i)
+        pandas_df = pandas.DataFrame(
+            {"A": list(range(400)), "B": list(range(400))}, index=i
+        )
+        df_equals(modin_df.first("3D"), pandas_df.first("3D"))
+        df_equals(modin_df.first("20D"), pandas_df.first("20D"))
 
     @pytest.mark.skip(reason="Defaulting to Pandas")
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1368,10 +1368,11 @@ def test_filter():
 
 
 def test_first():
-    i = pd.date_range("2018-04-09", periods=4, freq="2D")
-    ts = pd.Series([1, 2, 3, 4], index=i)
-    with pytest.warns(UserWarning):
-        ts.first("3D")
+    i = pd.date_range("2010-04-09", periods=400, freq="2D")
+    modin_series = pd.Series(list(range(400)), index=i)
+    pandas_series = pandas.Series(list(range(400)), index=i)
+    df_equals(modin_series.first("3D"), pandas_series.first("3D"))
+    df_equals(modin_series.first("20D"), pandas_series.first("20D"))
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)


### PR DESCRIPTION
* Resolves #1004
* Implement `first` by wrapping the `DatetimeIndex` in a `Series` and calling
  first. This introduces a <1ms overhead for computing the `loc` values,
  then we can use `loc`.
* Update tests

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
