### PR TITLE
Fix CSV reader when `sep=None`

### DIFF
--- a/modin/backends/pandas/parsers.py
+++ b/modin/backends/pandas/parsers.py
@@ -11,15 +11,17 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+from io import BytesIO
 import numpy as np
 import pandas
 from pandas.core.dtypes.cast import find_common_type
 from pandas.core.dtypes.concat import union_categoricals
 from pandas.io.common import infer_compression
+import warnings
+
 from modin.engines.base.io import FileReader
 from modin.data_management.utils import split_result_of_axis_func_pandas
 from modin.error_message import ErrorMessage
-from io import BytesIO
 
 
 def _split_result_for_readers(axis, num_splits, df):  # pragma: no cover
@@ -82,6 +84,7 @@ class PandasParser(object):
 class PandasCSVParser(PandasParser):
     @staticmethod
     def parse(fname, **kwargs):
+        warnings.filterwarnings("ignore")
         num_splits = kwargs.pop("num_splits", None)
         start = kwargs.pop("start", None)
         end = kwargs.pop("end", None)

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -107,7 +107,7 @@ def _make_parser_func(sep):
         float_precision=None,
     ):
         _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
-        if not kwargs.get("sep", sep):
+        if kwargs.get("sep", sep) is False:
             kwargs["sep"] = "\t"
         return _read(**kwargs)
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -14,6 +14,7 @@
 import pytest
 import numpy as np
 import pandas
+from pandas.errors import ParserWarning
 from collections import OrderedDict
 from modin.pandas.utils import to_pandas
 from pathlib import Path
@@ -658,6 +659,16 @@ def test_from_csv(make_csv_file):
     pandas_df = pandas.read_csv(Path(TEST_CSV_FILENAME))
     modin_df = pd.read_csv(Path(TEST_CSV_FILENAME))
 
+    df_equals(modin_df, pandas_df)
+
+
+def test_from_csv_sep_none(make_csv_file):
+    make_csv_file()
+
+    with pytest.warns(ParserWarning):
+        pandas_df = pandas.read_csv(TEST_CSV_FILENAME, sep=None)
+    with pytest.warns(ParserWarning):
+        modin_df = pd.read_csv(TEST_CSV_FILENAME, sep=None)
     df_equals(modin_df, pandas_df)
 
 


### PR DESCRIPTION
* Resolves #1452

Change the way we check for `sep=False`. Previously, pandas allowed
`sep=False` for tab delimeted text files. Because we explicitly look for
a `sep` character we converted `sep=False` to `sep="\t"`. We checked
with a line `if not sep` which also evaluated to True when `sep` is
`None`. `sep=None` has a different behavior as outlined in #1452.

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1452 <!-- issue must be created for each patch -->
- [x] tests added and passing
