### PR TITLE
Fixed bug #1619. If dataframe.index contains duplicates sort should work correctly

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2779,10 +2779,14 @@ class BasePandasDataset(object):
                 kind=kind,
                 na_position=na_position,
             ).index
-            result = self.reset_index(drop=True)
-            result = result.reindex(index=new_index2, copy=not inplace)
-            result.index = new_index1
-            return result
+            if inplace:
+                self.reindex(index=new_index2, copy=False)
+                self.index = new_index1
+            else:
+                result = self.reset_index(drop=True)
+                result = result.reindex(index=new_index2, copy=True)
+                result.index = new_index1
+                return result
         else:
             broadcast_value_list = [
                 self[row :: len(self.index)]._to_pandas() for row in by

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2756,6 +2756,7 @@ class BasePandasDataset(object):
             by = [by]
         # Currently, sort_values will just reindex based on the sorted values.
         # TODO create a more efficient way to sort
+        ErrorMessage.default_to_pandas("sort_values")
         if axis == 0:
             broadcast_value_dict = {col: self[col]._to_pandas() for col in by}
             # Index may contain duplicates

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5736,6 +5736,15 @@ class TestDataFrameJoinSort:
             )
             df_equals(modin_df_cp, pandas_df_cp)
 
+    def test_sort_values_with_duplicates(self):
+        modin_df = pd.DataFrame({"col": [2, 1, 1], }, index=[1, 1, 0], )
+        pandas_df = pandas.DataFrame({"col": [2, 1, 1], }, index=[1, 1, 0], )
+
+        key = modin_df.columns[0]
+        modin_result = modin_df.sort_values(key, inplace=False,)
+        pandas_result = pandas_df.sort_values(key, inplace=False,)
+        df_equals(modin_result, pandas_result)
+
     def test_where(self):
         frame_data = random_state.randn(100, 10)
         pandas_df = pandas.DataFrame(frame_data, columns=list("abcdefghij"))

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5737,8 +5737,8 @@ class TestDataFrameJoinSort:
             df_equals(modin_df_cp, pandas_df_cp)
 
     def test_sort_values_with_duplicates(self):
-        modin_df = pd.DataFrame({"col": [2, 1, 1], }, index=[1, 1, 0], )
-        pandas_df = pandas.DataFrame({"col": [2, 1, 1], }, index=[1, 1, 0], )
+        modin_df = pd.DataFrame({"col": [2, 1, 1]}, index=[1, 1, 0])
+        pandas_df = pandas.DataFrame({"col": [2, 1, 1]}, index=[1, 1, 0])
 
         key = modin_df.columns[0]
         modin_result = modin_df.sort_values(key, inplace=False,)


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #? <!-- issue must be created for each patch -->
- [x] tests added and passing
