### PR TITLE
Update Test infrastructure to use testmon when possible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       matrix:
         python-version: ["3.6.x", "3.7.x"]
         engine: ["python", "ray", "dask"]
-        part: ["Reduction_A::test_all", "Reduction_A::test_any", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
     env:
       MODIN_ENGINE: ${{matrix.engine}}
     name: test (${{matrix.engine}}, part ${{matrix.part}}, python ${{matrix.python-version}})
@@ -69,21 +69,21 @@ jobs:
         if: matrix.engine == 'ray'
       - run: pip install dask[complete] distributed
         if: matrix.engine == 'dask'
-      - run: python -m pytest modin/pandas/test/test_dataframe.py::TestDataFrame${{matrix.part}}
+      - run: bash run-tests.sh ${{matrix.engine}} -k "TestDataFrame${{matrix.part}}"
         if: matrix.part != 3
-      - run: python -m pytest modin/pandas/test/test_series.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_series.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_concat.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_concat.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_groupby.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_groupby.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_reshape.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_reshape.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_general.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_general.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_io.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_io.py
         if: matrix.part == 3
-      - run: python -m pytest modin/experimental/pandas/test/test_io_exp.py
+      - run: python -m pytest --testmon-noselect modin/experimental/pandas/test/test_io_exp.py
         if: matrix.part == 3
   test-windows:
     needs: [lint-flake8, lint-black]
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6.x", "3.7.x"]
-        part: ["Reduction_A::test_all", "Reduction_A::test_any", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
     env:
       MODIN_ENGINE: dask
     name: test-windows
@@ -117,19 +117,19 @@ jobs:
       - name: Install pip requirements
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r windows_test_requires.txt
-      - run: python -m pytest modin/pandas/test/test_dataframe.py::TestDataFrame${{matrix.part}}
+      - run: bash run-tests.sh ${{matrix.engine}} -k "TestDataFrame${{matrix.part}}"
         if: matrix.part != 3
-      - run: python -m pytest modin/pandas/test/test_series.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_series.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_concat.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_concat.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_groupby.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_groupby.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_reshape.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_reshape.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_general.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_general.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_io.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_io.py
         if: matrix.part == 3
   test-pyarrow:
     needs: [lint-flake8, lint-black]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6.x", "3.7.x"]
-        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        part: ["Reduction_A::test_all", "Reduction_A::test_any", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
     env:
       MODIN_ENGINE: dask
     name: test-windows
@@ -117,19 +117,19 @@ jobs:
       - name: Install pip requirements
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r windows_test_requires.txt
-      - run: bash run-tests.sh ${{matrix.engine}} -k "TestDataFrame${{matrix.part}}"
+      - run: python -m pytest modin/pandas/test/test_dataframe.py::TestDataFrame${{matrix.part}}
         if: matrix.part != 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_series.py
+      - run: python -m pytest modin/pandas/test/test_series.py
         if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_concat.py
+      - run: python -m pytest modin/pandas/test/test_concat.py
         if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_groupby.py
+      - run: python -m pytest modin/pandas/test/test_groupby.py
         if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_reshape.py
+      - run: python -m pytest modin/pandas/test/test_reshape.py
         if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_general.py
+      - run: python -m pytest modin/pandas/test/test_general.py
         if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_io.py
+      - run: python -m pytest modin/pandas/test/test_io.py
         if: matrix.part == 3
   test-pyarrow:
     needs: [lint-flake8, lint-black]

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -23,11 +23,9 @@ jobs:
       - name: Install AWSCLI
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install awscli
-      - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_ray .
-      - run: mv testmondata_ray .testmondata
       - run: sudo apt install -y libhdf5-dev
       - run: pip install -r requirements.txt
-      - run: MODIN_ENGINE=ray python -m pytest modin/pandas/test/
+      - run: bash run-tests.sh ray
       - run: mv .testmondata testmondata_ray
       - run: aws s3api put-object --bucket=modin-testing --key=testmondata_ray --body=./testmondata_ray
   testmon_python:
@@ -52,11 +50,9 @@ jobs:
       - name: Install AWSCLI
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install awscli
-      - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_python .
-      - run: mv testmondata_python .testmondata
       - run: sudo apt install -y libhdf5-dev
       - run: pip install -r requirements.txt
-      - run: MODIN_ENGINE=python python -m pytest modin/pandas/test/
+      - run: bash run-tests.sh python
       - run: mv .testmondata testmondata_python
       - run: aws s3api put-object --bucket=modin-testing --key=testmondata_python --body=./testmondata_python
   testmon_dask:
@@ -81,11 +77,9 @@ jobs:
       - name: InstallAWSCLI
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install awscli
-      - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_dask .
-      - run: mv testmondata_dask .testmondata
       - run: sudo apt install -y libhdf5-dev
       - run: pip install -r requirements.txt
-      - run: MODIN_ENGINE=dask python -m pytest modin/pandas/test/
+      - run: bash run-tests.sh dask
       - run: mv .testmondata testmondata_dask
       - run: aws s3api put-object --bucket=modin-testing --key=testmondata_dask --body=./testmondata_dask
   testmon_pyarrow:
@@ -120,15 +114,14 @@ jobs:
       - run: mv .testmondata testmondata_pyarrow
       - run: aws s3api put-object --bucket=modin-testing --key=testmondata_pyarrow --body=./testmondata_pyarrow
   test-all:
+    needs: [lint-flake8, lint-black]
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.6.x", "3.7.x"]
         engine: ["python", "ray", "dask"]
-        part: ["Reduction_A::test_all", "Reduction_A::test_any", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
     env:
-      CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
-      PYTEST_ADDOPTS:  "--cov-config=.coveragerc --cov=modin  --cov-append"
       MODIN_ENGINE: ${{matrix.engine}}
     name: test (${{matrix.engine}}, part ${{matrix.part}}, python ${{matrix.python-version}})
     steps:
@@ -145,6 +138,11 @@ jobs:
           key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
           restore-keys: |
             ${{ runner.os }}-pip-
+      - name: InstallAWSCLI
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pip install awscli
+      - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_${{matrix.engine}} .
+      - run: mv testmondata_${{matrix.engine}} .testmondata
       - name: Install HDF5
         if: matrix.part == 3
         run: sudo apt install -y libhdf5-dev
@@ -157,70 +155,68 @@ jobs:
         if: matrix.engine == 'ray'
       - run: pip install dask[complete] distributed
         if: matrix.engine == 'dask'
-      - run: pip install coverage pytest-cov
+      - run: bash run-tests.sh ${{matrix.engine}} -k "TestDataFrame${{matrix.part}}"
         if: matrix.part != 3
-      - run: python -m pytest modin/pandas/test/test_dataframe.py::TestDataFrame${{matrix.part}}
-        if: matrix.part != 3
-      - run: python -m pytest modin/pandas/test/test_series.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_series.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_concat.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_concat.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_groupby.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_groupby.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_reshape.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_reshape.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_general.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_general.py
         if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_io.py
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_io.py
         if: matrix.part == 3
-      - run: python -m pytest modin/experimental/pandas/test/test_io_exp.py
+      - run: python -m pytest --testmon-noselect modin/experimental/pandas/test/test_io_exp.py
         if: matrix.part == 3
-      - run: bash <(curl -s https://codecov.io/bash)
-  test-windows:
-    runs-on: windows-latest
-    strategy:
-      matrix:
-        python-version: ["3.6.x", "3.7.x"]
-        part: ["Reduction_A::test_all", "Reduction_A::test_any", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
-    env:
-      MODIN_ENGINE: dask
-    name: test-windows
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: ${{matrix.python-version}}
-          architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{runner.os}}-pip-${{hashFiles('**/requirements.txt')}}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install AWSCLI
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install awscli
-      - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_dask .
-      - run: mv testmondata_dask .testmondata
-      - name: Install pip requirements
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install -r windows_test_requires.txt
-      - run: python -m pytest modin/pandas/test/test_dataframe.py::TestDataFrame${{matrix.part}}
-        if: matrix.part != 3
-      - run: python -m pytest modin/pandas/test/test_series.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_concat.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_groupby.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_reshape.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_general.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_io.py
-        if: matrix.part == 3
+    test-windows:
+      needs: [lint-flake8, lint-black]
+      runs-on: windows-latest
+      strategy:
+        matrix:
+          python-version: ["3.6.x", "3.7.x"]
+          part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+      env:
+        MODIN_ENGINE: dask
+      name: test-windows
+      steps:
+        - uses: actions/checkout@v1
+          with:
+            fetch-depth: 1
+        - uses: actions/setup-python@v1
+          with:
+            python-version: ${{matrix.python-version}}
+            architecture: "x64"
+        - uses: actions/cache@v1
+          with:
+            path: ~\AppData\Local\pip\Cache
+            key: ${{runner.os}}-pip-${{hashFiles('**/requirements.txt')}}
+            restore-keys: |
+              ${{ runner.os }}-pip-
+        - name: Install AWSCLI
+          if: steps.cache.outputs.cache-hit != 'true'
+          run: pip install awscli
+        - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_dask .
+        - run: mv testmondata_dask .testmondata
+        - name: Install pip requirements
+          if: steps.cache.outputs.cache-hit != 'true'
+          run: pip install -r windows_test_requires.txt
+        - run: bash run-tests.sh ${{matrix.engine}} -k "TestDataFrame${{matrix.part}}"
+          if: matrix.part != 3
+        - run: python -m pytest --testmon-noselect modin/pandas/test/test_series.py
+          if: matrix.part == 3
+        - run: python -m pytest --testmon-noselect modin/pandas/test/test_concat.py
+          if: matrix.part == 3
+        - run: python -m pytest --testmon-noselect modin/pandas/test/test_groupby.py
+          if: matrix.part == 3
+        - run: python -m pytest --testmon-noselect modin/pandas/test/test_reshape.py
+          if: matrix.part == 3
+        - run: python -m pytest --testmon-noselect modin/pandas/test/test_general.py
+          if: matrix.part == 3
+        - run: python -m pytest --testmon-noselect modin/pandas/test/test_io.py
+          if: matrix.part == 3
   test-pyarrow:
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -175,7 +175,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.6.x", "3.7.x"]
-        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        part: ["Reduction_A::test_all", "Reduction_A::test_any", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
     env:
       MODIN_ENGINE: dask
     name: test-windows
@@ -201,19 +201,19 @@ jobs:
       - name: Install pip requirements
         if: steps.cache.outputs.cache-hit != 'true'
         run: pip install -r windows_test_requires.txt
-      - run: bash run-tests.sh ${{matrix.engine}} -k "TestDataFrame${{matrix.part}}"
+      - run: python -m pytest modin/pandas/test/test_dataframe.py::TestDataFrame${{matrix.part}}
         if: matrix.part != 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_series.py
+      - run: python -m pytest modin/pandas/test/test_series.py
         if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_concat.py
+      - run: python -m pytest modin/pandas/test/test_concat.py
         if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_groupby.py
+      - run: python -m pytest modin/pandas/test/test_groupby.py
         if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_reshape.py
+      - run: python -m pytest modin/pandas/test/test_reshape.py
         if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_general.py
+      - run: python -m pytest modin/pandas/test/test_general.py
         if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_io.py
+      - run: python -m pytest modin/pandas/test/test_io.py
         if: matrix.part == 3
   test-pyarrow:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -114,7 +114,6 @@ jobs:
       - run: mv .testmondata testmondata_pyarrow
       - run: aws s3api put-object --bucket=modin-testing --key=testmondata_pyarrow --body=./testmondata_pyarrow
   test-all:
-    needs: [lint-flake8, lint-black]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -171,52 +170,51 @@ jobs:
         if: matrix.part == 3
       - run: python -m pytest --testmon-noselect modin/experimental/pandas/test/test_io_exp.py
         if: matrix.part == 3
-    test-windows:
-      needs: [lint-flake8, lint-black]
-      runs-on: windows-latest
-      strategy:
-        matrix:
-          python-version: ["3.6.x", "3.7.x"]
-          part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
-      env:
-        MODIN_ENGINE: dask
-      name: test-windows
-      steps:
-        - uses: actions/checkout@v1
-          with:
-            fetch-depth: 1
-        - uses: actions/setup-python@v1
-          with:
-            python-version: ${{matrix.python-version}}
-            architecture: "x64"
-        - uses: actions/cache@v1
-          with:
-            path: ~\AppData\Local\pip\Cache
-            key: ${{runner.os}}-pip-${{hashFiles('**/requirements.txt')}}
-            restore-keys: |
-              ${{ runner.os }}-pip-
-        - name: Install AWSCLI
-          if: steps.cache.outputs.cache-hit != 'true'
-          run: pip install awscli
-        - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_dask .
-        - run: mv testmondata_dask .testmondata
-        - name: Install pip requirements
-          if: steps.cache.outputs.cache-hit != 'true'
-          run: pip install -r windows_test_requires.txt
-        - run: bash run-tests.sh ${{matrix.engine}} -k "TestDataFrame${{matrix.part}}"
-          if: matrix.part != 3
-        - run: python -m pytest --testmon-noselect modin/pandas/test/test_series.py
-          if: matrix.part == 3
-        - run: python -m pytest --testmon-noselect modin/pandas/test/test_concat.py
-          if: matrix.part == 3
-        - run: python -m pytest --testmon-noselect modin/pandas/test/test_groupby.py
-          if: matrix.part == 3
-        - run: python -m pytest --testmon-noselect modin/pandas/test/test_reshape.py
-          if: matrix.part == 3
-        - run: python -m pytest --testmon-noselect modin/pandas/test/test_general.py
-          if: matrix.part == 3
-        - run: python -m pytest --testmon-noselect modin/pandas/test/test_io.py
-          if: matrix.part == 3
+  test-windows:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        python-version: ["3.6.x", "3.7.x"]
+        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+    env:
+      MODIN_ENGINE: dask
+    name: test-windows
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: ${{matrix.python-version}}
+          architecture: "x64"
+      - uses: actions/cache@v1
+        with:
+          path: ~\AppData\Local\pip\Cache
+          key: ${{runner.os}}-pip-${{hashFiles('**/requirements.txt')}}
+          restore-keys: |
+            ${{ runner.os }}-pip-
+      - name: Install AWSCLI
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pip install awscli
+      - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_dask .
+      - run: mv testmondata_dask .testmondata
+      - name: Install pip requirements
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: pip install -r windows_test_requires.txt
+      - run: bash run-tests.sh ${{matrix.engine}} -k "TestDataFrame${{matrix.part}}"
+        if: matrix.part != 3
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_series.py
+        if: matrix.part == 3
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_concat.py
+        if: matrix.part == 3
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_groupby.py
+        if: matrix.part == 3
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_reshape.py
+        if: matrix.part == 3
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_general.py
+        if: matrix.part == 3
+      - run: python -m pytest --testmon-noselect modin/pandas/test/test_io.py
+        if: matrix.part == 3
   test-pyarrow:
     runs-on: ubuntu-latest
     strategy:

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --disable-pytest-warnings --suppress-no-test-exit-code
+addopts = --testmon-forceselect --disable-pytest-warnings --suppress-no-test-exit-code

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --testmon-forceselect --disable-pytest-warnings --suppress-no-test-exit-code
+addopts = --disable-pytest-warnings --suppress-no-test-exit-code

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -12,18 +12,33 @@ if [ "$arg" == "ray" ] || [ "$arg" == "all" ]; then
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_ray .
     mv testmondata_ray .testmondata
     MODIN_ENGINE=ray pytest modin/pandas/test/ $@
+    # This happens on sqlite error from testmon if too many files were changed.
+    if [ "$?" -eq 3 ]; then
+      rm .testmondata
+      MODIN_ENGINE=ray pytest modin/pandas/test/ $@
+    fi
 fi
 if [ "$arg" == "python" ] || [ "$arg" == "all" ]; then
     echo "Running Python tests"
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_python .
     mv testmondata_python .testmondata
     MODIN_ENGINE=python pytest modin/pandas/test/ $@
+    # This happens on sqlite error from testmon if too many files were changed.
+    if [ "$?" -eq 3 ]; then
+      rm .testmondata
+      MODIN_ENGINE=python pytest modin/pandas/test/ $@
+    fi
 fi
 if [ "$arg" == "dask" ] || [ "$arg" == "all" ]; then
     echo "Running Dask tests"
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_dask .
     mv testmondata_dask .testmondata
     MODIN_ENGINE=dask pytest modin/pandas/test/ $@
+    # This happens on sqlite error from testmon if too many files were changed.
+    if [ "$?" -eq 3 ]; then
+      rm .testmondata
+      MODIN_ENGINE=dask pytest modin/pandas/test/ $@
+    fi
 fi
 if [ "$arg" == "pyarrow" ] || [ "$arg" == "all" ]; then
     echo "Running Pyarrow tests"

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -11,38 +11,38 @@ if [ "$arg" == "ray" ] || [ "$arg" == "all" ]; then
     echo "Running Ray tests"
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_ray .
     mv testmondata_ray .testmondata
-    MODIN_ENGINE=ray pytest modin/pandas/test/ $@
+    MODIN_ENGINE=ray pytest --testmon modin/pandas/test/ $@
     # This happens on sqlite error from testmon if too many files were changed.
     if [ "$?" -eq 3 ]; then
       rm .testmondata
-      MODIN_ENGINE=ray pytest modin/pandas/test/ $@
+      MODIN_ENGINE=ray pytest --testmon modin/pandas/test/ $@
     fi
 fi
 if [ "$arg" == "python" ] || [ "$arg" == "all" ]; then
     echo "Running Python tests"
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_python .
     mv testmondata_python .testmondata
-    MODIN_ENGINE=python pytest modin/pandas/test/ $@
+    MODIN_ENGINE=python pytest --testmon modin/pandas/test/ $@
     # This happens on sqlite error from testmon if too many files were changed.
     if [ "$?" -eq 3 ]; then
       rm .testmondata
-      MODIN_ENGINE=python pytest modin/pandas/test/ $@
+      MODIN_ENGINE=python pytest --testmon modin/pandas/test/ $@
     fi
 fi
 if [ "$arg" == "dask" ] || [ "$arg" == "all" ]; then
     echo "Running Dask tests"
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_dask .
     mv testmondata_dask .testmondata
-    MODIN_ENGINE=dask pytest modin/pandas/test/ $@
+    MODIN_ENGINE=dask pytest --testmon modin/pandas/test/ $@
     # This happens on sqlite error from testmon if too many files were changed.
     if [ "$?" -eq 3 ]; then
       rm .testmondata
-      MODIN_ENGINE=dask pytest modin/pandas/test/ $@
+      MODIN_ENGINE=dask pytest --testmon modin/pandas/test/ $@
     fi
 fi
 if [ "$arg" == "pyarrow" ] || [ "$arg" == "all" ]; then
     echo "Running Pyarrow tests"
     aws s3 cp  --no-sign-request s3://modin-testing/testmondata_pyarrow .
     mv testmondata_pyarrow .testmondata
-    MODIN_BACKEND=pyarrow MODIN_EXPERIMENTAL=1 pytest modin/pandas/test/test_io.py::test_from_csv $@
+    MODIN_BACKEND=pyarrow MODIN_EXPERIMENTAL=1 pytest --testmon modin/pandas/test/test_io.py::test_from_csv $@
 fi


### PR DESCRIPTION
* Previously ran into errors with too many changes, this resolves that
* Still update the testmon files in S3
* Force run certain tests no matter what

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests ~added and~ passing
