### PR TITLE
Make query compiler base class a Python ABC

### DIFF
--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -10,11 +10,10 @@
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
+import abc
 
-NOT_IMPLEMENTED_MESSAGE = "Must be implemented in children classes"
 
-
-class BaseQueryCompiler(object):
+class BaseQueryCompiler(abc.ABC):
     """Abstract Class that handles the queries to Modin dataframes.
 
     Note: See the Abstract Methods and Fields section immediately below this
@@ -27,11 +26,13 @@ class BaseQueryCompiler(object):
     # treated differently.
 
     # Metadata modification abstract methods
+    @abc.abstractmethod
     def add_prefix(self, prefix, axis=1):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def add_suffix(self, suffix, axis=1):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Metadata modification abstract methods
 
@@ -39,13 +40,15 @@ class BaseQueryCompiler(object):
     # For copy, we don't want a situation where we modify the metadata of the
     # copies if we end up modifying something here. We copy all of the metadata
     # to prevent that.
+    @abc.abstractmethod
     def copy(self):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract copy
 
     # Abstract join and append helper functions
 
+    @abc.abstractmethod
     def concat(self, axis, other, **kwargs):
         """Concatenates two objects together.
 
@@ -56,29 +59,32 @@ class BaseQueryCompiler(object):
         Returns:
             Concatenated objects.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract join and append helper functions
 
     # Data Management Methods
+    @abc.abstractmethod
     def free(self):
         """In the future, this will hopefully trigger a cleanup of this object.
         """
         # TODO create a way to clean up this object.
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Data Management Methods
 
     # To/From Pandas
+    @abc.abstractmethod
     def to_pandas(self):
         """Converts Modin DataFrame to Pandas DataFrame.
 
         Returns:
             Pandas DataFrame of the QueryCompiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     @classmethod
+    @abc.abstractmethod
     def from_pandas(cls, df, block_partitions_cls):
         """Improve simple Pandas DataFrame to an advanced and superior Modin DataFrame.
 
@@ -90,18 +96,19 @@ class BaseQueryCompiler(object):
         Returns:
             Returns QueryCompiler containing data from the Pandas DataFrame.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END To/From Pandas
 
     # To NumPy
+    @abc.abstractmethod
     def to_numpy(self):
         """Converts Modin DataFrame to NumPy DataFrame.
 
         Returns:
             NumPy Array of the QueryCompiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END To NumPy
 
@@ -111,43 +118,111 @@ class BaseQueryCompiler(object):
     # such that columns/rows that don't have an index on the other DataFrame
     # result in NaN values.
 
-    def binary_op(self, op, other, **kwargs):
-        """Perform an operation between two objects.
+    @abc.abstractmethod
+    def add(self, other, **kwargs):
+        pass
 
-        Note: The list of operations is as follows:
-            - add
-            - eq
-            - floordiv
-            - ge
-            - gt
-            - le
-            - lt
-            - mod
-            - mul
-            - ne
-            - pow
-            - rfloordiv
-            - rmod
-            - rpow
-            - rsub
-            - rtruediv
-            - sub
-            - truediv
-            - __and__
-            - __or__
-            - __xor__
-        Args:
-            op: The operation. See list of operations above
-            other: The object to operate against.
+    @abc.abstractmethod
+    def combine(self, other, **kwargs):
+        pass
 
-        Returns:
-            A new QueryCompiler object.
-        """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+    @abc.abstractmethod
+    def combine_first(self, other, **kwargs):
+        pass
 
-    def clip(self, lower, upper, **kwargs):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+    @abc.abstractmethod
+    def eq(self, other, **kwargs):
+        pass
 
+    @abc.abstractmethod
+    def floordiv(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def ge(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def gt(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def le(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def lt(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def mod(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def mul(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def ne(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def pow(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def rfloordiv(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def rmod(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def rpow(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def rsub(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def rtruediv(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def sub(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def truediv(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def __and__(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def __or__(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def __rand__(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def __ror__(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def __rxor__(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
+    def __xor__(self, other, **kwargs):
+        pass
+
+    @abc.abstractmethod
     def update(self, other, **kwargs):
         """Uses other manager to update corresponding values in this manager.
 
