### PR TITLE
Change Error to warning for pandas version pin

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -1,12 +1,12 @@
 import pandas
+import warnings
 
 __pandas_version__ = "0.25.3"
 
 if pandas.__version__ != __pandas_version__:
-    raise ImportError(
-        "The pandas version installed does not match the required pandas "
-        "version in Modin. Please install pandas {} to use "
-        "Modin.".format(__pandas_version__)
+    warnings.warn(
+        "The pandas version installed does not match the required pandas version in "
+        "Modin. This may cause undesired side effects!".format(__pandas_version__)
     )
 
 from pandas import (

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -1,9 +1,10 @@
 import pandas
-import warnings
 
 __pandas_version__ = "0.25.3"
 
 if pandas.__version__ != __pandas_version__:
+    import warnings
+
     warnings.warn(
         "The pandas version installed does not match the required pandas version in "
         "Modin. This may cause undesired side effects!".format(__pandas_version__)


### PR DESCRIPTION
* Resolves #1046
* Allow users to choose their pandas version, but mention that it's not
  supported

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
