### PR TITLE
Make it possible to switch engine on the fly

### DIFF
--- a/ci/teamcity/comment_on_pr.py
+++ b/ci/teamcity/comment_on_pr.py
@@ -51,7 +51,9 @@ for out in pytest_outputs:
         for i in content.split("+ python3 -m pytest ")
     )
     if len(full_comment) > 65_000:
-        full_comment = full_comment[-65_000:] + "\n\n<b>Remaining output truncated<b>\n\n"
+        full_comment = (
+            full_comment[-65_000:] + "\n\n<b>Remaining output truncated<b>\n\n"
+        )
     full_comment = "<details><summary>Tests Logs</summary>\n\n\n```\n" + full_comment
     full_comment += "\n```\n\n</details>\n"
 if "FAILURES" not in full_comment:

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -85,6 +85,7 @@ def get_partition_format():
     # See note above about engine + backing.
     return os.environ.get("MODIN_BACKEND", "Pandas").title()
 
+
 class Publisher(object):
     def __init__(self, name, value):
         self.name = name
@@ -123,9 +124,10 @@ class Publisher(object):
                         callback(self)
             del self.__once[value]
 
+
 __version__ = "0.6.3"
-execution_engine = Publisher(name='execution_engine', value=get_execution_engine())
-partition_format = Publisher(name='partition_format', value=get_partition_format())
+execution_engine = Publisher(name="execution_engine", value=get_execution_engine())
+partition_format = Publisher(name="partition_format", value=get_partition_format())
 
 # We don't want these used outside of this file.
 del get_execution_engine

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -15,6 +15,7 @@ import os
 import sys
 import warnings
 from packaging import version
+import weakref
 
 from ._version import get_versions
 
@@ -83,10 +84,30 @@ def get_partition_format():
     # See note above about engine + backing.
     return os.environ.get("MODIN_BACKEND", "Pandas").title()
 
+class Publisher(object):
+    def __init__(self, name, value):
+        self.name = name
+        self.__value = value
+        self.__subs = weakref.WeakSet()
+
+    def subscribe(self, callback):
+        self.__subs.add(callback)
+        callback(self)
+
+    def get(self):
+        return self.__value
+
+    def put(self, value):
+        oldvalue, self.__value = self.__value, value
+        if oldvalue != value:
+            for weakCallback in list(self.__subs): # take a copy before iterating
+                callback = weakCallback()
+                if callback:
+                    callback(self)
 
 __version__ = "0.6.3"
-__execution_engine__ = get_execution_engine()
-__partition_format__ = get_partition_format()
+execution_engine = Publisher(name='execution_engine', value=get_execution_engine())
+partition_format = Publisher(name='partition_format', value=get_partition_format())
 
 # We don't want these used outside of this file.
 del get_execution_engine

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -97,7 +97,10 @@ class Publisher(object):
         callback(self)
 
     def once(self, onvalue, callback):
-        self.__once[onvalue].add(callback)
+        if onvalue == self.__value:
+            callback(self)
+        else:
+            self.__once[onvalue].add(callback)
 
     def get(self):
         return self.__value

--- a/modin/backends/pyarrow/query_compiler.py
+++ b/modin/backends/pyarrow/query_compiler.py
@@ -19,6 +19,7 @@ from pandas.core.computation.ops import UnaryOp, BinOp, Term, MathCall, Constant
 
 from modin import partition_format, Publisher
 
+
 class FakeSeries:
     def __init__(self, dtype):
         self.dtype = dtype
@@ -30,6 +31,7 @@ class PyarrowQueryCompiler(PandasQueryCompiler):
     @classmethod
     def _update(cls, publisher: Publisher):
         import pyarrow
+
         cls.pa = pyarrow
 
     def query(self, expr, **kwargs):
@@ -204,5 +206,6 @@ class PyarrowQueryCompiler(PandasQueryCompiler):
             NumPy array of the QueryCompiler.
         """
         return self._modin_frame.to_numpy()
+
 
 partition_format.once("Pyarrow", PyarrowQueryCompiler._update)

--- a/modin/backends/pyarrow/query_compiler.py
+++ b/modin/backends/pyarrow/query_compiler.py
@@ -146,7 +146,9 @@ class PyarrowQueryCompiler(PandasQueryCompiler):
             root = build_node(table, expr.terms, builder)
             cond = builder.make_condition(root)
             filt = gandiva.make_filter(table.schema, cond)
-            sel_vec = filt.evaluate(table.to_batches()[0], self.pa.default_memory_pool())
+            sel_vec = filt.evaluate(
+                table.to_batches()[0], self.pa.default_memory_pool()
+            )
             result = filter_with_selection_vector(table, sel_vec)
             return result
 

--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -17,6 +17,7 @@ from modin import execution_engine, partition_format
 
 from modin.data_management import factories
 
+
 class EngineDispatcher(object):
     """
     This is the 'ingestion' point which knows where to route the work
@@ -30,10 +31,14 @@ class EngineDispatcher(object):
             factory_name = "Experimental{}On{}Factory"
         else:
             factory_name = "{}On{}Factory"
-        partition = (publisher if publisher.name == 'partition_format' else partition_format).get()
-        engine = (publisher if publisher.name == 'execution_engine' else execution_engine).get()
+        partition = (
+            publisher if publisher.name == "partition_format" else partition_format
+        ).get()
+        engine = (
+            publisher if publisher.name == "execution_engine" else execution_engine
+        ).get()
         cls.__engine = getattr(factories, factory_name.format(partition, engine))
-        
+
     @classmethod
     def from_pandas(cls, df):
         return cls.__engine._from_pandas(df)
@@ -117,6 +122,7 @@ class EngineDispatcher(object):
     @classmethod
     def to_pickle(cls, *args, **kwargs):
         return cls.__engine._to_pickle(*args, **kwargs)
+
 
 EngineDispatcher._update_engine(execution_engine)
 execution_engine.subscribe(EngineDispatcher._update_engine)

--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -1,0 +1,123 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import os
+
+from modin import execution_engine, partition_format
+
+from modin.data_management import factories
+
+class EngineDispatcher(object):
+    """
+    This is the 'ingestion' point which knows where to route the work
+    """
+
+    __engine = None
+
+    @classmethod
+    def _update_engine(cls, publisher):
+        if os.environ.get("MODIN_EXPERIMENTAL", "").title() == "True":
+            factory_name = "Experimental{}On{}Factory"
+        else:
+            factory_name = "{}On{}Factory"
+        partition = (publisher if publisher.name == 'partition_format' else partition_format).get()
+        engine = (publisher if publisher.name == 'execution_engine' else execution_engine).get()
+        cls.__engine = getattr(factories, factory_name.format(partition, engine))
+        
+    @classmethod
+    def from_pandas(cls, df):
+        return cls.__engine._from_pandas(df)
+
+    @classmethod
+    def from_non_pandas(cls, *args, **kwargs):
+        return cls.__engine._from_non_pandas(*args, **kwargs)
+
+    @classmethod
+    def read_parquet(cls, **kwargs):
+        return cls.__engine._read_parquet(**kwargs)
+
+    @classmethod
+    def read_csv(cls, **kwargs):
+        return cls.__engine._read_csv(**kwargs)
+
+    @classmethod
+    def read_json(cls, **kwargs):
+        return cls.__engine._read_json(**kwargs)
+
+    @classmethod
+    def read_gbq(cls, **kwargs):
+        return cls.__engine._read_gbq(**kwargs)
+
+    @classmethod
+    def read_html(cls, **kwargs):
+        return cls.__engine._read_html(**kwargs)
+
+    @classmethod
+    def read_clipboard(cls, **kwargs):  # pragma: no cover
+        return cls.__engine._read_clipboard(**kwargs)
+
+    @classmethod
+    def read_excel(cls, **kwargs):
+        return cls.__engine._read_excel(**kwargs)
+
+    @classmethod
+    def read_hdf(cls, **kwargs):
+        return cls.__engine._read_hdf(**kwargs)
+
+    @classmethod
+    def read_feather(cls, **kwargs):
+        return cls.__engine._read_feather(**kwargs)
+
+    @classmethod
+    def read_stata(cls, **kwargs):
+        return cls.__engine._read_stata(**kwargs)
+
+    @classmethod
+    def read_sas(cls, **kwargs):  # pragma: no cover
+        return cls.__engine._read_sas(**kwargs)
+
+    @classmethod
+    def read_pickle(cls, **kwargs):
+        return cls.__engine._read_pickle(**kwargs)
+
+    @classmethod
+    def read_sql(cls, **kwargs):
+        return cls.__engine._read_sql(**kwargs)
+
+    @classmethod
+    def read_fwf(cls, **kwargs):
+        return cls.__engine._read_fwf(**kwargs)
+
+    @classmethod
+    def read_sql_table(cls, **kwargs):
+        return cls.__engine._read_sql_table(**kwargs)
+
+    @classmethod
+    def read_sql_query(cls, **kwargs):
+        return cls.__engine._read_sql_query(**kwargs)
+
+    @classmethod
+    def read_spss(cls, **kwargs):
+        return cls.__engine._read_spss(**kwargs)
+
+    @classmethod
+    def to_sql(cls, *args, **kwargs):
+        return cls.__engine._to_sql(*args, **kwargs)
+
+    @classmethod
+    def to_pickle(cls, *args, **kwargs):
+        return cls.__engine._to_pickle(*args, **kwargs)
+
+EngineDispatcher._update_engine(execution_engine)
+execution_engine.subscribe(EngineDispatcher._update_engine)
+partition_format.subscribe(EngineDispatcher._update_engine)

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -26,7 +26,8 @@ class BaseFactory(object):
     """
     Abstract factory which allows to override the io module easily.
     """
