### PR TITLE
Parity fixes

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3245,6 +3245,9 @@ class BasePandasDataset(object):
     def __and__(self, other):
         return self._binary_op("__and__", other, axis=0)
 
+    def __rand__(self, other):
+        return self._binary_op("__and__", other, axis=0)
+
     def __array__(self, dtype=None):
         arr = self.to_numpy(dtype)
         return arr
@@ -3287,8 +3290,8 @@ class BasePandasDataset(object):
     def __finalize__(self, other, method=None, **kwargs):
         return self._default_to_pandas("__finalize__", other, method=method, **kwargs)
 
-    def __ge__(self, other):
-        return self.ge(other)
+    def __ge__(self, right):
+        return self.ge(right)
 
     def __getitem__(self, key):
         if len(self) == 0:
@@ -3353,8 +3356,8 @@ class BasePandasDataset(object):
     def __getstate__(self):
         return self._default_to_pandas("__getstate__")
 
-    def __gt__(self, other):
-        return self.gt(other)
+    def __gt__(self, right):
+        return self.gt(right)
 
     def __invert__(self):
         if not all(is_numeric_dtype(d) for d in self._get_dtypes()):
@@ -3365,8 +3368,8 @@ class BasePandasDataset(object):
             )
         return self.__constructor__(query_compiler=self._query_compiler.invert())
 
-    def __le__(self, other):
-        return self.le(other)
+    def __le__(self, right):
+        return self.le(right)
 
     def __len__(self):
         """Gets the length of the DataFrame.
@@ -3376,8 +3379,8 @@ class BasePandasDataset(object):
         """
         return len(self.index)
 
-    def __lt__(self, other):
-        return self.lt(other)
+    def __lt__(self, right):
+        return self.lt(right)
 
     def __ne__(self, other):
         return self.ne(other)
@@ -3404,6 +3407,9 @@ class BasePandasDataset(object):
     def __or__(self, other):
         return self._binary_op("__or__", other, axis=0)
 
+    def __ror__(self, other):
+        return self._binary_op("__or__", other, axis=0)
+
     def __sizeof__(self):
         return self._default_to_pandas("__sizeof__")
 
@@ -3411,6 +3417,9 @@ class BasePandasDataset(object):
         return repr(self)
 
     def __xor__(self, other):
+        return self._binary_op("__xor__", other, axis=0)
+
+    def __rxor__(self, other):
         return self._binary_op("__xor__", other, axis=0)
 
     @property

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -200,36 +200,20 @@ class _LocIndexer(_LocationIndexerBase):
     """A indexer for ray_df.loc[] functionality"""
 
     def __getitem__(self, key):
-        # When getting along a single axis,
-        if not isinstance(key, tuple):
-            # Try to fasttrack the code through already optimized path
-            try:
-                return self.df.__getitem__(key)
-            # This can happen if it is a list of rows
-            except KeyError:
-                pass
-        else:
-            if len(key) > self.df.ndim:
-                raise IndexingError("Too many indexers")
-            # If we're only slicing columns, handle the case with `__getitem__`
-            if isinstance(key[0], slice) and key[0] == slice(None):
-                if not isinstance(key[1], slice):
-                    # Boolean indexers can just be sliced into the columns object and
-                    # then passed to `__getitem__`
-                    if is_boolean_array(key[1]):
-                        return self.df.__getitem__(self.df.columns[key[1]])
-                    return self.df.__getitem__(key[1])
-                else:
-                    result_slice = self.df.columns.slice_locs(key[1].start, key[1].stop)
-                    return self.df.iloc[:, slice(*result_slice)]
         row_loc, col_loc, ndim, self.row_scaler, self.col_scaler = _parse_tuple(key)
+        if isinstance(row_loc, slice) and row_loc == slice(None):
+            # If we're only slicing columns, handle the case with `__getitem__`
+            if not isinstance(col_loc, slice):
+                # Boolean indexers can just be sliced into the columns object and
+                # then passed to `__getitem__`
+                if is_boolean_array(col_loc):
+                    col_loc = self.df.columns[col_loc]
+                return self.df.__getitem__(col_loc)
+            else:
+                result_slice = self.df.columns.slice_locs(col_loc.start, col_loc.stop)
+                return self.df.iloc[:, slice(*result_slice)]
+
         row_lookup, col_lookup = self._compute_lookup(row_loc, col_loc)
