### PR TITLE
Correctly handle mismatched quotes and csv.QUOTE_NONE flag.

### DIFF
--- a/modin/engines/base/io/text/text_file_reader.py
+++ b/modin/engines/base/io/text/text_file_reader.py
@@ -26,7 +26,7 @@ class TextFileReader(FileReader):
         line = f.readline()  # Ensure we read up to a newline
         # We need to ensure that one row isn't being split across different partitions
 
-        if not args['quoting'] == csv.QUOTE_NONE:
+        if not args["quoting"] == csv.QUOTE_NONE:
             quote_count = (
                 re.subn(quotechar, b"", chunk)[1] + re.subn(quotechar, b"", line)[1]
             )
@@ -37,7 +37,7 @@ class TextFileReader(FileReader):
                     break
 
             if quote_count % 2 != 0:
-                warnings.warn('File has mismatched quotes')
+                warnings.warn("File has mismatched quotes")
 
         else:
             f.seek(0, 2)

--- a/modin/engines/base/io/text/text_file_reader.py
+++ b/modin/engines/base/io/text/text_file_reader.py
@@ -14,6 +14,8 @@
 from modin.engines.base.io.file_reader import FileReader
 import re
 import numpy as np
+import warnings
+import csv
 
 
 class TextFileReader(FileReader):
@@ -22,12 +24,24 @@ class TextFileReader(FileReader):
         args["start"] = f.tell()
         chunk = f.read(chunk_size)
         line = f.readline()  # Ensure we read up to a newline
-        # We need to ensure that
-        quote_count = (
-            re.subn(quotechar, b"", chunk)[1] + re.subn(quotechar, b"", line)[1]
-        )
-        while quote_count % 2 != 0:
-            quote_count += re.subn(quotechar, b"", f.readline())[1]
+        # We need to ensure that one row isn't being split across different partitions
+
+        if not args['quoting'] == csv.QUOTE_NONE:
+            quote_count = (
+                re.subn(quotechar, b"", chunk)[1] + re.subn(quotechar, b"", line)[1]
+            )
+            while quote_count % 2 != 0:
+                line = f.readline()
+                quote_count += re.subn(quotechar, b"", line)[1]
+                if not line:
+                    break
+
+            if quote_count % 2 != 0:
+                warnings.warn('File has mismatched quotes')
+
+        else:
+            f.seek(0, 2)
+
         # The workers return multiple objects for each part of the file read:
         # - The first n - 2 objects are partitions of data
         # - The n - 1 object is the length of the partition or the index if

--- a/modin/engines/base/io/text/text_file_reader.py
+++ b/modin/engines/base/io/text/text_file_reader.py
@@ -34,13 +34,11 @@ class TextFileReader(FileReader):
                 line = f.readline()
                 quote_count += re.subn(quotechar, b"", line)[1]
                 if not line:
+                    warnings.warn("Reached EOF but have not found matching quote.")
                     break
 
             if quote_count % 2 != 0:
                 warnings.warn("File has mismatched quotes")
-
-        else:
-            f.seek(0, 2)
 
         # The workers return multiple objects for each part of the file read:
         # - The first n - 2 objects are partitions of data

--- a/modin/engines/base/io/text/text_file_reader.py
+++ b/modin/engines/base/io/text/text_file_reader.py
@@ -26,7 +26,7 @@ class TextFileReader(FileReader):
         line = f.readline()  # Ensure we read up to a newline
         # We need to ensure that one row isn't being split across different partitions
 
-        if not args["quoting"] == csv.QUOTE_NONE:
+        if args.get("quoting", "") != csv.QUOTE_NONE:
             quote_count = (
                 re.subn(quotechar, b"", chunk)[1] + re.subn(quotechar, b"", line)[1]
             )
@@ -34,7 +34,6 @@ class TextFileReader(FileReader):
                 line = f.readline()
                 quote_count += re.subn(quotechar, b"", line)[1]
                 if not line:
-                    warnings.warn("Reached EOF but have not found matching quote.")
                     break
 
             if quote_count % 2 != 0:

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -23,6 +23,8 @@ import pyarrow.parquet as pq
 import os
 import shutil
 import sqlalchemy as sa