-    io_cls = None # The module where the I/O functionality exists.
+
+    io_cls = None  # The module where the I/O functionality exists.
 
     @classmethod
     def _from_pandas(cls, df):

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -12,7 +12,6 @@
 # governing permissions and limitations under the License.
 
 import os
-import sys
 import warnings
 
 from modin import execution_engine, partition_format

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -15,8 +15,7 @@ import os
 import sys
 import warnings
 
-from modin import __execution_engine__ as execution_engine
-from modin import __partition_format__ as partition_format
+from modin import execution_engine, partition_format
 
 import pandas
 
@@ -24,185 +23,90 @@ types_dictionary = {"pandas": {"category": pandas.CategoricalDtype}}
 
 
 class BaseFactory(object):
-    @property
-    def io_cls(self):
-        """The module where the I/O functionality exists."""
-        raise NotImplementedError("Implement in children classes!")
-
-    @classmethod
-    def _determine_engine(cls):
-        if os.environ.get("MODIN_EXPERIMENTAL", "") == "True":
-            return ExperimentalBaseFactory._determine_engine()
-        factory_name = partition_format + "On" + execution_engine + "Factory"
-        return getattr(sys.modules[__name__], factory_name)
-
-    @classmethod
-    def build_manager(cls):
-        return cls._determine_engine().build_manager()
-
-    @classmethod
-    def from_pandas(cls, df):
-        return cls._determine_engine()._from_pandas(df)
+    """
+    Abstract factory which allows to override the io module easily.
+    """
+    io_cls = None # The module where the I/O functionality exists.
 
     @classmethod
     def _from_pandas(cls, df):
         return cls.io_cls.from_pandas(df)
 
     @classmethod
-    def from_non_pandas(cls, *args, **kwargs):
-        return cls._determine_engine()._from_non_pandas(*args, **kwargs)
-
-    @classmethod
     def _from_non_pandas(cls, *args, **kwargs):
         return cls.io_cls.from_non_pandas(*args, **kwargs)
-
-    @classmethod
-    def read_parquet(cls, **kwargs):
-        return cls._determine_engine()._read_parquet(**kwargs)
 
     @classmethod
     def _read_parquet(cls, **kwargs):
         return cls.io_cls.read_parquet(**kwargs)
 
     @classmethod
-    def read_csv(cls, **kwargs):
-        return cls._determine_engine()._read_csv(**kwargs)
-
-    @classmethod
     def _read_csv(cls, **kwargs):
         return cls.io_cls.read_csv(**kwargs)
-
-    @classmethod
-    def read_json(cls, **kwargs):
-        return cls._determine_engine()._read_json(**kwargs)
 
     @classmethod
     def _read_json(cls, **kwargs):
         return cls.io_cls.read_json(**kwargs)
 
     @classmethod
-    def read_gbq(cls, **kwargs):
-        return cls._determine_engine()._read_gbq(**kwargs)
-
-    @classmethod
     def _read_gbq(cls, **kwargs):
         return cls.io_cls.read_gbq(**kwargs)
-
-    @classmethod
-    def read_html(cls, **kwargs):
-        return cls._determine_engine()._read_html(**kwargs)
 
     @classmethod
     def _read_html(cls, **kwargs):
         return cls.io_cls.read_html(**kwargs)
 
     @classmethod
-    def read_clipboard(cls, **kwargs):  # pragma: no cover
-        return cls._determine_engine()._read_clipboard(**kwargs)
-
-    @classmethod
     def _read_clipboard(cls, **kwargs):  # pragma: no cover
         return cls.io_cls.read_clipboard(**kwargs)
-
-    @classmethod
-    def read_excel(cls, **kwargs):
-        return cls._determine_engine()._read_excel(**kwargs)
 
     @classmethod
     def _read_excel(cls, **kwargs):
         return cls.io_cls.read_excel(**kwargs)
 
     @classmethod
-    def read_hdf(cls, **kwargs):
-        return cls._determine_engine()._read_hdf(**kwargs)
-
-    @classmethod
     def _read_hdf(cls, **kwargs):
         return cls.io_cls.read_hdf(**kwargs)
-
-    @classmethod
-    def read_feather(cls, **kwargs):
-        return cls._determine_engine()._read_feather(**kwargs)
 
     @classmethod
     def _read_feather(cls, **kwargs):
         return cls.io_cls.read_feather(**kwargs)
 
     @classmethod
-    def read_stata(cls, **kwargs):
-        return cls._determine_engine()._read_stata(**kwargs)
-
-    @classmethod
     def _read_stata(cls, **kwargs):
         return cls.io_cls.read_stata(**kwargs)
-
-    @classmethod
-    def read_sas(cls, **kwargs):  # pragma: no cover
-        return cls._determine_engine()._read_sas(**kwargs)
 
     @classmethod
     def _read_sas(cls, **kwargs):  # pragma: no cover
         return cls.io_cls.read_sas(**kwargs)
 
     @classmethod
-    def read_pickle(cls, **kwargs):
-        return cls._determine_engine()._read_pickle(**kwargs)
-
-    @classmethod
     def _read_pickle(cls, **kwargs):
         return cls.io_cls.read_pickle(**kwargs)
-
-    @classmethod
-    def read_sql(cls, **kwargs):
-        return cls._determine_engine()._read_sql(**kwargs)
 
     @classmethod
     def _read_sql(cls, **kwargs):
         return cls.io_cls.read_sql(**kwargs)
 
     @classmethod
-    def read_fwf(cls, **kwargs):
-        return cls._determine_engine()._read_fwf(**kwargs)
-
-    @classmethod
     def _read_fwf(cls, **kwargs):
         return cls.io_cls.read_fwf(**kwargs)
-
-    @classmethod
-    def read_sql_table(cls, **kwargs):
-        return cls._determine_engine()._read_sql_table(**kwargs)
 
     @classmethod
     def _read_sql_table(cls, **kwargs):
         return cls.io_cls.read_sql_table(**kwargs)
 
     @classmethod
-    def read_sql_query(cls, **kwargs):
-        return cls._determine_engine()._read_sql_query(**kwargs)
-
-    @classmethod
     def _read_sql_query(cls, **kwargs):
         return cls.io_cls.read_sql_query(**kwargs)
-
-    @classmethod
-    def read_spss(cls, **kwargs):
-        return cls._determine_engine()._read_spss(**kwargs)
 
     @classmethod
     def _read_spss(cls, **kwargs):
         return cls.io_cls.read_spss(**kwargs)
 
     @classmethod
-    def to_sql(cls, *args, **kwargs):
-        return cls._determine_engine()._to_sql(*args, **kwargs)
-
-    @classmethod
     def _to_sql(cls, *args, **kwargs):
         return cls.io_cls.to_sql(*args, **kwargs)
-
-    @classmethod
-    def to_pickle(cls, *args, **kwargs):
-        return cls._determine_engine()._to_pickle(*args, **kwargs)
 
     @classmethod
     def _to_pickle(cls, *args, **kwargs):
@@ -232,7 +136,7 @@ class PandasOnDaskFactory(BaseFactory):
 
 class PyarrowOnRayFactory(BaseFactory):
 
