### PR TITLE
Move groupby aggregate functionality into query compiler

### DIFF
--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -793,19 +793,19 @@ class BaseQueryCompiler(abc.ABC):
     def groupby_agg(self, by, axis, agg_func, groupby_args, agg_args):
         pass
 
-    @abc.abstractmethod
-    def groupby_reduce(
-        self,
-        by,
-        axis,
-        groupby_args,
-        map_func,
-        map_args,
-        reduce_func=None,
-        reduce_args=None,
-        numeric_only=True,
-    ):
-        pass
+    # @abc.abstractmethod
+    # def groupby_reduce(
+    #     self,
+    #     by,
+    #     axis,
+    #     groupby_args,
+    #     map_func,
+    #     map_args,
+    #     reduce_func=None,
+    #     reduce_args=None,
+    #     numeric_only=True,
+    # ):
+    #     pass
 
     # END Manual Partitioning methods
 

--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -789,23 +789,298 @@ class BaseQueryCompiler(abc.ABC):
     # These methods require some sort of manual partitioning due to their
     # nature. They require certain data to exist on the same partition, and
     # after the shuffle, there should be only a local map required.
+
+    @abc.abstractmethod
+    def groupby_count(
+        self,
+        by,
+        axis,
+        groupby_args,
+        map_args,
+        reduce_args=None,
+        numeric_only=True,
+        drop=False,
+    ):
+        """Perform a groupby count.
+
+        Parameters
+        ----------
+        by : BaseQueryCompiler
+            The query compiler object to groupby.
+        axis : 0 or 1
+            The axis to groupby. Must be 0 currently.
+        groupby_args : dict
+            The arguments for the groupby component.
+        map_args : dict
+            The arguments for the `map_func`.
+        reduce_args : dict
+            The arguments for `reduce_func`.
+        numeric_only : bool
+            Whether to drop non-numeric columns.
+        drop : bool
+            Whether the data in `by` was dropped.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        pass
+
+    @abc.abstractmethod
+    def groupby_any(
+        self,
+        by,
+        axis,
+        groupby_args,
+        map_args,
+        reduce_args=None,
+        numeric_only=True,
+        drop=False,
+    ):
+        """Perform a groupby any.
+
+        Parameters
+        ----------
+        by : BaseQueryCompiler
+            The query compiler object to groupby.
+        axis : 0 or 1
+            The axis to groupby. Must be 0 currently.
+        groupby_args : dict
+            The arguments for the groupby component.
+        map_args : dict
+            The arguments for the `map_func`.
+        reduce_args : dict
+            The arguments for `reduce_func`.
+        numeric_only : bool
+            Whether to drop non-numeric columns.
+        drop : bool
+            Whether the data in `by` was dropped.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        pass
+
+    @abc.abstractmethod
+    def groupby_min(
+        self,
+        by,
+        axis,
+        groupby_args,
+        map_args,
+        reduce_args=None,
+        numeric_only=True,
+        drop=False,
+    ):
+        """Perform a groupby min.
+
+        Parameters
+        ----------
+        by : BaseQueryCompiler
+            The query compiler object to groupby.
+        axis : 0 or 1
+            The axis to groupby. Must be 0 currently.
+        groupby_args : dict
+            The arguments for the groupby component.
+        map_args : dict
+            The arguments for the `map_func`.
+        reduce_args : dict
+            The arguments for `reduce_func`.
+        numeric_only : bool
+            Whether to drop non-numeric columns.
+        drop : bool
+            Whether the data in `by` was dropped.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        pass
+
+    @abc.abstractmethod
+    def groupby_prod(
+        self,
+        by,
+        axis,
+        groupby_args,
+        map_args,
+        reduce_args=None,
+        numeric_only=True,
+        drop=False,
+    ):
+        """Perform a groupby prod.
+
+        Parameters
+        ----------
+        by : BaseQueryCompiler
+            The query compiler object to groupby.
+        axis : 0 or 1
+            The axis to groupby. Must be 0 currently.
+        groupby_args : dict
+            The arguments for the groupby component.
+        map_args : dict
+            The arguments for the `map_func`.
+        reduce_args : dict
+            The arguments for `reduce_func`.
+        numeric_only : bool
+            Whether to drop non-numeric columns.
+        drop : bool
+            Whether the data in `by` was dropped.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        pass
+
+    @abc.abstractmethod
+    def groupby_max(
+        self,
+        by,
+        axis,
+        groupby_args,
+        map_args,
+        reduce_args=None,
+        numeric_only=True,
+        drop=False,
+    ):
+        """Perform a groupby max.
+
+        Parameters
+        ----------
+        by : BaseQueryCompiler
+            The query compiler object to groupby.
+        axis : 0 or 1
+            The axis to groupby. Must be 0 currently.
+        groupby_args : dict
+            The arguments for the groupby component.
+        map_args : dict
+            The arguments for the `map_func`.
+        reduce_args : dict
+            The arguments for `reduce_func`.
+        numeric_only : bool
+            Whether to drop non-numeric columns.
+        drop : bool
+            Whether the data in `by` was dropped.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        pass
+
+    @abc.abstractmethod
+    def groupby_all(
+        self,
+        by,
+        axis,
+        groupby_args,
+        map_args,
+        reduce_args=None,
+        numeric_only=True,
+        drop=False,
+    ):
+        """Perform a groupby all.
+
+        Parameters
+        ----------
+        by : BaseQueryCompiler
+            The query compiler object to groupby.
+        axis : 0 or 1
+            The axis to groupby. Must be 0 currently.
+        groupby_args : dict
+            The arguments for the groupby component.
+        map_args : dict
+            The arguments for the `map_func`.
+        reduce_args : dict
+            The arguments for `reduce_func`.
+        numeric_only : bool
+            Whether to drop non-numeric columns.
+        drop : bool
+            Whether the data in `by` was dropped.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        pass
+
+    @abc.abstractmethod
+    def groupby_sum(
+        self,
+        by,
+        axis,
+        groupby_args,
+        map_args,
+        reduce_args=None,
+        numeric_only=True,
+        drop=False,
+    ):
+        """Perform a groupby sum.
+
+        Parameters
+        ----------
+        by : BaseQueryCompiler
+            The query compiler object to groupby.
+        axis : 0 or 1
+            The axis to groupby. Must be 0 currently.
+        groupby_args : dict
+            The arguments for the groupby component.
+        map_args : dict
+            The arguments for the `map_func`.
+        reduce_args : dict
+            The arguments for `reduce_func`.
+        numeric_only : bool
+            Whether to drop non-numeric columns.
+        drop : bool
+            Whether the data in `by` was dropped.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        pass
+
+    @abc.abstractmethod
+    def groupby_size(
+        self,
+        by,
+        axis,
+        groupby_args,
+        map_args,
+        reduce_args=None,
+        numeric_only=True,
+        drop=False,
+    ):
+        """Perform a groupby size.
+
+        Parameters
+        ----------
+        by : BaseQueryCompiler
+            The query compiler object to groupby.
+        axis : 0 or 1
+            The axis to groupby. Must be 0 currently.
+        groupby_args : dict
+            The arguments for the groupby component.
+        map_args : dict
+            The arguments for the `map_func`.
+        reduce_args : dict
+            The arguments for `reduce_func`.
+        numeric_only : bool
+            Whether to drop non-numeric columns.
+        drop : bool
+            Whether the data in `by` was dropped.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        pass
+
     @abc.abstractmethod
     def groupby_agg(self, by, axis, agg_func, groupby_args, agg_args):
         pass