@@ -157,8 +232,13 @@ class BaseQueryCompiler(object):
         Returns:
             New QueryCompiler with updated data and index.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
+    def clip(self, lower, upper, **kwargs):
+        pass
+
+    @abc.abstractmethod
     def where(self, cond, other, **kwargs):
         """Gets values from this manager where cond is true else from other.
 
@@ -168,22 +248,24 @@ class BaseQueryCompiler(object):
         Returns:
             New QueryCompiler with updated data and index.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract inter-data operations
 
     # Abstract Transpose
+    @abc.abstractmethod
     def transpose(self, *args, **kwargs):
         """Transposes this QueryCompiler.
 
         Returns:
             Transposed new QueryCompiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract Transpose
 
     # Abstract reindex/reset_index (may shuffle data)
+    @abc.abstractmethod
     def reindex(self, axis, labels, **kwargs):
         """Fits a new index for this Manger.
 
@@ -194,15 +276,16 @@ class BaseQueryCompiler(object):
         Returns:
             New QueryCompiler with updated data and new index.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def reset_index(self, **kwargs):
         """Removes all levels from index and sets a default level_0 index.
 
         Returns:
             New QueryCompiler with updated data and reset index.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract reindex/reset_index
 
@@ -213,88 +296,96 @@ class BaseQueryCompiler(object):
     # we will implement a Distributed Series, and this will be returned
     # instead.
 
+    @abc.abstractmethod
     def count(self, **kwargs):
         """Counts the number of non-NaN objects for each column or row.
 
         Return:
             Pandas series containing counts of non-NaN objects from each column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def max(self, **kwargs):
         """Returns the maximum value for each column or row.
 
         Return:
             Pandas series with the maximum values from each column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def mean(self, **kwargs):
         """Returns the mean for each numerical column or row.
 
         Return:
             Pandas series containing the mean from each numerical column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def min(self, **kwargs):
         """Returns the minimum from each column or row.
 
         Return:
             Pandas series with the minimum value from each column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def prod(self, **kwargs):
         """Returns the product of each numerical column or row.
 
         Return:
             Pandas series with the product of each numerical column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def sum(self, **kwargs):
         """Returns the sum of each numerical column or row.
 
         Return:
             Pandas series with the sum of each numerical column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract full Reduce operations
 
     # Abstract map partitions operations
     # These operations are operations that apply a function to every partition.
+    @abc.abstractmethod
     def abs(self):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def applymap(self, func):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def isin(self, **kwargs):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def isna(self):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
-    def isnull(self):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
-
+    @abc.abstractmethod
     def negative(self, **kwargs):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def notna(self):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
-    def notnull(self):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
-
+    @abc.abstractmethod
     def round(self, **kwargs):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract map partitions operations
 
     # Abstract map partitions across select indices
+    @abc.abstractmethod
     def astype(self, col_dtypes, **kwargs):
         """Converts columns dtypes to given dtypes.
 
@@ -305,7 +396,7 @@ class BaseQueryCompiler(object):
         Returns:
             DataFrame with updated dtypes.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract map partitions across select indices
 
@@ -315,117 +406,122 @@ class BaseQueryCompiler(object):
     # Currently, this means a Pandas Series will be returned, but in the future
     # we will implement a Distributed Series, and this will be returned
     # instead.
+    @abc.abstractmethod
     def all(self, **kwargs):
         """Returns whether all the elements are true, potentially over an axis.
 
         Return:
             Pandas Series containing boolean values or boolean.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def any(self, **kwargs):
         """Returns whether any the elements are true, potentially over an axis.
 
         Return:
             Pandas Series containing boolean values or boolean.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def first_valid_index(self):
         """Returns index of first non-NaN/NULL value.
 
         Return:
             Scalar of index name.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def idxmax(self, **kwargs):
         """Returns the first occurance of the maximum over requested axis.
 
         Returns:
             Series containing the maximum of each column or axis.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def idxmin(self, **kwargs):
         """Returns the first occurance of the minimum over requested axis.
 
         Returns:
             Series containing the minimum of each column or axis.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def last_valid_index(self):
         """Returns index of last non-NaN/NULL value.
 
         Return:
             Scalar of index name.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def median(self, **kwargs):
         """Returns median of each column or row.
 
         Returns:
             Series containing the median of each column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def memory_usage(self, **kwargs):
         """Returns the memory usage of each column.
 
         Returns:
             Series containing the memory usage of each column.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def nunique(self, **kwargs):
         """Returns the number of unique items over each column or row.
 
         Returns:
             Series of ints indexed by column or index names.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def quantile_for_single_value(self, **kwargs):
         """Returns quantile of each column or row.
 
         Returns:
             Series containing the quantile of each column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def skew(self, **kwargs):
         """Returns skew of each column or row.
 
         Returns:
             Series containing the skew of each column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def std(self, **kwargs):
         """Returns standard deviation of each column or row.
 
         Returns:
             Series containing the standard deviation of each column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
-    def to_datetime(self, **kwargs):
-        """Converts the Manager to a Series of DateTime objects.
-
-        Returns:
-            Series of DateTime objects.
-        """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
-
+    @abc.abstractmethod
     def var(self, **kwargs):
         """Returns variance of each column or row.
 
         Returns:
             Series containing the variance of each column or row.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract column/row partitions reduce operations
 
