### PR TITLE
Add docker images to run TeamCity CI tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ df = pd.DataFrame(frame_data)
 To use Modin, you do not need to know how many cores your system has and you do not need
 to  specify how to distribute the data. In fact, you can continue using your previous
 pandas notebooks while experiencing a considerable speedup from Modin, even on a single
-machine. Once you’ve changed your import statement, you’re ready to use Modin just like
+machine. Once you've changed your import statement, you're ready to use Modin just like
 you would pandas.
 
 

--- a/ci/teamcity/Dockerfile
+++ b/ci/teamcity/Dockerfile
@@ -1,0 +1,13 @@
+ARG BASE_IMAGE=ray-project/deploy
+
+FROM ${BASE_IMAGE}
+
+ARG REQUIREMENTS=requirements.txt
+
+ADD modin.tar /modin
+ADD git-rev /modin/git-rev
+WORKDIR /modin
+RUN pip install -U pip setuptools
+RUN pip install -U -r ${REQUIREMENTS}
+RUN pip install -U pytest-remotedata
+RUN pip install -e .[all]

--- a/ci/teamcity/Dockerfile.modin-base
+++ b/ci/teamcity/Dockerfile.modin-base
@@ -1,0 +1,5 @@
+ARG BASE_IMAGE=ray-project/deploy
+
+FROM ${BASE_IMAGE}
+RUN conda update python -y
+

--- a/ci/teamcity/Dockerfile.teamcity-ci
+++ b/ci/teamcity/Dockerfile.teamcity-ci
@@ -1,6 +1,4 @@
-ARG BASE_IMAGE=ray-project/deploy
-
-FROM ${BASE_IMAGE}
+FROM modin-project/modin-base
 
 ARG REQUIREMENTS=requirements.txt
 

--- a/ci/teamcity/build-docker.py
+++ b/ci/teamcity/build-docker.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+
+def execute_command(cmd):
+    status = os.system(cmd)
+    ec = os.WEXITSTATUS(status)
+    if ec != 0:
+        raise SystemExit('Command "{}" failed'.format(cmd))
+
+
+if sys.platform.startswith("linux"):
+    execute_command("git rev-parse HEAD > git-rev")
+    execute_command(
+        "(cd ../.. && git archive -o ci/teamcity/modin.tar $(cat ci/teamcity/git-rev))"
+    )
+    base_image = "ray-project/deploy"
+    requirements = "requirements.txt"
+else:
+    raise SystemExit(
+        "TeamCity CI in Docker containers is supported only on Linux at the moment."
+    )
+
+execute_command(
+    "docker build --build-arg BASE_IMAGE={} --build-arg REQUIREMENTS={} -t modin-project/teamcity-ci .".format(
+        base_image, requirements
+    )
+)
+execute_command("rm ./modin.tar ./git-rev")

--- a/ci/teamcity/build-docker.py
+++ b/ci/teamcity/build-docker.py
@@ -16,14 +16,21 @@ if sys.platform.startswith("linux"):
     )
     base_image = "ray-project/deploy"
     requirements = "requirements.txt"
+    execute_command(
+        "docker build -f Dockerfile.modin-base --build-arg BASE_IMAGE={} -t modin-project/modin-base .".format(
+            base_image
+        )
+    )
 else:
     raise SystemExit(
         "TeamCity CI in Docker containers is supported only on Linux at the moment."
     )
 
 execute_command(
-    "docker build --build-arg BASE_IMAGE={} --build-arg REQUIREMENTS={} -t modin-project/teamcity-ci .".format(
-        base_image, requirements
+    "docker build -f Dockerfile.teamcity-ci --build-arg REQUIREMENTS={} -t modin-project/teamcity-ci .".format(
+        requirements
     )
 )
-execute_command("rm ./modin.tar ./git-rev")
+
+if sys.platform.startswith("linux"):
+    execute_command("rm ./modin.tar ./git-rev")


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

When these images are in master branch, we'll be able to switch TeamCity to run all tests in docker containers.

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1433 <!-- issue must be created for each patch -->
- [x] tests added and passing
