### PR TITLE
Make DataFrame and Series behavior match pandas

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -227,6 +227,11 @@ class _LocIndexer(_LocationIndexerBase):
                 return self.df.iloc[:, slice(*result_slice)]
 
         row_lookup, col_lookup = self._compute_lookup(row_loc, col_loc)
+        if any(i == -1 for i in row_lookup) or any(i == -1 for i in col_lookup):
+            raise KeyError(
+                "Passing list-likes to .loc or [] with any missing labels is no longer "
+                "supported, see https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"
+            )
         result = super(_LocIndexer, self).__getitem__(row_lookup, col_lookup, ndim)
         # Pandas drops the levels that are in the `loc`, so we have to as well.
         if hasattr(result, "index") and isinstance(result.index, pandas.MultiIndex):

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -968,6 +968,30 @@ def test_compress(data):
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_constructor(data):
+    modin_series, pandas_series = create_test_series(data)
+    df_equals(modin_series, pandas_series)
+    df_equals(pd.Series(modin_series), pandas.Series(pandas_series))
+
+
+def test_constructor_columns_and_index():
+    modin_series = pd.Series([1, 1, 10], index=[1, 2, 3], name="health")
+    pandas_series = pandas.Series([1, 1, 10], index=[1, 2, 3], name="health")
+    df_equals(modin_series, pandas_series)
+    df_equals(pd.Series(modin_series), pandas.Series(pandas_series))
+    df_equals(
+        pd.Series(modin_series, name="max_speed"),
+        pandas.Series(pandas_series, name="max_speed"),
+    )
+    df_equals(
+        pd.Series(modin_series, index=[1, 2]),
+        pandas.Series(pandas_series, index=[1, 2]),
+    )
+    with pytest.raises(NotImplementedError):
+        pd.Series(modin_series, index=[1, 2, 99999])
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_copy(data):
     modin_series, pandas_series = create_test_series(data)
     df_equals(modin_series, modin_series.copy())


### PR DESCRIPTION
* Resolves #1166
* Resolves #1167
* Resolves #1374
* Handle case where DataFrame is passed index and columns with a Modin
  DataFrame object
* Handle case where Series is passed index and name with a Modin Series
* Add error checking for `loc`, which we use to subset the values.
* Add tests

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1166 <!-- issue must be created for each patch -->
- [x] tests added and passing