-        # Check that the row_lookup/col_lookup is longer than 1 or that the
-        # row_loc/col_loc is not boolean list to determine the ndim of the
-        # result properly for multiindex.
-        ndim = (0 if len(row_lookup) == 1 and not is_boolean_array(row_loc) else 1) + (
-            0 if len(col_lookup) == 1 and not is_boolean_array(col_loc) else 1
-        )
         result = super(_LocIndexer, self).__getitem__(row_lookup, col_lookup, ndim)
         # Pandas drops the levels that are in the `loc`, so we have to as well.
         if hasattr(result, "index") and isinstance(result.index, pandas.MultiIndex):

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -90,8 +90,8 @@ def _parse_tuple(tup):
 def _compute_ndim(row_loc, col_loc):
     """Compute the ndim of result from locators
     """
-    row_scaler = is_scalar(row_loc)
-    col_scaler = is_scalar(col_loc)
+    row_scaler = is_scalar(row_loc) or is_tuple(row_loc)
+    col_scaler = is_scalar(col_loc) or is_tuple(col_loc)
 
     if row_scaler and col_scaler:
         ndim = 0

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas
-from pandas.core.common import is_bool_indexer
+from pandas.core.common import apply_if_callable, is_bool_indexer
 from pandas.core.dtypes.common import (
     is_dict_like,
     is_list_like,
@@ -163,6 +163,7 @@ class Series(BasePandasDataset):
         return self.floordiv(right)
 
     def _getitem(self, key):
+        key = apply_if_callable(key, self)
         if isinstance(key, Series) and key.dtype == np.bool:
             # This ends up being significantly faster than looping through and getting
             # each item individually.

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -122,6 +122,9 @@ class Series(BasePandasDataset):
     def __add__(self, right):
         return self.add(right)
 
+    def __radd__(self, left):
+        return self.add(left)
+
     def __and__(self, other):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).__and__(new_other)
@@ -153,14 +156,23 @@ class Series(BasePandasDataset):
     def __div__(self, right):
         return self.div(right)
 
+    def __rdiv__(self, left):
+        return self.rdiv(left)
+
     def __divmod__(self, right):
         return self.divmod(right)
+
+    def __rdivmod__(self, left):
+        return self.rdivmod(left)
 
     def __float__(self):
         return float(self.squeeze())
 
     def __floordiv__(self, right):
         return self.floordiv(right)
+
+    def __rfloordiv__(self, right):
+        return self.rfloordiv(right)
 
     def _getitem(self, key):
         key = apply_if_callable(key, self)
@@ -223,8 +235,14 @@ class Series(BasePandasDataset):
     def __mod__(self, right):
         return self.mod(right)
 
+    def __rmod__(self, left):
+        return self.rmod(left)
+
     def __mul__(self, right):
         return self.mul(right)
+
+    def __rmul__(self, left):
+        return self.rmul(left)
 
     def __or__(self, other):
         new_self, new_other = self._prepare_inter_op(other)
@@ -232,6 +250,9 @@ class Series(BasePandasDataset):
 
     def __pow__(self, right):
         return self.pow(right)
+
+    def __rpow__(self, left):
+        return self.rpow(left)
 
     def __repr__(self):
         num_rows = pandas.get_option("max_rows") or 60
@@ -270,8 +291,14 @@ class Series(BasePandasDataset):
     def __sub__(self, right):
         return self.sub(right)
 
+    def __rsub__(self, left):
+        return self.rsub(left)
+
     def __truediv__(self, right):
         return self.truediv(right)
+
+    def __rtruediv__(self, left):
+        return self.rtruediv(left)
 
     __iadd__ = __add__
     __imul__ = __add__

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -545,8 +545,12 @@ class TestDataFrameBinary:
 
 class TestDataFrameMapMetadata:
     def test_indexing(self):
-        modin_df = pd.DataFrame(dict(a=[1,2,3],b=[4,5,6],c=[7,8,9]), index=['a','b','c'])
-        pandas_df = pandas.DataFrame(dict(a=[1,2,3],b=[4,5,6],c=[7,8,9]), index=['a','b','c'])
+        modin_df = pd.DataFrame(
+            dict(a=[1, 2, 3], b=[4, 5, 6], c=[7, 8, 9]),
+            index=['a', 'b', 'c'])
+        pandas_df = pandas.DataFrame(
+            dict(a=[1, 2, 3], b=[4, 5, 6], c=[7, 8, 9]),
+            index=['a', 'b', 'c'])
 
         modin_result = modin_df
         pandas_result = pandas_df
@@ -560,8 +564,8 @@ class TestDataFrameMapMetadata:
         pandas_result = pandas_df[['b']]
         df_equals(modin_result, pandas_result)
 
