### PR TITLE
Add implementation of read_fwf

### DIFF
--- a/modin/backends/pandas/parsers.py
+++ b/modin/backends/pandas/parsers.py
@@ -120,18 +120,26 @@ class PandasFWFParser(PandasParser):
         num_splits = kwargs.pop("num_splits", None)
         start = kwargs.pop("start", None)
         end = kwargs.pop("end", None)
+        index_col = kwargs.get("index_col", None)
         if start is not None and end is not None:
             # pop "compression" from kwargs because bio is uncompressed
-            bio = FileReader.file_open(fname, "rb", "infer")
+            bio = FileReader.file_open(fname, "rb", kwargs.pop("compression", "infer"))
+            if kwargs.get("encoding", None) is not None:
+                header = b"" + bio.readline()
+            else:
+                header = b""
             bio.seek(start)
-            to_read = b"" + bio.read(end - start)
+            to_read = header + bio.read(end - start)
             bio.close()
             pandas_df = pandas.read_fwf(BytesIO(to_read), **kwargs)
         else:
             # This only happens when we are reading with only one worker (Default)
             return pandas.read_fwf(fname, **kwargs)
-        # The lengths will become the RangeIndex
-        index = len(pandas_df)
+        if index_col is not None:
+            index = pandas_df.index
+        else:
+            # The lengths will become the RangeIndex
+            index = len(pandas_df)
         return _split_result_for_readers(1, num_splits, pandas_df) + [
             index,
             pandas_df.dtypes,

--- a/modin/backends/pandas/parsers.py
+++ b/modin/backends/pandas/parsers.py
@@ -120,26 +120,18 @@ class PandasFWFParser(PandasParser):
         num_splits = kwargs.pop("num_splits", None)
         start = kwargs.pop("start", None)
         end = kwargs.pop("end", None)
-        index_col = kwargs.get("index_col", None)
         if start is not None and end is not None:
             # pop "compression" from kwargs because bio is uncompressed
-            bio = FileReader.file_open(fname, "rb", kwargs.pop("compression", "infer"))
-            if kwargs.get("encoding", None) is not None:
-                header = b"" + bio.readline()
-            else:
-                header = b""
+            bio = FileReader.file_open(fname, "rb", "infer")
             bio.seek(start)
-            to_read = header + bio.read(end - start)
+            to_read = b"" + bio.read(end - start)
             bio.close()
             pandas_df = pandas.read_fwf(BytesIO(to_read), **kwargs)
         else:
             # This only happens when we are reading with only one worker (Default)
             return pandas.read_fwf(fname, **kwargs)
-        if index_col is not None:
-            index = pandas_df.index
-        else:
-            # The lengths will become the RangeIndex
-            index = len(pandas_df)
+        # The lengths will become the RangeIndex
+        index = len(pandas_df)
         return _split_result_for_readers(1, num_splits, pandas_df) + [
             index,
             pandas_df.dtypes,

--- a/modin/engines/base/io/__init__.py
+++ b/modin/engines/base/io/__init__.py
@@ -13,6 +13,7 @@
 
 from modin.engines.base.io.io import BaseIO
 from modin.engines.base.io.text.csv_reader import CSVReader
+from modin.engines.base.io.text.fwf_reader import FWFReader
 from modin.engines.base.io.text.json_reader import JSONReader
 from modin.engines.base.io.file_reader import FileReader
 from modin.engines.base.io.text.text_file_reader import TextFileReader
@@ -24,6 +25,7 @@ from modin.engines.base.io.sql.sql_reader import SQLReader
 __all__ = [
     "BaseIO",
     "CSVReader",
+    "FWFReader",
     "JSONReader",
     "FileReader",
     "TextFileReader",

--- a/modin/engines/base/io/text/fwf_reader.py
+++ b/modin/engines/base/io/text/fwf_reader.py
@@ -51,6 +51,12 @@ class FWFReader(TextFileReader):
         if chunksize is not None:
             return cls.single_worker_read(filepath_or_buffer, **kwargs)
 
+        # If infer_nrows is a significant portion of the number of rows, pandas may be
+        # faster.
+        infer_nrows = kwargs.get("infer_nrows", 100)
+        if infer_nrows > 100:
+            return cls.single_worker_read(filepath_or_buffer, **kwargs)
+
         skiprows = kwargs.get("skiprows")
         if skiprows is not None and not isinstance(skiprows, int):
             return cls.single_worker_read(filepath_or_buffer, **kwargs)

--- a/modin/engines/base/io/text/fwf_reader.py
+++ b/modin/engines/base/io/text/fwf_reader.py
@@ -1,0 +1,225 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+from modin.engines.base.io.text.text_file_reader import TextFileReader
+from modin.data_management.utils import compute_chunksize
+from pandas.io.parsers import _validate_usecols_arg
+import pandas
+import sys
+
+
+class FWFReader(TextFileReader):
+    @classmethod
+    def read(cls, filepath_or_buffer, **kwargs):
+        if isinstance(filepath_or_buffer, str):
+            if not cls.file_exists(filepath_or_buffer):
+                return cls.single_worker_read(filepath_or_buffer, **kwargs)
+            filepath_or_buffer = cls.get_path(filepath_or_buffer)
+        elif not cls.pathlib_or_pypath(filepath_or_buffer):
+            return cls.single_worker_read(filepath_or_buffer, **kwargs)
+        compression_type = cls.infer_compression(
+            filepath_or_buffer, kwargs.get("compression")
+        )
+        if compression_type is not None:
+            if (
+                compression_type == "gzip"
+                or compression_type == "bz2"
+                or compression_type == "xz"
+            ):
+                kwargs["compression"] = compression_type
+            elif (
+                compression_type == "zip"
+                and sys.version_info[0] == 3
+                and sys.version_info[1] >= 7
+            ):
+                # need python3.7 to .seek and .tell ZipExtFile
+                kwargs["compression"] = compression_type
+            else:
+                return cls.single_worker_read(filepath_or_buffer, **kwargs)
+
+        chunksize = kwargs.get("chunksize")
+        if chunksize is not None:
+            return cls.single_worker_read(filepath_or_buffer, **kwargs)
+
+        skiprows = kwargs.get("skiprows")
+        if skiprows is not None and not isinstance(skiprows, int):
+            return cls.single_worker_read(filepath_or_buffer, **kwargs)
+        # TODO: replace this by reading lines from file.
+        if kwargs.get("nrows") is not None:
+            return cls.single_worker_read(filepath_or_buffer, **kwargs)
+        names = kwargs.get("names", None)
+        index_col = kwargs.get("index_col", None)
+        if names is None:
+            # For the sake of the empty df, we assume no `index_col` to get the correct
+            # column names before we build the index. Because we pass `names` in, this
+            # step has to happen without removing the `index_col` otherwise it will not
+            # be assigned correctly
+            names = pandas.read_fwf(
+                filepath_or_buffer,
+                **dict(kwargs, usecols=None, nrows=0, skipfooter=0, index_col=None)
+            ).columns
+        empty_pd_df = pandas.read_fwf(
+            filepath_or_buffer, **dict(kwargs, nrows=0, skipfooter=0)
+        )
+        column_names = empty_pd_df.columns
+        skipfooter = kwargs.get("skipfooter", None)
+        skiprows = kwargs.pop("skiprows", None)
+        usecols = kwargs.get("usecols", None)
+        usecols_md = _validate_usecols_arg(usecols)
+        if usecols is not None and usecols_md[1] != "integer":
+            del kwargs["usecols"]
+            all_cols = pandas.read_fwf(
+                cls.file_open(filepath_or_buffer, "rb"),
+                **dict(kwargs, nrows=0, skipfooter=0)
+            ).columns
+            usecols = all_cols.get_indexer_for(list(usecols_md[0]))
+        parse_dates = kwargs.pop("parse_dates", False)
+        partition_kwargs = dict(
+            kwargs,
+            header=None,
+            names=names,
+            skipfooter=0,
+            skiprows=None,
+            parse_dates=parse_dates,
+            usecols=usecols,
+        )
+        encoding = kwargs.get("encoding", None)
+        quotechar = kwargs.get("quotechar", '"').encode(
+            encoding if encoding is not None else "UTF-8"
+        )
+        with cls.file_open(filepath_or_buffer, "rb", compression_type) as f:
+            # Skip the header since we already have the header information and skip the
+            # rows we are told to skip.
+            if isinstance(skiprows, int) or skiprows is None:
+                if skiprows is None:
+                    skiprows = 0
+                header = kwargs.get("header", "infer")
+                if header == "infer" and kwargs.get("names", None) is None:
+                    skiprows += 1
+                elif isinstance(header, int):
+                    skiprows += header + 1
+                elif hasattr(header, "__iter__") and not isinstance(header, str):
+                    skiprows += max(header) + 1
+                for _ in range(skiprows):
+                    f.readline()
+            if kwargs.get("encoding", None) is not None:
+                partition_kwargs["skiprows"] = 1
+            # Launch tasks to read partitions
+            partition_ids = []
+            index_ids = []
+            dtypes_ids = []
+            total_bytes = cls.file_size(f)
+            # Max number of partitions available
+            from modin.pandas import DEFAULT_NPARTITIONS
+
+            num_partitions = DEFAULT_NPARTITIONS
+            # This is the number of splits for the columns
+            num_splits = min(len(column_names), num_partitions)
+            # This is the chunksize each partition will read
+            chunk_size = max(1, (total_bytes - f.tell()) // num_partitions)
+
+            # Metadata
+            column_chunksize = compute_chunksize(empty_pd_df, num_splits, axis=1)
+            if column_chunksize > len(column_names):
+                column_widths = [len(column_names)]
+                # This prevents us from unnecessarily serializing a bunch of empty
+                # objects.
+                num_splits = 1
+            else:
+                column_widths = [
+                    column_chunksize
+                    if len(column_names) > (column_chunksize * (i + 1))
+                    else 0
+                    if len(column_names) < (column_chunksize * i)
+                    else len(column_names) - (column_chunksize * i)
+                    for i in range(num_splits)
+                ]
+
+            while f.tell() < total_bytes:
+                args = {
+                    "fname": filepath_or_buffer,
+                    "num_splits": num_splits,
+                    **partition_kwargs,
+                }
+                partition_id = cls.call_deploy(
+                    f, chunk_size, num_splits + 2, args, quotechar=quotechar
+                )
+                partition_ids.append(partition_id[:-2])
+                index_ids.append(partition_id[-2])
+                dtypes_ids.append(partition_id[-1])
+
+        # Compute the index based on a sum of the lengths of each partition (by default)
+        # or based on the column(s) that were requested.
+        if index_col is None:
+            row_lengths = cls.materialize(index_ids)
+            new_index = pandas.RangeIndex(sum(row_lengths))
+            # pandas has a really weird edge case here.
+            if kwargs.get("names", None) is not None and skiprows > 1:
+                new_index = pandas.RangeIndex(
+                    skiprows - 1, new_index.stop + skiprows - 1
+                )
+        else:
+            index_objs = cls.materialize(index_ids)
+            row_lengths = [len(o) for o in index_objs]
+            new_index = index_objs[0].append(index_objs[1:])
+            new_index.name = empty_pd_df.index.name
+
+        # Compute dtypes by getting collecting and combining all of the partitions. The
+        # reported dtypes from differing rows can be different based on the inference in
+        # the limited data seen by each worker. We use pandas to compute the exact dtype
+        # over the whole column for each column. The index is set below.
+        dtypes = cls.get_dtypes(dtypes_ids)
+
+        partition_ids = cls.build_partition(partition_ids, row_lengths, column_widths)
+        # If parse_dates is present, the column names that we have might not be
+        # the same length as the returned column names. If we do need to modify
+        # the column names, we remove the old names from the column names and
+        # insert the new one at the front of the Index.
+        if parse_dates is not None:
+            # We have to recompute the column widths if `parse_dates` is set because
+            # we are not guaranteed to have the correct information regarding how many
+            # columns are on each partition.
+            column_widths = None
+            # Check if is list of lists
+            if isinstance(parse_dates, list) and isinstance(parse_dates[0], list):
+                for group in parse_dates:
+                    new_col_name = "_".join(group)
+                    column_names = column_names.drop(group).insert(0, new_col_name)
+            # Check if it is a dictionary
+            elif isinstance(parse_dates, dict):
+                for new_col_name, group in parse_dates.items():
+                    column_names = column_names.drop(group).insert(0, new_col_name)
+        # Set the index for the dtypes to the column names
+        if isinstance(dtypes, pandas.Series):
+            dtypes.index = column_names
+        else:
+            dtypes = pandas.Series(dtypes, index=column_names)
+        new_frame = cls.frame_cls(
+            partition_ids,
+            new_index,
+            column_names,
+            row_lengths,
+            column_widths,
+            dtypes=dtypes,
+        )
+        new_query_compiler = cls.query_compiler_cls(new_frame)
+
+        if skipfooter:
+            new_query_compiler = new_query_compiler.drop(
+                new_query_compiler.index[-skipfooter:]
+            )
+        if kwargs.get("squeeze", False) and len(new_query_compiler.columns) == 1:
+            return new_query_compiler[new_query_compiler.columns[0]]
+        if index_col is None:
+            new_query_compiler._modin_frame._apply_index_objs(axis=0)
+        return new_query_compiler

--- a/modin/engines/base/io/text/fwf_reader.py
+++ b/modin/engines/base/io/text/fwf_reader.py
@@ -28,7 +28,7 @@ class FWFReader(TextFileReader):
         elif not cls.pathlib_or_pypath(filepath_or_buffer):
             return cls.single_worker_read(filepath_or_buffer, **kwargs)
         compression_type = cls.infer_compression(
-            filepath_or_buffer, kwargs.get("compression")
+            filepath_or_buffer, kwargs.get("compression", "infer")
         )
         if compression_type is not None:
             if (

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -15,6 +15,7 @@ from modin.backends.pandas.query_compiler import PandasQueryCompiler
 from modin.engines.ray.generic.io import RayIO
 from modin.engines.base.io import (
     CSVReader,
+    FWFReader,
     JSONReader,
     ParquetReader,
     FeatherReader,
@@ -22,6 +23,7 @@ from modin.engines.base.io import (
 )
 from modin.backends.pandas.parsers import (
     PandasCSVParser,
+    PandasFWFParser,
     PandasJSONParser,
     PandasParquetParser,
     PandasFeatherParser,
@@ -42,6 +44,7 @@ class PandasOnRayIO(RayIO):
         frame_cls=PandasOnRayFrame,
     )
     read_csv = type("", (RayTask, PandasCSVParser, CSVReader), build_args).read
+    read_fwf = type("", (RayTask, PandasFWFParser, FWFReader), build_args).read
     read_json = type("", (RayTask, PandasJSONParser, JSONReader), build_args).read
     read_parquet = type(
         "", (RayTask, PandasParquetParser, ParquetReader), build_args

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -394,7 +394,15 @@ def read_fwf(
 
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwds", {}))
-    return DataFrame(query_compiler=BaseFactory.read_fwf(**kwargs))
+    pd_obj = BaseFactory.read_fwf(**kwargs)
+    # When `read_fwf` returns a TextFileReader object for iterating through
+    if isinstance(pd_obj, pandas.io.parsers.TextFileReader):
+        reader = pd_obj.read
+        pd_obj.read = lambda *args, **kwargs: DataFrame(
+            query_compiler=reader(*args, **kwargs)
+        )
+        return pd_obj
+    return DataFrame(query_compiler=pd_obj)
 
 
 def read_sql_table(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -359,15 +359,31 @@ def make_sql_connection():
             os.remove(filename)
 
 
-def setup_fwf_file():
-    if os.path.exists(TEST_FWF_FILENAME):
+def setup_fwf_file(overwrite=False, fwf_data=None):
+    if not overwrite and os.path.exists(TEST_FWF_FILENAME):
         return
 
-    fwf_data = """id8141    360.242940  149.910199  11950.7
-    id1594  444.953632  166.985655 11788.4
-    id1849  364.136849  183.628767 11806.2
-    id1230  413.836124  184.375703 11916.8
-    id1948  502.953953  173.237159 12468.3"""
+    if fwf_data is None:
+        fwf_data = """ACW000116041961TAVG -142  k  183  k  419  k  720  k 1075  k 1546  k 1517  k 1428  k 1360  k 1121  k  457  k  -92  k
+ACW000116041962TAVG   60  k   32  k -207  k  582  k  855  k 1328  k 1457  k 1340  k 1110  k  941  k  270  k -179  k
+ACW000116041963TAVG -766  k -606  k -152  k  488  k 1171  k 1574  k 1567  k 1543  k 1279  k  887  k  513  k -161  k
+ACW000116041964TAVG    9  k -138  k    2  k  685  k 1166  k 1389  k 1453  k 1504  k 1168  k  735  k  493  k   59  k
+ACW000116041965TAVG   -9  k -158  k  -15  k  537  k  934  k 1447  k 1434  k 1424  k 1324  k  921  k  -22  k -231  k
+ACW000116041966TAVG -490  k -614  k  108  k  246  k 1082  k 1642  k 1620  k 1471  k 1195  k  803  k  329  k    2  k
+ACW000116041967TAVG -270  k   36  k  397  k  481  k 1052  k 1373  k 1655  k 1598  k 1318  k  997  k  559  k  -96  k
+ACW000116041968TAVG -306  k -183  k  220  k  714  k  935  k 1635  k 1572  k 1718  k 1331  k  781  k  180  k  -56  k
+ACW000116041969TAVG -134  k -494  k -185  k  497  k  962  k 1634  k 1687  k 1773  k 1379  k  932  k  321  k -275  k
+ACW000116041970TAVG -483  k -704  k  -75  k  261  k 1093  k 1724  k 1470  k 1609  k 1163  k  836  k  300  k   73  k
+ACW000116041971TAVG   -6  k   83  k  -40  k  472  k 1180  k 1411  k 1700  k 1600  k 1165  k  908  k  361  k  383  k
+ACW000116041972TAVG -377  k   -4  k  250  k  556  k 1117  k 1444  k 1778  k 1545  k 1073  k  797  k  481  k  404  k
+ACW000116041973TAVG   61  k  169  k  453  k  472  k 1075  k 1545  k 1866  k 1579  k 1199  k  563  k  154  k   11  k
+ACW000116041974TAVG  191  k  209  k  339  k  748  k 1094  k 1463  k 1498  k 1541  k 1319  k  585  k  428  k  335  k
+ACW000116041975TAVG  346  k   88  k  198  k  488  k 1165  k 1483  k 1756  k 1906  k 1374  k  845  k  406  k  387  k
+ACW000116041976TAVG -163  k  -62  k -135  k  502  k 1128  k 1461  k 1822  k 1759  k 1136  k  715  k  458  k -205  k
+ACW000116041977TAVG -192  k -279  k  234  k  332  k 1128  k 1566  k 1565  k 1556  k 1126  k  949  k  421  k  162  k
+ACW000116041978TAVG   55  k -354  k   66  k  493  k 1155  k 1552  k 1564  k 1555  k 1061  k  932  k  688  k -464  k
+ACW000116041979TAVG -618  k -632  k   35  k  474  k  993  k 1566  k 1484  k 1483  k 1229  k  647  k  412  k  -40  k
+ACW000116041980TAVG -340  k -500  k  -35  k  524  k 1071  k 1534  k 1655  k 1502  k 1269  k  660  k  138  k  125  k"""
 
     with open(TEST_FWF_FILENAME, "w") as f:
         f.write(fwf_data)
@@ -1311,7 +1327,13 @@ def test_ExcelFile():
 
 
 def test_fwf_file():
-    setup_fwf_file()
+    fwf_data = """id8141  360.242940  149.910199 11950.7
+id1594  444.953632  166.985655 11788.4
+id1849  364.136849  183.628767 11806.2
+id1230  413.836124  184.375703 11916.8
+id1948  502.953953  173.237159 12468.3"""
+
+    setup_fwf_file(True, fwf_data=fwf_data)
 
     colspecs = [(0, 6), (8, 20), (21, 33), (34, 43)]
     df = pd.read_fwf(TEST_FWF_FILENAME, colspecs=colspecs, header=None, index_col=0)
@@ -1320,63 +1342,137 @@ def test_fwf_file():
     teardown_fwf_file()
 
 
-def test_fwf_file_kwargs():
-    fwf_data = """ACW000116041961TAVG -142  k  183  k  419  k  720  k 1075  k 1546  k 1517  k 1428  k 1360  k 1121  k  457  k  -92  k
-ACW000116041962TAVG   60  k   32  k -207  k  582  k  855  k 1328  k 1457  k 1340  k 1110  k  941  k  270  k -179  k
-ACW000116041963TAVG -766  k -606  k -152  k  488  k 1171  k 1574  k 1567  k 1543  k 1279  k  887  k  513  k -161  k
-ACW000116041964TAVG    9  k -138  k    2  k  685  k 1166  k 1389  k 1453  k 1504  k 1168  k  735  k  493  k   59  k
-ACW000116041965TAVG   -9  k -158  k  -15  k  537  k  934  k 1447  k 1434  k 1424  k 1324  k  921  k  -22  k -231  k
-ACW000116041966TAVG -490  k -614  k  108  k  246  k 1082  k 1642  k 1620  k 1471  k 1195  k  803  k  329  k    2  k
-ACW000116041967TAVG -270  k   36  k  397  k  481  k 1052  k 1373  k 1655  k 1598  k 1318  k  997  k  559  k  -96  k
-ACW000116041968TAVG -306  k -183  k  220  k  714  k  935  k 1635  k 1572  k 1718  k 1331  k  781  k  180  k  -56  k
-ACW000116041969TAVG -134  k -494  k -185  k  497  k  962  k 1634  k 1687  k 1773  k 1379  k  932  k  321  k -275  k
-ACW000116041970TAVG -483  k -704  k  -75  k  261  k 1093  k 1724  k 1470  k 1609  k 1163  k  836  k  300  k   73  k
-ACW000116041971TAVG   -6  k   83  k  -40  k  472  k 1180  k 1411  k 1700  k 1600  k 1165  k  908  k  361  k  383  k
-ACW000116041972TAVG -377  k   -4  k  250  k  556  k 1117  k 1444  k 1778  k 1545  k 1073  k  797  k  481  k  404  k
-ACW000116041973TAVG   61  k  169  k  453  k  472  k 1075  k 1545  k 1866  k 1579  k 1199  k  563  k  154  k   11  k
-ACW000116041974TAVG  191  k  209  k  339  k  748  k 1094  k 1463  k 1498  k 1541  k 1319  k  585  k  428  k  335  k
-ACW000116041975TAVG  346  k   88  k  198  k  488  k 1165  k 1483  k 1756  k 1906  k 1374  k  845  k  406  k  387  k
-ACW000116041976TAVG -163  k  -62  k -135  k  502  k 1128  k 1461  k 1822  k 1759  k 1136  k  715  k  458  k -205  k
-ACW000116041977TAVG -192  k -279  k  234  k  332  k 1128  k 1566  k 1565  k 1556  k 1126  k  949  k  421  k  162  k
-ACW000116041978TAVG   55  k -354  k   66  k  493  k 1155  k 1552  k 1564  k 1555  k 1061  k  932  k  688  k -464  k
-ACW000116041979TAVG -618  k -632  k   35  k  474  k  993  k 1566  k 1484  k 1483  k 1229  k  647  k  412  k  -40  k
-ACW000116041980TAVG -340  k -500  k  -35  k  524  k 1071  k 1534  k 1655  k 1502  k 1269  k  660  k  138  k  125  k"""
-    with open(TEST_FWF_FILENAME, "w") as f:
-        f.write(fwf_data)
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {
+            "colspecs": [
+                (0, 11),
+                (11, 15),
+                (19, 24),
+                (27, 32),
+                (35, 40),
+                (43, 48),
+                (51, 56),
+                (59, 64),
+                (67, 72),
+                (75, 80),
+                (83, 88),
+                (91, 96),
+                (99, 104),
+                (107, 112),
+            ],
+            "names": ["stationID", "year", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            "na_values": ["-9999"],
+            "index_col": ["stationID", "year"],
+        },
+        {
+            "widths": [20, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8],
+            "names": ["id", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12],
+            "index_col": [0],
+        },
+    ],
+)
+def test_fwf_file_colspecs_widths(kwargs):
+    setup_fwf_file(overwrite=True)
 
-    column_specs = [
-        (0, 11),
-        (11, 15),
-        (19, 24),
-        (27, 32),
-        (35, 40),
-        (43, 48),
-        (51, 56),
-        (59, 64),
-        (67, 72),
-        (75, 80),
-        (83, 88),
-        (91, 96),
-        (99, 104),
-        (107, 112),
-    ]
-    column_names = ["stationID", "year", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
-    nan_values = ["-9999"]
-    modin_df = pd.read_fwf(
-        TEST_FWF_FILENAME,
-        colspecs=column_specs,
-        names=column_names,
-        na_values=nan_values,
-        index_col=["stationID", "year"],
-    )
-    pandas_df = pd.read_fwf(
-        TEST_FWF_FILENAME,
-        colspecs=column_specs,
-        names=column_names,
-        na_values=nan_values,
-        index_col=["stationID", "year"],
-    )
+    modin_df = pd.read_fwf(TEST_FWF_FILENAME, **kwargs)
+    pandas_df = pd.read_fwf(TEST_FWF_FILENAME, **kwargs)
 
+    df_equals(modin_df, pandas_df)
+
+
+@pytest.mark.parametrize("usecols", [["a"], ["a", "b", "d"], [0, 1, 3]])
+def test_fwf_file_usecols(usecols):
+    fwf_data = """a       b           c          d
+id8141  360.242940  149.910199 11950.7
+id1594  444.953632  166.985655 11788.4
+id1849  364.136849  183.628767 11806.2
+id1230  413.836124  184.375703 11916.8
+id1948  502.953953  173.237159 12468.3"""
+
+    setup_fwf_file(overwrite=True, fwf_data=fwf_data)
+
+    pandas_df = pandas.read_fwf(TEST_FWF_FILENAME, usecols=usecols)
+    modin_df = pd.read_fwf(TEST_FWF_FILENAME, usecols=usecols)
+
+    df_equals(modin_df, pandas_df)
+
+    teardown_fwf_file()
+
+
+@pytest.mark.skip(reason="Chunksize doesn't work with read_fwf yet")
+def test_fwf_file_chunksize():
+    setup_fwf_file(overwrite=True)
+
+    # Tests __next__ and correctness of reader as an iterator
+    # Use larger chunksize to read through file quicker
+    rdf_reader = pd.read_fwf(TEST_FWF_FILENAME, chunksize=50)
+    pd_reader = pandas.read_fwf(TEST_FWF_FILENAME, chunksize=50)
+
+    for modin_df, pd_df in zip(rdf_reader, pd_reader):
+        df_equals(modin_df, pd_df)
+
+
+def test_fwf_file_skiprows():
+    setup_fwf_file(overwrite=True)
+
+    pandas_df = pandas.read_fwf(TEST_FWF_FILENAME, skiprows=2)
+    modin_df = pd.read_fwf(TEST_FWF_FILENAME, skiprows=2)
+    df_equals(modin_df, pandas_df)
+
+    pandas_df = pandas.read_fwf(TEST_FWF_FILENAME, usecols=[0, 4, 7], skiprows=[2, 5])
+    modin_df = pd.read_fwf(TEST_FWF_FILENAME, usecols=[0, 4, 7], skiprows=[2, 5])
+    df_equals(modin_df, pandas_df)
+
+
+def test_fwf_file_index_col():
+    fwf_data = """a       b           c          d
+id8141  360.242940  149.910199 11950.7
+id1594  444.953632  166.985655 11788.4
+id1849  364.136849  183.628767 11806.2
+id1230  413.836124  184.375703 11916.8
+id1948  502.953953  173.237159 12468.3"""
+
+    setup_fwf_file(overwrite=True, fwf_data=fwf_data)
+
+    pandas_df = pandas.read_fwf(TEST_FWF_FILENAME, index_col="c")
+    modin_df = pd.read_fwf(TEST_FWF_FILENAME, index_col="c")
+    df_equals(modin_df, pandas_df)
+
+    teardown_fwf_file()
+
+
+def test_fwf_file_skipfooter():
+    setup_fwf_file(overwrite=True)
+
+    pandas_df = pandas.read_fwf(TEST_FWF_FILENAME, skipfooter=2)
+    modin_df = pd.read_fwf(TEST_FWF_FILENAME, skipfooter=2)
+
+    df_equals(modin_df, pandas_df)
+
+
+def test_fwf_file_parse_dates():
+    dates = pandas.date_range("2000", freq="h", periods=10)
+    fwf_data = "col1 col2        col3 col4"
+    for i in range(10, 20):
+        fwf_data = fwf_data + "\n{col1}   {col2}  {col3}   {col4}".format(
+            col1=str(i),
+            col2=str(dates[i - 10].date()),
+            col3=str(i),
+            col4=str(dates[i - 10].time()),
+        )
+
+    setup_fwf_file(overwrite=True, fwf_data=fwf_data)
+
+    pandas_df = pandas.read_fwf(TEST_FWF_FILENAME, parse_dates=[["col2", "col4"]])
+    modin_df = pd.read_fwf(TEST_FWF_FILENAME, parse_dates=[["col2", "col4"]])
+    df_equals(modin_df, pandas_df)
+
+    pandas_df = pandas.read_fwf(
+        TEST_FWF_FILENAME, parse_dates={"time": ["col2", "col4"]}
+    )
+    modin_df = pd.read_fwf(TEST_FWF_FILENAME, parse_dates={"time": ["col2", "col4"]})
     df_equals(modin_df, pandas_df)
 
     teardown_fwf_file()

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1314,9 +1314,8 @@ def test_fwf_file():
     setup_fwf_file()
 
     colspecs = [(0, 6), (8, 20), (21, 33), (34, 43)]
-    with pytest.warns(UserWarning):
-        df = pd.read_fwf(TEST_FWF_FILENAME, colspecs=colspecs, header=None, index_col=0)
-        assert isinstance(df, pd.DataFrame)
+    df = pd.read_fwf(TEST_FWF_FILENAME, colspecs=colspecs, header=None, index_col=0)
+    assert isinstance(df, pd.DataFrame)
 
     teardown_fwf_file()
 
@@ -1363,14 +1362,13 @@ ACW000116041980TAVG -340  k -500  k  -35  k  524  k 1071  k 1534  k 1655  k 1502
     ]
     column_names = ["stationID", "year", 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12]
     nan_values = ["-9999"]
-    with pytest.warns(UserWarning):
-        modin_df = pd.read_fwf(
-            TEST_FWF_FILENAME,
-            colspecs=column_specs,
-            names=column_names,
-            na_values=nan_values,
-            index_col=["stationID", "year"],
-        )
+    modin_df = pd.read_fwf(
+        TEST_FWF_FILENAME,
+        colspecs=column_specs,
+        names=column_names,
+        na_values=nan_values,
+        index_col=["stationID", "year"],
+    )
     pandas_df = pd.read_fwf(
         TEST_FWF_FILENAME,
         colspecs=column_specs,

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -391,7 +391,10 @@ ACW000116041980TAVG -340  k -500  k  -35  k  524  k 1071  k 1534  k 1655  k 1502
 
 def teardown_fwf_file():
     if os.path.exists(TEST_FWF_FILENAME):
-        os.remove(TEST_FWF_FILENAME)
+        try:
+            os.remove(TEST_FWF_FILENAME)
+        except PermissionError:
+            pass
 
 
 def test_from_parquet(make_parquet_file):

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1401,17 +1401,33 @@ id1948  502.953953  173.237159 12468.3"""
     teardown_fwf_file()
 
 
-@pytest.mark.skip(reason="Chunksize doesn't work with read_fwf yet")
 def test_fwf_file_chunksize():
     setup_fwf_file(overwrite=True)
 
     # Tests __next__ and correctness of reader as an iterator
-    # Use larger chunksize to read through file quicker
-    rdf_reader = pd.read_fwf(TEST_FWF_FILENAME, chunksize=50)
-    pd_reader = pandas.read_fwf(TEST_FWF_FILENAME, chunksize=50)
+    rdf_reader = pd.read_fwf(TEST_FWF_FILENAME, chunksize=5)
+    pd_reader = pandas.read_fwf(TEST_FWF_FILENAME, chunksize=5)
 
     for modin_df, pd_df in zip(rdf_reader, pd_reader):
         df_equals(modin_df, pd_df)
+
+    # Tests that get_chunk works correctly
+    rdf_reader = pd.read_fwf(TEST_FWF_FILENAME, chunksize=1)
+    pd_reader = pandas.read_fwf(TEST_FWF_FILENAME, chunksize=1)
+
+    modin_df = rdf_reader.get_chunk(1)
+    pd_df = pd_reader.get_chunk(1)
+
+    df_equals(modin_df, pd_df)
+
+    # Tests that read works correctly
+    rdf_reader = pd.read_fwf(TEST_FWF_FILENAME, chunksize=1)
+    pd_reader = pandas.read_fwf(TEST_FWF_FILENAME, chunksize=1)
+
+    modin_df = rdf_reader.read()
+    pd_df = pd_reader.read()
+
+    df_equals(modin_df, pd_df)
 
 
 def test_fwf_file_skiprows():


### PR DESCRIPTION
## What do these changes do?

Parallelize `read_fwf` with `FWFReader` and `PandasFWFParser`. 

Note: There is a lot of duplicate code between `FWFReader` and `CSVReader` in order to support `read_csv` arguments for `read_fwf`, probably should look into how we can reduce this. 

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s`
- [x] Resolves #752 
- [x] tests added and passing
