### PR TITLE
Add parallel support for binary functions with Series `other`

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -861,10 +861,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
         Returns:
             A new QueryCompiler.
         """
-        if isinstance(key, type(self)):
-            return self._modin_frame.broadcast_apply(
-                0, lambda l, r: l[r.squeeze(axis=1)], key._modin_frame, False, "copy"
-            )
         return self.__constructor__(self._modin_frame.mask(row_numeric_idx=key))
 
     def setitem(self, axis, key, value):

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -861,6 +861,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
         Returns:
             A new QueryCompiler.
         """
+        if isinstance(key, type(self)):
+            return self._modin_frame.broadcast_apply(
+                0, lambda l, r: l[r.squeeze(axis=1)], key._modin_frame, False, "copy"
+            )
         return self.__constructor__(self._modin_frame.mask(row_numeric_idx=key))
 
     def setitem(self, axis, key, value):

--- a/modin/data_management/functions/binary_function.py
+++ b/modin/data_management/functions/binary_function.py
@@ -50,12 +50,7 @@ class BinaryFunction(Function):
                     )
             else:
                 if isinstance(other, (list, np.ndarray, pandas.Series)):
-                    if axis == 1 and isinstance(other, pandas.Series):
-                        new_columns = query_compiler.columns.join(
-                            other.index, how="outer"
-                        )
-                    else:
-                        new_columns = query_compiler.columns
+                    new_columns = query_compiler.columns
                     new_modin_frame = query_compiler._modin_frame._apply_full_axis(
                         axis,
                         lambda df: func(df, other, *args, **kwargs),

--- a/modin/data_management/functions/binary_function.py
+++ b/modin/data_management/functions/binary_function.py
@@ -22,12 +22,20 @@ class BinaryFunction(Function):
     def call(cls, func, *call_args, **call_kwds):
         def caller(query_compiler, other, *args, **kwargs):
             axis = kwargs.get("axis", 0)
+            broadcast = kwargs.pop("broadcast", False)
             if isinstance(other, type(query_compiler)):
-                return query_compiler.__constructor__(
-                    query_compiler._modin_frame._binary_op(
-                        lambda x, y: func(x, y, *args, **kwargs), other._modin_frame,
+                if broadcast:
+                    return query_compiler.__constructor__(
+                        query_compiler._modin_frame.broadcast_apply(
+                            lambda x, y: func(x, y.squeeze(axis=axis ^ 1), *args, **kwargs), other._modin_frame,
+                        )
                     )
-                )
+                else:
+                    return query_compiler.__constructor__(
+                        query_compiler._modin_frame._binary_op(
+                            lambda x, y: func(x, y, *args, **kwargs), other._modin_frame,
+                        )
+                    )
             else:
                 if isinstance(other, (list, np.ndarray, pandas.Series)):
                     if axis == 1 and isinstance(other, pandas.Series):

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1012,6 +1012,48 @@ class BasePandasFrame(object):
                 self._column_widths_cache,
             )
 
+    def broadcast_apply(self, axis, func, other, preserve_labels=True, dtypes=None):
+        """Broadcast partitions of other dataframe partitions and apply a function.
+
+        Args:
+            axis: The axis to broadcast over.
+            func: The function to apply.
+            other: The Modin DataFrame to broadcast.
+            preserve_labels: Whether or not to keep labels from this Modin DataFrame.
+            dtypes: "copy" or None. Whether to keep old dtypes or infer new dtypes from
+                data.
+
+        Returns:
+             A new Modin DataFrame
+        """
+        left_parts, right_parts, joined_index = self._copartition(
+            axis, other, "left", sort=False
+        )
+        # unwrap list returned by `copartition`.
+        right_parts = right_parts[0]
+        new_frame = self._frame_mgr_cls.broadcast_apply(
+            axis, func, left_parts, right_parts
+        )
+        if dtypes == "copy":
+            dtypes = self._dtypes
+        if preserve_labels:
+            new_index = self.index
+            new_columns = self.columns
+        else:
+            if axis == 0:
+                new_columns = self.columns
+                new_index = self._frame_mgr_cls.get_indices(
+                    0, new_frame, lambda df: df.index
+                )
+            else:
+                new_columns = self._frame_mgr_cls.get_indices(
+                    1, new_frame, lambda df: df.columns
+                )
+                new_index = self.index
+        return self.__constructor__(
+            new_frame, new_index, new_columns, None, None, dtypes=dtypes
+        )
+
     def _copartition(self, axis, other, how, sort, force_repartition=False):
         """Copartition two dataframes.
 

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1026,8 +1026,10 @@ class BasePandasFrame(object):
         Returns:
              A new Modin DataFrame
         """
+        assert preserve_labels, "`preserve_labels=False` Not Yet Implemented"
+        # Only sort the indices if they do not match
         left_parts, right_parts, joined_index = self._copartition(
-            axis, other, "left", sort=False
+            axis, other, "left", sort=not self.axes[axis].equals(other.axes[axis])
         )
         # unwrap list returned by `copartition`.
         right_parts = right_parts[0]
@@ -1036,20 +1038,8 @@ class BasePandasFrame(object):
         )
         if dtypes == "copy":
             dtypes = self._dtypes
