### PR TITLE
Split engine dispatcher from BaseFactory

### DIFF
--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -18,6 +18,7 @@ from modin import __partition_format__ as partition_format
 
 from modin.data_management import factories
 
+
 class EngineDispatcher(object):
     """
     This is the 'ingestion' point which knows where to route the work
@@ -31,7 +32,9 @@ class EngineDispatcher(object):
             factory_name = "Experimental{}On{}Factory"
         else:
             factory_name = "{}On{}Factory"
-        cls.__engine = getattr(factories, factory_name.format(partition_format, execution_engine))
+        cls.__engine = getattr(
+            factories, factory_name.format(partition_format, execution_engine)
+        )
 
     @classmethod
     def from_pandas(cls, df):
@@ -116,5 +119,6 @@ class EngineDispatcher(object):
     @classmethod
     def to_pickle(cls, *args, **kwargs):
         return cls.__engine._to_pickle(*args, **kwargs)
+
 
 EngineDispatcher._update_engine()

--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -1,0 +1,120 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import os
+
+from modin import __execution_engine__ as execution_engine
+from modin import __partition_format__ as partition_format
+
+from modin.data_management import factories
+
+class EngineDispatcher(object):
+    """
+    This is the 'ingestion' point which knows where to route the work
+    """
+
+    __engine = None
+
+    @classmethod
+    def _update_engine(cls):
+        if os.environ.get("MODIN_EXPERIMENTAL", "").title() == "True":
+            factory_name = "Experimental{}On{}Factory"
+        else:
+            factory_name = "{}On{}Factory"
+        cls.__engine = getattr(factories, factory_name.format(partition_format, execution_engine))
+
+    @classmethod
+    def from_pandas(cls, df):
+        return cls.__engine._from_pandas(df)
+
+    @classmethod
+    def from_non_pandas(cls, *args, **kwargs):
+        return cls.__engine._from_non_pandas(*args, **kwargs)
+
+    @classmethod
+    def read_parquet(cls, **kwargs):
+        return cls.__engine._read_parquet(**kwargs)
+
+    @classmethod
+    def read_csv(cls, **kwargs):
+        return cls.__engine._read_csv(**kwargs)
+
+    @classmethod
+    def read_json(cls, **kwargs):
+        return cls.__engine._read_json(**kwargs)
+
+    @classmethod
+    def read_gbq(cls, **kwargs):
+        return cls.__engine._read_gbq(**kwargs)
+
+    @classmethod
+    def read_html(cls, **kwargs):
+        return cls.__engine._read_html(**kwargs)
+
+    @classmethod
+    def read_clipboard(cls, **kwargs):  # pragma: no cover
+        return cls.__engine._read_clipboard(**kwargs)
+
+    @classmethod
+    def read_excel(cls, **kwargs):
+        return cls.__engine._read_excel(**kwargs)
+
+    @classmethod
+    def read_hdf(cls, **kwargs):
+        return cls.__engine._read_hdf(**kwargs)
+
+    @classmethod
+    def read_feather(cls, **kwargs):
+        return cls.__engine._read_feather(**kwargs)
+
+    @classmethod
+    def read_stata(cls, **kwargs):
+        return cls.__engine._read_stata(**kwargs)
+
+    @classmethod
+    def read_sas(cls, **kwargs):  # pragma: no cover
+        return cls.__engine._read_sas(**kwargs)
+
+    @classmethod
+    def read_pickle(cls, **kwargs):
+        return cls.__engine._read_pickle(**kwargs)
+
+    @classmethod
+    def read_sql(cls, **kwargs):
+        return cls.__engine._read_sql(**kwargs)
+
+    @classmethod
+    def read_fwf(cls, **kwargs):
+        return cls.__engine._read_fwf(**kwargs)
+
+    @classmethod
+    def read_sql_table(cls, **kwargs):
+        return cls.__engine._read_sql_table(**kwargs)
+
+    @classmethod
+    def read_sql_query(cls, **kwargs):
+        return cls.__engine._read_sql_query(**kwargs)
+
+    @classmethod
+    def read_spss(cls, **kwargs):
+        return cls.__engine._read_spss(**kwargs)
+
+    @classmethod
+    def to_sql(cls, *args, **kwargs):
+        return cls.__engine._to_sql(*args, **kwargs)
+
+    @classmethod
+    def to_pickle(cls, *args, **kwargs):
+        return cls.__engine._to_pickle(*args, **kwargs)
+
+EngineDispatcher._update_engine()

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -12,7 +12,6 @@
 # governing permissions and limitations under the License.
 
 import os
-import sys
 import warnings
 
 from modin import __execution_engine__ as execution_engine
@@ -27,7 +26,8 @@ class BaseFactory(object):
     """
     Abstract factory which allows to override the io module easily.
     """
-    io_cls = None # The module where the I/O functionality exists.
+
+    io_cls = None  # The module where the I/O functionality exists.
 
     @classmethod
     def _from_pandas(cls, df):

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -24,185 +24,90 @@ types_dictionary = {"pandas": {"category": pandas.CategoricalDtype}}
 
 
 class BaseFactory(object):
-    @property
-    def io_cls(self):
-        """The module where the I/O functionality exists."""
-        raise NotImplementedError("Implement in children classes!")
-
-    @classmethod
-    def _determine_engine(cls):
-        if os.environ.get("MODIN_EXPERIMENTAL", "") == "True":
-            return ExperimentalBaseFactory._determine_engine()
-        factory_name = partition_format + "On" + execution_engine + "Factory"
-        return getattr(sys.modules[__name__], factory_name)
-
-    @classmethod
-    def build_manager(cls):
-        return cls._determine_engine().build_manager()
-
-    @classmethod
-    def from_pandas(cls, df):
-        return cls._determine_engine()._from_pandas(df)
+    """
+    Abstract factory which allows to override the io module easily.
+    """
+    io_cls = None # The module where the I/O functionality exists.
 
     @classmethod
     def _from_pandas(cls, df):
         return cls.io_cls.from_pandas(df)
 
     @classmethod
-    def from_non_pandas(cls, *args, **kwargs):
-        return cls._determine_engine()._from_non_pandas(*args, **kwargs)
-
-    @classmethod
     def _from_non_pandas(cls, *args, **kwargs):
         return cls.io_cls.from_non_pandas(*args, **kwargs)
-
-    @classmethod
-    def read_parquet(cls, **kwargs):
-        return cls._determine_engine()._read_parquet(**kwargs)
 
     @classmethod
     def _read_parquet(cls, **kwargs):
         return cls.io_cls.read_parquet(**kwargs)
 
     @classmethod
-    def read_csv(cls, **kwargs):
-        return cls._determine_engine()._read_csv(**kwargs)
-
-    @classmethod
     def _read_csv(cls, **kwargs):
         return cls.io_cls.read_csv(**kwargs)
-
-    @classmethod
-    def read_json(cls, **kwargs):
-        return cls._determine_engine()._read_json(**kwargs)
 
     @classmethod
     def _read_json(cls, **kwargs):
         return cls.io_cls.read_json(**kwargs)
 
     @classmethod
-    def read_gbq(cls, **kwargs):
-        return cls._determine_engine()._read_gbq(**kwargs)
-
-    @classmethod
     def _read_gbq(cls, **kwargs):
         return cls.io_cls.read_gbq(**kwargs)
-
-    @classmethod
-    def read_html(cls, **kwargs):
-        return cls._determine_engine()._read_html(**kwargs)
 
     @classmethod
     def _read_html(cls, **kwargs):
         return cls.io_cls.read_html(**kwargs)
 
     @classmethod
-    def read_clipboard(cls, **kwargs):  # pragma: no cover
-        return cls._determine_engine()._read_clipboard(**kwargs)
-
-    @classmethod
     def _read_clipboard(cls, **kwargs):  # pragma: no cover
         return cls.io_cls.read_clipboard(**kwargs)
-
-    @classmethod
-    def read_excel(cls, **kwargs):
-        return cls._determine_engine()._read_excel(**kwargs)
 
     @classmethod
     def _read_excel(cls, **kwargs):
         return cls.io_cls.read_excel(**kwargs)
 
     @classmethod
-    def read_hdf(cls, **kwargs):
-        return cls._determine_engine()._read_hdf(**kwargs)
-
-    @classmethod
     def _read_hdf(cls, **kwargs):
         return cls.io_cls.read_hdf(**kwargs)
-
-    @classmethod
-    def read_feather(cls, **kwargs):
-        return cls._determine_engine()._read_feather(**kwargs)
 
     @classmethod
     def _read_feather(cls, **kwargs):
         return cls.io_cls.read_feather(**kwargs)
 
     @classmethod
-    def read_stata(cls, **kwargs):
-        return cls._determine_engine()._read_stata(**kwargs)
-
-    @classmethod
     def _read_stata(cls, **kwargs):
         return cls.io_cls.read_stata(**kwargs)
-
-    @classmethod
-    def read_sas(cls, **kwargs):  # pragma: no cover
-        return cls._determine_engine()._read_sas(**kwargs)
 
     @classmethod
     def _read_sas(cls, **kwargs):  # pragma: no cover
         return cls.io_cls.read_sas(**kwargs)
 
     @classmethod
-    def read_pickle(cls, **kwargs):
-        return cls._determine_engine()._read_pickle(**kwargs)
-
-    @classmethod
     def _read_pickle(cls, **kwargs):
         return cls.io_cls.read_pickle(**kwargs)
-
-    @classmethod
-    def read_sql(cls, **kwargs):
-        return cls._determine_engine()._read_sql(**kwargs)
 
     @classmethod
     def _read_sql(cls, **kwargs):
         return cls.io_cls.read_sql(**kwargs)
 
     @classmethod
-    def read_fwf(cls, **kwargs):
-        return cls._determine_engine()._read_fwf(**kwargs)
-
-    @classmethod
     def _read_fwf(cls, **kwargs):
         return cls.io_cls.read_fwf(**kwargs)
-
-    @classmethod
-    def read_sql_table(cls, **kwargs):
-        return cls._determine_engine()._read_sql_table(**kwargs)
 
     @classmethod
     def _read_sql_table(cls, **kwargs):
         return cls.io_cls.read_sql_table(**kwargs)
 
     @classmethod
-    def read_sql_query(cls, **kwargs):
-        return cls._determine_engine()._read_sql_query(**kwargs)
-
-    @classmethod
     def _read_sql_query(cls, **kwargs):
         return cls.io_cls.read_sql_query(**kwargs)
-
-    @classmethod
-    def read_spss(cls, **kwargs):
-        return cls._determine_engine()._read_spss(**kwargs)
 
     @classmethod
     def _read_spss(cls, **kwargs):
         return cls.io_cls.read_spss(**kwargs)
 
     @classmethod
-    def to_sql(cls, *args, **kwargs):
-        return cls._determine_engine()._to_sql(*args, **kwargs)
-
-    @classmethod
     def _to_sql(cls, *args, **kwargs):
         return cls.io_cls.to_sql(*args, **kwargs)
-
-    @classmethod
-    def to_pickle(cls, *args, **kwargs):
-        return cls._determine_engine()._to_pickle(*args, **kwargs)
 
     @classmethod
     def _to_pickle(cls, *args, **kwargs):
@@ -242,13 +147,6 @@ class PyarrowOnRayFactory(BaseFactory):
 
 
 class ExperimentalBaseFactory(BaseFactory):
-    @classmethod
-    def _determine_engine(cls):
-        factory_name = "Experimental{}On{}Factory".format(
-            partition_format, execution_engine
-        )
-        return getattr(sys.modules[__name__], factory_name)
-
     @classmethod
     def _read_sql(cls, **kwargs):
         if execution_engine != "Ray":

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3086,9 +3086,9 @@ class BasePandasDataset(object):
             # so pandas._to_sql will not write the index to the database as well
             index = False
 
-        from modin.data_management.factories import BaseFactory
+        from modin.data_management.dispatcher import EngineDispatcher
 
-        BaseFactory.to_sql(
+        EngineDispatcher.to_sql(
             new_query_compiler,
             name=name,
             con=con,

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -35,10 +35,10 @@ def read_parquet(path, engine: str = "auto", columns=None, **kwargs):
         engine: This argument doesn't do anything for now.
         kwargs: Pass into parquet's read_pandas function.
     """
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
     return DataFrame(
-        query_compiler=BaseFactory.read_parquet(
+        query_compiler=EngineDispatcher.read_parquet(
             path=path, columns=columns, engine=engine, **kwargs
         )
     )
@@ -122,9 +122,9 @@ def _read(**kwargs):
               We only support local files for now.
         kwargs: Keyword arguments in pandas.read_csv
     """
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    pd_obj = BaseFactory.read_csv(**kwargs)
+    pd_obj = EngineDispatcher.read_csv(**kwargs)
     # This happens when `read_csv` returns a TextFileReader object for iterating through
     if isinstance(pd_obj, pandas.io.parsers.TextFileReader):
         reader = pd_obj.read
@@ -157,9 +157,9 @@ def read_json(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_json(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_json(**kwargs))
 
 
 def read_gbq(
@@ -181,9 +181,9 @@ def read_gbq(
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_gbq(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_gbq(**kwargs))
 
 
 def read_html(
@@ -205,18 +205,18 @@ def read_html(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_html(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_html(**kwargs))
 
 
 def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_clipboard(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_clipboard(**kwargs))
 
 
 def read_excel(
@@ -250,9 +250,9 @@ def read_excel(
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwds", {}))
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    intermediate = BaseFactory.read_excel(**kwargs)
+    intermediate = EngineDispatcher.read_excel(**kwargs)
     if isinstance(intermediate, (OrderedDict, dict)):
         parsed = type(intermediate)()
         for key in intermediate.keys():
@@ -278,17 +278,17 @@ def read_hdf(
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_hdf(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_hdf(**kwargs))
 
 
 def read_feather(path, columns=None, use_threads: bool = True):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_feather(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_feather(**kwargs))
 
 
 def read_stata(
@@ -305,9 +305,9 @@ def read_stata(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_stata(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_stata(**kwargs))
 
 
 def read_sas(
@@ -320,9 +320,9 @@ def read_sas(
 ):  # pragma: no cover
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_sas(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_sas(**kwargs))
 
 
 def read_pickle(
@@ -330,9 +330,9 @@ def read_pickle(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_pickle(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_pickle(**kwargs))
 
 
 def read_sql(
@@ -374,13 +374,13 @@ def read_sql(
     """
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
     if kwargs.get("chunksize") is not None:
         ErrorMessage.default_to_pandas("Parameters provided [chunksize]")
         df_gen = pandas.read_sql(**kwargs)
-        return (DataFrame(query_compiler=BaseFactory.from_pandas(df)) for df in df_gen)
-    return DataFrame(query_compiler=BaseFactory.read_sql(**kwargs))
+        return (DataFrame(query_compiler=EngineDispatcher.from_pandas(df)) for df in df_gen)
+    return DataFrame(query_compiler=EngineDispatcher.read_sql(**kwargs))
 
 
 def read_fwf(
@@ -390,11 +390,11 @@ def read_fwf(
     infer_nrows=100,
     **kwds,
 ):
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwds", {}))
-    pd_obj = BaseFactory.read_fwf(**kwargs)
+    pd_obj = EngineDispatcher.read_fwf(**kwargs)
     # When `read_fwf` returns a TextFileReader object for iterating through
     if isinstance(pd_obj, pandas.io.parsers.TextFileReader):
         reader = pd_obj.read
@@ -417,9 +417,9 @@ def read_sql_table(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_sql_table(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_sql_table(**kwargs))
 
 
 def read_sql_query(
@@ -433,9 +433,9 @@ def read_sql_query(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    return DataFrame(query_compiler=BaseFactory.read_sql_query(**kwargs))
+    return DataFrame(query_compiler=EngineDispatcher.read_sql_query(**kwargs))
 
 
 def read_spss(
@@ -443,10 +443,10 @@ def read_spss(
     usecols: Union[Sequence[str], type(None)] = None,
     convert_categoricals: bool = True,
 ):
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
     return DataFrame(
-        query_compiler=BaseFactory.read_spss(path, usecols, convert_categoricals)
+        query_compiler=EngineDispatcher.read_spss(path, usecols, convert_categoricals)
     )
 
 
@@ -456,11 +456,11 @@ def to_pickle(
     compression: Optional[str] = "infer",
     protocol: int = 4,
 ):
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
     if isinstance(obj, DataFrame):
         obj = obj._query_compiler
-    return BaseFactory.to_pickle(
+    return EngineDispatcher.to_pickle(
         obj, filepath_or_buffer, compression=compression, protocol=protocol
     )
 

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -379,7 +379,9 @@ def read_sql(
     if kwargs.get("chunksize") is not None:
         ErrorMessage.default_to_pandas("Parameters provided [chunksize]")
         df_gen = pandas.read_sql(**kwargs)
-        return (DataFrame(query_compiler=EngineDispatcher.from_pandas(df)) for df in df_gen)
+        return (
+            DataFrame(query_compiler=EngineDispatcher.from_pandas(df)) for df in df_gen
+        )
     return DataFrame(query_compiler=EngineDispatcher.read_sql(**kwargs))
 
 

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -13,9 +13,9 @@
 
 
 def from_non_pandas(df, index, columns, dtype):
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
 
-    new_qc = BaseFactory.from_non_pandas(df, index, columns, dtype)
+    new_qc = EngineDispatcher.from_non_pandas(df, index, columns, dtype)
     if new_qc is not None:
         from .dataframe import DataFrame
 
@@ -31,10 +31,10 @@ def from_pandas(df):
     Returns:
         A new Modin DataFrame object.
     """
-    from modin.data_management.factories import BaseFactory
+    from modin.data_management.dispatcher import EngineDispatcher
     from .dataframe import DataFrame
 
-    return DataFrame(query_compiler=BaseFactory.from_pandas(df))
+    return DataFrame(query_compiler=EngineDispatcher.from_pandas(df))
 
 
 def to_pandas(modin_obj):


### PR DESCRIPTION
## What do these changes do?

Split `BaseFactory` in two, as now it serves two unrelated purposes - one being the base for processing and one dispatching to a correct factory.

This also adds caching of chosen engine, so this _very slightly_ speeds up things.

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] First part of solving https://github.com/modin-project/modin/issues/1540
- [x] tests added and passing