-        modin_result = modin_df[['b','a']]
-        pandas_result = pandas_df[['b','a']]
+        modin_result = modin_df[['b', 'a']]
+        pandas_result = pandas_df[['b', 'a']]
         df_equals(modin_result, pandas_result)
 
         modin_result = modin_df.loc['b']
@@ -572,20 +576,20 @@ class TestDataFrameMapMetadata:
         pandas_result = pandas_df.loc[['b']]
         df_equals(modin_result, pandas_result)
 
-        modin_result = modin_df.loc[['b','a']]
-        pandas_result = pandas_df.loc[['b','a']]
+        modin_result = modin_df.loc[['b', 'a']]
+        pandas_result = pandas_df.loc[['b', 'a']]
         df_equals(modin_result, pandas_result)
 
-        modin_result = modin_df.loc[['b','a'],['a','c']]
-        pandas_result = pandas_df.loc[['b','a'],['a','c']]
+        modin_result = modin_df.loc[['b', 'a'], ['a', 'c']]
+        pandas_result = pandas_df.loc[['b', 'a'], ['a', 'c']]
         df_equals(modin_result, pandas_result)
 
-        modin_result = modin_df.loc[:,['a','c']]
-        pandas_result = pandas_df.loc[:,['a','c']]
+        modin_result = modin_df.loc[:, ['a', 'c']]
+        pandas_result = pandas_df.loc[:, ['a', 'c']]
         df_equals(modin_result, pandas_result)
 
-        modin_result = modin_df.loc[:,['c']]
-        pandas_result = pandas_df.loc[:,['c']]
+        modin_result = modin_df.loc[:, ['c']]
+        pandas_result = pandas_df.loc[:, ['c']]
         df_equals(modin_result, pandas_result)
 
         modin_result = modin_df.loc[[]]

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -544,6 +544,54 @@ class TestDataFrameBinary:
 
 
 class TestDataFrameMapMetadata:
+    def test_indexing(self):
+        modin_df = pd.DataFrame(dict(a=[1,2,3],b=[4,5,6],c=[7,8,9]), index=['a','b','c'])
+        pandas_df = pandas.DataFrame(dict(a=[1,2,3],b=[4,5,6],c=[7,8,9]), index=['a','b','c'])
+
+        modin_result = modin_df
+        pandas_result = pandas_df
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df['b']
+        pandas_result = pandas_df['b']
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df[['b']]
+        pandas_result = pandas_df[['b']]
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df[['b','a']]
+        pandas_result = pandas_df[['b','a']]
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.loc['b']
+        pandas_result = pandas_df.loc['b']
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.loc[['b']]
+        pandas_result = pandas_df.loc[['b']]
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.loc[['b','a']]
+        pandas_result = pandas_df.loc[['b','a']]
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.loc[['b','a'],['a','c']]
+        pandas_result = pandas_df.loc[['b','a'],['a','c']]
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.loc[:,['a','c']]
+        pandas_result = pandas_df.loc[:,['a','c']]
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.loc[:,['c']]
+        pandas_result = pandas_df.loc[:,['c']]
+        df_equals(modin_result, pandas_result)
+
+        modin_result = modin_df.loc[[]]
+        pandas_result = pandas_df.loc[[]]
+        df_equals(modin_result, pandas_result)
+
     def test_empty_df(self):
         df = pd.DataFrame(index=["a", "b"])
         df_is_empty(df)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -43,17 +43,20 @@ pd.DEFAULT_NPARTITIONS = 4
 # Force matplotlib to not use any Xwindows backend.
 matplotlib.use("Agg")
 
+
 def get_rop(op):
     if op.startswith('__') and op.endswith('__'):
         return '__r' + op[2:]
     else:
         return None
 
+
 def inter_df_math_helper(modin_series, pandas_series, op):
     inter_df_math_helper_one_side(modin_series, pandas_series, op)
     rop = get_rop(op)
     if rop:
         inter_df_math_helper_one_side(modin_series, pandas_series, rop)
+
 
 def inter_df_math_helper_one_side(modin_series, pandas_series, op):
     try:
@@ -176,7 +179,9 @@ def test_accessing_index_element_as_property():
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_callable_key_in_getitem(data):
     modin_series, pandas_series = create_test_series(data)
