### PR TITLE
Fixed #1412, losing dtypes when constructing DataFrame

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -111,9 +111,17 @@ class DataFrame(BasePandasDataset):
                 "Distributing {} object. This may take some time.".format(type(data))
             )
             if is_list_like(data) and not is_dict_like(data):
-                data = [
+                old_dtype = getattr(data, "dtype", None)
+                values = [
                     obj._to_pandas() if isinstance(obj, Series) else obj for obj in data
                 ]
+                if isinstance(data, np.ndarray):
+                    data = np.array(values, dtype=old_dtype)
+                else:
+                    try:
+                        data = type(data)(values, dtype=old_dtype)
+                    except:
+                        data = values
             elif is_dict_like(data) and not isinstance(
                 data, (pandas.Series, Series, pandas.DataFrame, DataFrame)
             ):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -120,7 +120,7 @@ class DataFrame(BasePandasDataset):
                 else:
                     try:
                         data = type(data)(values, dtype=old_dtype)
-                    except:
+                    except Exception:
                         data = values
             elif is_dict_like(data) and not isinstance(
                 data, (pandas.Series, Series, pandas.DataFrame, DataFrame)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -120,7 +120,7 @@ class DataFrame(BasePandasDataset):
                 else:
                     try:
                         data = type(data)(values, dtype=old_dtype)
-                    except Exception:
+                    except TypeError:
                         data = values
             elif is_dict_like(data) and not isinstance(
                 data, (pandas.Series, Series, pandas.DataFrame, DataFrame)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5434,7 +5434,7 @@ class TestDataFrameIter:
             pandas.Categorical([1, 2, 3, 4, 5]),
         ],
     )
-    def test_constructor_dtypes(self, data, dtype):
+    def test_constructor_dtypes(self, data):
         md_df, pd_df = create_test_dfs(data)
         df_equals(md_df, pd_df)
 

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -110,6 +110,7 @@ def eval_insert(modin_df, pandas_df, **kwargs):
 def create_test_dfs(*args, **kwargs):
     return pd.DataFrame(*args, **kwargs), pandas.DataFrame(*args, **kwargs)
 
+
 class TestDataFrameBinary:
     def inter_df_math_helper(self, modin_df, pandas_df, op):
         # Test dataframe to datframe
@@ -5421,10 +5422,18 @@ class TestDataFrameIter:
         modin_df = pd.DataFrame({k: pd.Series(v) for k, v in data.items()})
         df_equals(pandas_df, modin_df)
 
-    @pytest.mark.parametrize("data", [
-        np.arange(1, 10000, dtype=np.float32),
-        [pd.Series([1,2,3], dtype="int32"), pd.Series([4,5,6], dtype="int64"), np.array([7,8,9], dtype=np.float32)],
-    ], dtype=[None])
+    @pytest.mark.parametrize(
+        "data",
+        [
+            np.arange(1, 10000, dtype=np.float32),
+            [
+                pd.Series([1, 2, 3], dtype="int32"),
+                pandas.Series([4, 5, 6], dtype="int64"),
+                np.array([7, 8, 9], dtype=np.float32),
+            ],
+            pandas.Categorical([1, 2, 3, 4, 5]),
+        ],
+    )
     def test_constructor_dtypes(self, data, dtype):
         md_df, pd_df = create_test_dfs(data)
         df_equals(md_df, pd_df)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -107,6 +107,9 @@ def eval_insert(modin_df, pandas_df, **kwargs):
     )
 
 
+def create_test_dfs(*args, **kwargs):
+    return pd.DataFrame(*args, **kwargs), pandas.DataFrame(*args, **kwargs)
+
 class TestDataFrameBinary:
     def inter_df_math_helper(self, modin_df, pandas_df, op):
         # Test dataframe to datframe
@@ -5417,6 +5420,14 @@ class TestDataFrameIter:
         pandas_df = pandas.DataFrame({k: pandas.Series(v) for k, v in data.items()})
         modin_df = pd.DataFrame({k: pd.Series(v) for k, v in data.items()})
         df_equals(pandas_df, modin_df)
+
+    @pytest.mark.parametrize("data", [
+        np.arange(1, 10000, dtype=np.float32),
+        [pd.Series([1,2,3], dtype="int32"), pd.Series([4,5,6], dtype="int64"), np.array([7,8,9], dtype=np.float32)],
+    ], dtype=[None])
+    def test_constructor_dtypes(self, data, dtype):
+        md_df, pd_df = create_test_dfs(data)
+        df_equals(md_df, pd_df)
 
     def test_constructor_columns_and_index(self):
         modin_df = pd.DataFrame(


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1412 <!-- issue must be created for each patch -->
- [x] tests added and passing
