### PR TITLE
[Ray] Turn on lru_evict=True to ensure plasma LRU eviction

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -195,6 +195,7 @@ def initialize_ray():
                 redis_password=redis_password,
                 logging_level=100,
                 memory=object_store_memory,
+                lru_evict=True,
             )
 
         # Register a fix import function to run on all_workers including the driver.


### PR DESCRIPTION
This PR turns on LRU eviction. This is a new flag added in recent ray version. By default ray will crash when all the memory is used up while there are references to all the objects. When this flag is turned on, Ray will LRU evict objects with references.

Signed-off-by: simon-mo <xmo@berkeley.edu>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
