### PR TITLE
Fix bug where Parsing error was thrown when text spanned multiple lines

### DIFF
--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -79,7 +79,6 @@ class CSVReader(TextFileReader):
         column_names = empty_pd_df.columns
         skipfooter = kwargs.get("skipfooter", None)
         skiprows = kwargs.pop("skiprows", None)
-
         usecols = kwargs.get("usecols", None)
         usecols_md = _validate_usecols_arg(usecols)
         if usecols is not None and usecols_md[1] != "integer":
@@ -98,6 +97,10 @@ class CSVReader(TextFileReader):
             skiprows=None,
             parse_dates=parse_dates,
             usecols=usecols,
+        )
+        encoding = kwargs.get("encoding", None)
+        quotechar = kwargs.get("quotechar", '"').encode(
+            encoding if encoding is not None else "UTF-8"
         )
         with cls.file_open(filepath_or_buffer, "rb", compression_type) as f:
             # Skip the header since we already have the header information and skip the
@@ -153,7 +156,9 @@ class CSVReader(TextFileReader):
                     "num_splits": num_splits,
                     **partition_kwargs,
                 }
-                partition_id = cls.call_deploy(f, chunk_size, num_splits + 2, args)
+                partition_id = cls.call_deploy(
+                    f, chunk_size, num_splits + 2, args, quotechar=quotechar
+                )
                 partition_ids.append(partition_id[:-2])
                 index_ids.append(partition_id[-2])
                 dtypes_ids.append(partition_id[-1])

--- a/modin/pandas/test/data/newlines.csv
+++ b/modin/pandas/test/data/newlines.csv
@@ -1,0 +1,22 @@
+col1,col2,col3,col4
+"This is a very long
+string with several
+newline characters
+that will probably cause some
+problem for Modin
+and I suspect that
+we
+will hopefully
+reproduce the issue",2,3,4
+"H",2,3,4
+"I",2,3,4
+"J",2,3,4
+"H",2,3,4
+"I",2,3,4
+"J",2,3,4
+"H",2,3,4
+"I",2,3,4
+"J",2,3,4
+"H",2,3,4
+"I",2,3,4
+"J",2,3,4

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -997,6 +997,12 @@ def test_from_csv_parse_dates(make_csv_file):
     assert modin_df_equals_pandas(modin_df, pandas_df)
 
 
+def test_from_csv_newlines_in_quotes():
+    pandas_df = pandas.read_csv("modin/pandas/test/data/newlines.csv")
+    modin_df = pd.read_csv("modin/pandas/test/data/newlines.csv")
+    assert modin_df_equals_pandas(modin_df, pandas_df)
+
+
 @pytest.mark.skip(reason="No clipboard on Travis")
 def test_to_clipboard():
     modin_df = create_test_ray_dataframe()


### PR DESCRIPTION
* Resolves #1008
* Fast-forward to end of quotes when figuring out the partition offsets
* Add test and testfile

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
