### PR TITLE
Make all engine-related imports unconditional, as engines are imported lazily now

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -106,6 +106,7 @@ class Publisher(object):
         return self.__value
 
     def put(self, value):
+        value = value.title()  # normalize the value
         oldvalue, self.__value = self.__value, value
         if oldvalue != value:
             for callback in self.__subs:
@@ -123,9 +124,6 @@ class Publisher(object):
 __version__ = "0.6.3"
 execution_engine = Publisher(name="execution_engine", value=get_execution_engine())
 partition_format = Publisher(name="partition_format", value=get_partition_format())
-
-# for backwards compatibility, remove when all items are migrated to new PubSub model
-__execution_engine__ = execution_engine.get()
 
 # We don't want these used outside of this file.
 del get_execution_engine

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -88,7 +88,7 @@ def get_partition_format():
 class Publisher(object):
     def __init__(self, name, value):
         self.name = name
-        self.__value = value
+        self.__value = value.title()
         self.__subs = set()
         self.__once = collections.defaultdict(set)
 
@@ -97,6 +97,7 @@ class Publisher(object):
         callback(self)
 
     def once(self, onvalue, callback):
+        onvalue = onvalue.title()
         if onvalue == self.__value:
             callback(self)
         else:

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -13,7 +13,7 @@
 
 import warnings
 
-from modin import __execution_engine__ as execution_engine
+from modin import execution_engine
 
 import pandas
 
@@ -155,7 +155,7 @@ class PandasOnDaskFactory(BaseFactory):
 class ExperimentalBaseFactory(BaseFactory):
     @classmethod
     def _read_sql(cls, **kwargs):
