### PR TITLE
WIP - add support for SQL queries distribution against different SQL engines

### DIFF
--- a/modin/engines/base/io/sql/sql_reader.py
+++ b/modin/engines/base/io/sql/sql_reader.py
@@ -2,6 +2,7 @@ import math
 import numpy as np
 import pandas
 import warnings
+from .utils import SqlQuery
 
 from modin.engines.base.io.file_reader import FileReader
 
@@ -45,11 +46,14 @@ class SQLReader(FileReader):
                 "connection string instead of {}.".format(type(con))
             )
             return cls.single_worker_read(sql, con=con, index_col=index_col, **kwargs)
-        row_cnt_query = "SELECT COUNT(*) FROM ({}) as foo".format(sql)
+
+        sa_engine = sa.create_engine(con)
+        sql_query_engine = SqlQuery(sa_driver=sa_engine.driver)
+        row_cnt_query = sql_query_engine.row_cnt(sql=sql)
+        cols_names_query = sql_query_engine.empty(sql=sql)
+
         row_cnt = pandas.read_sql(row_cnt_query, con).squeeze()
-        cols_names_df = pandas.read_sql(
-            "SELECT * FROM ({}) as foo LIMIT 0".format(sql), con, index_col=index_col
-        )
+        cols_names_df = pandas.read_sql(cols_names_query, con, index_col=index_col)
         cols_names = cols_names_df.columns
         from modin.pandas import DEFAULT_NPARTITIONS
 
@@ -60,9 +64,7 @@ class SQLReader(FileReader):
         limit = math.ceil(row_cnt / num_partitions)
         for part in range(num_partitions):
             offset = part * limit
-            query = "SELECT * FROM ({}) as foo LIMIT {} OFFSET {}".format(
-                sql, limit, offset
-            )
+            query = sql_query_engine.partitioned(sql=sql, limit=limit, offset=offset)
             partition_id = cls.deploy(
                 cls.parse,
                 num_partitions + 2,

--- a/modin/engines/base/io/sql/utils.py
+++ b/modin/engines/base/io/sql/utils.py
@@ -1,0 +1,44 @@
+class SqlQuery:
+    engine = None
+
+    def __init__(self, sa_driver=None):
+        self.engine = BaseSqlQuery()
+        if sa_driver == "pymssql":
+            self.engine = MssqlSqlQuery()
+
+    def empty(self, sql):
+        return self.engine.get_empty(sql)
+
+    def row_cnt(self, sql):
+        return self.engine.get_row_cnt(sql)
+
+    def partitioned(self, sql, limit, offset):
+        return self.engine.get_partitioned(sql, limit, offset)
+
+
+class BaseSqlQuery:
+    @staticmethod
+    def get_empty(sql):
+        return "SELECT * FROM ({}) as foo LIMIT 0".format(sql)
+
+    @staticmethod
+    def get_row_cnt(sql):
+        return "SELECT COUNT(*) FROM ({}) as foo".format(sql)
+
+    @staticmethod
+    def get_partitioned(sql, limit, offset):
+        return "SELECT * FROM ({0}) as foo LIMIT {1} OFFSET {2}".format(
+            sql, limit, offset
+        )
+
+
+class MssqlSqlQuery(BaseSqlQuery):
+    @staticmethod
+    def get_empty(sql):
+        return "SELECT Top 0 * FROM ({}) as foo".format(sql)
+
+    @staticmethod
+    def get_partitioned(sql, limit, offset):
+        return "SELECT * FROM ({0}) as foo ORDER BY(SELECT NULL) OFFSET {1} ROWS FETCH NEXT {2} ROWS ONLY".format(
+            sql, offset, limit
+        )


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

The goal of this PR is to created a common layer for generating the SQL queries which are used for the distribution of user queries. Currentlly, only 2 variations will be supported: mssql (`MssqlSqlQuery`) and all the rest (`BaseSqlQuery`).
Unit tests needs to be added against different SQL engines.

## Related issue number
will resolve #979 
will be used in #923 

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] tests added and passing
