### PR TITLE
Add Pub-Sub class to enable switching of execution engine on the fly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           python-version: "3.6.x"
           architecture: "x64"
       - run: pip install -r requirements.txt
-      - run: python -m pytest modin/test/test_publisher.py
+      - run: python -m pytest modin/test/test_publisher.py modin/data_management/test/test_dispatcher.py
   test-all:
     needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,19 @@ jobs:
           architecture: "x64"
       - run: pip install -r requirements.txt
       - run: python -m pytest modin/test/test_headers.py
+  test-internals:
+    runs-on: ubuntu-latest
+    name: test-internals
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.6.x"
+          architecture: "x64"
+      - run: pip install -r requirements.txt
+      - run: python -m pytest modin/test/test_publisher.py
   test-all:
     needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -109,8 +109,7 @@ class Publisher(object):
     def put(self, value):
         oldvalue, self.__value = self.__value, value
         if oldvalue != value:
-            for weakCallback in self.__subs:
-                callback = weakCallback()
+            for callback in tuple(self.__subs):
                 if callback:
                     callback(self)
             try:
@@ -118,8 +117,7 @@ class Publisher(object):
             except KeyError:
                 return
             if once:
-                for weakCallback in once:
-                    callback = weakCallback()
+                for callback in tuple(once):
                     if callback:
                         callback(self)
             del self.__once[value]

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -15,7 +15,6 @@ import os
 import sys
 import warnings
 from packaging import version
-import weakref
 import collections
 
 from ._version import get_versions
@@ -90,8 +89,8 @@ class Publisher(object):
     def __init__(self, name, value):
         self.name = name
         self.__value = value
-        self.__subs = weakref.WeakSet()
-        self.__once = collections.defaultdict(weakref.WeakSet)
+        self.__subs = set()
+        self.__once = collections.defaultdict(set)
 
     def subscribe(self, callback):
         self.__subs.add(callback)
@@ -109,17 +108,15 @@ class Publisher(object):
     def put(self, value):
         oldvalue, self.__value = self.__value, value
         if oldvalue != value:
-            for callback in tuple(self.__subs):
-                if callback:
-                    callback(self)
+            for callback in self.__subs:
+                callback(self)
             try:
                 once = self.__once[value]
             except KeyError:
                 return
             if once:
-                for callback in tuple(once):
-                    if callback:
-                        callback(self)
+                for callback in once:
+                    callback(self)
             del self.__once[value]
 
 

--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -61,6 +61,10 @@ class EngineDispatcher(object):
     """
 
     __engine = None
+    @classmethod
+    def get_engine(cls):
+        # mostly for testing
+        return cls.__engine
 
     @classmethod
     def _update_engine(cls, _):

--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -61,6 +61,7 @@ class EngineDispatcher(object):
     """
 
     __engine = None
+
     @classmethod
     def get_engine(cls):
         # mostly for testing

--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -63,7 +63,7 @@ class EngineDispatcher(object):
     __engine = None
 
     @classmethod
-    def get_engine(cls):
+    def get_engine(cls) -> factories.BaseFactory:
         # mostly for testing
         return cls.__engine
 

--- a/modin/data_management/test/test_dispatcher.py
+++ b/modin/data_management/test/test_dispatcher.py
@@ -18,33 +18,39 @@ from modin import execution_engine, partition_format
 from modin.data_management.dispatcher import EngineDispatcher, FactoryNotFoundError
 from modin.data_management import factories
 
+
 class PandasOnTestFactory(factories.BaseFactory):
     """
     Stub factory to ensure we can switch execution engine to 'Test'
     """
+
 
 class TestOnPythonFactory(factories.BaseFactory):
     """
     Stub factory to ensure we can switch partition format to 'Test'
     """
 
+
 # inject the stubs
 factories.PandasOnTestFactory = PandasOnTestFactory
 factories.TestOnPythonFactory = TestOnPythonFactory
 
+
 def test_default_engine():
     assert EngineDispatcher.get_engine() == factories.PandasOnDaskFactory
 
-def test_engine_switch():
-    execution_engine.put('Test')
-    assert EngineDispatcher.get_engine() == PandasOnTestFactory
-    execution_engine.put('Python') # revert engine to default
 
-    partition_format.put('Test')
+def test_engine_switch():
+    execution_engine.put("Test")
+    assert EngineDispatcher.get_engine() == PandasOnTestFactory
+    execution_engine.put("Python")  # revert engine to default
+
+    partition_format.put("Test")
     assert EngineDispatcher.get_engine() == TestOnPythonFactory
-    partition_format.put('Pandas') # revert engine to default
+    partition_format.put("Pandas")  # revert engine to default
+
 
 def test_engine_wrong_factory():
     with pytest.raises(FactoryNotFoundError):
-        execution_engine.put('BadEngine')
-    execution_engine.put('Python') # revert engine to default
+        execution_engine.put("BadEngine")
+    execution_engine.put("Python")  # revert engine to default

