### PR TITLE
Make all factories initialize .io_cls lazily

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -126,7 +126,6 @@ partition_format = Publisher(name="partition_format", value=get_partition_format
 
 # for backwards compatibility, remove when all items are migrated to new PubSub model
 __execution_engine__ = execution_engine.get()
-__partition_format__ = partition_format.get()
 
 # We don't want these used outside of this file.
 del get_execution_engine

--- a/modin/backends/pyarrow/query_compiler.py
+++ b/modin/backends/pyarrow/query_compiler.py
@@ -17,19 +17,8 @@ from pandas.core.computation.expr import Expr
 from pandas.core.computation.scope import Scope
 from pandas.core.computation.ops import UnaryOp, BinOp, Term, MathCall, Constant
 
-from modin import partition_format
-
-
-def _update(_):
-    import pyarrow
-    import pyarrow.gandiva as gandiva
-
-    globals()["pa"] = pyarrow
-    globals()["gandiva"] = gandiva
-
-
-pa, gandiva = None, None  # filled later by _update()
-partition_format.once("Pyarrow", _update)
+import pyarrow as pa
+import pyarrow.gandiva as gandiva
 
 
 class FakeSeries:

--- a/modin/backends/pyarrow/query_compiler.py
+++ b/modin/backends/pyarrow/query_compiler.py
@@ -17,10 +17,19 @@ from pandas.core.computation.expr import Expr
 from pandas.core.computation.scope import Scope
 from pandas.core.computation.ops import UnaryOp, BinOp, Term, MathCall, Constant
 
-from modin import __partition_format__
+from modin import partition_format
 
-if __partition_format__ == "Pyarrow":
-    import pyarrow as pa
+
+def _update(_):
+    import pyarrow
+    import pyarrow.gandiva as gandiva
+
+    globals()["pa"] = pyarrow
+    globals()["gandiva"] = gandiva
+
+
+pa, gandiva = None, None  # filled later by _update()
+partition_format.once("Pyarrow", _update)
 
 
 class FakeSeries:
@@ -46,8 +55,6 @@ class PyarrowQueryCompiler(PandasQueryCompiler):
             }
             scope = Scope(level=0, resolvers=(resolver,))
             return Expr(expr=expr, env=scope)
-
-        import pyarrow.gandiva as gandiva
 
         unary_ops = {"~": "not"}
         math_calls = {"log": "log", "exp": "exp", "log10": "log10", "cbrt": "cbrt"}

--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -92,7 +92,7 @@ class EngineDispatcher(object):
                 )
             cls.__engine = StubFactory.set_failing_name(factory_name)
         else:
-            cls.__engine.fill_io_cls()
+            cls.__engine.prepare()
 
     @classmethod
     def from_pandas(cls, df):

--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -91,6 +91,8 @@ class EngineDispatcher(object):
                     msg.format(partition_format.get(), execution_engine.get())
                 )
             cls.__engine = StubFactory.set_failing_name(factory_name)
+        else:
+            cls.__engine.fill_io_cls()
 
     @classmethod
     def from_pandas(cls, df):

--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -18,12 +18,7 @@ from modin.data_management import factories
 
 
 class FactoryNotFoundError(AttributeError):
-    def __init__(self, partition_format, execution_engine):
-        super().__init__(
-            "Cannot find a factory for partition '{}' and execution engine '{}'. "
-            "Potential reason might be incorrect environment variable value for "
-            "MODIN_BACKEND or MODIN_ENGINE".format(partition_format, execution_engine)
-        )
+    pass
 
 
 class StubIoEngine(object):
@@ -81,8 +76,19 @@ class EngineDispatcher(object):
         except AttributeError:
             if not experimental:
                 # allow missing factories in experimenal mode only
+                if hasattr(factories, "Experimental" + factory_name):
+                    msg = (
+                        "{0} on {1} is only accessible through the experimental API.\nRun "
+                        "`import modin.experimental.pandas as pd` to use {0} on {1}."
+                    )
+                else:
+                    msg = (
+                        "Cannot find a factory for partition '{}' and execution engine '{}'. "
+                        "Potential reason might be incorrect environment variable value for "
+                        "MODIN_BACKEND or MODIN_ENGINE"
+                    )
                 raise FactoryNotFoundError(
-                    partition_format.get(), execution_engine.get()
+                    msg.format(partition_format.get(), execution_engine.get())
                 )
             cls.__engine = StubFactory.set_failing_name(factory_name)
 

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -28,6 +28,15 @@ class BaseFactory(object):
     io_cls = None  # The module where the I/O functionality exists.
 
     @classmethod
+    def fill_io_cls(cls):
+        """
+        Fills in .io_cls class attribute lazily
+        """
+        raise NotImplementedError(
+            "Subclasses of BaseFactory must implement fill_io_cls"
+        )
+
+    @classmethod
     def _from_pandas(cls, df):
         return cls.io_cls.from_pandas(df)
 