-        if preserve_labels:
-            new_index = self.index
-            new_columns = self.columns
-        else:
-            if axis == 0:
-                new_columns = self.columns
-                new_index = self._frame_mgr_cls.get_indices(
-                    0, new_frame, lambda df: df.index
-                )
-            else:
-                new_columns = self._frame_mgr_cls.get_indices(
-                    1, new_frame, lambda df: df.columns
-                )
-                new_index = self.index
+        new_index = self.index
+        new_columns = self.columns
         return self.__constructor__(
             new_frame, new_index, new_columns, None, None, dtypes=dtypes
         )

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -96,6 +96,40 @@ class BaseFrameManager(object):
         return cls.map_axis_partitions(axis, new_partitions, reduce_func)
 
     @classmethod
+    def broadcast_apply(cls, axis, apply_func, left, right):
+        """Broadcast the right partitions to left and apply a function.
+
+        Note: This will often be overridden by implementations. It materializes the
+            entire partitions of the right and applies them to the left through `apply`.
+
+        Args:
+            axis: The axis to apply and broadcast over.
+            apply_func: The function to apply.
+            left: The left partitions.
+            right: The right partitions.
+
+        Returns:
+            A new `np.array` of partition objects.
+        """
+        right_parts = np.squeeze(right)
+
+        [obj.drain_call_queue() for obj in right_parts]
+        return np.array(
+            [
+                [
+                    part.apply(
+                        apply_func,
+                        r=right_parts[col_idx].get()
+                        if axis
+                        else right_parts[row_idx].get(),
+                    )
+                    for col_idx, part in enumerate(left[row_idx])
+                ]
+                for row_idx in range(len(left))
+            ]
+        )
+
+    @classmethod
     def map_partitions(cls, partitions, map_func):
         """Applies `map_func` to every partition.
 

--- a/modin/engines/ray/pandas_on_ray/frame/partition_manager.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition_manager.py
@@ -29,6 +29,10 @@ if __execution_engine__ == "Ray":
     def func(df, other, apply_func, call_queue_df=None, call_queue_other=None):
         if call_queue_df is not None and len(call_queue_df) > 0:
             for call, kwargs in call_queue_df:
+                if isinstance(call, ray.ObjectID):
+                    call = ray.get(call)
+                if isinstance(kwargs, ray.ObjectID):
+                    kwargs = ray.get(kwargs)
                 df = call(df, **kwargs)
         if call_queue_other is not None and len(call_queue_other) > 0:
             for call, kwargs in call_queue_other:
@@ -116,7 +120,6 @@ class PandasOnRayFrameManager(RayFrameManager):
     def broadcast_apply(cls, axis, apply_func, left, right):
         map_func = ray.put(apply_func)
         right_parts = np.squeeze(right)
-
         if len(right_parts.shape) == 0:
             right_parts = np.array([right_parts.item()])
         assert (

--- a/modin/engines/ray/pandas_on_ray/frame/partition_manager.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition_manager.py
@@ -24,25 +24,20 @@ from modin import __execution_engine__
 
 if __execution_engine__ == "Ray":
     import ray
-    import time
-
 
     @ray.remote
-    def func(df, other, map_func, call_queue_df=[], call_queue_other=[]):
-        s = time.time()
-        if len(call_queue_df) > 0:
+    def func(df, other, apply_func, call_queue_df=None, call_queue_other=None):
+        if call_queue_df is not None and len(call_queue_df) > 0:
             for call, kwargs in call_queue_df:
                 df = call(df, **kwargs)
-        if len(call_queue_other) > 0:
+        if call_queue_other is not None and len(call_queue_other) > 0:
             for call, kwargs in call_queue_other:
                 if isinstance(call, ray.ObjectID):
                     call = ray.get(call)
                 if isinstance(kwargs, ray.ObjectID):
                     kwargs = ray.get(kwargs)
                 other = call(other, **kwargs)
-        x = map_func(df, other)
-        print(time.time() - s)
-        return x
+        return apply_func(df, other)
 
 
 class PandasOnRayFrameManager(RayFrameManager):
@@ -121,15 +116,23 @@ class PandasOnRayFrameManager(RayFrameManager):
     def broadcast_apply(cls, axis, apply_func, left, right):
         map_func = ray.put(apply_func)
         right_parts = np.squeeze(right)
+
         if len(right_parts.shape) == 0:
             right_parts = np.array([right_parts.item()])
+        assert (
+            len(right_parts.shape) == 1
+        ), "Invalid broadcast partitions shape {}\n{}".format(
+            right_parts.shape, [[i.get() for i in j] for j in right_parts]
+        )
         return np.array(
             [
                 [
                     PandasOnRayFramePartition(
                         func.remote(
                             part.oid,
-                            right_parts[col_idx].oid if axis else right_parts[row_idx].oid,
+                            right_parts[col_idx].oid
+                            if axis
+                            else right_parts[row_idx].oid,
                             map_func,
                             part.call_queue,
                             right_parts[col_idx].call_queue

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -135,8 +135,6 @@ class BasePandasDataset(object):
         if isinstance(other, BasePandasDataset):
             return other._query_compiler
         elif is_list_like(other):
-            if isinstance(other, pandas.Series):
-                other = other.reindex(self.axes[axis])
             if axis == 0:
                 if len(other) != len(self._query_compiler.index):
                     raise ValueError(
@@ -216,7 +214,7 @@ class BasePandasDataset(object):
             axis = 0
         if kwargs.get("level", None) is not None:
             # Broadcast is an internally used argument
-            kwargs.pop("broadcast")
+            kwargs.pop("broadcast", None)
             return self._default_to_pandas(
                 getattr(getattr(pandas, self.__name__), op), other, **kwargs
             )

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -215,6 +215,8 @@ class BasePandasDataset(object):
         else:
             axis = 0
         if kwargs.get("level", None) is not None:
+            # Broadcast is an internally used argument
+            kwargs.pop("broadcast")
             return self._default_to_pandas(
                 getattr(getattr(pandas, self.__name__), op), other, **kwargs
             )
@@ -338,7 +340,7 @@ class BasePandasDataset(object):
 
         Args:
             other: What to add this this DataFrame.
-            axis: The axis to apply addition over. Only applicaable to Series
+            axis: The axis to apply addition over. Only applicable to Series
                 or list 'other'.
             level: A level in the multilevel axis to add over.
             fill_value: The value to fill NaN.

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -451,10 +451,13 @@ class DataFrame(BasePandasDataset):
     T = property(transpose)
 
     def add(self, other, axis="columns", level=None, fill_value=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).add(
-            other, axis=axis, level=level, fill_value=fill_value
+        return self._binary_op(
+            "add",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     def append(self, other, ignore_index=False, verify_integrity=False, sort=False):
@@ -574,9 +577,9 @@ class DataFrame(BasePandasDataset):
         return self._default_to_pandas(pandas.DataFrame.cov, min_periods=min_periods)
 
     def eq(self, other, axis="columns", level=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).eq(other, axis=axis, level=level)
+        return self._binary_op(
+            "eq", other, axis=axis, level=level, broadcast=isinstance(other, Series)
+        )
 
     def equals(self, other):
         """