-    if partition_format == "Pyarrow" and not os.environ.get(
+    if partition_format.get() == "Pyarrow" and not os.environ.get(
         "MODIN_EXPERIMENTAL", False
     ):
         raise ImportError(
@@ -243,15 +147,8 @@ class PyarrowOnRayFactory(BaseFactory):
 
 class ExperimentalBaseFactory(BaseFactory):
     @classmethod
-    def _determine_engine(cls):
-        factory_name = "Experimental{}On{}Factory".format(
-            partition_format, execution_engine
-        )
-        return getattr(sys.modules[__name__], factory_name)
-
-    @classmethod
     def _read_sql(cls, **kwargs):
-        if execution_engine != "Ray":
+        if execution_engine.get() != "Ray":
             if "partition_column" in kwargs:
                 if kwargs["partition_column"] is not None:
                     warnings.warn(

--- a/modin/engines/base/io/file_reader.py
+++ b/modin/engines/base/io/file_reader.py
@@ -13,7 +13,7 @@
 
 import os
 import re
-from modin import __partition_format__ as partition_format
+from modin import partition_format
 
 S3_ADDRESS_REGEX = re.compile("[sS]3://(.*?)/(.*)")
 NOT_IMPLEMENTED_MESSAGE = "Implement in children classes!"
@@ -29,7 +29,7 @@ class FileReader:
         query_compiler = cls._read(*args, **kwargs)
         # TODO (devin-petersohn): Make this section more general for non-pandas kernel
         # implementations.
-        if partition_format.lower() != "pandas":
+        if partition_format.get().lower() != "pandas":
             raise NotImplementedError("FIXME")
         import pandas
 

--- a/modin/engines/dask/pandas_on_dask/frame/axis_partition.py
+++ b/modin/engines/dask/pandas_on_dask/frame/axis_partition.py
@@ -19,10 +19,7 @@ from modin import execution_engine, Publisher
 class PandasOnDaskFrameAxisPartition(PandasFrameAxisPartition):
     @classmethod
     def _update(cls, publisher: Publisher):
-        if publisher.get() == 'Dask':
-            cls.instance_type = DaskImportHelper.future
-        else:
-            cls.instance_type = super(cls).instance_type
+        cls.instance_type = DaskImportHelper.future
 
     def __init__(self, list_of_blocks):
         # Unwrap from BaseFramePartition object for ease of use
@@ -98,4 +95,4 @@ class PandasOnDaskFrameRowPartition(PandasOnDaskFrameAxisPartition):
 
     axis = 1
 
-execution_engine.subscribe(PandasOnDaskFrameAxisPartition._update)
+execution_engine.once("Dask", PandasOnDaskFrameAxisPartition._update)

--- a/modin/engines/dask/pandas_on_dask/frame/axis_partition.py
+++ b/modin/engines/dask/pandas_on_dask/frame/axis_partition.py
@@ -16,6 +16,7 @@ from .partition import PandasOnDaskFramePartition
 from .helper import DaskImportHelper
 from modin import execution_engine, Publisher
 
+
 class PandasOnDaskFrameAxisPartition(PandasFrameAxisPartition):
     @classmethod
     def _update(cls, publisher: Publisher):
@@ -94,5 +95,6 @@ class PandasOnDaskFrameRowPartition(PandasOnDaskFrameAxisPartition):
     """
 
     axis = 1
+
 
 execution_engine.once("Dask", PandasOnDaskFrameAxisPartition._update)

--- a/modin/engines/dask/pandas_on_dask/frame/data.py
+++ b/modin/engines/dask/pandas_on_dask/frame/data.py
@@ -15,6 +15,7 @@ from modin.engines.base.frame.data import BasePandasFrame
 from .partition_manager import DaskFrameManager
 from modin import execution_engine, Publisher
 
+
 class PandasOnDaskFrame(BasePandasFrame):
     __get_global_client = None
     _frame_mgr_cls = DaskFrameManager
@@ -22,6 +23,7 @@ class PandasOnDaskFrame(BasePandasFrame):
     @classmethod
     def _update(cls, publisher: Publisher):
         from distributed.client import _get_global_client
+
         cls.__get_global_client = _get_global_client
 
     @property
@@ -54,5 +56,6 @@ class PandasOnDaskFrame(BasePandasFrame):
                 ]
             )
         return self._column_widths_cache
+
 
 execution_engine.once("Dask", PandasOnDaskFrame._update)

--- a/modin/engines/dask/pandas_on_dask/frame/data.py
+++ b/modin/engines/dask/pandas_on_dask/frame/data.py
@@ -13,17 +13,16 @@
 
 from modin.engines.base.frame.data import BasePandasFrame
 from .partition_manager import DaskFrameManager
-from modin import execution_engine
+from modin import execution_engine, Publisher
 
 class PandasOnDaskFrame(BasePandasFrame):
     __get_global_client = None
     _frame_mgr_cls = DaskFrameManager
 
     @classmethod
-    def _update(cls, publisher):
-        if cls.__get_global_client is None and publisher.get() == "Dask":
-            from distributed.client import _get_global_client
-            cls.__get_global_client = _get_global_client
+    def _update(cls, publisher: Publisher):
+        from distributed.client import _get_global_client
+        cls.__get_global_client = _get_global_client
 
     @property
     def _row_lengths(self):
@@ -56,4 +55,4 @@ class PandasOnDaskFrame(BasePandasFrame):
             )
         return self._column_widths_cache
 
-execution_engine.subscribe(PandasOnDaskFrame._update)
+execution_engine.once("Dask", PandasOnDaskFrame._update)

--- a/modin/engines/dask/pandas_on_dask/frame/data.py
+++ b/modin/engines/dask/pandas_on_dask/frame/data.py
@@ -24,7 +24,7 @@ class PandasOnDaskFrame(BasePandasFrame):
     def _update(cls, publisher: Publisher):
         from distributed.client import _get_global_client
 
-        cls.__get_global_client = _get_global_client
+        cls.__get_global_client = staticmethod(_get_global_client)
 
     @property
     def _row_lengths(self):

--- a/modin/engines/dask/pandas_on_dask/frame/helper.py
+++ b/modin/engines/dask/pandas_on_dask/frame/helper.py
@@ -1,0 +1,34 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+from modin import execution_engine, Publisher
+
+class DaskImportHelper(object):
+    pickle = None
+    get_global_client = None
+    get_client = None
+    future = None
+
+    @classmethod
+    def _update(cls, publisher: Publisher):
+        if publisher.get() == "Dask":
+            from distributed.client import _get_global_client, get_client
+            from distributed import Future
+            import cloudpickle
+
+            cls.pickle = cloudpickle
+            cls.get_global_client = _get_global_client
+            cls.get_client = get_client
+            cls.future = Future
+
+execution_engine.subscribe(DaskImportHelper._update)

--- a/modin/engines/dask/pandas_on_dask/frame/helper.py
+++ b/modin/engines/dask/pandas_on_dask/frame/helper.py
@@ -13,6 +13,7 @@
 
 from modin import execution_engine, Publisher
 
+
 class DaskImportHelper(object):
     pickle = None
     get_global_client = None
@@ -29,5 +30,6 @@ class DaskImportHelper(object):
         cls.get_global_client = _get_global_client
         cls.get_client = get_client
         cls.future = Future
+
 
 execution_engine.once("Dask", DaskImportHelper._update)

--- a/modin/engines/dask/pandas_on_dask/frame/helper.py
+++ b/modin/engines/dask/pandas_on_dask/frame/helper.py
@@ -21,14 +21,13 @@ class DaskImportHelper(object):
 
     @classmethod
     def _update(cls, publisher: Publisher):
-        if publisher.get() == "Dask":
-            from distributed.client import _get_global_client, get_client
-            from distributed import Future
-            import cloudpickle
+        from distributed.client import _get_global_client, get_client
+        from distributed import Future
+        import cloudpickle
 
-            cls.pickle = cloudpickle
-            cls.get_global_client = _get_global_client
-            cls.get_client = get_client
-            cls.future = Future
+        cls.pickle = cloudpickle
+        cls.get_global_client = _get_global_client
+        cls.get_client = get_client
+        cls.future = Future
 
-execution_engine.subscribe(DaskImportHelper._update)
+execution_engine.once("Dask", DaskImportHelper._update)

--- a/modin/engines/dask/pandas_on_dask/frame/partition.py
+++ b/modin/engines/dask/pandas_on_dask/frame/partition.py
@@ -18,6 +18,7 @@ from modin.data_management.utils import length_fn_pandas, width_fn_pandas
 
 from .helper import DaskImportHelper
 
+
 def apply_list_of_funcs(funcs, df):
     for func, kwargs in funcs:
         if isinstance(func, bytes):
@@ -83,7 +84,9 @@ class PandasOnDaskFramePartition(BaseFramePartition):
 
     def add_to_apply_calls(self, func, **kwargs):
         return PandasOnDaskFramePartition(
-            self.future, call_queue=self.call_queue + [[DaskImportHelper.pickle.dumps(func), kwargs]]
+            self.future,
+            call_queue=self.call_queue
+            + [[DaskImportHelper.pickle.dumps(func), kwargs]],
         )
 
     def drain_call_queue(self):

--- a/modin/engines/dask/pandas_on_dask/frame/partition_manager.py
+++ b/modin/engines/dask/pandas_on_dask/frame/partition_manager.py
@@ -22,6 +22,7 @@ from .partition import PandasOnDaskFramePartition
 from .helper import DaskImportHelper
 from modin.error_message import ErrorMessage
 
+
 def deploy_func(df, other, apply_func, call_queue_df=None, call_queue_other=None):
     if call_queue_df is not None and len(call_queue_df) > 0:
         for call, kwargs in call_queue_df:
@@ -40,6 +41,7 @@ def deploy_func(df, other, apply_func, call_queue_df=None, call_queue_other=None
     if isinstance(apply_func, bytes):
         apply_func = DaskImportHelper.pickle.loads(apply_func)
     return apply_func(df, other)
+
 
 class DaskFrameManager(BaseFrameManager):
     """This class implements the interface in `BaseFrameManager`."""

--- a/modin/engines/dask/task_wrapper.py
+++ b/modin/engines/dask/task_wrapper.py
@@ -13,12 +13,14 @@
 
 from modin import execution_engine, Publisher
 
+
 class DaskTask:
     get_global_client = None
 
     @classmethod
     def _update(cls, publisher: Publisher):
         from distributed.client import _get_global_client
+
         cls.get_global_client = _get_global_client
 
     @classmethod
@@ -34,5 +36,6 @@ class DaskTask:
     def materialize(cls, future):
         client = cls.get_global_client()
         return client.gather(future)
+
 
 execution_engine.once("Dask", DaskTask._update)

--- a/modin/engines/dask/task_wrapper.py
+++ b/modin/engines/dask/task_wrapper.py
@@ -11,16 +11,15 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from modin import execution_engine
+from modin import execution_engine, Publisher
 
 class DaskTask:
     get_global_client = None
 
     @classmethod
-    def _update(cls, publisher):
-        if cls.get_global_client is None and publisher.get() == 'Dask':
-            from distributed.client import _get_global_client
-            cls.get_global_client = _get_global_client
+    def _update(cls, publisher: Publisher):
+        from distributed.client import _get_global_client
+        cls.get_global_client = _get_global_client
 
     @classmethod
     def deploy(cls, func, num_return_vals, kwargs):
@@ -36,5 +35,4 @@ class DaskTask:
         client = cls.get_global_client()
         return client.gather(future)
 
-DaskTask._update(execution_engine)
-execution_engine.subscribe(DaskTask._update)
+execution_engine.once("Dask", DaskTask._update)

--- a/modin/engines/ray/generic/frame/partition_manager.py
+++ b/modin/engines/ray/generic/frame/partition_manager.py
@@ -16,13 +16,16 @@ import numpy as np
 from modin.engines.base.frame.partition_manager import BaseFrameManager
 from modin import execution_engine, Publisher
 
+
 class RayFrameManager(BaseFrameManager):
     """This method implements the interface in `BaseFrameManager`."""
 
     ray = None
+
     @classmethod
     def _update(cls, publisher: Publisher):
         import ray
+
         cls.ray = ray
 
     @classmethod
@@ -44,5 +47,6 @@ class RayFrameManager(BaseFrameManager):
 
         arr = np.block(parts)
         return arr
+
 
 execution_engine.once("Ray", RayFrameManager._update)

--- a/modin/engines/ray/pandas_on_ray/frame/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/axis_partition.py
@@ -17,6 +17,7 @@ from modin.engines.base.frame.axis_partition import PandasFrameAxisPartition
 from .partition import PandasOnRayFramePartition
 from modin import execution_engine, Publisher
 
+
 class PandasOnRayFrameAxisPartition(PandasFrameAxisPartition):
     deploy_ray_func = None
 
@@ -112,5 +113,6 @@ class PandasOnRayFrameRowPartition(PandasOnRayFrameAxisPartition):
     """
 
     axis = 1
+
 
 execution_engine.once("Ray", PandasOnRayFrameAxisPartition._update)

--- a/modin/engines/ray/pandas_on_ray/frame/data.py
+++ b/modin/engines/ray/pandas_on_ray/frame/data.py
@@ -18,12 +18,14 @@ from modin.engines.base.frame.data import BasePandasFrame
 from modin import execution_engine, Publisher
 from modin.backends.pandas.parsers import find_common_type_cat as find_common_type
 
+
 class PandasOnRayFrame(BasePandasFrame):
     ray = None
 
     @classmethod
     def _update(cls, publisher: Publisher):
         import ray
+
         cls.ray = ray
 
     _frame_mgr_cls = PandasOnRayFrameManager
@@ -41,5 +43,6 @@ class PandasOnRayFrame(BasePandasFrame):
         )
         dtypes.index = column_names
         return dtypes
+
 
 execution_engine.once("Ray", PandasOnRayFrame._update)

--- a/modin/engines/ray/pandas_on_ray/frame/partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition.py
@@ -40,7 +40,7 @@ class PandasOnRayFramePartition(BaseFramePartition):
             self.drain_call_queue()
         try:
             return RayImportHelper.ray.get(self.oid)
-        except RayTaskError as e:
+        except RayImportHelper.RayTaskError as e:
             handle_ray_task_error(e)
 
     def apply(self, func, **kwargs):
@@ -183,7 +183,7 @@ class PandasOnRayFramePartition(BaseFramePartition):
         if isinstance(self._width_cache, RayImportHelper.ray.ObjectID):
             try:
                 self._width_cache = RayImportHelper.ray.get(self._width_cache)
-            except RayTaskError as e:
+            except RayImportHelper.RayTaskError as e:
                 handle_ray_task_error(e)
         return self._width_cache
 

--- a/modin/engines/ray/pandas_on_ray/frame/partition_manager.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition_manager.py
@@ -22,6 +22,7 @@ from .partition import PandasOnRayFramePartition
 from modin.error_message import ErrorMessage
 from modin import execution_engine, Publisher
 
+
 class PandasOnRayFrameManager(RayFrameManager):
     """This method implements the interface in `BaseFrameManager`."""
 
@@ -154,5 +155,6 @@ class PandasOnRayFrameManager(RayFrameManager):
                 for row_idx in range(len(left))
             ]
         )
