### PR TITLE
fixed bug where .to_frame(name) ignored name; added parity with panda…

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -197,6 +197,22 @@ class Series(BasePandasDataset):
             return self._reduce_dimension(result)
         return self.__constructor__(query_compiler=result)
 
+    def __getattr__(self, key):
+        """After regular attribute access, looks up the name in the index
+
+        Args:
+            key (str): Attribute name.
+
+        Returns:
+            The value of the attribute.
+        """
+        try:
+            return object.__getattribute__(self, key)
+        except AttributeError as e:
+            if key in self.index:
+                return self[key]
+            raise e
+
     def __int__(self):
         return int(self.squeeze())
 
@@ -1020,7 +1036,7 @@ class Series(BasePandasDataset):
         self_cp = self.copy()
         if name is not None:
             self_cp.name = name
-        return DataFrame(self.copy())
+        return DataFrame(self_cp)
 
     def to_list(self):
         return self._default_to_pandas(pandas.Series.to_list)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -140,6 +140,16 @@ def create_test_series(vals):
         pandas_series = pandas.Series(vals)
     return modin_series, pandas_series
 
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_to_frame(data):
+    modin_series, pandas_series = create_test_series(data)
+    df_equals(modin_series.to_frame(name='miao'), pandas_series.to_frame(name='miao'))
+
+def test_accessing_index_element_as_property():
+    s = pd.Series([10,20,30], index=['a','b','c'])
+    assert s.b == 20
+    with pytest.raises(Exception):
+        v = s.d
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_T(data):

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -144,11 +144,11 @@ def create_test_series(vals):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_to_frame(data):
     modin_series, pandas_series = create_test_series(data)
-    df_equals(modin_series.to_frame(name='miao'), pandas_series.to_frame(name='miao'))
+    df_equals(modin_series.to_frame(name="miao"), pandas_series.to_frame(name="miao"))
 
 
 def test_accessing_index_element_as_property():
-    s = pd.Series([10, 20, 30], index=['a', 'b', 'c'])
+    s = pd.Series([10, 20, 30], index=["a", "b", "c"])
     assert s.b == 20
     with pytest.raises(Exception):
         _ = s.d

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -140,16 +140,19 @@ def create_test_series(vals):
         pandas_series = pandas.Series(vals)
     return modin_series, pandas_series
 
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_to_frame(data):
     modin_series, pandas_series = create_test_series(data)
     df_equals(modin_series.to_frame(name='miao'), pandas_series.to_frame(name='miao'))
 
+
 def test_accessing_index_element_as_property():
-    s = pd.Series([10,20,30], index=['a','b','c'])
+    s = pd.Series([10, 20, 30], index=['a', 'b', 'c'])
     assert s.b == 20
     with pytest.raises(Exception):
-        v = s.d
+        _ = s.d
+
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_T(data):


### PR DESCRIPTION
…s supporting accessing a series element by treating its index as a property

<!--
Thank you for your contribution!
-->

## What do these changes do?

Fixed two mis-parity bugs with pandas.Series:
If s is a Series,
1. .to_frame(name) ignored name.
2. s.some_index_entry should be identical to s['some_index_entry'], but was not.

## Related issue number

I could not find any related issues.

- [ yes] passes `flake8 modin`
- [ yes] passes `black --check modin`
- [ yes] tests added and passing
