### PR TITLE
Fix cases where `read_json` should fall back to pandas

### DIFF
--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -18,24 +18,6 @@ import pandas
 import sys
 
 
-def pathlib_or_pypath(filepath_or_buffer):
-    try:
-        import py
-
-        if isinstance(filepath_or_buffer, py.path.local):
-            return True
-    except ImportError:  # pragma: no cover
-        pass
-    try:
-        import pathlib
-
-        if isinstance(filepath_or_buffer, pathlib.Path):
-            return True
-    except ImportError:  # pragma: no cover
-        pass
-    return False
-
-
 class CSVReader(TextFileReader):
     @classmethod
     def read(cls, filepath_or_buffer, **kwargs):
@@ -43,7 +25,7 @@ class CSVReader(TextFileReader):
             if not cls.file_exists(filepath_or_buffer):
                 return cls.single_worker_read(filepath_or_buffer, **kwargs)
             filepath_or_buffer = cls.get_path(filepath_or_buffer)
-        elif not pathlib_or_pypath(filepath_or_buffer):
+        elif not cls.pathlib_or_pypath(filepath_or_buffer):
             return cls.single_worker_read(filepath_or_buffer, **kwargs)
         compression_type = cls.infer_compression(
             filepath_or_buffer, kwargs.get("compression")

--- a/modin/engines/base/io/text/json_reader.py
+++ b/modin/engines/base/io/text/json_reader.py
@@ -21,7 +21,12 @@ import numpy as np
 class JSONReader(TextFileReader):
     @classmethod
     def read(cls, path_or_buf, **kwargs):
-        path_or_buf = cls.get_path(path_or_buf)
+        if isinstance(path_or_buf, str):
+            if not cls.file_exists(path_or_buf):
+                return cls.single_worker_read(path_or_buf, **kwargs)
+            path_or_buf = cls.get_path(path_or_buf)
+        elif not cls.pathlib_or_pypath(path_or_buf):
+            return cls.single_worker_read(path_or_buf, **kwargs)
         if not kwargs.get("lines", False):
             return cls.single_worker_read(path_or_buf, **kwargs)
         columns = pandas.read_json(

--- a/modin/engines/base/io/text/text_file_reader.py
+++ b/modin/engines/base/io/text/text_file_reader.py
@@ -52,3 +52,21 @@ class TextFileReader(FileReader):
                 for i in range(len(partition_ids))
             ]
         )
+
+    @classmethod
+    def pathlib_or_pypath(cls, filepath_or_buffer):
+        try:
+            import py
+
+            if isinstance(filepath_or_buffer, py.path.local):
+                return True
+        except ImportError:  # pragma: no cover
+            pass
+        try:
+            import pathlib
+
+            if isinstance(filepath_or_buffer, pathlib.Path):
+                return True
+        except ImportError:  # pragma: no cover
+            pass
+        return False

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -22,6 +22,7 @@ import pyarrow.parquet as pq
 import os
 import shutil
 import sqlalchemy as sa
+from io import BytesIO
 
 from .utils import df_equals
 
@@ -454,6 +455,104 @@ def test_from_json_lines():
     assert modin_df_equals_pandas(modin_df, pandas_df)
 
     teardown_json_file()