@@ -435,13 +531,14 @@ class BaseQueryCompiler(object):
     # Currently, this means a Pandas Series will be returned, but in the future
     # we will implement a Distributed Series, and this will be returned
     # instead.
+    @abc.abstractmethod
     def describe(self, **kwargs):
         """Generates descriptive statistics.
 
         Returns:
             DataFrame object containing the descriptive statistics of the DataFrame.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract column/row partitions reduce operations over select indices
 
@@ -449,28 +546,35 @@ class BaseQueryCompiler(object):
     # These operations require some global knowledge of the full column/row
     # that is being operated on. This means that we have to put all of that
     # data in the same place.
+    @abc.abstractmethod
     def cumsum(self, **kwargs):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def cummax(self, **kwargs):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def cummin(self, **kwargs):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def cumprod(self, **kwargs):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def diff(self, **kwargs):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def dropna(self, **kwargs):
         """Returns a new QueryCompiler with null values dropped along given axis.
         Return:
             New QueryCompiler
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def eval(self, expr, **kwargs):
         """Returns a new QueryCompiler with expr evaluated on columns.
 
@@ -480,24 +584,27 @@ class BaseQueryCompiler(object):
         Returns:
             A new QueryCompiler with new columns after applying expr.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def mode(self, **kwargs):
         """Returns a new QueryCompiler with modes calculated for each label along given axis.
 
         Returns:
             A new QueryCompiler with modes calculated.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def fillna(self, **kwargs):
         """Replaces NaN values with the method provided.
 
         Returns:
             A new QueryCompiler with null values filled.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def query(self, expr, **kwargs):
         """Query columns of the QueryCompiler with a boolean expression.
 
@@ -507,23 +614,25 @@ class BaseQueryCompiler(object):
         Returns:
             QueryCompiler containing the rows where the boolean expression is satisfied.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def rank(self, **kwargs):
         """Computes numerical rank along axis. Equal values are set to the average.
 
         Returns:
             QueryCompiler containing the ranks of the values along an axis.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def sort_index(self, **kwargs):
         """Sorts the data with respect to either the columns or the indices.
 
         Returns:
             QueryCompiler containing the data sorted by columns or indices.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract map across rows/columns
 
@@ -531,17 +640,19 @@ class BaseQueryCompiler(object):
     # These operations require some global knowledge of the full column/row
     # that is being operated on. This means that we have to put all of that
     # data in the same place.
+    @abc.abstractmethod
     def quantile_for_list_of_values(self, **kwargs):
         """Returns Manager containing quantiles along an axis for numeric columns.
 
         Returns:
             QueryCompiler containing quantiles of original QueryCompiler along an axis.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract map across rows/columns
 
     # Abstract head/tail/front/back
+    @abc.abstractmethod
     def head(self, n):
         """Returns the first n rows.
 
@@ -551,8 +662,9 @@ class BaseQueryCompiler(object):
         Returns:
             QueryCompiler containing the first n rows of the original QueryCompiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def tail(self, n):
         """Returns the last n rows.
 
@@ -562,8 +674,9 @@ class BaseQueryCompiler(object):
         Returns:
             QueryCompiler containing the last n rows of the original QueryCompiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def front(self, n):
         """Returns the first n columns.
 