--- a/modin/data_management/test/test_dispatcher.py
+++ b/modin/data_management/test/test_dispatcher.py
@@ -1,0 +1,50 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pytest
+
+from modin import execution_engine, partition_format
+
+from modin.data_management.dispatcher import EngineDispatcher, FactoryNotFoundError
+from modin.data_management import factories
+
+class PandasOnTestFactory(factories.BaseFactory):
+    """
+    Stub factory to ensure we can switch execution engine to 'Test'
+    """
+
+class TestOnPythonFactory(factories.BaseFactory):
+    """
+    Stub factory to ensure we can switch partition format to 'Test'
+    """
+
+# inject the stubs
+factories.PandasOnTestFactory = PandasOnTestFactory
+factories.TestOnPythonFactory = TestOnPythonFactory
+
+def test_default_engine():
+    assert EngineDispatcher.get_engine() == factories.PandasOnDaskFactory
+
+def test_engine_switch():
+    execution_engine.put('Test')
+    assert EngineDispatcher.get_engine() == PandasOnTestFactory
+    execution_engine.put('Python') # revert engine to default
+
+    partition_format.put('Test')
+    assert EngineDispatcher.get_engine() == TestOnPythonFactory
+    partition_format.put('Pandas') # revert engine to default
+
+def test_engine_wrong_factory():
+    with pytest.raises(FactoryNotFoundError):
+        execution_engine.put('BadEngine')
+    execution_engine.put('Python') # revert engine to default

--- a/modin/data_management/test/test_dispatcher.py
+++ b/modin/data_management/test/test_dispatcher.py
@@ -37,7 +37,8 @@ factories.TestOnPythonFactory = TestOnPythonFactory
 
 
 def test_default_engine():
-    assert EngineDispatcher.get_engine() == factories.PandasOnDaskFactory
+    assert issubclass(EngineDispatcher.get_engine(), factories.BaseFactory)
+    assert EngineDispatcher.get_engine().io_cls
 
 
 def test_engine_switch():

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -56,6 +56,7 @@ def test_top_level_api_equality():
         "datetimes",
         "reshape",
         "execution_engine",
+        "Publisher",
         "types",
         "sys",
         "initialize_ray",
@@ -66,7 +67,7 @@ def test_top_level_api_equality():
         "os",
         "multiprocessing",
         "Client",
-        "client",
+        "dask_client",
         "get_client",
     ]
 

--- a/modin/test/test_publisher.py
+++ b/modin/test/test_publisher.py
@@ -1,0 +1,50 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+from collections import defaultdict
+
+from modin import Publisher
+
+def test_equals():
+    pub = Publisher('name', 'value1')
+    assert pub.get() == 'value1'
+
+    pub.put('value2')
+    assert pub.get() == 'value2'
+
+def test_triggers():
+    results = defaultdict(int)
+    callbacks = []
+    def make_callback(name, res=results):
+        def callback(p: Publisher):
+            res[name] += 1
+        # keep reference to callbacks so they won't be removed by GC
+        callbacks.append(callback)
+        return callback
+
+    pub = Publisher('name', 'init')
+    pub.once('init', make_callback('init'))
+    assert results['init'] == 1
+
+    pub.once('never', make_callback('never'))
+    pub.once('once', make_callback('once'))
+    pub.subscribe(make_callback('subscribe'))
+
+    pub.put('multi')
+    pub.put('once')
+    pub.put('multi')
+    pub.put('once')
+
+    expected = [('init', 1), ('never', 0), ('once', 1), ('subscribe', 5)]
+    for name, val in expected:
+        assert results[name] == val, "{} has wrong count".format(name)

--- a/modin/test/test_publisher.py
+++ b/modin/test/test_publisher.py
@@ -15,36 +15,40 @@ from collections import defaultdict
 
 from modin import Publisher
 
-def test_equals():
-    pub = Publisher('name', 'value1')
-    assert pub.get() == 'value1'
 
-    pub.put('value2')
-    assert pub.get() == 'value2'
+def test_equals():
+    pub = Publisher("name", "value1")
+    assert pub.get() == "value1"
+
+    pub.put("value2")
+    assert pub.get() == "value2"
+
 
 def test_triggers():
     results = defaultdict(int)
     callbacks = []
+
     def make_callback(name, res=results):
         def callback(p: Publisher):
             res[name] += 1
+
         # keep reference to callbacks so they won't be removed by GC
         callbacks.append(callback)
         return callback
 
-    pub = Publisher('name', 'init')
-    pub.once('init', make_callback('init'))
-    assert results['init'] == 1
+    pub = Publisher("name", "init")
+    pub.once("init", make_callback("init"))
+    assert results["init"] == 1
 
-    pub.once('never', make_callback('never'))
-    pub.once('once', make_callback('once'))
-    pub.subscribe(make_callback('subscribe'))
+    pub.once("never", make_callback("never"))
+    pub.once("once", make_callback("once"))
+    pub.subscribe(make_callback("subscribe"))
 
-    pub.put('multi')
-    pub.put('once')
-    pub.put('multi')
-    pub.put('once')
+    pub.put("multi")
+    pub.put("once")
+    pub.put("multi")
+    pub.put("once")
 
-    expected = [('init', 1), ('never', 0), ('once', 1), ('subscribe', 5)]
+    expected = [("init", 1), ("never", 0), ("once", 1), ("subscribe", 5)]
     for name, val in expected:
         assert results[name] == val, "{} has wrong count".format(name)


### PR DESCRIPTION
Currently most modules are not ready to switch dynamically, will be added later

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
* Add class that provides Pubish-Subscribe model to enable the possibility to change execution engine or partition format on the fly
* Old `modin.__execution_engine__` and `modin.__partition_format__` are retained for compatibility, will be removed when all parts are migrated
* `modin.pandas` client instantiation and `EngineDispatcher` are fully migrated

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Continues https://github.com/modin-project/modin/pull/1547 to eventually fulfill https://github.com/modin-project/modin/issues/1540
- [x] tests added and passing
