### PR TITLE
Fixed #1509. Indexing DataFrameGroupBy should return SeriesGroupBy

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -266,15 +266,20 @@ class DataFrameGroupBy(object):
 
     def __getitem__(self, key):
         kwargs = self._kwargs.copy()
+        # Most of time indexing DataFrameGroupBy results in another DataFrameGroupBy object unless circumstances are
+        # special in which case SeriesGroupBy has to be returned. Such circumstances are when key equals to a single
+        # column name and is not a list of column names or list of one column name.
+        make_dataframe = True
         if self._drop:
             if not isinstance(key, list):
                 key = [key]
                 kwargs["squeeze"] = True
+                make_dataframe = False
         # When `as_index` is False, pandas will always convert to a `DataFrame`, we
         # convert to a list here so that the result will be a `DataFrame`.
         elif not self._as_index and not isinstance(key, list):
             key = [key]
-        if isinstance(key, list):
+        if isinstance(key, list) and (make_dataframe or not self._as_index):
             return DataFrameGroupBy(
                 self._df[key],
                 self._by,


### PR DESCRIPTION
when as_index is True and a single column name is passed as not a list.

Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1509 <!-- issue must be created for each patch -->
- [x] tests added and passing