+
 
 execution_engine.once("Ray", RayFrameManager._update)

--- a/modin/engines/ray/pandas_on_ray/frame/partition_manager.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition_manager.py
@@ -157,4 +157,4 @@ class PandasOnRayFrameManager(RayFrameManager):
         )
 
 
-execution_engine.once("Ray", RayFrameManager._update)
+execution_engine.once("Ray", PandasOnRayFrameManager._update)

--- a/modin/engines/ray/task_wrapper.py
+++ b/modin/engines/ray/task_wrapper.py
@@ -13,6 +13,7 @@
 
 from modin import execution_engine, Publisher
 
+
 class RayTask:
     ray = None
     deploy_ray_func = None
@@ -20,6 +21,7 @@ class RayTask:
     @classmethod
     def _update(cls, publisher: Publisher):
         import ray
+
         @ray.remote
         def deploy_ray_func(func, args):  # pragma: no cover
             return func(**args)
@@ -36,5 +38,6 @@ class RayTask:
     @classmethod
     def materialize(cls, obj_id):
         return cls.ray.get(obj_id)
+
 
 execution_engine.once("Ray", RayTask._update)

--- a/modin/experimental/engines/pandas_on_ray/io_exp.py
+++ b/modin/experimental/engines/pandas_on_ray/io_exp.py
@@ -20,8 +20,9 @@ from modin.backends.pandas.parsers import _split_result_for_readers
 from modin.engines.ray.pandas_on_ray.frame.partition import PandasOnRayFramePartition
 from modin import execution_engine, Publisher
 
+
 class ExperimentalPandasOnRayIO(PandasOnRayIO):
