### PR TITLE
Fixed #1368. Import official api packages instead of deprecated

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -33,11 +33,6 @@ warnings.filterwarnings(
     message="The pandas.datetime class is deprecated and will be removed from pandas in a future version. "
     "Import from datetime module instead.",
 )
-warnings.filterwarnings(
-    "ignore",
-    message="pandas.core.index is deprecated and will be removed in a future version. "
-    "The public classes are available in the top-level namespace.",
-)
 
 
 def get_execution_engine():

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -15,7 +15,7 @@ from itertools import groupby
 import numpy as np
 from operator import itemgetter
 import pandas
-from pandas.core.index import ensure_index
+from pandas.core.indexes.api import ensure_index
 from pandas.core.dtypes.common import is_numeric_dtype
 
 from modin.backends.pandas.query_compiler import PandasQueryCompiler

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -19,7 +19,7 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_numeric_dtype,
 )
-from pandas.core.index import ensure_index_from_sequences
+from pandas.core.indexes.api import ensure_index_from_sequences
 from pandas.core.indexing import check_bool_indexer
 from pandas.util._validators import validate_bool_kwarg
 


### PR DESCRIPTION
Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Updated imports to use official api packages instead of unofficial deprecated ones.

<!-- Please give a short brief about these changes. -->

- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #1368  <!-- issue must be created for each patch -->
- [ ] tests added and passing