@@ -113,24 +122,27 @@ class BaseFactory(object):
 
 
 class PandasOnRayFactory(BaseFactory):
+    @classmethod
+    def fill_io_cls(cls):
+        from modin.engines.ray.pandas_on_ray.io import PandasOnRayIO
 
-    from modin.engines.ray.pandas_on_ray.io import PandasOnRayIO
-
-    io_cls = PandasOnRayIO
+        cls.io_cls = PandasOnRayIO
 
 
 class PandasOnPythonFactory(BaseFactory):
+    @classmethod
+    def fill_io_cls(cls):
+        from modin.engines.python.pandas_on_python.io import PandasOnPythonIO
 
-    from modin.engines.python.pandas_on_python.io import PandasOnPythonIO
-
-    io_cls = PandasOnPythonIO
+        cls.io_cls = PandasOnPythonIO
 
 
 class PandasOnDaskFactory(BaseFactory):
+    @classmethod
+    def fill_io_cls(cls):
+        from modin.engines.dask.pandas_on_dask.io import PandasOnDaskIO
 
-    from modin.engines.dask.pandas_on_dask.io import PandasOnDaskIO
-
-    io_cls = PandasOnDaskIO
+        cls.io_cls = PandasOnDaskIO
 
 
 class ExperimentalBaseFactory(BaseFactory):
@@ -165,21 +177,22 @@ class ExperimentalBaseFactory(BaseFactory):
 
 
 class ExperimentalPandasOnRayFactory(ExperimentalBaseFactory, PandasOnRayFactory):
+    @classmethod
+    def fill_io_cls(cls):
+        from modin.experimental.engines.pandas_on_ray.io_exp import (
+            ExperimentalPandasOnRayIO,
+        )
 
-    from modin.experimental.engines.pandas_on_ray.io_exp import (
-        ExperimentalPandasOnRayIO,
-    )
-
-    io_cls = ExperimentalPandasOnRayIO
+        cls.io_cls = ExperimentalPandasOnRayIO
 
 
 class ExperimentalPandasOnPythonFactory(ExperimentalBaseFactory, PandasOnPythonFactory):
-
     pass
 
 
 class ExperimentalPyarrowOnRayFactory(BaseFactory):  # pragma: no cover
+    @classmethod
+    def fill_io_cls(cls):
+        from modin.experimental.engines.pyarrow_on_ray.io import PyarrowOnRayIO
 
-    from modin.experimental.engines.pyarrow_on_ray.io import PyarrowOnRayIO
-
-    io_cls = PyarrowOnRayIO
+        cls.io_cls = PyarrowOnRayIO

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -28,13 +28,11 @@ class BaseFactory(object):
     io_cls = None  # The module where the I/O functionality exists.
 
     @classmethod
-    def fill_io_cls(cls):
+    def prepare(cls):
         """
         Fills in .io_cls class attribute lazily
         """
-        raise NotImplementedError(
-            "Subclasses of BaseFactory must implement fill_io_cls"
-        )
+        raise NotImplementedError("Subclasses of BaseFactory must implement prepare")
 
     @classmethod
     def _from_pandas(cls, df):
@@ -123,7 +121,10 @@ class BaseFactory(object):
 
 class PandasOnRayFactory(BaseFactory):
     @classmethod
-    def fill_io_cls(cls):
+    def prepare(cls):
+        """
+        Fills in .io_cls class attribute lazily
+        """
         from modin.engines.ray.pandas_on_ray.io import PandasOnRayIO
 
         cls.io_cls = PandasOnRayIO
@@ -131,7 +132,10 @@ class PandasOnRayFactory(BaseFactory):
 
 class PandasOnPythonFactory(BaseFactory):
     @classmethod
-    def fill_io_cls(cls):
+    def prepare(cls):
+        """
+        Fills in .io_cls class attribute lazily
+        """
         from modin.engines.python.pandas_on_python.io import PandasOnPythonIO
 
         cls.io_cls = PandasOnPythonIO
@@ -139,7 +143,10 @@ class PandasOnPythonFactory(BaseFactory):
 
 class PandasOnDaskFactory(BaseFactory):
     @classmethod
-    def fill_io_cls(cls):
+    def prepare(cls):
+        """
+        Fills in .io_cls class attribute lazily
+        """
         from modin.engines.dask.pandas_on_dask.io import PandasOnDaskIO
 
         cls.io_cls = PandasOnDaskIO
@@ -178,7 +185,10 @@ class ExperimentalBaseFactory(BaseFactory):
 
 class ExperimentalPandasOnRayFactory(ExperimentalBaseFactory, PandasOnRayFactory):
     @classmethod
