### PR TITLE
Add Implementation for `SeriesGroupBy`

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -253,8 +253,22 @@ class DataFrameGroupBy(object):
 
     def __getitem__(self, key):
         if isinstance(key, list):
-            return DataFrameGroupBy(self._df[key], self._by, self._axis, idx_name=self._idx_name, drop=self._drop, **self._kwargs)
-        return SeriesGroupBy(self._df[[key]], self._by, self._axis, idx_name=self._idx_name, drop=self._drop, **self._kwargs)
+            return DataFrameGroupBy(
+                self._df[key],
+                self._by,
+                self._axis,
+                idx_name=self._idx_name,
+                drop=self._drop,
+                **self._kwargs
+            )
+        return SeriesGroupBy(
+            self._df[key],
+            self._by,
+            self._axis,
+            idx_name=self._idx_name,
+            drop=self._drop,
+            **self._kwargs
+        )
 
     def cummin(self, axis=0, **kwargs):
         result = self._apply_agg_function(lambda df: df.cummin(axis=axis, **kwargs))
@@ -474,9 +488,7 @@ class DataFrameGroupBy(object):
         else:
             groupby_qc = self._query_compiler
 
-        from .dataframe import DataFrame
-
-        return DataFrame(
+        return type(self._df)(
             query_compiler=groupby_qc.groupby_reduce(
                 self._by,
                 self._axis,
@@ -500,7 +512,6 @@ class DataFrameGroupBy(object):
              A new combined DataFrame with the result of all groups.
         """
         assert callable(f), "'{0}' object is not callable".format(type(f))
-        from .dataframe import DataFrame
 
         if self._is_multi_by:
             return self._default_to_pandas(f, **kwargs)
@@ -522,7 +533,7 @@ class DataFrameGroupBy(object):
         )
         if self._idx_name is not None and self._as_index:
             new_manager.index.name = self._idx_name
-        return DataFrame(query_compiler=new_manager)
+        return type(self._df)(query_compiler=new_manager)
 
     def _default_to_pandas(self, f, **kwargs):
         """Defailts the execution of this function to pandas.
@@ -550,7 +561,6 @@ class DataFrameGroupBy(object):
 
 
 class SeriesGroupBy(DataFrameGroupBy):  # pragma: no cover
-
     def __getattribute__(self, item):
         obj = object.__getattribute__(self, item)
 
@@ -559,7 +569,7 @@ class SeriesGroupBy(DataFrameGroupBy):  # pragma: no cover
             # is given back to the user to re-distribute it.
             def wrapper(*args, **kwargs):
                 return_val = obj(*args, **kwargs)
-                return return_val.squeeze()
+                return return_val
 
             return wrapper
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -252,7 +252,9 @@ class DataFrameGroupBy(object):
         return self.bfill(limit)
 
     def __getitem__(self, key):
-        return SeriesGroupBy(self._default_to_pandas(lambda df: df.__getitem__(key)))
+        if isinstance(key, list):
+            return DataFrameGroupBy(self._df[key], self._by, self._axis, idx_name=self._idx_name, drop=self._drop, **self._kwargs)
+        return SeriesGroupBy(self._df[[key]], self._by, self._axis, idx_name=self._idx_name, drop=self._drop, **self._kwargs)
 
     def cummin(self, axis=0, **kwargs):
         result = self._apply_agg_function(lambda df: df.cummin(axis=axis, **kwargs))
@@ -547,35 +549,19 @@ class DataFrameGroupBy(object):
         return self._df._default_to_pandas(groupby_on_multiple_columns)
 
 
-class SeriesGroupBy(object):  # pragma: no cover
-    def __init__(self, pandas_groupby_obj):
-        self._pandas_groupby_obj = pandas_groupby_obj
+class SeriesGroupBy(DataFrameGroupBy):  # pragma: no cover
 
     def __getattribute__(self, item):
-        if item in ["_pandas_groupby_obj"]:
-            return object.__getattribute__(self, item)
-        return_val = self._pandas_groupby_obj.__getattribute__(item)
-        from .series import Series
-        from .dataframe import DataFrame
+        obj = object.__getattribute__(self, item)
 
-        if isinstance(return_val, pandas.Series):
-            return Series(return_val)
-        elif isinstance(return_val, pandas.DataFrame):
-            return DataFrame(return_val)
-        elif callable(return_val):
-
+        if callable(obj):
             # This wraps the pandas callable and intercepts the return value before it
             # is given back to the user to re-distribute it.
             def wrapper(*args, **kwargs):
-                pandas_return_val = return_val(*args, **kwargs)
-                if isinstance(pandas_return_val, pandas.Series):
-                    return Series(pandas_return_val)
-                elif isinstance(pandas_return_val, pandas.DataFrame):
-                    return DataFrame(pandas_return_val)
-                else:
-                    return pandas_return_val
+                return_val = obj(*args, **kwargs)
+                return return_val.squeeze()
 
             return wrapper
 
         else:
-            return return_val
+            return obj

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -595,11 +595,15 @@ class Series(BasePandasDataset):
     ):
         from .groupby import SeriesGroupBy
 
+        if not as_index:
+            raise TypeError("as_index=False only valid with DataFrame")
+        # SeriesGroupBy expects a query compiler object if it is available
         if isinstance(by, Series):
             by = by._query_compiler
-        elif by is None:
-            by = self._query_compiler
-
+        elif callable(by):
+            by = by(self.index)
+        elif by is None and level is None:
+            raise TypeError("You have to supply one of 'by' and 'level'")
         return SeriesGroupBy(
             self,
             by,

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -595,18 +595,23 @@ class Series(BasePandasDataset):
     ):
         from .groupby import SeriesGroupBy
 
+        if isinstance(by, Series):
+            by = by._query_compiler
+        elif by is None:
+            by = self._query_compiler
+
         return SeriesGroupBy(
-            self._default_to_pandas(
-                pandas.Series.groupby,
-                by=by,
-                axis=axis,
-                level=level,
-                as_index=as_index,
-                sort=sort,
-                group_keys=group_keys,
-                squeeze=squeeze,
-                observed=observed,
-            )
+            self,
+            by,
+            axis,
+            level,
+            as_index,
+            sort,
+            group_keys,
+            squeeze,
+            idx_name=None,
+            observed=observed,
+            drop=False,
         )
 
     def gt(self, other, level=None, fill_value=None, axis=0):

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1365,16 +1365,6 @@ def test_get(data):
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_groupby(data):
-    modin_series, _ = create_test_series(data)
-
-    with pytest.warns(UserWarning):
-        result = modin_series.groupby(modin_series).count()
-
-    assert isinstance(result, pd.Series)
-
-
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_gt(data):
     modin_series, pandas_series = create_test_series(data)
     inter_df_math_helper(modin_series, pandas_series, "gt")


### PR DESCRIPTION
* Resolves #1114
* Uses `DataFrameGroupBy` object for implementation and squeeze the
  result to a Modin `Series` object after operator.
* Implementation overrides `__getattribute__` and intercepts method
  to apply and `squeeze` the return value before it is returned to the
  user
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1114 <!-- issue must be created for each patch -->
- [x] tests added and passing
