### PR TITLE
Match `groupby.agg` to pandas API

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -338,19 +338,21 @@ class DataFrameGroupBy(object):
     def std(self, ddof=1, *args, **kwargs):
         return self._apply_agg_function(lambda df: df.std(ddof, *args, **kwargs))
 
-    def aggregate(self, arg, *args, **kwargs):
+    def aggregate(self, func=None, *args, **kwargs):
         if self._axis != 0:
             # This is not implemented in pandas,
             # so we throw a different message
             raise NotImplementedError("axis other than 0 is not supported")
 
-        if is_list_like(arg):
+        if func is None or is_list_like(func):
             return self._default_to_pandas(
-                lambda df: df.aggregate(arg, *args, **kwargs)
+                lambda df: df.aggregate(func, *args, **kwargs)
             )
         return self._apply_agg_function(
-            lambda df: df.aggregate(arg, *args, **kwargs), drop=self._as_index
+            lambda df: df.aggregate(func, *args, **kwargs), drop=self._as_index
         )
+
+    agg = aggregate
 
     def last(self, **kwargs):
         return self._default_to_pandas(lambda df: df.last(**kwargs))
@@ -490,9 +492,6 @@ class DataFrameGroupBy(object):
 
     def __iter__(self):
         return self._iter.__iter__()
-
-    def agg(self, arg, *args, **kwargs):
-        return self.aggregate(arg, *args, **kwargs)
 
     def cov(self):
         return self._default_to_pandas(lambda df: df.cov())

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1052,3 +1052,24 @@ def test_groupby_multiindex():
 
     by = ["one", "two"]
     df_equals(modin_df.groupby(by=by).count(), pandas_df.groupby(by=by).count())
+
+
+def test_agg_func_None_rename():
+    pandas_df = pandas.DataFrame(
+        {
+            "col1": np.random.randint(0, 100, size=1000),
+            "col2": np.random.randint(0, 100, size=1000),
+            "col3": np.random.randint(0, 100, size=1000),
+            "col4": np.random.randint(0, 100, size=1000),
+        },
+        index=["row{}".format(i) for i in range(1000)],
+    )
+    modin_df = from_pandas(pandas_df)
+
+    modin_result = modin_df.groupby(["col1", "col2"]).agg(
+        max=("col3", np.max), min=("col3", np.min)
+    )
+    pandas_result = pandas_df.groupby(["col1", "col2"]).agg(
+        max=("col3", np.max), min=("col3", np.min)
+    )
+    df_equals(modin_result, pandas_result)


### PR DESCRIPTION
* Resolves #1458
* Change `agg` parameter to `func=None`

While the public pandas API shows `agg` to accept an `arg` parameter
that is not optional, the actual implementation allows for an optional
func parameter instead.

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1458 <!-- issue must be created for each patch -->
- [x] tests added and passing