-        if execution_engine != "Ray":
+        if execution_engine.get() != "Ray":
             if "partition_column" in kwargs:
                 if kwargs["partition_column"] is not None:
                     warnings.warn(

--- a/modin/engines/dask/pandas_on_dask/frame/axis_partition.py
+++ b/modin/engines/dask/pandas_on_dask/frame/axis_partition.py
@@ -13,11 +13,9 @@
 
 from modin.engines.base.frame.axis_partition import PandasFrameAxisPartition
 from .partition import PandasOnDaskFramePartition
-from modin import __execution_engine__
 
-if __execution_engine__ == "Dask":
-    from distributed.client import get_client
-    from distributed import Future
+from distributed.client import get_client
+from distributed import Future
 
 
 class PandasOnDaskFrameAxisPartition(PandasFrameAxisPartition):
@@ -28,8 +26,7 @@ class PandasOnDaskFrameAxisPartition(PandasFrameAxisPartition):
         self.list_of_blocks = [obj.future for obj in list_of_blocks]
 
     partition_type = PandasOnDaskFramePartition
-    if __execution_engine__ == "Dask":
-        instance_type = Future
+    instance_type = Future
 
     @classmethod
     def deploy_axis_func(

--- a/modin/engines/dask/pandas_on_dask/frame/data.py
+++ b/modin/engines/dask/pandas_on_dask/frame/data.py
@@ -13,10 +13,8 @@
 
 from modin.engines.base.frame.data import BasePandasFrame
 from .partition_manager import DaskFrameManager
-from modin import __execution_engine__
 
-if __execution_engine__ == "Dask":
-    from distributed.client import _get_global_client
+from distributed.client import _get_global_client
 
 
 class PandasOnDaskFrame(BasePandasFrame):

--- a/modin/engines/dask/pandas_on_dask/frame/partition.py
+++ b/modin/engines/dask/pandas_on_dask/frame/partition.py
@@ -15,11 +15,9 @@ import pandas
 
 from modin.engines.base.frame.partition import BaseFramePartition
 from modin.data_management.utils import length_fn_pandas, width_fn_pandas
-from modin import __execution_engine__
 
-if __execution_engine__ == "Dask":
-    from distributed.client import get_client
-    import cloudpickle as pkl
+from distributed.client import get_client
+import cloudpickle as pkl
 
 
 def apply_list_of_funcs(funcs, df):

--- a/modin/engines/dask/pandas_on_dask/frame/partition_manager.py
+++ b/modin/engines/dask/pandas_on_dask/frame/partition_manager.py
@@ -20,30 +20,29 @@ from .axis_partition import (
 )
 from .partition import PandasOnDaskFramePartition
 from modin.error_message import ErrorMessage
-from modin import __execution_engine__
 
-if __execution_engine__ == "Dask":
-    from distributed.client import _get_global_client
-    import cloudpickle as pkl
+from distributed.client import _get_global_client
+import cloudpickle as pkl
 
-    def deploy_func(df, other, apply_func, call_queue_df=None, call_queue_other=None):
-        if call_queue_df is not None and len(call_queue_df) > 0:
-            for call, kwargs in call_queue_df:
-                if isinstance(call, bytes):
-                    call = pkl.loads(call)
-                if isinstance(kwargs, bytes):
-                    kwargs = pkl.loads(kwargs)
-                df = call(df, **kwargs)
-        if call_queue_other is not None and len(call_queue_other) > 0:
-            for call, kwargs in call_queue_other:
-                if isinstance(call, bytes):
-                    call = pkl.loads(call)
-                if isinstance(kwargs, bytes):
-                    kwargs = pkl.loads(kwargs)
-                other = call(other, **kwargs)
-        if isinstance(apply_func, bytes):
-            apply_func = pkl.loads(apply_func)
-        return apply_func(df, other)
+
+def deploy_func(df, other, apply_func, call_queue_df=None, call_queue_other=None):
+    if call_queue_df is not None and len(call_queue_df) > 0:
+        for call, kwargs in call_queue_df:
+            if isinstance(call, bytes):
+                call = pkl.loads(call)
+            if isinstance(kwargs, bytes):
+                kwargs = pkl.loads(kwargs)
+            df = call(df, **kwargs)
+    if call_queue_other is not None and len(call_queue_other) > 0:
+        for call, kwargs in call_queue_other:
+            if isinstance(call, bytes):
+                call = pkl.loads(call)
+            if isinstance(kwargs, bytes):
+                kwargs = pkl.loads(kwargs)
+            other = call(other, **kwargs)
+    if isinstance(apply_func, bytes):
+        apply_func = pkl.loads(apply_func)
+    return apply_func(df, other)
 
 
 class DaskFrameManager(BaseFrameManager):

--- a/modin/engines/dask/task_wrapper.py
+++ b/modin/engines/dask/task_wrapper.py
@@ -11,10 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from modin import __execution_engine__
-
-if __execution_engine__ == "Dask":
-    from distributed.client import _get_global_client
+from distributed.client import _get_global_client
 
 
 class DaskTask:

--- a/modin/engines/ray/generic/frame/partition_manager.py
+++ b/modin/engines/ray/generic/frame/partition_manager.py
@@ -14,10 +14,8 @@
 import numpy as np
 
 from modin.engines.base.frame.partition_manager import BaseFrameManager
-from modin import __execution_engine__
 
-if __execution_engine__ == "Ray":
-    import ray
+import ray
 
 
 class RayFrameManager(BaseFrameManager):

--- a/modin/engines/ray/pandas_on_ray/frame/data.py
+++ b/modin/engines/ray/pandas_on_ray/frame/data.py
@@ -15,11 +15,9 @@ import pandas
 
 from .partition_manager import PandasOnRayFrameManager
 from modin.engines.base.frame.data import BasePandasFrame
-from modin import __execution_engine__
 from modin.backends.pandas.parsers import find_common_type_cat as find_common_type
 
-if __execution_engine__ == "Ray":
-    import ray
+import ray
 
 
 class PandasOnRayFrame(BasePandasFrame):

--- a/modin/engines/ray/pandas_on_ray/frame/partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition.py
@@ -16,11 +16,9 @@ import pandas
 from modin.engines.base.frame.partition import BaseFramePartition
 from modin.data_management.utils import length_fn_pandas, width_fn_pandas
 from modin.engines.ray.utils import handle_ray_task_error
-from modin import __execution_engine__
 
-if __execution_engine__ == "Ray":
-    import ray
-    from ray.worker import RayTaskError
+import ray
+from ray.worker import RayTaskError
 
 
 class PandasOnRayFramePartition(BaseFramePartition):
@@ -198,39 +196,38 @@ class PandasOnRayFramePartition(BaseFramePartition):
         return cls.put(pandas.DataFrame())
 
 
-if __execution_engine__ == "Ray":
+@ray.remote(num_return_vals=2)
+def get_index_and_columns(df):
+    return len(df.index), len(df.columns)
 
-    @ray.remote(num_return_vals=2)
-    def get_index_and_columns(df):
-        return len(df.index), len(df.columns)
 
-    @ray.remote(num_return_vals=3)
-    def deploy_ray_func(call_queue, partition):  # pragma: no cover
-        def deserialize(obj):
-            if isinstance(obj, ray.ObjectID):
-                return ray.get(obj)
-            return obj
+@ray.remote(num_return_vals=3)
+def deploy_ray_func(call_queue, partition):  # pragma: no cover
+    def deserialize(obj):
+        if isinstance(obj, ray.ObjectID):
+            return ray.get(obj)
+        return obj
 
-        if len(call_queue) > 1:
-            for func, kwargs in call_queue[:-1]:
-                func = deserialize(func)
-                kwargs = deserialize(kwargs)
-                try:
-                    partition = func(partition, **kwargs)
-                except ValueError:
-                    partition = func(partition.copy(), **kwargs)
-        func, kwargs = call_queue[-1]
-        func = deserialize(func)
-        kwargs = deserialize(kwargs)
-        try:
-            result = func(partition, **kwargs)
-        # Sometimes Arrow forces us to make a copy of an object before we operate on it. We
-        # don't want the error to propagate to the user, and we want to avoid copying unless
-        # we absolutely have to.
-        except ValueError:
-            result = func(partition.copy(), **kwargs)
-        return (
-            result,
-            len(result) if hasattr(result, "__len__") else 0,
-            len(result.columns) if hasattr(result, "columns") else 0,
-        )
+    if len(call_queue) > 1:
+        for func, kwargs in call_queue[:-1]:
+            func = deserialize(func)
+            kwargs = deserialize(kwargs)
+            try:
+                partition = func(partition, **kwargs)
+            except ValueError:
+                partition = func(partition.copy(), **kwargs)
+    func, kwargs = call_queue[-1]
+    func = deserialize(func)
+    kwargs = deserialize(kwargs)
+    try:
+        result = func(partition, **kwargs)
+    # Sometimes Arrow forces us to make a copy of an object before we operate on it. We
+    # don't want the error to propagate to the user, and we want to avoid copying unless
+    # we absolutely have to.
+    except ValueError:
+        result = func(partition.copy(), **kwargs)
+    return (
+        result,
+        len(result) if hasattr(result, "__len__") else 0,
+        len(result.columns) if hasattr(result, "columns") else 0,
+    )

--- a/modin/engines/ray/task_wrapper.py
+++ b/modin/engines/ray/task_wrapper.py
@@ -11,14 +11,12 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from modin import __execution_engine__
+import ray
 
-if __execution_engine__ == "Ray":
-    import ray
 
-    @ray.remote
-    def deploy_ray_func(func, args):  # pragma: no cover
-        return func(**args)
+@ray.remote
+def deploy_ray_func(func, args):  # pragma: no cover
+    return func(**args)
 
 
 class RayTask:

--- a/modin/experimental/engines/pandas_on_ray/io_exp.py
+++ b/modin/experimental/engines/pandas_on_ray/io_exp.py
@@ -18,43 +18,41 @@ import warnings
 from modin.engines.ray.pandas_on_ray.io import PandasOnRayIO
 from modin.backends.pandas.parsers import _split_result_for_readers
 from modin.engines.ray.pandas_on_ray.frame.partition import PandasOnRayFramePartition
-from modin import __execution_engine__
 
-if __execution_engine__ == "Ray":
-    import ray
+import ray
 
-    @ray.remote
-    def _read_parquet_columns(path, columns, num_splits, kwargs):  # pragma: no cover
-        """Use a Ray task to read columns from Parquet into a Pandas DataFrame.
 
-        Note: Ray functions are not detected by codecov (thus pragma: no cover)
+@ray.remote
+def _read_parquet_columns(path, columns, num_splits, kwargs):  # pragma: no cover
+    """Use a Ray task to read columns from Parquet into a Pandas DataFrame.
 
-        Args:
-            path: The path of the Parquet file.
-            columns: The list of column names to read.
-            num_splits: The number of partitions to split the column into.
+    Note: Ray functions are not detected by codecov (thus pragma: no cover)
 
-        Returns:
-             A list containing the split Pandas DataFrames and the Index as the last
-                element. If there is not `index_col` set, then we just return the length.
-                This is used to determine the total length of the DataFrame to build a
-                default Index.
-        """
-        import pyarrow.parquet as pq
+    Args:
+        path: The path of the Parquet file.
+        columns: The list of column names to read.
+        num_splits: The number of partitions to split the column into.
 
-        df = (
-            pq.ParquetDataset(path, **kwargs)
-            .read(columns=columns, use_pandas_metadata=True)
-            .to_pandas()
-        )
-        df = df[columns]
-        # Append the length of the index here to build it externally
-        return _split_result_for_readers(0, num_splits, df) + [len(df.index)]
+    Returns:
+            A list containing the split Pandas DataFrames and the Index as the last
+            element. If there is not `index_col` set, then we just return the length.
+            This is used to determine the total length of the DataFrame to build a
+            default Index.
+    """
+    import pyarrow.parquet as pq
+
+    df = (
+        pq.ParquetDataset(path, **kwargs)
+        .read(columns=columns, use_pandas_metadata=True)
+        .to_pandas()
+    )
+    df = df[columns]
+    # Append the length of the index here to build it externally
+    return _split_result_for_readers(0, num_splits, df) + [len(df.index)]
 
 
 class ExperimentalPandasOnRayIO(PandasOnRayIO):
-    if __execution_engine__ == "Ray":
-        read_parquet_remote_task = _read_parquet_columns
+    read_parquet_remote_task = _read_parquet_columns
 
     @classmethod
     def read_sql(
@@ -162,40 +160,38 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
         )
 
 
-if __execution_engine__ == "Ray":
+@ray.remote
+def _read_sql_with_offset_pandas_on_ray(
+    partition_column,
+    start,
+    end,
+    num_splits,
+    sql,
+    con,
+    index_col=None,
+    coerce_float=True,
+    params=None,
+    parse_dates=None,
+    columns=None,
+    chunksize=None,
+):  # pragma: no cover
+    """Use a Ray task to read a chunk of SQL source.
 
-    @ray.remote
-    def _read_sql_with_offset_pandas_on_ray(
-        partition_column,
-        start,
-        end,
-        num_splits,
-        sql,
+    Note: Ray functions are not detected by codecov (thus pragma: no cover)
+    """
+
+    from .sql import query_put_bounders
+
+    query_with_bounders = query_put_bounders(sql, partition_column, start, end)
+    pandas_df = pandas.read_sql(
+        query_with_bounders,
         con,
-        index_col=None,
-        coerce_float=True,
-        params=None,
-        parse_dates=None,
-        columns=None,
-        chunksize=None,
-    ):  # pragma: no cover
-        """Use a Ray task to read a chunk of SQL source.
-
-        Note: Ray functions are not detected by codecov (thus pragma: no cover)
-        """
-
-        from .sql import query_put_bounders
-
-        query_with_bounders = query_put_bounders(sql, partition_column, start, end)
-        pandas_df = pandas.read_sql(
-            query_with_bounders,
-            con,
-            index_col=index_col,
-            coerce_float=coerce_float,
-            params=params,
-            parse_dates=parse_dates,
-            columns=columns,
-            chunksize=chunksize,
-        )
-        index = len(pandas_df)
-        return _split_result_for_readers(1, num_splits, pandas_df) + [index]
+        index_col=index_col,
+        coerce_float=coerce_float,
+        params=params,
+        parse_dates=parse_dates,
+        columns=columns,
+        chunksize=chunksize,
+    )
+    index = len(pandas_df)
+    return _split_result_for_readers(1, num_splits, pandas_df) + [index]

--- a/modin/experimental/engines/pyarrow_on_ray/frame/axis_partition.py
+++ b/modin/experimental/engines/pyarrow_on_ray/frame/axis_partition.py
@@ -13,13 +13,9 @@
 
 from modin.engines.base.frame.axis_partition import BaseFrameAxisPartition
 from .partition import PyarrowOnRayFramePartition
-from modin import __execution_engine__
 
-if __execution_engine__ == "Ray":
-    import ray
-    import pyarrow
-else:
-    pass
+import ray
+import pyarrow
 
 
 class PyarrowOnRayFrameAxisPartition(BaseFrameAxisPartition):
@@ -150,76 +146,76 @@ def split_arrow_table_result(axis, result, num_partitions, num_splits, metadata)
         ]
 
 