-    read_parquet_remote_task = None # updated by RayImportHelper
+    read_parquet_remote_task = None  # updated by RayImportHelper
 
     @classmethod
     def read_sql(
@@ -138,7 +139,9 @@ class RayImportHelper(object):
         import ray
 
         @ray.remote
-        def _read_parquet_columns(path, columns, num_splits, kwargs):  # pragma: no cover
+        def _read_parquet_columns(
+            path, columns, num_splits, kwargs
+        ):  # pragma: no cover
             """Use a Ray task to read columns from Parquet into a Pandas DataFrame.
 
             Note: Ray functions are not detected by codecov (thus pragma: no cover)
@@ -202,7 +205,12 @@ class RayImportHelper(object):
             return _split_result_for_readers(1, num_splits, pandas_df) + [index]
 
         cls.ray = ray
-        ExperimentalPandasOnRayIO.read_parquet_remote_task = staticmethod(_read_parquet_columns)
-        cls.read_sql_with_offset_pandas_on_ray = staticmethod(_read_sql_with_offset_pandas_on_ray)
+        ExperimentalPandasOnRayIO.read_parquet_remote_task = staticmethod(
+            _read_parquet_columns
+        )
+        cls.read_sql_with_offset_pandas_on_ray = staticmethod(
+            _read_sql_with_offset_pandas_on_ray
+        )
+
 
 execution_engine.once("Ray", RayImportHelper._update)

--- a/modin/experimental/engines/pyarrow_on_ray/frame/axis_partition.py
+++ b/modin/experimental/engines/pyarrow_on_ray/frame/axis_partition.py
@@ -15,6 +15,7 @@ from modin.engines.base.frame.axis_partition import BaseFrameAxisPartition
 from .partition import PyarrowOnRayFramePartition
 from modin import execution_engine, Publisher
 
+
 class PyarrowOnRayFrameAxisPartition(BaseFrameAxisPartition):
     def __init__(self, list_of_blocks):
         # Unwrap from BaseFramePartition object for ease of use
@@ -51,7 +52,9 @@ class PyarrowOnRayFrameAxisPartition(BaseFrameAxisPartition):
         args.extend(self.list_of_blocks)
         return [
             PyarrowOnRayFramePartition(obj)
-            for obj in RayImportHelper.deploy_ray_axis_func._remote(args, num_return_vals=num_splits)
+            for obj in RayImportHelper.deploy_ray_axis_func._remote(
+                args, num_return_vals=num_splits
+            )
         ]
 
     def shuffle(self, func, num_splits=None, **kwargs):
@@ -71,7 +74,9 @@ class PyarrowOnRayFrameAxisPartition(BaseFrameAxisPartition):
         args.extend(self.list_of_blocks)
         return [
             PyarrowOnRayFramePartition(obj)
-            for obj in RayImportHelper.deploy_ray_axis_func._remote(args, num_return_vals=num_splits)
+            for obj in RayImportHelper.deploy_ray_axis_func._remote(
+                args, num_return_vals=num_splits
+            )
         ]
 
 
@@ -118,7 +123,8 @@ def split_arrow_table_result(axis, result, num_partitions, num_splits, metadata)
     )
     if axis == 0:
         return [
-            RayImportHelper.pyarrow.Table.from_batches([part]) for part in result.to_batches(chunksize)
+            RayImportHelper.pyarrow.Table.from_batches([part])
+            for part in result.to_batches(chunksize)
         ]
     else:
         return [
@@ -230,7 +236,10 @@ class RayImportHelper(object):
             cls.ray = ray
             cls.pyarrow = pyarrow
             cls.deploy_ray_axis_func = staticmethod(deploy_ray_axis_func)
-            cls.deploy_ray_func_between_two_axis_partitions = staticmethod(deploy_ray_func_between_two_axis_partitions)
+            cls.deploy_ray_func_between_two_axis_partitions = staticmethod(
+                deploy_ray_func_between_two_axis_partitions
+            )
             cls.deploy_ray_shuffle_func = staticmethod(deploy_ray_shuffle_func)
+
 
 execution_engine.once("Ray", RayImportHelper._update)

--- a/modin/experimental/engines/pyarrow_on_ray/frame/data.py
+++ b/modin/experimental/engines/pyarrow_on_ray/frame/data.py
@@ -18,12 +18,14 @@ from .partition_manager import PyarrowOnRayFrameManager
 from modin.engines.base.frame.data import BasePandasFrame
 from modin import execution_engine, Publisher
 
+
 class PyarrowOnRayFrame(BasePandasFrame):
     ray = None
 
     @classmethod
     def _update(cls, publisher: Publisher):
         import ray
+
         cls.ray = ray
 
     _frame_mgr_cls = PyarrowOnRayFrameManager
@@ -59,5 +61,6 @@ class PyarrowOnRayFrame(BasePandasFrame):
         df.index = self.index
         df.columns = self.columns
         return df
+
 
 execution_engine.once("Ray", PyarrowOnRayFrame._update)

--- a/modin/experimental/engines/pyarrow_on_ray/frame/partition.py
+++ b/modin/experimental/engines/pyarrow_on_ray/frame/partition.py
@@ -15,6 +15,7 @@ import pandas
 from modin.engines.ray.pandas_on_ray.frame.partition import PandasOnRayFramePartition
 from modin import execution_engine, Publisher
 
+
 class PyarrowOnRayFramePartition(PandasOnRayFramePartition):
     ray = None
     pyarrow = None
@@ -48,7 +49,9 @@ class PyarrowOnRayFramePartition(PandasOnRayFramePartition):
         Returns:
             A `RayRemotePartition` object.
         """
-        return PyarrowOnRayFramePartition(cls.ray.put(cls.pyarrow.Table.from_pandas(obj)))
+        return PyarrowOnRayFramePartition(
+            cls.ray.put(cls.pyarrow.Table.from_pandas(obj))
+        )
 
     @classmethod
     def length_extraction_fn(cls):
@@ -61,5 +64,6 @@ class PyarrowOnRayFramePartition(PandasOnRayFramePartition):
     @classmethod
     def empty(cls):
         return cls.put(pandas.DataFrame())
+
 
 execution_engine.once("Ray", PyarrowOnRayFramePartition._update)

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -242,6 +242,7 @@ DEFAULT_NPARTITIONS = 4
 _is_first_update = True
 client = None
 
+
 def _update_engine(publisher: Publisher):
     global DEFAULT_NPARTITIONS, _is_first_update, client
 

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -240,10 +240,10 @@ def initialize_ray():
 
 DEFAULT_NPARTITIONS = 4
 _is_first_update = True
-
+client = None
 
 def _update_engine(publisher: Publisher):
-    global DEFAULT_NPARTITIONS, _is_first_update
+    global DEFAULT_NPARTITIONS, _is_first_update, client
 
     num_cpus = DEFAULT_NPARTITIONS
     if publisher.get() == "Ray":

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -134,7 +134,7 @@ from .general import (
     unique,
 )
 from .plotting import Plotting as plotting
-from .. import __execution_engine__ as execution_engine
+from .. import execution_engine, Publisher
 
 # Set this so that Pandas doesn't try to multithread by itself
 os.environ["OMP_NUM_THREADS"] = "1"
@@ -237,18 +237,23 @@ def initialize_ray():
 
         ray.worker.global_worker.run_function_on_all_workers(import_pandas)
 
+DEFAULT_NPARTITIONS = 4
+_is_first_update = True
+def _update_engine(publisher: Publisher):
+    global DEFAULT_NPARTITIONS, _is_first_update
 
-if execution_engine == "Ray":
-    import ray
+    num_cpus = DEFAULT_NPARTITIONS
+    if publisher.get() == "Ray":
+        import ray
+        if _is_first_update:
+            initialize_ray()
+        num_cpus = ray.cluster_resources()["CPU"]
+    elif publisher.get() == "Dask":  # pragma: no cover
+        from distributed.client import get_client
+        if threading.current_thread().name == "MainThread" and _is_first_update:
+            import warnings
+            warnings.warn("The Dask Engine for Modin is experimental.")
 
-    initialize_ray()
-    num_cpus = ray.cluster_resources()["CPU"]
-elif execution_engine == "Dask":  # pragma: no cover
-    from distributed.client import get_client
-    import warnings
-
-    if threading.current_thread().name == "MainThread":
-        warnings.warn("The Dask Engine for Modin is experimental.")
         try:
             client = get_client()
         except ValueError:
@@ -256,10 +261,14 @@ elif execution_engine == "Dask":  # pragma: no cover
 
             num_cpus = os.environ.get("MODIN_CPUS", None) or multiprocessing.cpu_count()
             client = Client(n_workers=int(num_cpus))
-elif execution_engine != "Python":
-    raise ImportError("Unrecognized execution engine: {}.".format(execution_engine))
 
-DEFAULT_NPARTITIONS = max(4, int(num_cpus))
+    elif publisher.get() != "Python":
+        raise ImportError("Unrecognized execution engine: {}.".format(publisher.get()))
+
+    _is_first_update = False
+    DEFAULT_NPARTITIONS = max(4, int(num_cpus))
+
+execution_engine.subscribe(_update_engine)
 
 __all__ = [
     "DataFrame",

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -237,21 +237,27 @@ def initialize_ray():
 
         ray.worker.global_worker.run_function_on_all_workers(import_pandas)
 
+
 DEFAULT_NPARTITIONS = 4
 _is_first_update = True
+
+
 def _update_engine(publisher: Publisher):
     global DEFAULT_NPARTITIONS, _is_first_update
 
     num_cpus = DEFAULT_NPARTITIONS
     if publisher.get() == "Ray":
         import ray
+
         if _is_first_update:
             initialize_ray()
         num_cpus = ray.cluster_resources()["CPU"]
     elif publisher.get() == "Dask":  # pragma: no cover
         from distributed.client import get_client
+
         if threading.current_thread().name == "MainThread" and _is_first_update:
             import warnings
+
             warnings.warn("The Dask Engine for Modin is experimental.")
 
         try:
@@ -267,6 +273,7 @@ def _update_engine(publisher: Publisher):
 
     _is_first_update = False
     DEFAULT_NPARTITIONS = max(4, int(num_cpus))
+
 
 execution_engine.subscribe(_update_engine)
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3086,9 +3086,9 @@ class BasePandasDataset(object):
             # so pandas._to_sql will not write the index to the database as well
             index = False
 
-        from modin.data_management.factories import BaseFactory
+        from modin.data_management.dispatcher import EngineDispatcher
 
-        BaseFactory.to_sql(
+        EngineDispatcher.to_sql(
             new_query_compiler,
             name=name,
             con=con,

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -35,10 +35,10 @@ def read_parquet(path, engine: str = "auto", columns=None, **kwargs):
         engine: This argument doesn't do anything for now.
         kwargs: Pass into parquet's read_pandas function.
     """
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
     return DataFrame(
-        query_compiler=BaseFactory.read_parquet(
+        query_compiler=EngineDispatcher.read_parquet(
             path=path, columns=columns, engine=engine, **kwargs
         )
     )
@@ -122,9 +122,9 @@ def _read(**kwargs):
               We only support local files for now.
         kwargs: Keyword arguments in pandas.read_csv
     """
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    pd_obj = BaseFactory.read_csv(**kwargs)
+    pd_obj = EngineDispatcher.read_csv(**kwargs)
     # This happens when `read_csv` returns a TextFileReader object for iterating through
     if isinstance(pd_obj, pandas.io.parsers.TextFileReader):
         reader = pd_obj.read
@@ -157,9 +157,9 @@ def read_json(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_json(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_json(**kwargs))
 
 
 def read_gbq(
@@ -181,9 +181,9 @@ def read_gbq(
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_gbq(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_gbq(**kwargs))
 
 
 def read_html(
@@ -205,18 +205,18 @@ def read_html(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_html(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_html(**kwargs))
 
 
 def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_clipboard(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_clipboard(**kwargs))
 
 
 def read_excel(
@@ -250,9 +250,9 @@ def read_excel(
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwds", {}))
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    intermediate = BaseFactory.read_excel(**kwargs)
+    intermediate = EngineDispatcher.read_excel(**kwargs)
     if isinstance(intermediate, (OrderedDict, dict)):
         parsed = type(intermediate)()
         for key in intermediate.keys():
@@ -278,17 +278,17 @@ def read_hdf(
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_hdf(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_hdf(**kwargs))
 
 
 def read_feather(path, columns=None, use_threads: bool = True):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_feather(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_feather(**kwargs))
 
 
 def read_stata(
@@ -305,9 +305,9 @@ def read_stata(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_stata(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_stata(**kwargs))
 
 
 def read_sas(
@@ -320,9 +320,9 @@ def read_sas(
 ):  # pragma: no cover
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_sas(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_sas(**kwargs))
 
 
 def read_pickle(
@@ -330,9 +330,9 @@ def read_pickle(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_pickle(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_pickle(**kwargs))
 
 
 def read_sql(
@@ -374,13 +374,13 @@ def read_sql(
     """
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
     if kwargs.get("chunksize") is not None:
         ErrorMessage.default_to_pandas("Parameters provided [chunksize]")
         df_gen = pandas.read_sql(**kwargs)
-        return (DataFrame(query_compiler=BaseFactory.from_pandas(df)) for df in df_gen)
-    return DataFrame(query_compiler=BaseFactory.read_sql(**kwargs))
+        return (DataFrame(query_compiler=EngineDispatcher.from_pandas(df)) for df in df_gen)
+    return DataFrame(query_compiler=EngineDispatcher.read_sql(**kwargs))
 
 
 def read_fwf(
@@ -390,11 +390,11 @@ def read_fwf(
     infer_nrows=100,
     **kwds,
 ):
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwds", {}))
-    pd_obj = BaseFactory.read_fwf(**kwargs)
+    pd_obj = EngineDispatcher.read_fwf(**kwargs)
     # When `read_fwf` returns a TextFileReader object for iterating through
     if isinstance(pd_obj, pandas.io.parsers.TextFileReader):
         reader = pd_obj.read
@@ -417,9 +417,9 @@ def read_sql_table(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_sql_table(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_sql_table(**kwargs))
 
 
 def read_sql_query(
@@ -433,9 +433,9 @@ def read_sql_query(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_sql_query(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_sql_query(**kwargs))
 
 
 def read_spss(
@@ -443,10 +443,10 @@ def read_spss(
     usecols: Union[Sequence[str], type(None)] = None,
     convert_categoricals: bool = True,
 ):
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
     return DataFrame(
-        query_compiler=BaseFactory.read_spss(path, usecols, convert_categoricals)
+        query_compiler=EngineDispatcher.read_spss(path, usecols, convert_categoricals)
     )
 
 
@@ -456,11 +456,11 @@ def to_pickle(
     compression: Optional[str] = "infer",
     protocol: int = 4,
 ):
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
     if isinstance(obj, DataFrame):
         obj = obj._query_compiler
-    return BaseFactory.to_pickle(
+    return EngineDispatcher.to_pickle(
         obj, filepath_or_buffer, compression=compression, protocol=protocol
     )
 

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -379,7 +379,9 @@ def read_sql(
     if kwargs.get("chunksize") is not None:
         ErrorMessage.default_to_pandas("Parameters provided [chunksize]")
         df_gen = pandas.read_sql(**kwargs)
-        return (DataFrame(query_compiler=EngineDispatcher.from_pandas(df)) for df in df_gen)
+        return (
+            DataFrame(query_compiler=EngineDispatcher.from_pandas(df)) for df in df_gen
+        )
     return DataFrame(query_compiler=EngineDispatcher.read_sql(**kwargs))
 
 

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -46,6 +46,7 @@ def test_top_level_api_equality():
 
     ignore_modin = [
         "DEFAULT_NPARTITIONS",
+        "Publisher",
         "iterator",
         "series",
         "base",

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -32,7 +32,7 @@ from .utils import (
     json_long_bytes,
 )
 
-from modin import __execution_engine__
+from modin import execution_engine
 
 if os.environ.get("MODIN_BACKEND", "Pandas").lower() == "pandas":
     import modin.pandas as pd
@@ -938,7 +938,7 @@ def test_from_csv_with_usecols(usecols):
 
 
 @pytest.mark.skipif(
-    __execution_engine__.lower() == "python", reason="Using pandas implementation"
+    execution_engine.get().lower() == "python", reason="Using pandas implementation"
 )
 def test_from_csv_s3(make_csv_file):
     dataset_url = "s3://noaa-ghcn-pds/csv/1788.csv"

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -13,9 +13,9 @@
 
 
 def from_non_pandas(df, index, columns, dtype):
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    new_qc = BaseFactory.from_non_pandas(df, index, columns, dtype)
+    new_qc = EngineDispatcher.from_non_pandas(df, index, columns, dtype)
     if new_qc is not None:
         from .dataframe import DataFrame
 
@@ -31,10 +31,10 @@ def from_pandas(df):
     Returns:
         A new Modin DataFrame object.
     """
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
     from .dataframe import DataFrame
 
-    return DataFrame(query_compiler=BaseFactory.from_pandas(df))
+    return DataFrame(query_compiler=EngineDispatcher.from_pandas(df))
 
 
 def to_pandas(modin_obj):

--- a/stress_tests/kaggle/kaggle3.py
+++ b/stress_tests/kaggle/kaggle3.py
@@ -223,8 +223,8 @@ data.dtypes
 data.info()
 data["Type 2"].value_counts(dropna=False)
 data1 = (
-    data
-)  # also we will use data to fill missing value so I assign it to data1 variable
+    data  # also we will use data to fill missing value so I assign it to data1 variable
+)
 data1["Type 2"].dropna(
     inplace=True
 )  # inplace = True means we do not assign it to new variable. Changes automatically assigned to data

--- a/versioneer.py
+++ b/versioneer.py
@@ -1,4 +1,3 @@
-
 # Version: 0.18
 
 """The Versioneer - like a rocketeer, but for versions.
@@ -277,6 +276,7 @@ https://creativecommons.org/publicdomain/zero/1.0/ .
 """
 
 from __future__ import print_function
+
 try:
     import configparser
 except ImportError:
@@ -308,11 +308,13 @@ def get_root():
         setup_py = os.path.join(root, "setup.py")
         versioneer_py = os.path.join(root, "versioneer.py")
     if not (os.path.exists(setup_py) or os.path.exists(versioneer_py)):
-        err = ("Versioneer was unable to run the project root directory. "
-               "Versioneer requires setup.py to be executed from "
-               "its immediate directory (like 'python setup.py COMMAND'), "
-               "or in a way that lets it use sys.argv[0] to find the root "
-               "(like 'python path/to/setup.py COMMAND').")
+        err = (
+            "Versioneer was unable to run the project root directory. "
+            "Versioneer requires setup.py to be executed from "
+            "its immediate directory (like 'python setup.py COMMAND'), "
+            "or in a way that lets it use sys.argv[0] to find the root "
+            "(like 'python path/to/setup.py COMMAND')."
+        )
         raise VersioneerBadRootError(err)
     try:
         # Certain runtime workflows (setup.py install/develop in a setuptools
@@ -325,8 +327,10 @@ def get_root():
         me_dir = os.path.normcase(os.path.splitext(me)[0])
         vsr_dir = os.path.normcase(os.path.splitext(versioneer_py)[0])
         if me_dir != vsr_dir:
-            print("Warning: build in %s is using versioneer.py from %s"
-                  % (os.path.dirname(me), versioneer_py))
+            print(
+                "Warning: build in %s is using versioneer.py from %s"
+                % (os.path.dirname(me), versioneer_py)
+            )
     except NameError:
         pass
     return root
@@ -348,6 +352,7 @@ def get_config_from_root(root):
         if parser.has_option("versioneer", name):
             return parser.get("versioneer", name)
         return None
+
     cfg = VersioneerConfig()
     cfg.VCS = VCS
     cfg.style = get(parser, "style") or ""
@@ -372,17 +377,18 @@ HANDLERS = {}
 
 def register_vcs_handler(vcs, method):  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
+
     def decorate(f):
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
         HANDLERS[vcs][method] = f
         return f
+
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
-                env=None):
+def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -390,10 +396,13 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
         try:
             dispcmd = str([c] + args)
             # remember shell=False, so use git.cmd on windows, not just git
-            p = subprocess.Popen([c] + args, cwd=cwd, env=env,
-                                 stdout=subprocess.PIPE,
-                                 stderr=(subprocess.PIPE if hide_stderr
-                                         else None))
+            p = subprocess.Popen(
+                [c] + args,
+                cwd=cwd,
+                env=env,
+                stdout=subprocess.PIPE,
+                stderr=(subprocess.PIPE if hide_stderr else None),
+            )
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
@@ -418,7 +427,9 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False,
     return stdout, p.returncode
 
 
-LONG_VERSION_PY['git'] = '''
+LONG_VERSION_PY[
+    "git"
+] = '''
 # This file helps to compute a version number in source trees obtained from
 # git-archive tarball (such as those provided by githubs download-from-tag
 # feature). Distribution tarballs (built by setup.py sdist) and build
@@ -993,7 +1004,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     # starting in git-1.8.3, tags are listed as "tag: foo-1.0" instead of
     # just "foo-1.0". If we see a "tag: " prefix, prefer those.
     TAG = "tag: "
-    tags = set([r[len(TAG):] for r in refs if r.startswith(TAG)])
+    tags = set([r[len(TAG) :] for r in refs if r.startswith(TAG)])
     if not tags:
         # Either we're using git < 1.8.3, or there really are no tags. We use
         # a heuristic: assume all version tags have a digit. The old git %d
@@ -1002,7 +1013,7 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
         # between branches and tags. By ignoring refnames without digits, we
         # filter out many common branch names like "release" and
         # "stabilization", as well as "HEAD" and "master".
-        tags = set([r for r in refs if re.search(r'\d', r)])
+        tags = set([r for r in refs if re.search(r"\d", r)])
         if verbose:
             print("discarding '%s', no digits" % ",".join(refs - tags))
     if verbose:
@@ -1010,19 +1021,26 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
     for ref in sorted(tags):
         # sorting will prefer e.g. "2.0" over "2.0rc1"
         if ref.startswith(tag_prefix):
-            r = ref[len(tag_prefix):]
+            r = ref[len(tag_prefix) :]
             if verbose:
                 print("picking %s" % r)
-            return {"version": r,
-                    "full-revisionid": keywords["full"].strip(),
-                    "dirty": False, "error": None,
-                    "date": date}
+            return {
+                "version": r,
+                "full-revisionid": keywords["full"].strip(),
+                "dirty": False,
+                "error": None,
+                "date": date,
+            }
     # no suitable tags, so version is "0+unknown", but full hex is still there
     if verbose:
         print("no suitable tags, using unknown + full revision id")
-    return {"version": "0+unknown",
-            "full-revisionid": keywords["full"].strip(),
-            "dirty": False, "error": "no suitable tags", "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": keywords["full"].strip(),
+        "dirty": False,
+        "error": "no suitable tags",
+        "date": None,
+    }
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
@@ -1037,8 +1055,7 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     if sys.platform == "win32":
         GITS = ["git.cmd", "git.exe"]
 
-    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root,
-                          hide_stderr=True)
+    out, rc = run_command(GITS, ["rev-parse", "--git-dir"], cwd=root, hide_stderr=True)
     if rc != 0:
         if verbose:
             print("Directory %s not under git control" % root)
@@ -1046,10 +1063,19 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
 
     # if there is a tag matching tag_prefix, this yields TAG-NUM-gHEX[-dirty]
     # if there isn't one, this yields HEX[-dirty] (no NUM)
-    describe_out, rc = run_command(GITS, ["describe", "--tags", "--dirty",
-                                          "--always", "--long",
-                                          "--match", "%s*" % tag_prefix],
-                                   cwd=root)
+    describe_out, rc = run_command(
+        GITS,
+        [
+            "describe",
+            "--tags",
+            "--dirty",
+            "--always",
+            "--long",
+            "--match",
+            "%s*" % tag_prefix,
+        ],
+        cwd=root,
+    )
     # --long was added in git-1.5.5
     if describe_out is None:
         raise NotThisMethod("'git describe' failed")
@@ -1072,17 +1098,16 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     dirty = git_describe.endswith("-dirty")
     pieces["dirty"] = dirty
     if dirty:
-        git_describe = git_describe[:git_describe.rindex("-dirty")]
+        git_describe = git_describe[: git_describe.rindex("-dirty")]
 
     # now we have TAG-NUM-gHEX or HEX
 
     if "-" in git_describe:
         # TAG-NUM-gHEX
-        mo = re.search(r'^(.+)-(\d+)-g([0-9a-f]+)$', git_describe)
+        mo = re.search(r"^(.+)-(\d+)-g([0-9a-f]+)$", git_describe)
         if not mo:
             # unparseable. Maybe git-describe is misbehaving?
-            pieces["error"] = ("unable to parse git-describe output: '%s'"
-                               % describe_out)
+            pieces["error"] = "unable to parse git-describe output: '%s'" % describe_out
             return pieces
 
         # tag
@@ -1091,10 +1116,12 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
             if verbose:
                 fmt = "tag '%s' doesn't start with prefix '%s'"
                 print(fmt % (full_tag, tag_prefix))
-            pieces["error"] = ("tag '%s' doesn't start with prefix '%s'"
-                               % (full_tag, tag_prefix))
+            pieces["error"] = "tag '%s' doesn't start with prefix '%s'" % (
+                full_tag,
+                tag_prefix,
+            )
             return pieces
-        pieces["closest-tag"] = full_tag[len(tag_prefix):]
+        pieces["closest-tag"] = full_tag[len(tag_prefix) :]
 
         # distance: number of commits since tag
         pieces["distance"] = int(mo.group(2))
@@ -1105,13 +1132,13 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     else:
         # HEX: no tags
         pieces["closest-tag"] = None
-        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"],
-                                    cwd=root)
+        count_out, rc = run_command(GITS, ["rev-list", "HEAD", "--count"], cwd=root)
         pieces["distance"] = int(count_out)  # total number of commits
 
     # commit date: see ISO-8601 comment in git_versions_from_keywords()
-    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"],
-                       cwd=root)[0].strip()
+    date = run_command(GITS, ["show", "-s", "--format=%ci", "HEAD"], cwd=root)[
+        0
+    ].strip()
     pieces["date"] = date.strip().replace(" ", "T", 1).replace(" ", "", 1)
 
     return pieces
@@ -1167,16 +1194,22 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
     for i in range(3):
         dirname = os.path.basename(root)
         if dirname.startswith(parentdir_prefix):
-            return {"version": dirname[len(parentdir_prefix):],
-                    "full-revisionid": None,
-                    "dirty": False, "error": None, "date": None}
+            return {
+                "version": dirname[len(parentdir_prefix) :],
+                "full-revisionid": None,
+                "dirty": False,
+                "error": None,
+                "date": None,
+            }
         else:
             rootdirs.append(root)
             root = os.path.dirname(root)  # up a level
 
     if verbose:
-        print("Tried directories %s but none started with prefix %s" %
-              (str(rootdirs), parentdir_prefix))
+        print(
+            "Tried directories %s but none started with prefix %s"
+            % (str(rootdirs), parentdir_prefix)
+        )
     raise NotThisMethod("rootdir doesn't start with parentdir_prefix")
 
 
@@ -1205,11 +1238,13 @@ def versions_from_file(filename):
             contents = f.read()
     except EnvironmentError:
         raise NotThisMethod("unable to read _version.py")
-    mo = re.search(r"version_json = '''\n(.*)'''  # END VERSION_JSON",
-                   contents, re.M | re.S)
+    mo = re.search(
+        r"version_json = '''\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S
+    )
     if not mo:
-        mo = re.search(r"version_json = '''\r\n(.*)'''  # END VERSION_JSON",
-                       contents, re.M | re.S)
+        mo = re.search(
+            r"version_json = '''\r\n(.*)'''  # END VERSION_JSON", contents, re.M | re.S
+        )
     if not mo:
         raise NotThisMethod("no version_json in _version.py")
     return json.loads(mo.group(1))
@@ -1218,8 +1253,7 @@ def versions_from_file(filename):
 def write_to_version_file(filename, versions):
     """Write the given version number to the given _version.py file."""
     os.unlink(filename)
-    contents = json.dumps(versions, sort_keys=True,
-                          indent=1, separators=(",", ": "))
+    contents = json.dumps(versions, sort_keys=True, indent=1, separators=(",", ": "))
     with open(filename, "w") as f:
         f.write(SHORT_VERSION_PY % contents)
 
@@ -1251,8 +1285,7 @@ def render_pep440(pieces):
                 rendered += ".dirty"
     else:
         # exception #1
-        rendered = "0+untagged.%d.g%s" % (pieces["distance"],
-                                          pieces["short"])
+        rendered = "0+untagged.%d.g%s" % (pieces["distance"], pieces["short"])
         if pieces["dirty"]:
             rendered += ".dirty"
     return rendered
@@ -1366,11 +1399,13 @@ def render_git_describe_long(pieces):
 def render(pieces, style):
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
-        return {"version": "unknown",
-                "full-revisionid": pieces.get("long"),
-                "dirty": None,
-                "error": pieces["error"],
-                "date": None}
+        return {
+            "version": "unknown",
+            "full-revisionid": pieces.get("long"),
+            "dirty": None,
+            "error": pieces["error"],
+            "date": None,
+        }
 
     if not style or style == "default":
         style = "pep440"  # the default
@@ -1390,9 +1425,13 @@ def render(pieces, style):
     else:
         raise ValueError("unknown style '%s'" % style)
 
-    return {"version": rendered, "full-revisionid": pieces["long"],
-            "dirty": pieces["dirty"], "error": None,
-            "date": pieces.get("date")}
+    return {
+        "version": rendered,
+        "full-revisionid": pieces["long"],
+        "dirty": pieces["dirty"],
+        "error": None,
+        "date": pieces.get("date"),
+    }
 
 
 class VersioneerBadRootError(Exception):
@@ -1415,8 +1454,9 @@ def get_versions(verbose=False):
     handlers = HANDLERS.get(cfg.VCS)
     assert handlers, "unrecognized VCS '%s'" % cfg.VCS
     verbose = verbose or cfg.verbose
-    assert cfg.versionfile_source is not None, \
-        "please set versioneer.versionfile_source"
+    assert (
+        cfg.versionfile_source is not None
+    ), "please set versioneer.versionfile_source"
     assert cfg.tag_prefix is not None, "please set versioneer.tag_prefix"
 
     versionfile_abs = os.path.join(root, cfg.versionfile_source)
@@ -1470,9 +1510,13 @@ def get_versions(verbose=False):
     if verbose:
         print("unable to compute version")
 
-    return {"version": "0+unknown", "full-revisionid": None,
-            "dirty": None, "error": "unable to compute version",
-            "date": None}
+    return {
+        "version": "0+unknown",
+        "full-revisionid": None,
+        "dirty": None,
+        "error": "unable to compute version",
+        "date": None,
+    }
 
 
 def get_version():
@@ -1521,6 +1565,7 @@ def get_cmdclass():
             print(" date: %s" % vers.get("date"))
             if vers["error"]:
                 print(" error: %s" % vers["error"])
+
     cmds["version"] = cmd_version
 
     # we override "build_py" in both distutils and setuptools
@@ -1553,14 +1598,15 @@ def get_cmdclass():
             # now locate _version.py in the new build/ directory and replace
             # it with an updated value
             if cfg.versionfile_build:
-                target_versionfile = os.path.join(self.build_lib,
-                                                  cfg.versionfile_build)
+                target_versionfile = os.path.join(self.build_lib, cfg.versionfile_build)
                 print("UPDATING %s" % target_versionfile)
                 write_to_version_file(target_versionfile, versions)
+
     cmds["build_py"] = cmd_build_py
 
     if "cx_Freeze" in sys.modules:  # cx_freeze enabled?
         from cx_Freeze.dist import build_exe as _build_exe
+
         # nczeczulin reports that py2exe won't like the pep440-style string
         # as FILEVERSION, but it can be used for PRODUCTVERSION, e.g.
         # setup(console=[{
@@ -1581,17 +1627,21 @@ def get_cmdclass():
                 os.unlink(target_versionfile)
                 with open(cfg.versionfile_source, "w") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
-                    f.write(LONG %
-                            {"DOLLAR": "$",
-                             "STYLE": cfg.style,
-                             "TAG_PREFIX": cfg.tag_prefix,
-                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                             })
+                    f.write(
+                        LONG
+                        % {
+                            "DOLLAR": "$",
+                            "STYLE": cfg.style,
+                            "TAG_PREFIX": cfg.tag_prefix,
+                            "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                            "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        }
+                    )
+
         cmds["build_exe"] = cmd_build_exe
         del cmds["build_py"]
 
-    if 'py2exe' in sys.modules:  # py2exe enabled?
+    if "py2exe" in sys.modules:  # py2exe enabled?
         try:
             from py2exe.distutils_buildexe import py2exe as _py2exe  # py3
         except ImportError:
@@ -1610,13 +1660,17 @@ def get_cmdclass():
                 os.unlink(target_versionfile)
                 with open(cfg.versionfile_source, "w") as f:
                     LONG = LONG_VERSION_PY[cfg.VCS]
-                    f.write(LONG %
-                            {"DOLLAR": "$",
-                             "STYLE": cfg.style,
-                             "TAG_PREFIX": cfg.tag_prefix,
-                             "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                             "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                             })
+                    f.write(
+                        LONG
+                        % {
+                            "DOLLAR": "$",
+                            "STYLE": cfg.style,
+                            "TAG_PREFIX": cfg.tag_prefix,
+                            "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                            "VERSIONFILE_SOURCE": cfg.versionfile_source,
+                        }
+                    )
+
         cmds["py2exe"] = cmd_py2exe
 
     # we override different "sdist" commands for both environments
@@ -1643,8 +1697,10 @@ def get_cmdclass():
             # updated value
             target_versionfile = os.path.join(base_dir, cfg.versionfile_source)
             print("UPDATING %s" % target_versionfile)
-            write_to_version_file(target_versionfile,
-                                  self._versioneer_generated_versions)
+            write_to_version_file(
+                target_versionfile, self._versioneer_generated_versions
+            )
+
     cmds["sdist"] = cmd_sdist
 
     return cmds
@@ -1699,11 +1755,13 @@ def do_setup():
     root = get_root()
     try:
         cfg = get_config_from_root(root)
-    except (EnvironmentError, configparser.NoSectionError,
-            configparser.NoOptionError) as e:
+    except (
+        EnvironmentError,
+        configparser.NoSectionError,
+        configparser.NoOptionError,
+    ) as e:
         if isinstance(e, (EnvironmentError, configparser.NoSectionError)):
-            print("Adding sample versioneer config to setup.cfg",
-                  file=sys.stderr)
+            print("Adding sample versioneer config to setup.cfg", file=sys.stderr)
             with open(os.path.join(root, "setup.cfg"), "a") as f:
                 f.write(SAMPLE_CONFIG)
         print(CONFIG_ERROR, file=sys.stderr)
@@ -1712,15 +1770,18 @@ def do_setup():
     print(" creating %s" % cfg.versionfile_source)
     with open(cfg.versionfile_source, "w") as f:
         LONG = LONG_VERSION_PY[cfg.VCS]
-        f.write(LONG % {"DOLLAR": "$",
-                        "STYLE": cfg.style,
-                        "TAG_PREFIX": cfg.tag_prefix,
-                        "PARENTDIR_PREFIX": cfg.parentdir_prefix,
-                        "VERSIONFILE_SOURCE": cfg.versionfile_source,
-                        })
+        f.write(
+            LONG
+            % {
+                "DOLLAR": "$",
+                "STYLE": cfg.style,
+                "TAG_PREFIX": cfg.tag_prefix,
+                "PARENTDIR_PREFIX": cfg.parentdir_prefix,
+                "VERSIONFILE_SOURCE": cfg.versionfile_source,
+            }
+        )
 
-    ipy = os.path.join(os.path.dirname(cfg.versionfile_source),
-                       "__init__.py")
+    ipy = os.path.join(os.path.dirname(cfg.versionfile_source), "__init__.py")
     if os.path.exists(ipy):
         try:
             with open(ipy, "r") as f:
@@ -1762,8 +1823,10 @@ def do_setup():
     else:
         print(" 'versioneer.py' already in MANIFEST.in")
     if cfg.versionfile_source not in simple_includes:
-        print(" appending versionfile_source ('%s') to MANIFEST.in" %
-              cfg.versionfile_source)
+        print(
+            " appending versionfile_source ('%s') to MANIFEST.in"
+            % cfg.versionfile_source
+        )
         with open(manifest_in, "a") as f:
             f.write("include %s\n" % cfg.versionfile_source)
     else:


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
* Split `BaseFactory` in two - `EngineDispatcher` part which chooses the factory to use and a real base for other factories
* Introduce a PubSub model for changes to execution engine and partition format
* Replace all checks for `__execution_engine__` with callbacks fired when desired engine is selected

<!-- Please give a short brief about these changes. -->
## Notes:
* Untested
* Draft PR made for starting the discussion

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1540
- [x] tests added and passing
