### PR TITLE
Make query compiler interface consistent for binary ops

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -14,6 +14,7 @@ from modin.data_management.functions import (
     MapFunction,
     MapReduceFunction,
     ReductionFunction,
+    BinaryFunction,
 )
 
 
@@ -44,6 +45,23 @@ def _str_map(func_name):
         return getattr(pandas.Series.str, func_name)(str_s, *args, **kwargs).to_frame()
 
     return str_op_builder
+
+
+def copy_df_for_func(func):
+    """Create a function that copies the dataframe, likely because `func` is inplace.
+
+    Args:
+        func: The function, usually updates a dataframe inplace.
+
+    Returns:
+        A callable function to be applied in the partitions
+    """
+    def caller(df, *args, **kwargs):
+        df = df.copy()
+        func(df, *args, **kwargs)
+        return df
+
+    return caller
 
 
 class PandasQueryCompiler(BaseQueryCompiler):
@@ -159,96 +177,33 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # such that columns/rows that don't have an index on the other DataFrame
     # result in NaN values.
 
-    def binary_op(self, op, other, **kwargs):
-        """Perform an operation between two objects.
-
-        Note: The list of operations is as follows:
-            - add
-            - eq
-            - floordiv
-            - ge
-            - gt
-            - le
-            - lt
-            - mod
-            - mul
-            - ne
-            - pow
-            - rfloordiv
-            - rmod
-            - rpow
-            - rsub
-            - rtruediv
-            - sub
-            - truediv
-            - __and__
-            - __or__
-            - __xor__
-        Args:
-            op: The operation. See list of operations above
-            other: The object to operate against.
-
-        Returns:
-            A new QueryCompiler object.
-        """
-        if not callable(op):
-            func = getattr(pandas.DataFrame, op)
-        else:
-            func = op
-        axis = kwargs.get("axis", 0)
-        if isinstance(other, type(self)):
-            return self.__constructor__(
-                self._modin_frame._binary_op(
-                    lambda x, y: func(x, y, **kwargs), other._modin_frame
-                )
-            )
-        else:
-            if isinstance(other, (list, np.ndarray, pandas.Series)):
-                if axis == 1 and isinstance(other, pandas.Series):
-                    new_columns = self.columns.join(other.index, how="outer")
-                else:
-                    new_columns = self.columns
-                new_modin_frame = self._modin_frame._apply_full_axis(
-                    axis,
-                    lambda df: func(df, other, **kwargs),
-                    new_index=self.index,
-                    new_columns=new_columns,
-                )
-            else:
-                new_modin_frame = self._modin_frame._map(
-                    lambda df: func(df, other, **kwargs)
-                )
-            return self.__constructor__(new_modin_frame)
-
-    def clip(self, lower, upper, **kwargs):
-        kwargs["upper"] = upper
-        kwargs["lower"] = lower
-        axis = kwargs.get("axis", 0)
-        if is_list_like(lower) or is_list_like(upper):
-            new_modin_frame = self._modin_frame._fold(
-                axis, lambda df: df.clip(**kwargs)
-            )
-        else:
-            new_modin_frame = self._modin_frame._map(lambda df: df.clip(**kwargs))
-        return self.__constructor__(new_modin_frame)
-
-    def update(self, other, **kwargs):
-        """Uses other manager to update corresponding values in this manager.
-
-        Args:
-            other: The other manager.
-
-        Returns:
-            New QueryCompiler with updated data and index.
-        """
-
-        def update_builder(df, other, **kwargs):
-            # This is because of a requirement in Arrow
-            df = df.copy()
-            df.update(other, **kwargs)
-            return df
-
-        return self.binary_op(update_builder, other, **kwargs)
+    add = BinaryFunction.register(pandas.DataFrame.add)
+    combine = BinaryFunction.register(pandas.DataFrame.combine)
+    combine_first = BinaryFunction.register(pandas.DataFrame.combine_first)
+    eq = BinaryFunction.register(pandas.DataFrame.eq)
+    floordiv = BinaryFunction.register(pandas.DataFrame.floordiv)
+    ge = BinaryFunction.register(pandas.DataFrame.ge)
+    gt = BinaryFunction.register(pandas.DataFrame.gt)
+    le = BinaryFunction.register(pandas.DataFrame.le)
+    lt = BinaryFunction.register(pandas.DataFrame.lt)
+    mod = BinaryFunction.register(pandas.DataFrame.mod)
+    mul = BinaryFunction.register(pandas.DataFrame.mul)
+    ne = BinaryFunction.register(pandas.DataFrame.ne)
+    pow = BinaryFunction.register(pandas.DataFrame.pow)
+    rfloordiv = BinaryFunction.register(pandas.DataFrame.rfloordiv)
+    rmod = BinaryFunction.register(pandas.DataFrame.rmod)
+    rpow = BinaryFunction.register(pandas.DataFrame.rpow)
+    rsub = BinaryFunction.register(pandas.DataFrame.rsub)
+    rtruediv = BinaryFunction.register(pandas.DataFrame.rtruediv)
+    sub = BinaryFunction.register(pandas.DataFrame.sub)
+    truediv = BinaryFunction.register(pandas.DataFrame.truediv)
+    __and__ = BinaryFunction.register(pandas.DataFrame.__and__)
+    __or__ = BinaryFunction.register(pandas.DataFrame.__or__)
+    __rand__ = BinaryFunction.register(pandas.DataFrame.__rand__)
+    __ror__ = BinaryFunction.register(pandas.DataFrame.__ror__)
+    __rxor__ = BinaryFunction.register(pandas.DataFrame.__rxor__)
+    __xor__ = BinaryFunction.register(pandas.DataFrame.__xor__)
+    update = BinaryFunction.register(copy_df_for_func(pandas.DataFrame.update))
 
     def where(self, cond, other, **kwargs):
         """Gets values from this manager where cond is true else from other.
@@ -566,6 +521,18 @@ class PandasQueryCompiler(BaseQueryCompiler):
     cumsum = FoldFunction.register(pandas.DataFrame.cumsum)
     cumprod = FoldFunction.register(pandas.DataFrame.cumprod)
     diff = FoldFunction.register(pandas.DataFrame.diff)
+
+    def clip(self, lower, upper, **kwargs):
+        kwargs["upper"] = upper
+        kwargs["lower"] = lower
+        axis = kwargs.get("axis", 0)
+        if is_list_like(lower) or is_list_like(upper):
+            new_modin_frame = self._modin_frame._fold(
+                axis, lambda df: df.clip(**kwargs)
+            )
+        else:
+            new_modin_frame = self._modin_frame._map(lambda df: df.clip(**kwargs))
+        return self.__constructor__(new_modin_frame)
 
     def dot(self, other):
         """Computes the matrix multiplication of self and other.

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -56,6 +56,7 @@ def copy_df_for_func(func):
     Returns:
         A callable function to be applied in the partitions
     """
+
     def caller(df, *args, **kwargs):
         df = df.copy()
         func(df, *args, **kwargs)

--- a/modin/data_management/functions/__init__.py
+++ b/modin/data_management/functions/__init__.py
@@ -2,5 +2,12 @@ from .mapfunction import MapFunction
 from .mapreducefunction import MapReduceFunction
 from .reductionfunction import ReductionFunction
 from .foldfunction import FoldFunction
+from .binary_function import BinaryFunction
 
-__all__ = ["MapFunction", "MapReduceFunction", "ReductionFunction", "FoldFunction"]
+__all__ = [
+    "MapFunction",
+    "MapReduceFunction",
+    "ReductionFunction",
+    "FoldFunction",
+    "BinaryFunction",
+]

--- a/modin/data_management/functions/binary_function.py
+++ b/modin/data_management/functions/binary_function.py
@@ -1,0 +1,39 @@
+import numpy as np
+import pandas
+
+from .function import Function
+
+
+class BinaryFunction(Function):
+    @classmethod
+    def call(cls, func, *call_args, **call_kwds):
+        def caller(query_compiler, other, *args, **kwargs):
+            axis = kwargs.get("axis", 0)
+            if isinstance(other, type(query_compiler)):
+                return query_compiler.__constructor__(
+                    query_compiler._modin_frame._binary_op(
+                        lambda x, y: func(x, y, *call_args, **call_kwds),
+                        other._modin_frame,
+                    )
+                )
+            else:
+                if isinstance(other, (list, np.ndarray, pandas.Series)):
+                    if axis == 1 and isinstance(other, pandas.Series):
+                        new_columns = query_compiler.columns.join(
+                            other.index, how="outer"
+                        )
+                    else:
+                        new_columns = query_compiler.columns
+                    new_modin_frame = query_compiler._modin_frame._apply_full_axis(
+                        axis,
+                        lambda df: func(df, other, *call_args, **call_kwds),
+                        new_index=query_compiler.index,
+                        new_columns=new_columns,
+                    )
+                else:
+                    new_modin_frame = query_compiler._modin_frame._map(
+                        lambda df: func(df, other, *call_args, **call_kwds)
+                    )
+                return query_compiler.__constructor__(new_modin_frame)
+
+        return caller

--- a/modin/data_management/functions/binary_function.py
+++ b/modin/data_management/functions/binary_function.py
@@ -12,7 +12,7 @@ class BinaryFunction(Function):
             if isinstance(other, type(query_compiler)):
                 return query_compiler.__constructor__(
                     query_compiler._modin_frame._binary_op(
-                        lambda x, y: func(x, y, *call_args, **call_kwds),
+                        lambda x, y: func(x, y, *args, **kwargs),
                         other._modin_frame,
                     )
                 )
@@ -26,13 +26,13 @@ class BinaryFunction(Function):
                         new_columns = query_compiler.columns
                     new_modin_frame = query_compiler._modin_frame._apply_full_axis(
                         axis,
-                        lambda df: func(df, other, *call_args, **call_kwds),
+                        lambda df: func(df, other, *args, **kwargs),
                         new_index=query_compiler.index,
                         new_columns=new_columns,
                     )
                 else:
                     new_modin_frame = query_compiler._modin_frame._map(
-                        lambda df: func(df, other, *call_args, **call_kwds)
+                        lambda df: func(df, other, *args, **kwargs)
                     )
                 return query_compiler.__constructor__(new_modin_frame)
 

--- a/modin/data_management/functions/binary_function.py
+++ b/modin/data_management/functions/binary_function.py
@@ -12,8 +12,7 @@ class BinaryFunction(Function):
             if isinstance(other, type(query_compiler)):
                 return query_compiler.__constructor__(
                     query_compiler._modin_frame._binary_op(
-                        lambda x, y: func(x, y, *args, **kwargs),
-                        other._modin_frame,
+                        lambda x, y: func(x, y, *args, **kwargs), other._modin_frame,
                     )
                 )
             else:

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -206,7 +206,7 @@ class BasePandasDataset(object):
                 getattr(getattr(pandas, self.__name__), op), other, **kwargs
             )
         other = self._validate_other(other, axis, numeric_or_object_only=True)
-        new_query_compiler = self._query_compiler.binary_op(op, other=other, **kwargs)
+        new_query_compiler = getattr(self._query_compiler, op)(other, **kwargs)
         return self._create_or_update_from_compiler(new_query_compiler)
 
     def _default_to_pandas(self, op, *args, **kwargs):
@@ -3248,7 +3248,7 @@ class BasePandasDataset(object):
         return self._binary_op("__and__", other, axis=0)
 
     def __rand__(self, other):
-        return self._binary_op("__and__", other, axis=0)
+        return self._binary_op("__rand__", other, axis=0)
 
     def __array__(self, dtype=None):
         arr = self.to_numpy(dtype)
@@ -3410,7 +3410,7 @@ class BasePandasDataset(object):
         return self._binary_op("__or__", other, axis=0)
 
     def __ror__(self, other):
-        return self._binary_op("__or__", other, axis=0)
+        return self._binary_op("__ror__", other, axis=0)
 
     def __sizeof__(self):
         return self._default_to_pandas("__sizeof__")
@@ -3422,7 +3422,7 @@ class BasePandasDataset(object):
         return self._binary_op("__xor__", other, axis=0)
 
     def __rxor__(self, other):
-        return self._binary_op("__xor__", other, axis=0)
+        return self._binary_op("__rxor__", other, axis=0)
 
     @property
     def blocks(self):


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
* Resolves #1064
* Add a new function type for internal query compilers
  * `BinaryFunction`
* Enumerate the binary function calls into the query compiler
* Code quality updates and organization

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>
<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1064  <!-- issue must be created for each patch -->
- [ ] tests added and passing