@@ -660,10 +663,13 @@ class DataFrame(BasePandasDataset):
             )
 
     def floordiv(self, other, axis="columns", level=None, fill_value=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).floordiv(
-            other, axis=axis, level=level, fill_value=fill_value
+        return self._binary_op(
+            "floordiv",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     @classmethod
@@ -700,14 +706,14 @@ class DataFrame(BasePandasDataset):
         )
 
     def ge(self, other, axis="columns", level=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).ge(other, axis=axis, level=level)
+        return self._binary_op(
+            "ge", other, axis=axis, level=level, broadcast=isinstance(other, Series)
+        )
 
     def gt(self, other, axis="columns", level=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).gt(other, axis=axis, level=level)
+        return self._binary_op(
+            "gt", other, axis=axis, level=level, broadcast=isinstance(other, Series)
+        )
 
     def head(self, n=5):
         if n == 0:
@@ -1032,17 +1038,17 @@ class DataFrame(BasePandasDataset):
         return new_frame
 
     def le(self, other, axis="columns", level=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).le(other, axis=axis, level=level)
+        return self._binary_op(
+            "le", other, axis=axis, level=level, broadcast=isinstance(other, Series)
+        )
 
     def lookup(self, row_labels, col_labels):
         return self._default_to_pandas(pandas.DataFrame.lookup, row_labels, col_labels)
 
     def lt(self, other, axis="columns", level=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).lt(other, axis=axis, level=level)
+        return self._binary_op(
+            "lt", other, axis=axis, level=level, broadcast=isinstance(other, Series)
+        )
 
     def melt(
         self,
@@ -1155,25 +1161,31 @@ class DataFrame(BasePandasDataset):
             )
 
     def mod(self, other, axis="columns", level=None, fill_value=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).mod(
-            other, axis=axis, level=level, fill_value=fill_value
+        return self._binary_op(
+            "mod",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     def mul(self, other, axis="columns", level=None, fill_value=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).mul(
-            other, axis=axis, level=level, fill_value=fill_value
+        return self._binary_op(
+            "mul",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     rmul = multiply = mul
 
     def ne(self, other, axis="columns", level=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).ne(other, axis=axis, level=level)
+        return self._binary_op(
+            "ne", other, axis=axis, level=level, broadcast=isinstance(other, Series)
+        )
 
     def nlargest(self, n, columns, keep="first"):
         return self._default_to_pandas(pandas.DataFrame.nlargest, n, columns, keep=keep)
@@ -1250,9 +1262,16 @@ class DataFrame(BasePandasDataset):
 
     def pow(self, other, axis="columns", level=None, fill_value=None):
         if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).pow(
-            other, axis=axis, level=level, fill_value=fill_value
+            return self._default_to_pandas(
+                "pow", other, axis=axis, level=level, fill_value=fill_value
+            )
+        return self._binary_op(
+            "pow",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     def prod(
@@ -1383,38 +1402,57 @@ class DataFrame(BasePandasDataset):
             return renamed
 
     def rfloordiv(self, other, axis="columns", level=None, fill_value=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).rfloordiv(
-            other, axis=axis, level=level, fill_value=fill_value
+        return self._binary_op(
+            "rfloordiv",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     def rmod(self, other, axis="columns", level=None, fill_value=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).rmod(
-            other, axis=axis, level=level, fill_value=fill_value
+        return self._binary_op(
+            "rmod",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     def rpow(self, other, axis="columns", level=None, fill_value=None):
         if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).rpow(
-            other, axis=axis, level=level, fill_value=fill_value
+            return self._default_to_pandas(
+                "rpow", other, axis=axis, level=level, fill_value=fill_value
+            )
+        return self._binary_op(
+            "rpow",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     def rsub(self, other, axis="columns", level=None, fill_value=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).rsub(
-            other, axis=axis, level=level, fill_value=fill_value
+        return self._binary_op(
+            "rsub",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     def rtruediv(self, other, axis="columns", level=None, fill_value=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).rtruediv(
-            other, axis=axis, level=level, fill_value=fill_value
+        return self._binary_op(
+            "rtruediv",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     rdiv = rtruediv
@@ -1550,10 +1588,13 @@ class DataFrame(BasePandasDataset):
         )
 
     def sub(self, other, axis="columns", level=None, fill_value=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).sub(
-            other, axis=axis, level=level, fill_value=fill_value
+        return self._binary_op(
+            "sub",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     subtract = sub
@@ -1731,10 +1772,13 @@ class DataFrame(BasePandasDataset):
         )
 
     def truediv(self, other, axis="columns", level=None, fill_value=None):
-        if isinstance(other, Series):
-            other = other._to_pandas()
-        return super(DataFrame, self).truediv(
-            other, axis=axis, level=level, fill_value=fill_value
+        return self._binary_op(
+            "truediv",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
         )
 
     div = divide = truediv
@@ -1884,7 +1928,10 @@ class DataFrame(BasePandasDataset):
         return s
 
     def _getitem_array(self, key):
-        if is_bool_indexer(key) or (isinstance(key, Series) and key.dtype == np.bool_):
+        # TODO: dont convert to pandas for array indexing
+        if isinstance(key, Series):
+            key = key._to_pandas()
+        if is_bool_indexer(key):
             if isinstance(key, pandas.Series) and not key.index.equals(self.index):
                 warnings.warn(
                     "Boolean Series key will be reindexed to match DataFrame index.",
@@ -1897,17 +1944,17 @@ class DataFrame(BasePandasDataset):
                         len(key), len(self.index)
                     )
                 )
-            if not isinstance(key, Series):
-                key = check_bool_indexer(self.index, key)
-                # We convert to a RangeIndex because getitem_row_array is expecting a
-                # list of indices, and RangeIndex will give us the exact indices of each
-                # boolean requested.
-                key = pandas.RangeIndex(len(self.index))[key]
+            key = check_bool_indexer(self.index, key)
+            # We convert to a RangeIndex because getitem_row_array is expecting a list
+            # of indices, and RangeIndex will give us the exact indices of each boolean
+            # requested.
+            key = pandas.RangeIndex(len(self.index))[key]
+            if len(key):
+                return DataFrame(
+                    query_compiler=self._query_compiler.getitem_row_array(key)
+                )
             else:
-                key = key._query_compiler
-            return DataFrame(
-                query_compiler=self._query_compiler.getitem_row_array(key)
-            )
+                return DataFrame(columns=self.columns)
         else:
             if any(k not in self.columns for k in key):
                 raise KeyError(

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -170,6 +170,28 @@ class TestDataFrameBinary:
             modin_result = getattr(modin_df, op)(series_test_modin, axis=1)
             df_equals(modin_result, pandas_result)
 
+        # Test dataframe to list axis=1
+        series_test_modin = series_test_pandas = list(pandas_df.iloc[0])
+        try:
+            pandas_result = getattr(pandas_df, op)(series_test_pandas, axis=1)
+        except Exception as e:
+            with pytest.raises(type(e)):
+                getattr(modin_df, op)(series_test_modin, axis=1)
+        else:
+            modin_result = getattr(modin_df, op)(series_test_modin, axis=1)
+            df_equals(modin_result, pandas_result)
+
+        # Test dataframe to list axis=0
+        series_test_modin = series_test_pandas = list(pandas_df[pandas_df.columns[0]])
+        try:
+            pandas_result = getattr(pandas_df, op)(series_test_pandas, axis=0)
+        except Exception as e:
+            with pytest.raises(type(e)):
+                getattr(modin_df, op)(series_test_modin, axis=0)
+        else:
+            modin_result = getattr(modin_df, op)(series_test_modin, axis=0)
+            df_equals(modin_result, pandas_result)
+
         # Test dataframe to series missing values
         series_test_modin = modin_df.iloc[0, :-2]
         series_test_pandas = pandas_df.iloc[0, :-2]


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Evaluating the performance, this PR represents a 4-5x improvement over previous implementation for `df.add(df["col0"], axis=0)` and other binary functions. 
<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1060 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
