### PR TITLE
Add MODIN_CPUS env variable for command line CPU specification

### DIFF
--- a/df_test_requires.txt
+++ b/df_test_requires.txt
@@ -4,6 +4,7 @@ psutil==5.4.8
 pytest
 pytest-testmon
 pytest-custom_exit_code
+pytest-xdist
 matplotlib
 xarray
 scipy

--- a/docs/using_modin.rst
+++ b/docs/using_modin.rst
@@ -96,7 +96,26 @@ Reducing or limiting the resources Modin can use
 
 By default, Modin will use all of the resources available on your machine. It is
 possible, however, to limit the amount of resources Modin uses to free resources for
-another task or user. Here is how you would limit the number of CPUs Modin used:
+another task or user. Here is how you would limit the number of CPUs Modin used in
+your bash environment variables:
+
+.. code-block:: bash
+
+   export MODIN_CPUS=4
+
+
+You can also specify this in your python script with ``os.environ``. **Make sure
+you update the CPUS before you import Modin!**:
+
+.. code-block:: python
+
+   import os
+   os.environ["MODIN_CPUS"] = "4"
+   import modin.pandas as pd
+
+If you're using a specific engine and want more control over the environment Modin
+uses, you can start Ray or Dask in your environment and Modin will connect to it.
+**Make sure you start the environment before you import Modin!**
 
 .. code-block:: python
 

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -75,6 +75,7 @@ import threading
 import os
 import types
 import sys
+import multiprocessing
 
 from .. import __version__
 from .concat import concat
@@ -232,7 +233,6 @@ elif execution_engine == "Dask":  # pragma: no cover
             client = get_client()
         except ValueError:
             from distributed import Client
-            import multiprocessing
 
             num_cpus = os.environ.get("MODIN_CPUS", None) or multiprocessing.cpu_count()
             client = Client(n_workers=int(num_cpus))

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -134,12 +134,14 @@ def initialize_ray():
         import secrets
 
         plasma_directory = None
+        num_cpus = os.environ.get("MODIN_CPUS", None) or multiprocessing.cpu_count()
         cluster = os.environ.get("MODIN_RAY_CLUSTER", None)
         redis_address = os.environ.get("MODIN_REDIS_ADDRESS", None)
         redis_password = secrets.token_hex(16)
         if cluster == "True" and redis_address is not None:
             # We only start ray in a cluster setting for the head node.
             ray.init(
+                num_cpus=int(num_cpus),
                 include_webui=False,
                 ignore_reinit_error=True,
                 redis_address=redis_address,
@@ -171,6 +173,7 @@ def initialize_ray():
             else:
                 object_store_memory = int(object_store_memory)
             ray.init(
+                num_cpus=int(num_cpus),
                 include_webui=False,
                 ignore_reinit_error=True,
                 plasma_directory=plasma_directory,
@@ -231,8 +234,8 @@ elif execution_engine == "Dask":  # pragma: no cover
             from distributed import Client
             import multiprocessing
 
-            num_cpus = multiprocessing.cpu_count()
-            client = Client(n_workers=num_cpus)
+            num_cpus = os.environ.get("MODIN_CPUS", None) or multiprocessing.cpu_count()
+            client = Client(n_workers=int(num_cpus))
 elif execution_engine != "Python":
     raise ImportError("Unrecognized execution engine: {}.".format(execution_engine))
 

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -51,6 +51,10 @@ def test_top_level_api_equality():
         "num_cpus",
         "warnings",
         "os",
+        "multiprocessing",
+        "Client",
+        "client",
+        "get_client",
     ]
 
     assert not len(

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,6 +16,7 @@ coverage<5.0
 pytest-cov
 pytest-testmon
 pytest-custom_exit_code
+pytest-xdist
 feather-format
 lxml
 openpyxl

--- a/windows_test_requires.txt
+++ b/windows_test_requires.txt
@@ -15,6 +15,7 @@ coverage<5.0
 pytest-cov
 pytest-testmon
 pytest-custom_exit_code
+pytest-xdist
 feather-format
 lxml
 openpyxl


### PR DESCRIPTION
* Resolves #1136
* Parallel testing will be done through xdist
* pytest-xdist added to requirements.txt
* TeamCity testing will use 1 CPU for Modin and Ray to aviod concurrent
  test issues.

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
