### PR TITLE
Changes in column are propagated to dataframe if column belongs to one

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -323,6 +323,9 @@ class Series(BasePandasDataset):
         self._create_or_update_from_compiler(
             self._query_compiler.setitem(1, key, value), inplace=True
         )
+        # Propagate changes back to parent so that column in dataframe had the same contents
+        if self._parent is not None:
+            self._parent[self.name] = self
 
     def __sub__(self, right):
         return self.sub(right)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5111,6 +5111,11 @@ class TestDataFrameIndexing:
 
         df_equals(modin_df, pandas_df)
 
+        modin_df[modin_df.columns[0]][modin_df.index[0]] = 12345
+        pandas_df[pandas_df.columns[0]][pandas_df.index[0]] = 12345
+
+        df_equals(modin_df, pandas_df)
+
     def test_setitem_on_empty_df(self):
         columns = ["id", "max_speed", "health"]
         modin_df = pd.DataFrame(columns=columns)


### PR DESCRIPTION
Fixed bug #1429.

Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1429 <!-- issue must be created for each patch -->
- [x] tests added and passing
