### PR TITLE
Fix pd.to_datetime when using a Series object.

### DIFF
--- a/modin/pandas/datetimes.py
+++ b/modin/pandas/datetimes.py
@@ -1,6 +1,8 @@
 import pandas
 
+from modin.error_message import ErrorMessage
 from .dataframe import DataFrame
+from .series import Series
 
 
 def to_datetime(
@@ -40,14 +42,13 @@ def to_datetime(
         - Series: Series of datetime64 dtype
         - scalar: Timestamp
     """
-    if not isinstance(arg, DataFrame):
+    if not isinstance(arg, (DataFrame, Series)):
         return pandas.to_datetime(
             arg,
             errors=errors,
             dayfirst=dayfirst,
             yearfirst=yearfirst,
             utc=utc,
-            box=box,
             format=format,
             exact=exact,
             unit=unit,
@@ -55,14 +56,12 @@ def to_datetime(
             origin=origin,
             cache=cache,
         )
-    # Pandas seems to ignore this kwarg so we will too
-    pandas.to_datetime(
-        pandas.DataFrame(columns=arg.columns),
+    return arg._default_to_pandas(
+        pandas.to_datetime,
         errors=errors,
         dayfirst=dayfirst,
         yearfirst=yearfirst,
         utc=utc,
-        box=box,
         format=format,
         exact=exact,
         unit=unit,
@@ -70,4 +69,3 @@ def to_datetime(
         origin=origin,
         cache=cache,
     )
-    return arg._query_compiler.to_datetime()

--- a/modin/pandas/datetimes.py
+++ b/modin/pandas/datetimes.py
@@ -1,6 +1,5 @@
 import pandas
 
-from modin.error_message import ErrorMessage
 from .dataframe import DataFrame
 from .series import Series
 

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -2613,6 +2613,13 @@ class TestDataFrameDefault:
         if not name_contains(request.node.name, ["nan"]):
             assert np.array_equal(modin_df.to_records(), pandas_df.to_records())
 
+    def test_to_datetime(self):
+        modin_df = pd.DataFrame({"year": [2015, 2016], "month": [2, 3], "day": [4, 5]})
+        pandas_df = pandas.DataFrame(
+            {"year": [2015, 2016], "month": [2, 3], "day": [4, 5]}
+        )
+        df_equals(pd.to_datetime(modin_df), pandas.to_datetime(pandas_df))
+
     def test_to_sparse(self):
         data = test_data_values[0]
         with pytest.warns(UserWarning):

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -245,3 +245,14 @@ def test_pivot_table():
         pd.pivot_table(
             test_df["C"], values="D", index=["A", "B"], columns=["C"], aggfunc=np.sum
         )
+
+
+def test_to_datetime():
+    value = 1490195805
+    assert pd.to_datetime(value, unit="s") == pandas.to_datetime(value, unit="s")
+    value = 1490195805433502912
+    assert pd.to_datetime(value, unit="ns") == pandas.to_datetime(value, unit="ns")
+    value = [1, 2, 3]
+    assert pd.to_datetime(value, unit="D", origin=pd.Timestamp("2000-01-01")).equals(
+        pandas.to_datetime(value, unit="D", origin=pandas.Timestamp("2000-01-01"))
+    )

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2551,6 +2551,12 @@ def test_explode(data):
     df_equals(modin_result, pandas_result)
 
 
+def test_to_datetime():
+    modin_s = pd.Series(["3/11/2000", "3/12/2000", "3/13/2000"] * 1000)
+    pandas_s = pandas.Series(["3/11/2000", "3/12/2000", "3/13/2000"] * 1000)
+    df_equals(pd.to_datetime(modin_s), pandas.to_datetime(pandas_s))
+
+
 def test_to_period():
     idx = pd.date_range("1/1/2012", periods=5, freq="M")
     series = pd.Series(np.random.randint(0, 100, size=(len(idx))), index=idx)


### PR DESCRIPTION
* Resolves #1034
* Restructure defaulting to pandas code
* Add tests for dataframe, series, and other types

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
