### PR TITLE
Fix for #1403. Added test for dataframe with "index" column

### DIFF
--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -111,7 +111,10 @@ class BaseFrameManager(object):
         Returns:
             A new `np.array` of partition objects.
         """
-        right_parts = np.squeeze(right)
+        if right.shape == (1, 1):
+            right_parts = right[0]
+        else:
+            right_parts = np.squeeze(right)
 
         [obj.drain_call_queue() for obj in right_parts]
         return np.array(

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2048,7 +2048,7 @@ class DataFrame(BasePandasDataset):
         # _query_compiler before we check if the key is in self
         if key in ["_query_compiler"] or key in self.__dict__:
             pass
-        elif key in self:
+        elif key in self and key not in dir(self):
             self.__setitem__(key, value)
         elif isinstance(value, pandas.Series):
             warnings.warn(

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1258,7 +1258,7 @@ class Series(BasePandasDataset):
     def is_monotonic_decreasing(self):
         # We cannot default to pandas without a named function to call.
         def is_monotonic_decreasing(df):
-            return df.is_monotonic
+            return df.is_monotonic_decreasing
 
         return self._default_to_pandas(is_monotonic_decreasing)
 
@@ -1266,7 +1266,7 @@ class Series(BasePandasDataset):
     def is_monotonic_increasing(self):
         # We cannot default to pandas without a named function to call.
         def is_monotonic_increasing(df):
-            return df.is_monotonic
+            return df.is_monotonic_increasing
 
         return self._default_to_pandas(is_monotonic_increasing)
 

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -2596,7 +2596,14 @@ class TestDataFrameDefault:
 
         # Skips nan because only difference is nan instead of NaN
         if not name_contains(request.node.name, ["nan"]):
-            assert np.array_equal(modin_df.to_records(), pandas_df.to_records())
+            try:
+                pandas_result = pandas_df.to_records()
+            except Exception as e:
+                with pytest.raises(type(e)):
+                    modin_df.to_records()
+            else:
+                modin_result = modin_df.to_records()
+                assert np.array_equal(modin_result, pandas_result)
 
     def test_to_datetime(self):
         modin_df = pd.DataFrame({"year": [2015, 2016], "month": [2, 3], "day": [4, 5]})

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2176,14 +2176,24 @@ def test_rtruediv(data):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_sample(data):
     modin_series, pandas_series = create_test_series(data)
-    df_equals(
-        modin_series.sample(frac=0.5, random_state=21019),
-        pandas_series.sample(frac=0.5, random_state=21019),
-    )
-    df_equals(
-        modin_series.sample(n=12, random_state=21019),
-        pandas_series.sample(n=12, random_state=21019),
-    )
+    try:
+        pandas_result = pandas_series.sample(frac=0.5, random_state=21019)
+    except Exception as e:
+        with pytest.raises(type(e)):
+            modin_series.sample(frac=0.5, random_state=21019)
+    else:
+        modin_result = modin_series.sample(frac=0.5, random_state=21019)
+        df_equals(pandas_result, modin_result)
+
+    try:
+        pandas_result = pandas_series.sample(n=12, random_state=21019)
+    except Exception as e:
+        with pytest.raises(type(e)):
+            modin_series.sample(n=12, random_state=21019)
+    else:
+        modin_result = modin_series.sample(n=12, random_state=21019)
+        df_equals(pandas_result, modin_result)
+
     with pytest.warns(UserWarning):
         df_equals(
             modin_series.sample(n=0, random_state=21019),

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -63,6 +63,14 @@ test_data = {
         ]
         for i in range(NCOLS)
     },
+    "with_index_column": {
+        "index": [1, 2, 3, 4, 5, 6],
+        "col1": [4, 5, 6, 7, 8, 9],
+        "col2": [10, 20, 30, 40, 50, 60],
+        "col3": [11, 12, 13, 14, 15, 16],
+        "col4": [50, 60, 70, 80, 90, 0],
+        "col5": [6, 5, 4, 3, 2, 1],
+    },
     # "int_float_object_data": {
     #     "col3": [1, 2, 3, 4],
     #     "col4": [4, 5, 6, 7],
@@ -155,6 +163,7 @@ numeric_dfs = [
     "float_data",
     "sparse_nan_data",
     "dense_nan_data",
+    "with_index_column",
     "100x100",
 ]
 

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import copy
 import numpy as np
 import pandas
 from pandas.util.testing import assert_almost_equal, assert_frame_equal
@@ -63,14 +64,6 @@ test_data = {
         ]
         for i in range(NCOLS)
     },
-    "with_index_column": {
-        "index": [1, 2, 3, 4, 5, 6],
-        "col1": [4, 5, 6, 7, 8, 9],
-        "col2": [10, 20, 30, 40, 50, 60],
-        "col3": [11, 12, 13, 14, 15, 16],
-        "col4": [50, 60, 70, 80, 90, 0],
-        "col5": [6, 5, 4, 3, 2, 1],
-    },
     # "int_float_object_data": {
     #     "col3": [1, 2, 3, 4],
     #     "col4": [4, 5, 6, 7],
@@ -117,6 +110,14 @@ test_data = {
         for i in range(100)
     },
 }
+
+# Create a dataframe based on integer dataframe but with one column called "index". Because of bug #1481 it cannot be
+# created in normal way and has to be copied from dataset that works.
+# TODO(gshimansky): when bug #1481 is fixed replace this dataframe initialization with ordinary one.
+test_data["with_index_column"] = copy.copy(test_data["int_data"])
+test_data["with_index_column"]["index"] = test_data["with_index_column"].pop(
+    "col{}".format(int(NCOLS / 2))
+)
 
 test_data_values = list(test_data.values())
 test_data_keys = list(test_data.keys())


### PR DESCRIPTION
Fixed __setitem__ when column has name "index".
Fixed to_records test to catch exceptions (they happen because of
index column).
Fixed python engine when series object contains only 1 partition.

Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1403 <!-- issue must be created for each patch -->
- [x] tests added and passing