+
+
+def test_from_json_string():
+    json_string = """[{"project": "modin"}]"""
+    with pytest.warns(UserWarning):
+        modin_df = pd.read_json(json_string)
+    df_equals(modin_df, pandas.read_json(json_string))
+
+    json_string = """{
+        "quiz": {
+            "sport": {
+                "q1": {
+                    "question": "Which one is correct team name in NBA?",
+                    "options": [
+                        "New York Bulls",
+                        "Los Angeles Kings",
+                        "Golden State Warriros",
+                        "Huston Rocket"
+                    ],
+                    "answer": "Huston Rocket"
+                }
+            },
+            "maths": {
+                "q1": {
+                    "question": "5 + 7 = ?",
+                    "options": [
+                        "10",
+                        "11",
+                        "12",
+                        "13"
+                    ],
+                    "answer": "12"
+                },
+                "q2": {
+                    "question": "12 - 8 = ?",
+                    "options": [
+                        "1",
+                        "2",
+                        "3",
+                        "4"
+                    ],
+                    "answer": "4"
+                }
+            }
+        }
+    }"""
+    with pytest.warns(UserWarning):
+        modin_df = pd.read_json(json_string)
+    df_equals(modin_df, pandas.read_json(json_string))
+
+
+def test_from_json_bytesio():
+    json_bytes = b"""[{"project": "modin"}]"""
+    with pytest.warns(UserWarning):
+        modin_df = pd.read_json(BytesIO(json_bytes))
+    df_equals(modin_df, pandas.read_json(BytesIO(json_bytes)))
+
+    json_bytes = b"""{
+            "quiz": {
+                "sport": {
+                    "q1": {
+                        "question": "Which one is correct team name in NBA?",
+                        "options": [
+                            "New York Bulls",
+                            "Los Angeles Kings",
+                            "Golden State Warriros",
+                            "Huston Rocket"
+                        ],
+                        "answer": "Huston Rocket"
+                    }
+                },
+                "maths": {
+                    "q1": {
+                        "question": "5 + 7 = ?",
+                        "options": [
+                            "10",
+                            "11",
+                            "12",
+                            "13"
+                        ],
+                        "answer": "12"
+                    },
+                    "q2": {
+                        "question": "12 - 8 = ?",
+                        "options": [
+                            "1",
+                            "2",
+                            "3",
+                            "4"
+                        ],
+                        "answer": "4"
+                    }
+                }
+            }
+        }"""
+    with pytest.warns(UserWarning):
+        modin_df = pd.read_json(BytesIO(json_bytes))
+    df_equals(modin_df, pandas.read_json(BytesIO(json_bytes)))
 
 
 def test_from_html():

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -16,6 +16,7 @@ import pandas
 from pandas.util.testing import assert_almost_equal, assert_frame_equal
 import modin.pandas as pd
 from modin.pandas.utils import to_pandas
+from io import BytesIO
 
 random_state = np.random.RandomState(seed=42)
 
@@ -299,6 +300,48 @@ int_arg_keys = list(int_arg.keys())
 int_arg_values = list(int_arg.values())
 
 # END parametrizations of common kwargs
+
+json_short_string = """[{"project": "modin"}]"""
+json_long_string = """{
+        "quiz": {
+            "sport": {
+                "q1": {
+                    "question": "Which one is correct team name in NBA?",
+                    "options": [
+                        "New York Bulls",
+                        "Los Angeles Kings",
+                        "Golden State Warriros",
+                        "Huston Rocket"
+                    ],
+                    "answer": "Huston Rocket"
+                }
+            },
+            "maths": {
+                "q1": {
+                    "question": "5 + 7 = ?",
+                    "options": [
+                        "10",
+                        "11",
+                        "12",
+                        "13"
+                    ],
+                    "answer": "12"
+                },
+                "q2": {
+                    "question": "12 - 8 = ?",
+                    "options": [
+                        "1",
+                        "2",
+                        "3",
+                        "4"
+                    ],
+                    "answer": "4"
+                }
+            }
+        }
+    }"""
+json_long_bytes = BytesIO(json_long_string.encode(encoding="UTF-8"))
+json_short_bytes = BytesIO(json_short_string.encode(encoding="UTF-8"))
 
 
 def df_equals(df1, df2):


### PR DESCRIPTION
* Resolves #1379
* Adds cases for when we are passed objects strings directly or if we
  are passed some IO object. For these cases we default to pandas.
* Add tests to verify behavior

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1379 <!-- issue must be created for each patch -->
- [x] tests added and passing
