### PR TITLE
Fix column indexing when 2 or more columns have same name

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1908,8 +1908,9 @@ class DataFrame(BasePandasDataset):
     def _getitem_column(self, key):
         if key not in self.keys():
             raise KeyError("{}".format(key))
-        s = self._reduce_dimension(self._query_compiler.getitem_column_array([key]))
-        s._parent = self
+        s = DataFrame(query_compiler=self._query_compiler.getitem_column_array([key])).squeeze(axis=1)
+        if isinstance(s, Series):
+            s._parent = self
         return s
 
     def _getitem_array(self, key):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1908,7 +1908,9 @@ class DataFrame(BasePandasDataset):
     def _getitem_column(self, key):
         if key not in self.keys():
             raise KeyError("{}".format(key))
-        s = DataFrame(query_compiler=self._query_compiler.getitem_column_array([key])).squeeze(axis=1)
+        s = DataFrame(
+            query_compiler=self._query_compiler.getitem_column_array([key])
+        ).squeeze(axis=1)
         if isinstance(s, Series):
             s._parent = self
         return s

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5096,7 +5096,13 @@ class TestDataFrameIndexing:
         df_equals(modin_df[s], pandas_df[s])
 
     def test_getitem_same_name(self):
-        data = [[1,2,3,4],[5,6,7,8],[9,10,11,12],[13,14,15,16],[17,18,19,20]]
+        data = [
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11, 12],
+            [13, 14, 15, 16],
+            [17, 18, 19, 20],
+        ]
         columns = ["c1", "c2", "c1", "c3"]
         modin_df = pd.DataFrame(data, columns=columns)
         pandas_df = pandas.DataFrame(data, columns=columns)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5095,6 +5095,16 @@ class TestDataFrameIndexing:
         s = slice("2017-01-06", "2017-01-09")
         df_equals(modin_df[s], pandas_df[s])
 
+    def test_getitem_same_name(self):
+        data = [[1,2,3,4],[5,6,7,8],[9,10,11,12],[13,14,15,16],[17,18,19,20]]
+        columns = ["c1", "c2", "c1", "c3"]
+        modin_df = pd.DataFrame(data, columns=columns)
+        pandas_df = pandas.DataFrame(data, columns=columns)
+        df_equals(modin_df["c1"], pandas_df["c1"])
+        df_equals(modin_df["c2"], pandas_df["c2"])
+        df_equals(modin_df[["c1", "c2"]], pandas_df[["c1", "c2"]])
+        df_equals(modin_df["c3"], pandas_df["c3"])
+
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test___getattr__(self, request, data):
         modin_df = pd.DataFrame(data)


### PR DESCRIPTION
* Resolves #1069
* Change the way we treat the object immediately
  * First treat as `DataFrame`, then try to `squeeze`
  * This has the benefit of not needing to look at the index from the
    API layer
* Add simple unit tests

<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
