### PR TITLE
df.rename works with 'mapper' and 'axis' params

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1364,6 +1364,8 @@ class DataFrame(BasePandasDataset):
         # inplace should always be true because this is just a copy, and we will use the
         # results after.
         kwargs["inplace"] = False
+        if axis is not None:
+            axis = self._get_axis_number(axis)
         if index is not None or (mapper is not None and axis == 0):
             new_index = pandas.DataFrame(index=self.index).rename(**kwargs).index
         else:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1364,11 +1364,11 @@ class DataFrame(BasePandasDataset):
         # inplace should always be true because this is just a copy, and we will use the
         # results after.
         kwargs["inplace"] = False
-        if index is not None:
+        if index is not None or (mapper is not None and axis == 0):
             new_index = pandas.DataFrame(index=self.index).rename(**kwargs).index
         else:
             new_index = self.index
-        if columns is not None:
+        if columns is not None or (mapper is not None and axis == 1):
             new_columns = (
                 pandas.DataFrame(columns=self.columns).rename(**kwargs).columns
             )

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4639,6 +4639,16 @@ class TestDataFrameIndexing:
         tm.assert_index_equal(
             modin_df.rename(index=str.upper).index, df.rename(index=str.upper).index
         )
+
+        # Using the `mapper` functionality with `axis`
+        tm.assert_index_equal(
+            modin_df.rename(str.upper, axis=0).index, df.rename(str.upper, axis=0).index
+        )
+        tm.assert_index_equal(
+            modin_df.rename(str.upper, axis=1).columns,
+            df.rename(str.upper, axis=1).columns,
+        )
+
         # have to pass something
         with pytest.raises(TypeError):
             modin_df.rename()


### PR DESCRIPTION
DataFrame.rename() will now change column names if `mapper` and `axis=1` are provided as parameters, and axis names of `mapper` and `axis=0` are provided


<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number
Resolves #1056 

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