-
-    # @abc.abstractmethod
-    # def groupby_reduce(
-    #     self,
-    #     by,
-    #     axis,
-    #     groupby_args,
-    #     map_func,
-    #     map_args,
-    #     reduce_func=None,
-    #     reduce_args=None,
-    #     numeric_only=True,
-    # ):
-    #     pass
 
     # END Manual Partitioning methods
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -28,6 +28,7 @@ from modin.data_management.functions import (
     MapReduceFunction,
     ReductionFunction,
     BinaryFunction,
+    GroupbyReduceFunction,
 )
 
 
@@ -1293,159 +1294,30 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # nature. They require certain data to exist on the same partition, and
     # after the shuffle, there should be only a local map required.
 
-    def groupby_reduce(
-        self,
-        by,
-        axis,
-        groupby_args,
-        map_func,
-        map_args,
-        reduce_func=None,
-        reduce_args=None,
-        numeric_only=True,
-        drop=False,
-    ):
-        """Apply a Groupby via MapReduce pattern.
-
-        Note: Result length will be the number of unique values in `by`.
-
-        Currently, here is how this is implemented:
-        - map phase:
-            During the map phase we set `as_index` to True to force the `by` into the
-            index for the next phase. We always do this so that the reduce phase has
-            complete access of the `by` data without having to shuffle it twice. The map
-            function is applied with the arguments provided. The `index` of the
-            partitions will become the new `by` column. Sometimes, the name of `by` is
-            the same as a data column. In these cases we add "_modin_groupby_" to the
-            name of the index. This does not happen when grouping by multiple columns
-            because those columns have already been dropped as a requirement.
-        - reduce phase:
-            During the reduce phase, the `by` data is moved from the `index` into the
-            data. The names of those inserted become the `by` for the reduce phase of
-            the groupby. Once applied, we drop the columns in all partitions after the
-            first so we do not insert the data multiple times. We also avoid inserting
-            data when the data from the `by` parameter did not come from this object.
-            The columns can be derived externally but the new index must be computed
-            post hoc.
-
-        Args:
-            by: The query compiler object to groupby.
-            axis: The axis to groupby. Must be 0 currently.
-            groupby_args: The arguments for the groupby component.
-            map_func: The function to perform during the map phase.
-            map_args: The arguments for the `map_func`.
-            reduce_func: The function to perform during the reduce phase.
-            reduce_args: The arguments for `reduce_func`.
-            numeric_only: Whether to drop non-numeric columns.
-            drop: Whether the data in `by` was dropped.
-
-        Returns:
-            A new Query Compiler
-        """
-        assert isinstance(
-            by, type(self)
-        ), "Can only use groupby reduce with another Query Compiler"
-        assert axis == 0, "Can only groupby reduce with axis=0"
-
-        if numeric_only:
-            qc = self.getitem_column_array(self._modin_frame._numeric_columns(True))
-        else:
-            qc = self
-        as_index = groupby_args.get("as_index", True)
-        # For simplicity we allow only one function to be passed in if both are the
-        # same.
-        if reduce_func is None:
-            reduce_func = map_func
-            reduce_args = map_args
-
-        def _map(df, other):
-            def compute_map(df, other):
-                # Set `as_index` to True to track the metadata of the grouping object
-                # It is used to make sure that between phases we are constructing the
-                # right index and placing columns in the correct order.
-                groupby_args["as_index"] = True
-                other = other.squeeze(axis=axis ^ 1)
-                if isinstance(other, pandas.DataFrame):
-                    df = pandas.concat(
-                        [df] + [other[[o for o in other if o not in df]]], axis=1
-                    )
-                    other = list(other.columns)
-                result = map_func(
-                    df.groupby(by=other, axis=axis, **groupby_args), **map_args
-                )
-                # The _modin_groupby_ prefix indicates that this is the first partition,
-                # and since we may need to insert the grouping data in the reduce phase
-                if (
-                    not isinstance(result.index, pandas.MultiIndex)
-                    and result.index.name is not None
-                    and result.index.name in result.columns
-                ):
-                    result.index.name = "{}{}".format(
-                        "_modin_groupby_", result.index.name
-                    )
-                return result
-
-            try:
-                return compute_map(df, other)
-            # This will happen with Arrow buffer read-only errors. We don't want to copy
-            # all the time, so this will try to fast-path the code first.
-            except (ValueError):
-                return compute_map(df.copy(), other.copy())
-
-        def _reduce(df):
-            def compute_reduce(df):
-                other_len = len(df.index.names)
-                df = df.reset_index(drop=False)
-                # See note above about setting `as_index`
-                groupby_args["as_index"] = as_index
-                if other_len > 1:
-                    by_part = list(df.columns[0:other_len])
-                else:
-                    by_part = df.columns[0]
-                result = reduce_func(
-                    df.groupby(by=by_part, axis=axis, **groupby_args), **reduce_args
-                )
-                if (
-                    not isinstance(result.index, pandas.MultiIndex)
-                    and result.index.name is not None
-                    and "_modin_groupby_" in result.index.name
-                ):
-                    result.index.name = result.index.name[len("_modin_groupby_") :]
-                if isinstance(by_part, str) and by_part in result.columns:
-                    if "_modin_groupby_" in by_part and drop:
-                        col_name = by_part[len("_modin_groupby_") :]
-                        new_result = result.drop(columns=col_name)
-                        new_result.columns = [
-                            col_name if "_modin_groupby_" in c else c
-                            for c in new_result.columns
-                        ]
-                        return new_result
-                    else:
-                        return result.drop(columns=by_part)
-                return result
-
-            try:
-                return compute_reduce(df)
-            # This will happen with Arrow buffer read-only errors. We don't want to copy
-            # all the time, so this will try to fast-path the code first.
-            except (ValueError):
-                return compute_reduce(df.copy())
-
-        if axis == 0:
-            new_columns = qc.columns
-            new_index = None
-        else:
-            new_index = self.index
-            new_columns = None
-        new_modin_frame = qc._modin_frame.groupby_reduce(
-            axis,
-            by._modin_frame,
-            _map,
-            _reduce,
-            new_columns=new_columns,
-            new_index=new_index,
-        )
-        return self.__constructor__(new_modin_frame)
+    groupby_count = GroupbyReduceFunction.register(
+        lambda df, **kwargs: df.count(**kwargs), lambda df, **kwargs: df.sum(**kwargs)
+    )
+    groupby_any = GroupbyReduceFunction.register(
+        lambda df, **kwargs: df.any(**kwargs), lambda df, **kwargs: df.any(**kwargs)
+    )
+    groupby_min = GroupbyReduceFunction.register(
+        lambda df, **kwargs: df.min(**kwargs), lambda df, **kwargs: df.min(**kwargs)
+    )
+    groupby_prod = GroupbyReduceFunction.register(
+        lambda df, **kwargs: df.prod(**kwargs), lambda df, **kwargs: df.prod(**kwargs)
+    )
+    groupby_max = GroupbyReduceFunction.register(
+        lambda df, **kwargs: df.max(**kwargs), lambda df, **kwargs: df.max(**kwargs)
+    )
+    groupby_all = GroupbyReduceFunction.register(
+        lambda df, **kwargs: df.all(**kwargs), lambda df, **kwargs: df.all(**kwargs)
+    )
+    groupby_sum = GroupbyReduceFunction.register(
+        lambda df, **kwargs: df.sum(**kwargs), lambda df, **kwargs: df.sum(**kwargs)
+    )
+    groupby_size = GroupbyReduceFunction.register(
+        lambda df, **kwargs: pandas.DataFrame(df.size()), lambda df, **kwargs: df.sum()
+    )
 
     def groupby_agg(self, by, axis, agg_func, groupby_args, agg_args, drop=False):
         as_index = groupby_args.get("as_index", True)