-if __execution_engine__ == "Ray":
+@ray.remote
+def deploy_ray_axis_func(axis, func, num_splits, kwargs, *partitions):
+    """Deploy a function along a full axis in Ray.
 
-    @ray.remote
-    def deploy_ray_axis_func(axis, func, num_splits, kwargs, *partitions):
-        """Deploy a function along a full axis in Ray.
+    Args:
+        axis: The axis to perform the function along.
+        func: The function to perform.
+        num_splits: The number of splits to return
+            (see `split_result_of_axis_func_pandas`)
+        kwargs: A dictionary of keyword arguments.
+        partitions: All partitions that make up the full axis (row or column)
 
-        Args:
-            axis: The axis to perform the function along.
-            func: The function to perform.
-            num_splits: The number of splits to return
-                (see `split_result_of_axis_func_pandas`)
-            kwargs: A dictionary of keyword arguments.
-            partitions: All partitions that make up the full axis (row or column)
+    Returns:
+        A list of Pandas DataFrames.
+    """
+    table = concat_arrow_table_partitions(axis, partitions)
+    try:
+        result = func(table, **kwargs)
+    except Exception:
+        result = pyarrow.Table.from_pandas(func(table.to_pandas(), **kwargs))
+    return split_arrow_table_result(
+        axis, result, len(partitions), num_splits, table.schema.metadata
+    )
 
-        Returns:
-            A list of Pandas DataFrames.
-        """
-        table = concat_arrow_table_partitions(axis, partitions)
-        try:
-            result = func(table, **kwargs)
-        except Exception:
-            result = pyarrow.Table.from_pandas(func(table.to_pandas(), **kwargs))
-        return split_arrow_table_result(
-            axis, result, len(partitions), num_splits, table.schema.metadata
-        )
 
