### PR TITLE
Choosing depedencies for `pip install modin[all]` based on platform

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -1,9 +1,43 @@
 To update Modin version, use the following method (uses versioneer):
 
-* Commit
+### Commit
 
-        `git commit -a -m "bump version to x.x.x"`
+        `git commit -a -m "Bump version to x.x.x"`
 
-* Tag commit
+### Tag commit
 
-        `git tag -a x.x.x -m 'Version x.x.x'`
+        `git tag -as x.x.x`
+
+  * Include release documentation in the annotation and make sure it is signed.
+  * Push the tag to master: `git push upstream :refs/tags/x.x.x`
+
+### Build wheels:
+
+```bash
+# Fresh clone Modin
+git clone git@github.com:modin-project/modin.git
+cd modin
+# Build wheels. Wheels must be built per-distribution
+SETUP_PLAT_NAME=macos python3 setup.py sdist bdist_wheel --plat-name macosx_10_9_x86_64
+SETUP_PLAT_NAME=win32 python3 setup.py sdist bdist_wheel --plat-name win32
+SETUP_PLAT_NAME=win_amd64 python3 setup.py sdist bdist_wheel --plat-name win_amd64
+SETUP_PLAT_NAME=linux python3 setup.py sdist bdist_wheel --plat-name manylinux1_x86_64
+SETUP_PLAT_NAME=linux python3 setup.py sdist bdist_wheel --plat-name manylinux1_i686
+```
+
+You may see the wheels in the `dist` folder: `ls -l dist`. Make sure the version is correct,
+and make sure there are 5 distributions listed above with the `--plat-name` arguments.
+Also make sure there is a `tar` file that contains the source.
+
+### Upload wheels:
+
+Use `twine` to upload wheels:
+
+```bash
+twine upload dist/*
+```
+
+### Check with `pip install`:
+
+Run `pip install -U modin[all]` on Linux, Mac, and Windows systems in a new environment
+to test that the wheels were uploaded correctly.

--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,6 @@ if HAS_WHEEL:
             return py, abi, plat
 
 
-else:
-
-    class ModinWheel(bdist_wheel):
-        pass
-
-
 class ModinDistribution(Distribution):
     def __init__(self, *attrs):
         Distribution.__init__(self, *attrs)

--- a/setup.py
+++ b/setup.py
@@ -2,8 +2,10 @@ from setuptools import setup, find_packages
 import versioneer
 import os
 from setuptools.dist import Distribution
+
 try:
     from wheel.bdist_wheel import bdist_wheel
+
     HAS_WHEEL = True
 except ImportError:
     HAS_WHEEL = False
@@ -12,6 +14,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 if HAS_WHEEL:
+
     class ModinWheel(bdist_wheel):
         def finalize_options(self):
             bdist_wheel.finalize_options(self)
@@ -22,17 +25,19 @@ if HAS_WHEEL:
             py = "py3"
             abi = "none"
             return py, abi, plat
+
+
 else:
+
     class ModinWheel(bdist_wheel):
         pass
 
 
 class ModinDistribution(Distribution):
-
     def __init__(self, *attrs):
         Distribution.__init__(self, *attrs)
         if HAS_WHEEL:
-            self.cmdclass['bdist_wheel'] = ModinWheel
+            self.cmdclass["bdist_wheel"] = ModinWheel
 
     def is_pure(self):
         return False

--- a/setup.py
+++ b/setup.py
@@ -1,18 +1,61 @@
 from setuptools import setup, find_packages
 import versioneer
+import os
+from setuptools.dist import Distribution
+try:
+    from wheel.bdist_wheel import bdist_wheel
+    HAS_WHEEL = True
+except ImportError:
+    HAS_WHEEL = False
 
 with open("README.md", "r") as fh:
     long_description = fh.read()
 
+if HAS_WHEEL:
+    class ModinWheel(bdist_wheel):
+        def finalize_options(self):
+            bdist_wheel.finalize_options(self)
+            self.root_is_pure = False
+
+        def get_tag(self):
+            _, _, plat = bdist_wheel.get_tag(self)
+            py = "py3"
+            abi = "none"
+            return py, abi, plat
+else:
+    class ModinWheel(bdist_wheel):
+        pass
+
+
+class ModinDistribution(Distribution):
+
+    def __init__(self, *attrs):
+        Distribution.__init__(self, *attrs)
+        if HAS_WHEEL:
+            self.cmdclass['bdist_wheel'] = ModinWheel
+
+    def is_pure(self):
+        return False
+
+
 dask_deps = ["dask>=2.1.0", "distributed>=2.3.2"]
 ray_deps = ["ray==0.8.3"]
+if "SETUP_PLAT_NAME" in os.environ:
+    if "win" in os.environ["SETUP_PLAT_NAME"]:
+        all_deps = dask_deps
+    else:
+        all_deps = dask_deps + ray_deps
+else:
+    all_deps = dask_deps if os.name == "nt" else dask_deps + ray_deps
 
 setup(
     name="modin",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
+    distclass=ModinDistribution,
     description="Modin: Make your pandas code run faster by changing one line of code.",
     packages=find_packages(),
+    license="Apache 2",
     url="https://github.com/modin-project/modin",
     long_description=long_description,
     long_description_content_type="text/markdown",
@@ -21,7 +64,7 @@ setup(
         # can be installed by pip install modin[dask]
         "dask": dask_deps,
         "ray": ray_deps,
-        "all": dask_deps + ray_deps,
+        "all": all_deps,
     },
     python_requires=">=3.5",
 )


### PR DESCRIPTION
* Resolves #1123
* Adds logic in setup.py to handle different operating systems and
  ensure that we upload wheels with proper targets for the operating
  system being used.
* Add documentation for release on how to handle the upload of these
  wheels.
* Include logic to handle the developer case where they would like to
  install with `modin[all]` on Windows without building a wheel for
  upload.

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1123 <!-- issue must be created for each patch -->
- [ ] tests added and passing