@@ -573,8 +686,9 @@ class BaseQueryCompiler(object):
         Returns:
             QueryCompiler containing the first n columns of the original QueryCompiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def back(self, n):
         """Returns the last n columns.
 
@@ -584,11 +698,12 @@ class BaseQueryCompiler(object):
         Returns:
             QueryCompiler containing the last n columns of the original QueryCompiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END head/tail/front/back
 
     # Abstract __getitem__ methods
+    @abc.abstractmethod
     def getitem_column_array(self, key):
         """Get column data for target labels.
 
@@ -598,8 +713,9 @@ class BaseQueryCompiler(object):
         Returns:
             A new Query Compiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def getitem_row_array(self, key):
         """Get row data for target labels.
 
@@ -609,7 +725,7 @@ class BaseQueryCompiler(object):
         Returns:
             A new Query Compiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract __getitem__ methods
 
@@ -618,6 +734,7 @@ class BaseQueryCompiler(object):
     # operation is always inplace, but this object is immutable, so we just
     # return a new one from here and let the front end handle the inplace
     # update.
+    @abc.abstractmethod
     def insert(self, loc, column, value):
         """Insert new column data.
 
@@ -629,11 +746,12 @@ class BaseQueryCompiler(object):
         Returns:
             A new QueryCompiler with new data inserted.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract insert
 
     # Abstract drop
+    @abc.abstractmethod
     def drop(self, index=None, columns=None):
         """Remove row data for target index and columns.
 
@@ -644,13 +762,14 @@ class BaseQueryCompiler(object):
         Returns:
             A new QueryCompiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END drop
 
     # UDF (apply and agg) methods
     # There is a wide range of behaviors that are supported, so a lot of the
     # logic can get a bit convoluted.
+    @abc.abstractmethod
     def apply(self, func, axis, *args, **kwargs):
         """Apply func across given axis.
 
@@ -661,7 +780,7 @@ class BaseQueryCompiler(object):
         Returns:
             A new QueryCompiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END UDF
 
@@ -669,9 +788,11 @@ class BaseQueryCompiler(object):
     # These methods require some sort of manual partitioning due to their
     # nature. They require certain data to exist on the same partition, and
     # after the shuffle, there should be only a local map required.
+    @abc.abstractmethod
     def groupby_agg(self, by, axis, agg_func, groupby_args, agg_args):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
+    @abc.abstractmethod
     def groupby_reduce(
         self,
         by,
@@ -683,10 +804,11 @@ class BaseQueryCompiler(object):
         reduce_args=None,
         numeric_only=True,
     ):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Manual Partitioning methods
 
+    @abc.abstractmethod
     def get_dummies(self, columns, **kwargs):
         """Convert categorical variables to dummy variables for certain columns.
 
@@ -696,17 +818,16 @@ class BaseQueryCompiler(object):
         Returns:
             A new QueryCompiler.
         """
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # Indexing
+    @abc.abstractmethod
     def view(self, index=None, columns=None):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
-    def squeeze(self, ndim=0, axis=None):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
-
+    @abc.abstractmethod
     def write_items(self, row_numeric_index, col_numeric_index, broadcasted_items):
-        raise NotImplementedError(NOT_IMPLEMENTED_MESSAGE)
+        pass
 
     # END Abstract methods for QueryCompiler
 


### PR DESCRIPTION
I was having a look at the query compiler, and thought it could be a good idea to use a Python ABC. So an exception is raised if children is missing one of the methods, and it's also more readable.

After changing that, I realized and made couple of adjustments:
- `isnull` and `notnull` wheren't being implemented, I made them aliases of `isna` and `notna` in the base class
- `to_datetime` was listed as a reduction. I think pandas provides just as a helper, and it's not part of the dataframe API. Removed it here.
- `squeeze` was not implemented in the pandas query compiler, I made it explicit in the pandas compiler itself.
- `binary_op` is implemented in the base class, but not in the pandas query compiler, where individual methods are defined. I added a comment, and make the method call the corresponding method (`binary_op(add, ...)` -> `add(...)`).

Not sure if all those make sense or are good ideas, happy to have feedback and comments.