-    @ray.remote
-    def deploy_ray_func_between_two_axis_partitions(
-        axis, func, num_splits, len_of_left, kwargs, *partitions
-    ):
-        """Deploy a function along a full axis between two data sets in Ray.
+@ray.remote
+def deploy_ray_func_between_two_axis_partitions(
+    axis, func, num_splits, len_of_left, kwargs, *partitions
+):
+    """Deploy a function along a full axis between two data sets in Ray.
 
-        Args:
-            axis: The axis to perform the function along.
-            func: The function to perform.
-            num_splits: The number of splits to return
-                (see `split_result_of_axis_func_pandas`).
-            len_of_left: The number of values in `partitions` that belong to the
-                left data set.
-            kwargs: A dictionary of keyword arguments.
-            partitions: All partitions that make up the full axis (row or column)
-                for both data sets.
+    Args:
+        axis: The axis to perform the function along.
+        func: The function to perform.
+        num_splits: The number of splits to return
+            (see `split_result_of_axis_func_pandas`).
+        len_of_left: The number of values in `partitions` that belong to the
+            left data set.
+        kwargs: A dictionary of keyword arguments.
+        partitions: All partitions that make up the full axis (row or column)
+            for both data sets.
 
-        Returns:
-            A list of Pandas DataFrames.
-        """
-        lt_table = concat_arrow_table_partitions(axis, partitions[:len_of_left])
-        rt_table = concat_arrow_table_partitions(axis, partitions[len_of_left:])
-        try:
-            result = func(lt_table, rt_table, **kwargs)
-        except Exception:
-            lt_frame = lt_table.from_pandas()
-            rt_frame = rt_table.from_pandas()
-            result = pyarrow.Table.from_pandas(func(lt_frame, rt_frame, **kwargs))
-        return split_arrow_table_result(
-            axis, result, len(result.num_rows), num_splits, result.schema.metadata
-        )
+    Returns:
+        A list of Pandas DataFrames.
+    """
+    lt_table = concat_arrow_table_partitions(axis, partitions[:len_of_left])
+    rt_table = concat_arrow_table_partitions(axis, partitions[len_of_left:])
+    try:
+        result = func(lt_table, rt_table, **kwargs)
+    except Exception:
+        lt_frame = lt_table.from_pandas()
+        rt_frame = rt_table.from_pandas()
+        result = pyarrow.Table.from_pandas(func(lt_frame, rt_frame, **kwargs))
+    return split_arrow_table_result(
+        axis, result, len(result.num_rows), num_splits, result.schema.metadata
+    )
 