-    def fill_io_cls(cls):
+    def prepare(cls):
+        """
+        Fills in .io_cls class attribute lazily
+        """
         from modin.experimental.engines.pandas_on_ray.io_exp import (
             ExperimentalPandasOnRayIO,
         )
@@ -192,7 +202,10 @@ class ExperimentalPandasOnPythonFactory(ExperimentalBaseFactory, PandasOnPythonF
 
 class ExperimentalPyarrowOnRayFactory(BaseFactory):  # pragma: no cover
     @classmethod
-    def fill_io_cls(cls):
+    def prepare(cls):
+        """
+        Fills in .io_cls class attribute lazily
+        """
         from modin.experimental.engines.pyarrow_on_ray.io import PyarrowOnRayIO
 
         cls.io_cls = PyarrowOnRayIO

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -11,11 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-import os
 import warnings
 
 from modin import __execution_engine__ as execution_engine
-from modin import __partition_format__ as partition_format
 
 import pandas
 
@@ -133,17 +131,6 @@ class PandasOnDaskFactory(BaseFactory):
     from modin.engines.dask.pandas_on_dask.io import PandasOnDaskIO
 
     io_cls = PandasOnDaskIO
-
-
-class PyarrowOnRayFactory(BaseFactory):
-
-    if partition_format == "Pyarrow" and not os.environ.get(
-        "MODIN_EXPERIMENTAL", False
-    ):
-        raise ImportError(
-            "Pyarrow on Ray is only accessible through the experimental API.\nRun "
-            "`import modin.experimental.pandas as pd` to use Pyarrow on Ray."
-        )
 
 
 class ExperimentalBaseFactory(BaseFactory):

--- a/modin/data_management/test/test_dispatcher.py
+++ b/modin/data_management/test/test_dispatcher.py
@@ -24,11 +24,19 @@ class PandasOnTestFactory(factories.BaseFactory):
     Stub factory to ensure we can switch execution engine to 'Test'
     """
 
+    @classmethod
+    def fill_io_cls(cls):
+        cls.io_cls = "Foo"
+
 
 class TestOnPythonFactory(factories.BaseFactory):
     """
     Stub factory to ensure we can switch partition format to 'Test'
     """
+
+    @classmethod
+    def fill_io_cls(cls):
+        cls.io_cls = "Bar"
 
 
 # inject the stubs
@@ -44,10 +52,12 @@ def test_default_engine():
 def test_engine_switch():
     execution_engine.put("Test")
     assert EngineDispatcher.get_engine() == PandasOnTestFactory
+    assert EngineDispatcher.get_engine().io_cls == "Foo"
     execution_engine.put("Python")  # revert engine to default
 
     partition_format.put("Test")
     assert EngineDispatcher.get_engine() == TestOnPythonFactory
+    assert EngineDispatcher.get_engine().io_cls == "Bar"
     partition_format.put("Pandas")  # revert engine to default
 
 

--- a/modin/data_management/test/test_dispatcher.py
+++ b/modin/data_management/test/test_dispatcher.py
@@ -25,7 +25,10 @@ class PandasOnTestFactory(factories.BaseFactory):
     """
 
     @classmethod
-    def fill_io_cls(cls):
+    def prepare(cls):
+        """
+        Fills in .io_cls class attribute lazily
+        """
         cls.io_cls = "Foo"
 
 
@@ -35,7 +38,10 @@ class TestOnPythonFactory(factories.BaseFactory):
     """
 
     @classmethod
-    def fill_io_cls(cls):
+    def prepare(cls):
+        """
+        Fills in .io_cls class attribute lazily
+        """
         cls.io_cls = "Bar"
 
 

--- a/modin/engines/base/io/file_reader.py
+++ b/modin/engines/base/io/file_reader.py
@@ -13,7 +13,7 @@
 
 import os
 import re
-from modin import __partition_format__ as partition_format
+from modin import partition_format
 
 S3_ADDRESS_REGEX = re.compile("[sS]3://(.*?)/(.*)")
 NOT_IMPLEMENTED_MESSAGE = "Implement in children classes!"
@@ -29,7 +29,7 @@ class FileReader:
         query_compiler = cls._read(*args, **kwargs)
         # TODO (devin-petersohn): Make this section more general for non-pandas kernel
         # implementations.
-        if partition_format.lower() != "pandas":
+        if partition_format.get().lower() != "pandas":
             raise NotImplementedError("FIXME")
         import pandas
 


### PR DESCRIPTION

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
* Remove legacy `modin.__partition_format__` and make all its users use new PubSub model introduced in #1578
* Handle "experimental-only" factories nicer
* Now all factories do not import their engines immediately, but only when requested. This should shorten import time further from #1385 while allowing to remove some of its effects and also works towards #1099. It also allows to enable switching engines on the fly.

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x]  Continues #1578 to eventually fulfill #1540
- [x] tests added and passing
