### PR TITLE
Fix parquet file reading when file was written with pandas Index

### DIFF
--- a/modin/engines/base/io/column_stores/column_store_reader.py
+++ b/modin/engines/base/io/column_stores/column_store_reader.py
@@ -60,7 +60,11 @@ class ColumnStoreReader(FileReader):
         from modin.pandas import DEFAULT_NPARTITIONS
 
         index_len = cls.materialize(partition_ids[-2][0])
-        index = pandas.RangeIndex(index_len)
+        if isinstance(index_len, int):
+            index = pandas.RangeIndex(index_len)
+        else:
+            index = index_len
+            index_len = len(index)
         index_chunksize = compute_chunksize(
             pandas.DataFrame(index=index), DEFAULT_NPARTITIONS, axis=0
         )

--- a/modin/engines/base/io/column_stores/parquet_reader.py
+++ b/modin/engines/base/io/column_stores/parquet_reader.py
@@ -66,7 +66,18 @@ class ParquetReader(ColumnStoreReader):
                 pd = ParquetDataset(path)
                 column_names = pd.schema.names
             else:
-                pf = ParquetFile(path)
-                column_names = pf.metadata.schema.names
+                meta = ParquetFile(path).metadata
+                column_names = meta.schema.names
+                # This is how we convert the metadata from pyarrow to a python
+                # dictionary, from which we then get the index columns.
+                # We use these to filter out from the columns in the metadata since
+                # the pyarrow storage has no concept of row labels/index.
+                # This ensures that our metadata lines up with the partitions without
+                # extra communication steps once we `have done all the remote
+                # computation.
+                index_columns = eval(
+                    meta.metadata[b"pandas"].replace(b"null", b"None")
+                ).get("index_columns", [])
+                column_names = [c for c in column_names if c not in index_columns]
             columns = [name for name in column_names if not PQ_INDEX_REGEX.match(name)]
         return cls.build_query_compiler(path, columns, **kwargs)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -442,14 +442,6 @@ def test_from_parquet_pandas_index():
     # read the same parquet using modin.pandas
     df_equals(pd.read_parquet("tmp.parquet"), pandas.read_parquet("tmp.parquet"))
 
-    pandas_df = pandas.DataFrame(
-        {
-            "idx": np.random.randint(0, 100_000, size=2000),
-            "A": np.random.randint(0, 100_000, size=2000),
-            "B": ["a", "b"] * 1000,
-            "C": ["c"] * 2000,
-        }
-    )
     pandas_df.set_index(["idx", "A"]).to_parquet("tmp.parquet")
     df_equals(pd.read_parquet("tmp.parquet"), pandas.read_parquet("tmp.parquet"))
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -428,6 +428,32 @@ def test_from_parquet_partitioned_columns_with_columns(make_parquet_file):
     df_equals(modin_df, pandas_df)
 
 
+def test_from_parquet_pandas_index():
+    # Ensure modin can read parquet files written by pandas with a non-RangeIndex object
+    pandas_df = pandas.DataFrame(
+        {
+            "idx": np.random.randint(0, 100_000, size=2000),
+            "A": np.random.randint(0, 100_000, size=2000),
+            "B": ["a", "b"] * 1000,
+            "C": ["c"] * 2000,
+        }
+    )
+    pandas_df.set_index("idx").to_parquet("tmp.parquet")
+    # read the same parquet using modin.pandas
+    df_equals(pd.read_parquet("tmp.parquet"), pandas.read_parquet("tmp.parquet"))
+
+    pandas_df = pandas.DataFrame(
+        {
+            "idx": np.random.randint(0, 100_000, size=2000),
+            "A": np.random.randint(0, 100_000, size=2000),
+            "B": ["a", "b"] * 1000,
+            "C": ["c"] * 2000,
+        }
+    )
+    pandas_df.set_index(["idx", "A"]).to_parquet("tmp.parquet")
+    df_equals(pd.read_parquet("tmp.parquet"), pandas.read_parquet("tmp.parquet"))
+
+
 def test_from_parquet_hdfs():
     path = "modin/pandas/test/data/hdfs.parquet"
     pandas_df = pandas.read_parquet(path)


### PR DESCRIPTION
* Resolves #1366
* Add a check for the Index columns from the pandas metadata maintained
  by parquet.
* Do not assign work for the columns that are actually pandas Index
  objects.
* Add tests for this behavior.

Also test for MultiIndex object

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1366 <!-- issue must be created for each patch -->
- [x] tests added and passing