--- a/modin/data_management/functions/__init__.py
+++ b/modin/data_management/functions/__init__.py
@@ -16,6 +16,7 @@ from .mapreducefunction import MapReduceFunction
 from .reductionfunction import ReductionFunction
 from .foldfunction import FoldFunction
 from .binary_function import BinaryFunction
+from .groupby_function import GroupbyReduceFunction
 
 __all__ = [
     "MapFunction",
@@ -23,4 +24,5 @@ __all__ = [
     "ReductionFunction",
     "FoldFunction",
     "BinaryFunction",
+    "GroupbyReduceFunction",
 ]

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -1,0 +1,134 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pandas
+
+from .mapreducefunction import MapReduceFunction
+
+
+class GroupbyReduceFunction(MapReduceFunction):
+    @classmethod
+    def call(cls, map_func, reduce_func, *call_args, **call_kwds):
+        def caller(
+            query_compiler,
+            by,
+            axis,
+            groupby_args,
+            map_args,
+            reduce_args=None,
+            numeric_only=True,
+            drop=False,
+        ):
+            assert isinstance(
+                by, type(query_compiler)
+            ), "Can only use groupby reduce with another Query Compiler"
+            assert axis == 0, "Can only groupby reduce with axis=0"
+
+            if numeric_only:
+                qc = query_compiler.getitem_column_array(
+                    query_compiler._modin_frame._numeric_columns(True)
+                )
+            else:
+                qc = query_compiler
+            as_index = groupby_args.get("as_index", True)
+
+            def _map(df, other):
+                def compute_map(df, other):
+                    # Set `as_index` to True to track the metadata of the grouping object
+                    # It is used to make sure that between phases we are constructing the
+                    # right index and placing columns in the correct order.
+                    groupby_args["as_index"] = True
+                    other = other.squeeze(axis=axis ^ 1)
+                    if isinstance(other, pandas.DataFrame):
+                        df = pandas.concat(
+                            [df] + [other[[o for o in other if o not in df]]], axis=1
+                        )
+                        other = list(other.columns)
+                    result = map_func(
+                        df.groupby(by=other, axis=axis, **groupby_args), **map_args
+                    )
+                    # The _modin_groupby_ prefix indicates that this is the first partition,
+                    # and since we may need to insert the grouping data in the reduce phase
+                    if (
+                        not isinstance(result.index, pandas.MultiIndex)
+                        and result.index.name is not None
+                        and result.index.name in result.columns
+                    ):
+                        result.index.name = "{}{}".format(
+                            "_modin_groupby_", result.index.name
+                        )
+                    return result
+
+                try:
+                    return compute_map(df, other)
+                # This will happen with Arrow buffer read-only errors. We don't want to copy
+                # all the time, so this will try to fast-path the code first.
+                except ValueError:
+                    return compute_map(df.copy(), other.copy())
+
+            def _reduce(df):
+                def compute_reduce(df):
+                    other_len = len(df.index.names)
+                    df = df.reset_index(drop=False)
+                    # See note above about setting `as_index`
+                    groupby_args["as_index"] = as_index
+                    if other_len > 1:
+                        by_part = list(df.columns[0:other_len])
+                    else:
+                        by_part = df.columns[0]
+                    result = reduce_func(
+                        df.groupby(by=by_part, axis=axis, **groupby_args), **reduce_args
+                    )
+                    if (
+                        not isinstance(result.index, pandas.MultiIndex)
+                        and result.index.name is not None
+                        and "_modin_groupby_" in result.index.name
+                    ):
+                        result.index.name = result.index.name[len("_modin_groupby_") :]
+                    if isinstance(by_part, str) and by_part in result.columns:
+                        if "_modin_groupby_" in by_part and drop:
+                            col_name = by_part[len("_modin_groupby_") :]
+                            new_result = result.drop(columns=col_name)
+                            new_result.columns = [
+                                col_name if "_modin_groupby_" in c else c
+                                for c in new_result.columns
+                            ]
+                            return new_result
+                        else:
+                            return result.drop(columns=by_part)
+                    return result
+
+                try:
+                    return compute_reduce(df)
+                # This will happen with Arrow buffer read-only errors. We don't want to copy
+                # all the time, so this will try to fast-path the code first.
+                except ValueError:
+                    return compute_reduce(df.copy())
+
+            if axis == 0:
+                new_columns = qc.columns
+                new_index = None
+            else:
+                new_index = query_compiler.index
+                new_columns = None
+            new_modin_frame = qc._modin_frame.groupby_reduce(
+                axis,
+                by._modin_frame,
+                _map,
+                _reduce,
+                new_columns=new_columns,
+                new_index=new_index,
+            )
+            return query_compiler.__constructor__(new_modin_frame)
+
+        return caller

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -184,7 +184,7 @@ class DataFrameGroupBy(object):
     def any(self, **kwargs):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_any,
-            lambda df: df.any(**kwargs),
+            lambda df, **kwargs: df.any(**kwargs),
             numeric_only=False,
             **kwargs,
         )