-    df_equals(modin_series[lambda s:s.index%2==0], pandas_series[lambda s:s.index%2==0])
+    df_equals(
+        modin_series[lambda s:s.index % 2 == 0],
+        pandas_series[lambda s:s.index % 2 == 0])
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -155,6 +155,12 @@ def test_accessing_index_element_as_property():
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_callable_key_in_getitem(data):
+    modin_series, pandas_series = create_test_series(data)
+    df_equals(modin_series[lambda s:s.index%2==0], pandas_series[lambda s:s.index%2==0])
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_T(data):
     modin_series, pandas_series = create_test_series(data)
     df_equals(modin_series.T, pandas_series.T)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -43,24 +43,43 @@ pd.DEFAULT_NPARTITIONS = 4
 # Force matplotlib to not use any Xwindows backend.
 matplotlib.use("Agg")
 
+def get_rop(op):
+    if op.startswith('__') and op.endswith('__'):
+        return '__r' + op[2:]
+    else:
+        return None
 
 def inter_df_math_helper(modin_series, pandas_series, op):
+    inter_df_math_helper_one_side(modin_series, pandas_series, op)
+    rop = get_rop(op)
+    if rop:
+        inter_df_math_helper_one_side(modin_series, pandas_series, rop)
+
+def inter_df_math_helper_one_side(modin_series, pandas_series, op):
     try:
-        pandas_result = getattr(pandas_series, op)(4)
+        pandas_attr = getattr(pandas_series, op)
     except Exception as e:
         with pytest.raises(type(e)):
-            repr(getattr(modin_series, op)(4))  # repr to force materialization
+            _ = getattr(modin_series, op)
+        return
+    modin_attr = getattr(modin_series, op)
+
+    try:
+        pandas_result = pandas_attr(4)
+    except Exception as e:
+        with pytest.raises(type(e)):
+            repr(modin_attr(4))  # repr to force materialization
     else:
-        modin_result = getattr(modin_series, op)(4)
+        modin_result = modin_attr(4)
         df_equals(modin_result, pandas_result)
 
     try:
-        pandas_result = getattr(pandas_series, op)(4.0)
+        pandas_result = pandas_attr(4.0)
     except Exception as e:
         with pytest.raises(type(e)):
-            repr(getattr(modin_series, op)(4.0))  # repr to force materialization
+            repr(modin_attr(4.0))  # repr to force materialization
     else:
-        modin_result = getattr(modin_series, op)(4.0)
+        modin_result = modin_attr(4.0)
         df_equals(modin_result, pandas_result)
 
     # These operations don't support non-scalar `other` or have a strange behavior in
@@ -81,37 +100,37 @@ def inter_df_math_helper(modin_series, pandas_series, op):
         return
 
     try:
-        pandas_result = getattr(pandas_series, op)(pandas_series)
+        pandas_result = pandas_attr(pandas_series)
     except Exception as e:
         with pytest.raises(type(e)):
             repr(
-                getattr(modin_series, op)(modin_series)
+                modin_attr(modin_series)
             )  # repr to force materialization
     else:
-        modin_result = getattr(modin_series, op)(modin_series)
+        modin_result = modin_attr(modin_series)
         df_equals(modin_result, pandas_result)
 
     list_test = random_state.randint(RAND_LOW, RAND_HIGH, size=(modin_series.shape[0]))
     try:
-        pandas_result = getattr(pandas_series, op)(list_test)
+        pandas_result = pandas_attr(list_test)
     except Exception as e:
         with pytest.raises(type(e)):
-            repr(getattr(modin_series, op)(list_test))  # repr to force materialization
+            repr(modin_attr(list_test))  # repr to force materialization
     else:
-        modin_result = getattr(modin_series, op)(list_test)
+        modin_result = modin_attr(list_test)
         df_equals(modin_result, pandas_result)
 
     series_test_modin = pd.Series(list_test, index=modin_series.index)
     series_test_pandas = pandas.Series(list_test, index=pandas_series.index)
     try:
-        pandas_result = getattr(pandas_series, op)(series_test_pandas)
+        pandas_result = pandas_attr(series_test_pandas)
     except Exception as e:
         with pytest.raises(type(e)):
             repr(
-                getattr(modin_series, op)(series_test_modin)
+                modin_attr(series_test_modin)
             )  # repr to force materialization
     else:
-        modin_result = getattr(modin_series, op)(series_test_modin)
+        modin_result = modin_attr(series_test_modin)
         df_equals(modin_result, pandas_result)
 
     # Level test


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

A few parity fixes in series and dataframes:
1. Missing right-operators added (e.g. ```__radd__``` that allows 10+s where s is a Series)
2. Added support for callable key in ```Series.__getitem__```.
3. Fixed bug in ```df.loc[row_key]``` where ```row_key``` was used as a column key if it happened to match columns

## Related issue number

None that I could find

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
