### PR TITLE
Fixed #1115

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1094,8 +1094,14 @@ class BasePandasDataset(object):
                 deduplicated : DataFrame
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        if kwargs.get("subset", None) is not None:
-            duplicates = self.duplicated(keep=keep, subset=kwargs.get("subset"))
+        subset = kwargs.get("subset", None)
+        if subset is not None:
+            if is_list_like(subset):
+                if not isinstance(subset, list):
+                    subset = list(subset)
+            else:
+                subset = [subset]
+            duplicates = self.duplicated(keep=keep, subset=subset)
         else:
             duplicates = self.duplicated(keep=keep)
         indices = duplicates.values.nonzero()[0]

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -322,7 +322,7 @@ class DataFrame(BasePandasDataset):
             result = getattr(sys.modules[self.__module__], return_type)(
                 query_compiler=query_compiler
             )
-            if hasattr(result, "name"):
+            if isinstance(result, Series):
                 if axis == 0 and result.name == self.index[0]:
                     result.name = None
                 elif axis == 1 and result.name == self.columns[0]:

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1156,23 +1156,36 @@ class TestDataFrameMapMetadata:
         "keep", ["last", "first", False], ids=["last", "first", "False"]
     )
     @pytest.mark.parametrize(
-        "subset", [None, ["col1", "col3", "col7"]], ids=["None", "subset"]
+        "subset", [None,
+                   "col1",
+                   "name",
+                   ("col1", "col3"),
+                   ["col1", "col3", "col7"]],
+        ids=["None", "string", "name", "tuple", "list"]
     )
     def test_drop_duplicates(self, data, keep, subset):
         modin_df = pd.DataFrame(data)
         pandas_df = pandas.DataFrame(data)
 
-        df_equals(
-            modin_df.drop_duplicates(keep=keep, inplace=False, subset=subset),
-            pandas_df.drop_duplicates(keep=keep, inplace=False, subset=subset),
-        )
+        try:
+            pandas_df.drop_duplicates(keep=keep, inplace=False, subset=subset)
+        except Exception as e:
+            with pytest.raises(type(e)):
+                modin_df.drop_duplicates(keep=keep, inplace=False, subset=subset)
+        else:
+            df_equals(
+                pandas_df.drop_duplicates(keep=keep, inplace=False, subset=subset),
+                modin_df.drop_duplicates(keep=keep, inplace=False, subset=subset)
+            )
 
-        modin_results = modin_df.drop_duplicates(keep=keep, inplace=True, subset=subset)
-        pandas_results = pandas_df.drop_duplicates(
-            keep=keep, inplace=True, subset=subset
-        )
-
-        df_equals(modin_results, pandas_results)
+        try:
+            pandas_results = pandas_df.drop_duplicates(keep=keep, inplace=True, subset=subset)
+        except Exception as e:
+            with pytest.raises(type(e)):
+                modin_df.drop_duplicates(keep=keep, inplace=True, subset=subset)
+        else:
+            modin_results = modin_df.drop_duplicates(keep=keep, inplace=True, subset=subset)
+            df_equals(modin_results, pandas_results)
 
     def test_drop_duplicates_with_missing_index_values(self):
         data = {

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -1156,12 +1156,9 @@ class TestDataFrameMapMetadata:
         "keep", ["last", "first", False], ids=["last", "first", "False"]
     )
     @pytest.mark.parametrize(
-        "subset", [None,
-                   "col1",
-                   "name",
-                   ("col1", "col3"),
-                   ["col1", "col3", "col7"]],
-        ids=["None", "string", "name", "tuple", "list"]
+        "subset",
+        [None, "col1", "name", ("col1", "col3"), ["col1", "col3", "col7"]],
+        ids=["None", "string", "name", "tuple", "list"],
     )
     def test_drop_duplicates(self, data, keep, subset):
         modin_df = pd.DataFrame(data)
@@ -1175,16 +1172,20 @@ class TestDataFrameMapMetadata:
         else:
             df_equals(
                 pandas_df.drop_duplicates(keep=keep, inplace=False, subset=subset),
-                modin_df.drop_duplicates(keep=keep, inplace=False, subset=subset)
+                modin_df.drop_duplicates(keep=keep, inplace=False, subset=subset),
             )
 
         try:
-            pandas_results = pandas_df.drop_duplicates(keep=keep, inplace=True, subset=subset)
+            pandas_results = pandas_df.drop_duplicates(
+                keep=keep, inplace=True, subset=subset
+            )
         except Exception as e:
             with pytest.raises(type(e)):
                 modin_df.drop_duplicates(keep=keep, inplace=True, subset=subset)
         else:
-            modin_results = modin_df.drop_duplicates(keep=keep, inplace=True, subset=subset)
+            modin_results = modin_df.drop_duplicates(
+                keep=keep, inplace=True, subset=subset
+            )
             df_equals(modin_results, pandas_results)
 
     def test_drop_duplicates_with_missing_index_values(self):

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -123,6 +123,12 @@ test_data_with_duplicates = {
         ]
         for i in range(NCOLS)
     },
+    "has_name_column": {
+        "name": ["one", "two", "two", "three"],
+        "col1": [1, 2, 2, 3],
+        "col3": [10, 20, 20, 3],
+        "col7": [100, 201, 200, 300]
+    }
 }
 
 test_data_with_duplicates_values = list(test_data_with_duplicates.values())

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -127,8 +127,8 @@ test_data_with_duplicates = {
         "name": ["one", "two", "two", "three"],
         "col1": [1, 2, 2, 3],
         "col3": [10, 20, 20, 3],
-        "col7": [100, 201, 200, 300]
-    }
+        "col7": [100, 201, 200, 300],
+    },
 }
 
 test_data_with_duplicates_values = list(test_data_with_duplicates.values())


### PR DESCRIPTION
- DataFrame.drop_duplicates correctly identifies subset type now
- Check for Series type in DaraFrame.apply is done not based on presence
of "name" attribute any more.

Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1115  <!-- issue must be created for each patch -->
- [x] tests added and passing