@@ -210,7 +210,7 @@ class DataFrameGroupBy(object):
     def min(self, **kwargs):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_min,
-            lambda df: df.min(**kwargs),
+            lambda df, **kwargs: df.min(**kwargs),
             numeric_only=False,
             **kwargs,
         )
@@ -331,7 +331,7 @@ class DataFrameGroupBy(object):
     def prod(self, **kwargs):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_prod,
-            lambda df: df.prod(**kwargs),
+            lambda df, **kwargs: df.prod(**kwargs),
             **kwargs,
         )
 
@@ -374,7 +374,7 @@ class DataFrameGroupBy(object):
     def max(self, **kwargs):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_max,
-            lambda df: df.max(**kwargs),
+            lambda df, **kwargs: df.max(**kwargs),
             numeric_only=False,
             **kwargs,
         )
@@ -391,7 +391,7 @@ class DataFrameGroupBy(object):
     def all(self, **kwargs):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_all,
-            lambda df: df.all(**kwargs),
+            lambda df, **kwargs: df.all(**kwargs),
             numeric_only=False,
             **kwargs,
         )
@@ -432,7 +432,7 @@ class DataFrameGroupBy(object):
     def sum(self, **kwargs):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_sum,
-            lambda df: df.sum(**kwargs),
+            lambda df, **kwargs: df.sum(**kwargs),
             **kwargs,
         )
 
@@ -519,7 +519,7 @@ class DataFrameGroupBy(object):
     def count(self, **kwargs):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_count,
-            lambda df: df.count(**kwargs),
+            lambda df, **kwargs: df.count(**kwargs),
             numeric_only=False,
             **kwargs,
         )

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -591,11 +591,7 @@ class DataFrameGroupBy(object):
         DataFrame or Series
             Returns the same type as `self._df`.
         """
-        if (
-            self._is_multi_by
-            and not isinstance(self._by, type(self._query_compiler))
-            or not isinstance(self._by, type(self._query_compiler))
-        ):
+        if not isinstance(self._by, type(self._query_compiler)) or self._axis != 0:
             return self._default_to_pandas(default_func, **kwargs)
         # For aggregations, pandas behavior does this for the result.
         # For other operations it does not, so we wait until there is an aggregation to


### PR DESCRIPTION
* Resolves #1062

Instead of passing some opaque functions into the query compiler,
the api layer of groupby has been rewritten to call directly into
some new `grouby_<function>` methods that were also added to the query
compiler.

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1062 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