+import io
+import csv
 
 from .utils import (
     df_equals,
@@ -748,6 +750,29 @@ def test_from_csv_sep_none(make_csv_file):
         modin_df = pd.read_csv(TEST_CSV_FILENAME, sep=None)
     df_equals(modin_df, pandas_df)
 
+def test_from_csv_bad_quotes():
+    csv_bad_quotes = """
+    1, 2, 3, 4
+    one, two, three, four
+    five, "six", seven, "eight
+    """
+
+    pandas_df = pandas.read_csv(io.StringIO(csv_bad_quotes))
+    modin_df = pd.read_csv(io.StringIO(csv_bad_quotes))
+
+    df_equals(modin_df, pandas_df)
+
+def test_from_csv_quote_none():
+    csv_bad_quotes = """
+    1, 2, 3, 4
+    one, two, three, four
+    five, "six", seven, "eight
+    """
+
+    pandas_df = pandas.read_csv(io.StringIO(csv_bad_quotes), quoting=csv.QUOTE_NONE)
+    modin_df = pd.read_csv(io.StringIO(csv_bad_quotes), quoting=csv.QUOTE_NONE)
+
+    df_equals(modin_df, pandas_df)
 
 def test_from_csv_categories():
     pandas_df = pandas.read_csv(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -751,11 +751,11 @@ def test_from_csv_sep_none(make_csv_file):
 
 
 def test_from_csv_bad_quotes():
-    csv_bad_quotes = """
-    1, 2, 3, 4
-    one, two, three, four
-    five, "six", seven, "eight
-    """
+    csv_bad_quotes = """1, 2, 3, 4
+one, two, three, four
+five, "six", seven, "eight
+"""
+
     with open(TEST_CSV_FILENAME, "w") as f:
         f.write(csv_bad_quotes)
 
@@ -766,11 +766,10 @@ def test_from_csv_bad_quotes():
 
 
 def test_from_csv_quote_none():
-    csv_bad_quotes = """
-    1, 2, 3, 4
-    one, two, three, four
-    five, "six", seven, "eight
-    """
+    csv_bad_quotes = """1, 2, 3, 4
+one, two, three, four
+five, "six", seven, "eight
+"""
     with open(TEST_CSV_FILENAME, "w") as f:
         f.write(csv_bad_quotes)
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -750,17 +750,21 @@ def test_from_csv_sep_none(make_csv_file):
         modin_df = pd.read_csv(TEST_CSV_FILENAME, sep=None)
     df_equals(modin_df, pandas_df)
 
+
 def test_from_csv_bad_quotes():
     csv_bad_quotes = """
     1, 2, 3, 4
     one, two, three, four
     five, "six", seven, "eight
     """
+    with open(TEST_CSV_FILENAME, "w") as f:
+        f.write(csv_bad_quotes)
 
-    pandas_df = pandas.read_csv(io.StringIO(csv_bad_quotes))
-    modin_df = pd.read_csv(io.StringIO(csv_bad_quotes))
+    pandas_df = pandas.read_csv(TEST_CSV_FILENAME)
+    modin_df = pd.read_csv(TEST_CSV_FILENAME)
 
     df_equals(modin_df, pandas_df)
+
 
 def test_from_csv_quote_none():
     csv_bad_quotes = """
@@ -768,11 +772,14 @@ def test_from_csv_quote_none():
     one, two, three, four
     five, "six", seven, "eight
     """
+    with open(TEST_CSV_FILENAME, "w") as f:
+        f.write(csv_bad_quotes)
 
-    pandas_df = pandas.read_csv(io.StringIO(csv_bad_quotes), quoting=csv.QUOTE_NONE)
-    modin_df = pd.read_csv(io.StringIO(csv_bad_quotes), quoting=csv.QUOTE_NONE)
+    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, quoting=csv.QUOTE_NONE)
+    modin_df = pd.read_csv(TEST_CSV_FILENAME, quoting=csv.QUOTE_NONE)
 
     df_equals(modin_df, pandas_df)
+
 
 def test_from_csv_categories():
     pandas_df = pandas.read_csv(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -23,7 +23,6 @@ import pyarrow.parquet as pq
 import os
 import shutil
 import sqlalchemy as sa
-import io
 import csv
 
 from .utils import (


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR updates the `call_deploy` method on `TextFileReader` to handle an edge case where an odd number of quotes in a file causes an infinite loop.

In addition, the entire quoting check is skipped if `csv.QUOTE_NONE` or `3` are passed as arguments to the `quoting` variable of `read_csv`.

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1423
- [ ] tests added and passing
