### PR TITLE
Update GitHub Actions to remove those tests run on TeamCity

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,14 +27,28 @@ jobs:
           architecture: "x64"
       - run: pip install flake8 flake8-print
       - run: flake8 --enable=T modin
+  test-api:
+    runs-on: ubuntu-latest
+    name: test api
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.7.x"
+          architecture: "x64"
+      - run: sudo apt update && sudo apt install -y libhdf5-dev
+      - run: pip install -r requirements.txt
+      - run: python -m pytest modin/pandas/test/test_api.py
   test-all:
-    needs: [lint-flake8, lint-black]
+    needs: [lint-flake8, lint-black, test-api]
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.6.x", "3.7.x"]
-        engine: ["python", "ray", "dask"]
-        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        engine: ["ray"]
+        part: [3]
     env:
       MODIN_ENGINE: ${{matrix.engine}}
     name: test (${{matrix.engine}}, part ${{matrix.part}}, python ${{matrix.python-version}})
@@ -46,47 +60,14 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: InstallAWSCLI
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install awscli
-      - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_${{matrix.engine}} .
-      - run: mv testmondata_${{matrix.engine}} .testmondata
-      - name: Install HDF5
-        if: matrix.part == 3
-        run: sudo apt update && sudo apt install -y libhdf5-dev
-      - name: Install pip requirements
-        if: matrix.part == 3
-        run: pip install -r requirements.txt
-      - run: pip install -r df_test_requires.txt
-        if: matrix.part != 3
-      - run: pip install ray==0.8
-        if: matrix.engine == 'ray'
-      - run: pip install dask[complete] distributed
-        if: matrix.engine == 'dask'
-      - run: bash run-tests.sh ${{matrix.engine}} -k "TestDataFrame${{matrix.part}}"
-        if: matrix.part != 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_series.py
-        if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_concat.py
-        if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_groupby.py
-        if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_reshape.py
-        if: matrix.part == 3
-      - run: python -m pytest --testmon-noselect modin/pandas/test/test_general.py
-        if: matrix.part == 3
+      - run: sudo apt update && sudo apt install -y libhdf5-dev
+      - run: pip install -r requirements.txt
       - run: python -m pytest --testmon-noselect modin/pandas/test/test_io.py
         if: matrix.part == 3
       - run: python -m pytest --testmon-noselect modin/experimental/pandas/test/test_io_exp.py
         if: matrix.part == 3
   test-windows:
-    needs: [lint-flake8, lint-black]
+    needs: [lint-flake8, lint-black, test-api]
     runs-on: windows-latest
     strategy:
       matrix:
@@ -103,20 +84,7 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{runner.os}}-pip-${{hashFiles('**/requirements.txt')}}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install AWSCLI
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install awscli
-      - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_dask .
-      - run: mv testmondata_dask .testmondata
-      - name: Install pip requirements
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install -r windows_test_requires.txt
+      - run: pip install -r windows_test_requires.txt
       - run: python -m pytest modin/pandas/test/test_dataframe.py::TestDataFrame${{matrix.part}}
         if: matrix.part != 3
       - run: python -m pytest modin/pandas/test/test_series.py
@@ -132,7 +100,7 @@ jobs:
       - run: python -m pytest modin/pandas/test/test_io.py
         if: matrix.part == 3
   test-pyarrow:
-    needs: [lint-flake8, lint-black]
+    needs: [lint-flake8, lint-black, test-api]
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -149,46 +117,6 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install AWSCLI
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install awscli
-      - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_pyarrow .
-      - run: mv testmondata_pyarrow .testmondata
-      - name: Install HDF5
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: sudo apt update && sudo apt install -y libhdf5-dev
-      - name: Install pip requirements
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install -r requirements.txt
+      - run: sudo apt update && sudo apt install -y libhdf5-dev
+      - run: pip install -r requirements.txt
       - run: python -m pytest modin/pandas/test/test_io.py::test_from_csv
-  test-api:
-    needs: [lint-flake8, lint-black]
-    runs-on: ubuntu-latest
-    name: test api
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: "3.7.x"
-          architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install HDF5
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: sudo apt update && sudo apt install -y libhdf5-dev
-      - name: Install pip requirements
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install -r requirements.txt
-      - run: python -m pytest modin/pandas/test/test_api.py

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,128 +1,14 @@
 name: master
 on: push
 jobs:
