### PR TITLE
Fix issue with Dask engine where users were not able to use Dask 2.10+

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -1,6 +1,7 @@
 import os
 import sys
 import warnings
+from packaging import version
 
 from ._version import get_versions
 
@@ -34,7 +35,7 @@ def get_execution_engine():
                 except ImportError:
                     pass
                 else:
-                    if ray.__version__ != "0.8.0":
+                    if version.parse(ray.__version__) != version.parse("0.8.0"):
                         raise ImportError(
                             "Please `pip install modin[ray]` to install compatible Ray version."
                         )
@@ -50,10 +51,9 @@ def get_execution_engine():
                     )
                 )
             else:
-                if (
-                    str(dask.__version__) < "2.1.0"
-                    or str(distributed.__version__) < "2.3.2"
-                ):
+                if version.parse(dask.__version__) < version.parse(
+                    "2.1.0"
+                ) or version.parse(distributed.__version__) < version.parse("2.3.2"):
                     raise ImportError(
                         "Please `pip install modin[dask]` to install compatible Dask version."
                     )

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(
     url="https://github.com/modin-project/modin",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=["pandas==0.25.3"],
+    install_requires=["pandas==0.25.3", "packaging"],
     extras_require={
         # can be installed by pip install modin[dask]
         "dask": dask_deps,


### PR DESCRIPTION
* Resolves #1043
* Adds a dependency packaging to enable simpler version comparison

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests ~added and~ passing
