### PR TITLE
Fixed #1490. New column case is checked first in __setitem__

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2106,7 +2106,6 @@ class DataFrame(BasePandasDataset):
             return self._update_inplace(
                 self._default_to_pandas(setitem_without_string_columns)._query_compiler
             )
-
         if is_list_like(value):
             if isinstance(value, (pandas.DataFrame, DataFrame)):
                 value = value[value.columns[0]].values

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2059,45 +2059,8 @@ class DataFrame(BasePandasDataset):
         object.__setattr__(self, key, value)
 
     def __setitem__(self, key, value):
-        if not isinstance(key, str):
-
-            def setitem_without_string_columns(df):
-                # Arrow makes memory-mapped objects immutable, so copy will allow them
-                # to be mutable again.
-                df = df.copy(True)
-                df[key] = value
-                return df
-
-            return self._update_inplace(
-                self._default_to_pandas(setitem_without_string_columns)._query_compiler
-            )
-        if is_list_like(value):
-            if isinstance(value, (pandas.DataFrame, DataFrame)):
-                if value.shape[1] != 1 and key not in self.columns:
-                    raise ValueError(
-                        "Wrong number of items passed %i, placement implies 1"
-                        % value.shape[1]
-                    )
-                value = value[value.columns[0]].values
-            elif isinstance(value, np.ndarray):
-                if (
-                    len(value.shape) > 1
-                    and value.shape[1] != 1
-                    and key not in self.columns
-                ):
-                    raise ValueError(
-                        "Wrong number of items passed %i, placement implies 1"
-                        % value.shape[1]
-                    )
-                assert (
-                    len(value.shape) < 3
-                ), "Shape of new values must be compatible with manager shape"
-                value = value.T.reshape(-1)
-                if len(self) > 0:
-                    value = value[: len(self)]
-            if not isinstance(value, Series):
-                value = list(value)
         if key not in self.columns:
+            # Handle new column case first
             if isinstance(value, Series):
                 if len(self.columns) == 0:
                     self._query_compiler = value._query_compiler.copy()
@@ -2111,9 +2074,53 @@ class DataFrame(BasePandasDataset):
                 # last column name from the list (the appended value's name and append
                 # the new name.
                 self.columns = self.columns[:-1].append(pandas.Index([key]))
+            elif (
+                isinstance(value, np.ndarray)
+                and len(value.shape) > 1
+                and value.shape[1] != 1
+            ):
+                raise ValueError(
+                    "Wrong number of items passed %i, placement implies 1"
+                    % value.shape[1]
+                )
+            elif (
+                isinstance(value, (pandas.DataFrame, DataFrame)) and value.shape[1] != 1
+            ):
+                raise ValueError(
+                    "Wrong number of items passed %i, placement implies 1"
+                    % value.shape[1]
+                )
             else:
                 self.insert(loc=len(self.columns), column=key, value=value)
-        elif len(self.index) == 0:
+            return
+
+        if not isinstance(key, str):
+
+            def setitem_without_string_columns(df):
+                # Arrow makes memory-mapped objects immutable, so copy will allow them
+                # to be mutable again.
+                df = df.copy(True)
+                df[key] = value
+                return df
+
+            return self._update_inplace(
+                self._default_to_pandas(setitem_without_string_columns)._query_compiler
+            )
+
+        if is_list_like(value):
+            if isinstance(value, (pandas.DataFrame, DataFrame)):
+                value = value[value.columns[0]].values
+            elif isinstance(value, np.ndarray):
+                assert (
+                    len(value.shape) < 3
+                ), "Shape of new values must be compatible with manager shape"
+                value = value.T.reshape(-1)
+                if len(self) > 0:
+                    value = value[: len(self)]
+            if not isinstance(value, Series):
+                value = list(value)
+
+        if len(self.index) == 0:
             new_self = DataFrame({key: value}, columns=self.columns)
             self._update_inplace(new_self._query_compiler)
         else:


### PR DESCRIPTION
Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #? <!-- issue must be created for each patch -->
- [x] tests added and passing
