### PR TITLE
Fixed bug #1604. Check for word FAILURES in comment before truncating

### DIFF
--- a/ci/teamcity/comment_on_pr.py
+++ b/ci/teamcity/comment_on_pr.py
@@ -39,6 +39,7 @@ split_by_first = (
 )
 split_by_second = "--------------------------------------------------------------------------------------"
 
+tests_failed = False
 for out in pytest_outputs:
     content = open(out, "r").read()
     full_comment += "".join(
@@ -50,11 +51,15 @@ for out in pytest_outputs:
         )
         for i in content.split("+ python3 -m pytest ")
     )
+    tests_failed = tests_failed or ("FAILURES" in full_comment)
     if len(full_comment) > 65_000:
-        full_comment = full_comment[-65_000:] + "\n\n<b>Remaining output truncated<b>\n\n"
+        full_comment = (
+            full_comment[-65_000:] + "\n\n<b>Remaining output truncated<b>\n\n"
+        )
     full_comment = "<details><summary>Tests Logs</summary>\n\n\n```\n" + full_comment
     full_comment += "\n```\n\n</details>\n"
-if "FAILURES" not in full_comment:
+
+if not tests_failed:
     header += '<h3 align="center">Tests PASSed</h3>\n\n'
 else:
     header += '<h3 align="center">Tests FAILed</h3>\n\n'


### PR DESCRIPTION
Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #? <!-- issue must be created for each patch -->
- [x] tests added and passing
