### PR TITLE
Add cov flags to pytest.ini so coverage is always computed

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --disable-pytest-warnings --suppress-no-test-exit-code
+addopts = --disable-pytest-warnings --suppress-no-test-exit-code  --cov-config=.coveragerc --cov=modin --cov-append 


### PR DESCRIPTION
Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1131  <!-- issue must be created for each patch -->
- [ ] tests added and passing
