### PR TITLE
Fix bug in `loc` where slice on columns only threw Exception

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -212,7 +212,11 @@ class _LocIndexer(_LocationIndexerBase):
             if len(key) > self.df.ndim:
                 raise IndexingError("Too many indexers")
             if isinstance(key[0], slice) and key[0] == slice(None):
-                return self.df.__getitem__(key[1])
+                if not isinstance(key[1], slice):
+                    return self.df.__getitem__(key[1])
+                else:
+                    result_slice = self.df.columns.slice_locs(key[1].start, key[1].stop)
+                    return self.df.iloc[:, slice(*result_slice)]
         row_loc, col_loc, ndim, self.row_scaler, self.col_scaler = _parse_tuple(key)
         row_lookup, col_lookup = self._compute_lookup(row_loc, col_loc)
         # Check that the row_lookup/col_lookup is longer than 1 or that the

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4414,6 +4414,11 @@ class TestDataFrameIndexing:
             df_equals(modin_df.loc[:, [key2, key1]], pandas_df.loc[:, [key2, key1]])
             df_equals(modin_df.loc[[2, 1], :], pandas_df.loc[[2, 1], :])
 
+            # From issue #1023
+            key1 = modin_df.columns[0]
+            key2 = modin_df.columns[-2]
+            df_equals(modin_df.loc[:, key1:key2], pandas_df.loc[:, key1:key2])
+
             # Write Item
             modin_df_copy = modin_df.copy()
             pandas_df_copy = pandas_df.copy()


### PR DESCRIPTION
* Resolves #1023
* Add condition to keep fastpath for __getitem__
* Reroute to `iloc` to handle the slice in one place
* Add test

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