-  testmon_ray:
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: "3.6.x"
-          architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install AWSCLI
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install awscli
-      - run: sudo apt update && sudo apt install -y libhdf5-dev
-      - run: pip install -r requirements.txt
-      - run: bash run-tests.sh ray
-      - run: mv .testmondata testmondata_ray
-      - run: aws s3api put-object --bucket=modin-testing --key=testmondata_ray --body=./testmondata_ray
-  testmon_python:
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: "3.6.x"
-          architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install AWSCLI
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install awscli
-      - run: sudo apt update && sudo apt install -y libhdf5-dev
-      - run: pip install -r requirements.txt
-      - run: bash run-tests.sh python
-      - run: mv .testmondata testmondata_python
-      - run: aws s3api put-object --bucket=modin-testing --key=testmondata_python --body=./testmondata_python
-  testmon_dask:
-    runs-on: ubuntu-latest
-    env:
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: "3.6.x"
-          architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: InstallAWSCLI
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install awscli
-      - run: sudo apt update && sudo apt install -y libhdf5-dev
-      - run: pip install -r requirements.txt
-      - run: bash run-tests.sh dask
-      - run: mv .testmondata testmondata_dask
-      - run: aws s3api put-object --bucket=modin-testing --key=testmondata_dask --body=./testmondata_dask
-  testmon_pyarrow:
-    runs-on: ubuntu-latest
-    env:
-      MODIN_BACKEND: pyarrow
-      MODIN_EXPERIMENTAL: "True"
-      AWS_ACCESS_KEY_ID: ${{secrets.AWS_ACCESS_KEY_ID}}
-      AWS_SECRET_ACCESS_KEY: ${{secrets.AWS_SECRET_ACCESS_KEY}}
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: "3.6.x"
-          architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: InstallAWSCLI
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install awscli
-      - run: aws s3 cp  --no-sign-request s3://modin-testing/testmondata_pyarrow .
-      - run: mv testmondata_pyarrow .testmondata
-      - run: sudo apt update && sudo apt install -y libhdf5-dev
-      - run: pip install -r requirements.txt
-      - run: MODIN_BACKEND=pyarrow python -m pytest modin/pandas/test/test_io.py::test_from_csv
-      - run: mv .testmondata testmondata_pyarrow
-      - run: aws s3api put-object --bucket=modin-testing --key=testmondata_pyarrow --body=./testmondata_pyarrow
   test-all:
     runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: ["3.6.x", "3.7.x"]
-        engine: ["python", "ray", "dask"]
-        part: ["Reduction_A::test_all", "Reduction_A::test_any", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        engine: ["ray"]
+        part: [3]
     env:
-      CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
-      PYTEST_ADDOPTS:  "--cov-config=.coveragerc --cov=modin  --cov-append"
       MODIN_ENGINE: ${{matrix.engine}}
     name: test (${{matrix.engine}}, part ${{matrix.part}}, python ${{matrix.python-version}})
     steps:
@@ -133,42 +19,12 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install HDF5
-        if: matrix.part == 3
-        run: sudo apt update && sudo apt install -y libhdf5-dev
-      - name: Install pip requirements
-        if: matrix.part == 3
-        run: pip install -r requirements.txt
-      - run: pip install -r df_test_requires.txt
-        if: matrix.part != 3
-      - run: pip install ray==0.8
-        if: matrix.engine == 'ray'
-      - run: pip install dask[complete] distributed
-        if: matrix.engine == 'dask'
-      - run: pip install coverage pytest-cov
-      - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_dataframe.py::TestDataFrame${{matrix.part}}
-        if: matrix.part != 3
-      - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_series.py
-        if: matrix.part == 3
-      - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_concat.py
-        if: matrix.part == 3
-      - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_groupby.py
-        if: matrix.part == 3
-      - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_reshape.py
-        if: matrix.part == 3
-      - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_general.py
-        if: matrix.part == 3
+      - run: sudo apt update && sudo apt install -y libhdf5-dev
+      - run: pip install -r requirements.txt
       - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_io.py
         if: matrix.part == 3
       - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/experimental/pandas/test/test_io_exp.py
         if: matrix.part == 3
-      - run: bash <(curl -s https://codecov.io/bash)
   test-windows:
     runs-on: windows-latest
     strategy:
@@ -186,16 +42,7 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~\AppData\Local\pip\Cache
-          key: ${{runner.os}}-pip-${{hashFiles('**/requirements.txt')}}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install pip requirements
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install -r windows_test_requires.txt
-      - run: pip install coverage pytest-cov
+      - run: pip install -r windows_test_requires.txt
       - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_dataframe.py::TestDataFrame${{matrix.part}}
         if: matrix.part != 3
       - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_series.py
@@ -210,8 +57,6 @@ jobs:
         if: matrix.part == 3
       - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_io.py
         if: matrix.part == 3
-      - run: choco install codecov
-      - run: codecov -f .\coverage.xml -t ${{secrets.CODECOV_TOKEN}}
   test-pyarrow:
     runs-on: ubuntu-latest
     strategy:
@@ -230,41 +75,6 @@ jobs:
         with:
           python-version: ${{matrix.python-version}}
           architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install HDF5
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: sudo apt update && sudo apt install -y libhdf5-dev
-      - name: Install pip requirements
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install -r requirements.txt
+      - run: sudo apt update && sudo apt install -y libhdf5-dev
+      - run: pip install -r requirements.txt
       - run: python -m pytest --cov-config=.coveragerc --cov=modin --cov-append modin/pandas/test/test_io.py::test_from_csv
-      - run: bash <(curl -s https://codecov.io/bash)
-  test-api:
-    runs-on: ubuntu-latest
-    name: test api
-    steps:
-      - uses: actions/checkout@v1
-        with:
-          fetch-depth: 1
-      - uses: actions/setup-python@v1
-        with:
-          python-version: "3.7.x"
-          architecture: "x64"
-      - uses: actions/cache@v1
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
-          restore-keys: |
-            ${{ runner.os }}-pip-
-      - name: Install HDF5
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: sudo apt update && sudo apt install -y libhdf5-dev
-      - name: Install pip requirements
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: pip install -r requirements.txt
-      - run: python -m pytest modin/pandas/test/test_api.py


### PR DESCRIPTION
* Resolves #1149
* Removes tests from the Ubuntu line that are already done in TeamCity
* Keep tests for Windows since we do not have that setup yet in TeamCity
* Lint and API checks are now mandatory before every other PR test runs

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1149 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
