### PR TITLE
Fix metadata for partitioned parquet datasets

### DIFF
--- a/modin/engines/base/io/column_stores/parquet_reader.py
+++ b/modin/engines/base/io/column_stores/parquet_reader.py
@@ -69,16 +69,17 @@ class ParquetReader(ColumnStoreReader):
             else:
                 meta = ParquetFile(path).metadata
                 column_names = meta.schema.names
-            # This is how we convert the metadata from pyarrow to a python
-            # dictionary, from which we then get the index columns.
-            # We use these to filter out from the columns in the metadata since
-            # the pyarrow storage has no concept of row labels/index.
-            # This ensures that our metadata lines up with the partitions without
-            # extra communication steps once we `have done all the remote
-            # computation.
-            index_columns = eval(
-                meta.metadata[b"pandas"].replace(b"null", b"None")
-            ).get("index_columns", [])
-            column_names = [c for c in column_names if c not in index_columns]
+            if meta is not None:
+                # This is how we convert the metadata from pyarrow to a python
+                # dictionary, from which we then get the index columns.
+                # We use these to filter out from the columns in the metadata since
+                # the pyarrow storage has no concept of row labels/index.
+                # This ensures that our metadata lines up with the partitions without
+                # extra communication steps once we `have done all the remote
+                # computation.
+                index_columns = eval(
+                    meta.metadata[b"pandas"].replace(b"null", b"None")
+                ).get("index_columns", [])
+                column_names = [c for c in column_names if c not in index_columns]
             columns = [name for name in column_names if not PQ_INDEX_REGEX.match(name)]
         return cls.build_query_compiler(path, columns, **kwargs)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -436,12 +436,31 @@ def test_from_parquet_pandas_index():
             "C": ["c"] * 2000,
         }
     )
-    pandas_df.set_index("idx").to_parquet("tmp.parquet")
+    filepath = "tmp.parquet"
+    pandas_df.set_index("idx").to_parquet(filepath)
     # read the same parquet using modin.pandas
-    df_equals(pd.read_parquet("tmp.parquet"), pandas.read_parquet("tmp.parquet"))
+    df_equals(pd.read_parquet(filepath), pandas.read_parquet(filepath))
 
-    pandas_df.set_index(["idx", "A"]).to_parquet("tmp.parquet")
-    df_equals(pd.read_parquet("tmp.parquet"), pandas.read_parquet("tmp.parquet"))
+    pandas_df.set_index(["idx", "A"]).to_parquet(filepath)
+    df_equals(pd.read_parquet(filepath), pandas.read_parquet(filepath))
+    os.remove(filepath)
+
+
+def test_from_parquet_pandas_index_partitioned():
+    # Ensure modin can read parquet files written by pandas with a non-RangeIndex object
+    pandas_df = pandas.DataFrame(
+        {
+            "idx": np.random.randint(0, 100_000, size=2000),
+            "A": np.random.randint(0, 10, size=2000),
+            "B": ["a", "b"] * 1000,
+            "C": ["c"] * 2000,
+        }
+    )
+    filepath = "tmp_folder.parquet"
+    pandas_df.set_index("idx").to_parquet(filepath, partition_cols=["A"])
+    # read the same parquet using modin.pandas
+    df_equals(pd.read_parquet(filepath), pandas.read_parquet(filepath))
+    shutil.rmtree(filepath)
 
 
 def test_from_parquet_hdfs():


### PR DESCRIPTION
* Resolves #1451

Previously, we computed metadata for partitioned columns separately.
This was changed so that now partitioned parquet files are computed with
standard parquet files at the same time.

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1451 <!-- issue must be created for each patch -->
- [x] tests added and passing
