### PR TITLE
Fix Series.__getitem__ to accept a callable as key

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pandas
-from pandas.core.common import is_bool_indexer
+from pandas.core.common import apply_if_callable, is_bool_indexer
 from pandas.core.dtypes.common import (
     is_dict_like,
     is_list_like,
@@ -163,6 +163,7 @@ class Series(BasePandasDataset):
         return self.floordiv(right)
 
     def _getitem(self, key):
+        key = apply_if_callable(key, self)
         if isinstance(key, Series) and key.dtype == np.bool:
             # This ends up being significantly faster than looping through and getting
             # each item individually.

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -157,7 +157,10 @@ def test_accessing_index_element_as_property():
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_callable_key_in_getitem(data):
     modin_series, pandas_series = create_test_series(data)
-    df_equals(modin_series[lambda s:s.index%2==0], pandas_series[lambda s:s.index%2==0])
+    df_equals(
+        modin_series[lambda s: s.index % 2 == 0],
+        pandas_series[lambda s: s.index % 2 == 0],
+    )
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -155,6 +155,12 @@ def test_accessing_index_element_as_property():
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_callable_key_in_getitem(data):
+    modin_series, pandas_series = create_test_series(data)
+    df_equals(modin_series[lambda s:s.index%2==0], pandas_series[lambda s:s.index%2==0])
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_T(data):
     modin_series, pandas_series = create_test_series(data)
     df_equals(modin_series.T, pandas_series.T)


### PR DESCRIPTION
<!--
Thank you for your contribution!
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

## Related issue number
Resolves #1083 

Split from #1078
<!-- Are there any issues opened that will be resolved by merging this change? -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] tests added and passing