-    @ray.remote
-    def deploy_ray_shuffle_func(axis, func, numsplits, kwargs, *partitions):
-        """Deploy a function that defines the partitions along this axis.
 
-        Args:
-            axis:
-            func:
-            numsplits:
-            kwargs:
-            partitions:
+@ray.remote
+def deploy_ray_shuffle_func(axis, func, numsplits, kwargs, *partitions):
+    """Deploy a function that defines the partitions along this axis.
 
-        Returns:
-            A list of Pandas DataFrames.
-        """
-        pass
+    Args:
+        axis:
+        func:
+        numsplits:
+        kwargs:
+        partitions:
+
+    Returns:
+        A list of Pandas DataFrames.
+    """
+    pass

--- a/modin/experimental/engines/pyarrow_on_ray/frame/data.py
+++ b/modin/experimental/engines/pyarrow_on_ray/frame/data.py
@@ -16,10 +16,8 @@ from pandas.core.dtypes.cast import find_common_type
 
 from .partition_manager import PyarrowOnRayFrameManager
 from modin.engines.base.frame.data import BasePandasFrame
-from modin import __execution_engine__
 
-if __execution_engine__ == "Ray":
-    import ray
+import ray
 
 
 class PyarrowOnRayFrame(BasePandasFrame):

--- a/modin/experimental/engines/pyarrow_on_ray/frame/partition.py
+++ b/modin/experimental/engines/pyarrow_on_ray/frame/partition.py
@@ -13,11 +13,9 @@
 
 import pandas
 from modin.engines.ray.pandas_on_ray.frame.partition import PandasOnRayFramePartition
