### PR TITLE
Add explicit `read_*` instead of giving percentage

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,11 +40,18 @@ scheduling computation!
 
 <p align="center">
 
-| pandas Object   | Ray Engine Coverage                                                                  | Dask Engine Coverage |
-|-----------------|:------------------------------------------------------------------------------------:|:---------------:|
-| `pd.DataFrame`  | <img src=https://img.shields.io/badge/api%20coverage-83.03%25-orange.svg> | <img src=https://img.shields.io/badge/api%20coverage-83.03%25-orange.svg> |
-| `pd.Series`     | <img src=https://img.shields.io/badge/api%20coverage-77.71%25-orange.svg> | <img src=https://img.shields.io/badge/api%20coverage-77.71%25-orange.svg> |
-| `pd.read_*`     | <img src=https://img.shields.io/badge/api%20coverage-42.86%25-red.svg>    | <img src=https://img.shields.io/badge/api%20coverage-42.86%25-red.svg> |
+| pandas Object     | Ray Engine Coverage                                                                  | Dask Engine Coverage |
+|-------------------|:------------------------------------------------------------------------------------:|:---------------:|
+| `pd.DataFrame`    | <img src=https://img.shields.io/badge/api%20coverage-83.03%25-orange.svg> | <img src=https://img.shields.io/badge/api%20coverage-83.03%25-orange.svg> |
+| `pd.Series`       | <img src=https://img.shields.io/badge/api%20coverage-77.71%25-orange.svg> | <img src=https://img.shields.io/badge/api%20coverage-77.71%25-orange.svg> |
+| `pd.read_csv`     | ✅                                               | ✅ |
+| `pd.read_table`   | ✅                                               | ✅ |
+| `pd.read_parquet` | ✅                                               | ✅ |
+| `pd.read_sql`     | ✅                                               | ✅ |
+| `pd.read_feather` | ✅                                               | ✅ |
+| `pd.read_json`    | [✳️](https://github.com/modin-project/modin/issues/554)                                         | [✳️](https://github.com/modin-project/modin/issues/554) |
+| `pd.read_<other>` | [✴️](https://modin.readthedocs.io/en/latest/supported_apis/io_supported.html) | [✴️](https://modin.readthedocs.io/en/latest/supported_apis/io_supported.html) |
+
 
 </p>
 Some pandas APIs are easier to implement than other, so if something is missing feel


### PR DESCRIPTION
This more closely reflects what people are often using instead of opaquely giving a percentage.

Signed-off-by: Devin Petersohn devin.petersohn@gmail.com

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1487  <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