-from modin import __execution_engine__
 
-if __execution_engine__ == "Ray":
-    import ray
-    import pyarrow
+import ray
+import pyarrow
 
 
 class PyarrowOnRayFramePartition(PandasOnRayFramePartition):

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -32,7 +32,7 @@ from .utils import (
     json_long_bytes,
 )
 
-from modin import __execution_engine__
+from modin import execution_engine
 
 if os.environ.get("MODIN_BACKEND", "Pandas").lower() == "pandas":
     import modin.pandas as pd
@@ -938,7 +938,7 @@ def test_from_csv_with_usecols(usecols):
 
 
 @pytest.mark.skipif(
-    __execution_engine__.lower() == "python", reason="Using pandas implementation"
+    execution_engine.get().lower() == "python", reason="Using pandas implementation"
 )
 def test_from_csv_s3(make_csv_file):
     dataset_url = "s3://noaa-ghcn-pds/csv/1788.csv"

--- a/modin/test/test_publisher.py
+++ b/modin/test/test_publisher.py
@@ -18,10 +18,10 @@ from modin import Publisher
 
 def test_equals():
     pub = Publisher("name", "value1")
-    assert pub.get() == "value1"
+    assert pub.get() == "Value1"
 
     pub.put("value2")
-    assert pub.get() == "value2"
+    assert pub.get() == "Value2"
 
 
 def test_triggers():


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Remove conditions in engine-related parts, as since #1601 they should be imported only when requested engine is activated.

When this set of changes is merged, it should be possible to switch the engine used by Modin on the fly by calling `moding.execution_engine.put('NewName')`.
Note that this PR does not implement any validation yet, and on-the-fly switching is yet untested - all those are questions for later.

This set basically completes _enabling_ of dynamic switching, but so far it just retains the current behaviour.
<!-- Please give a short brief about these changes. -->


- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x]  Continues #1578 to eventually fulfill #1540
- [ ] tests added and passing

