### PR TITLE
Add parallel read_excel feature

### DIFF
--- a/modin/backends/pandas/parsers.py
+++ b/modin/backends/pandas/parsers.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+from collections import OrderedDict
 from io import BytesIO
 import numpy as np
 import pandas
@@ -76,6 +77,11 @@ class PandasParser(object):
                 pd_read(*args, **kwargs), cls.frame_cls
             )
             return pandas_frame
+        elif isinstance(pandas_frame, (OrderedDict, dict)):
+            return {
+                i: cls.query_compiler_cls.from_pandas(frame, cls.frame_cls)
+                for i, frame in pandas_frame.items()
+            }
         return cls.query_compiler_cls.from_pandas(pandas_frame, cls.frame_cls)
 
     infer_compression = infer_compression
@@ -135,6 +141,169 @@ class PandasFWFParser(PandasParser):
         else:
             # This only happens when we are reading with only one worker (Default)
             return pandas.read_fwf(fname, **kwargs)
+        if index_col is not None:
+            index = pandas_df.index
+        else:
+            # The lengths will become the RangeIndex
+            index = len(pandas_df)
+        return _split_result_for_readers(1, num_splits, pandas_df) + [
+            index,
+            pandas_df.dtypes,
+        ]
+
+
+class PandasExcelParser(PandasParser):
+    @classmethod
+    def get_sheet_data(cls, sheet, convert_float):
+        return [
+            [cls._convert_cell(cell, convert_float) for cell in row]
+            for row in sheet.rows
+        ]
+
+    @classmethod
+    def _convert_cell(cls, cell, convert_float):
+        if cell.is_date:
+            return cell.value
+        elif cell.data_type == "e":
+            return np.nan
+        elif cell.data_type == "b":
+            return bool(cell.value)
+        elif cell.value is None:
+            return ""
+        elif cell.data_type == "n":
+            if convert_float:
+                val = int(cell.value)
+                if val == cell.value:
+                    return val
+            else:
+                return float(cell.value)
+
+        return cell.value
+
+    @staticmethod
+    def parse(fname, **kwargs):
+        num_splits = kwargs.pop("num_splits", None)
+        start = kwargs.pop("start", None)
+        end = kwargs.pop("end", None)
+        header = kwargs.get("_header")
+        sheet_name = kwargs.get("sheet_name", 0)
+        footer = b"</sheetData></worksheet>"
+        _skiprows = kwargs.get("skiprows")
+
+        # Default to pandas case, where we are not splitting or partitioning
+        if start is None or end is None:
+            return pandas.read_excel(fname, **kwargs)
+
+        from zipfile import ZipFile
+        from openpyxl import load_workbook
+        from openpyxl.worksheet._reader import WorksheetReader
+        from openpyxl.reader.excel import ExcelReader
+        from openpyxl.worksheet.worksheet import Worksheet
+        from pandas.core.dtypes.common import is_integer, is_list_like
+        from pandas.io.excel._util import (
+            _fill_mi_header,
+            _maybe_convert_usecols,
+            _pop_header_name,
+        )
+        from pandas.io.parsers import TextParser
+        import re
+
+        wb = load_workbook(filename=fname, read_only=True)
+        # Get shared strings
+        ex = ExcelReader(fname, read_only=True)
+        ex.read_manifest()
+        ex.read_strings()
+        # Convert string name 0 to string
+        if sheet_name == 0:
+            sheet_name = wb.sheetnames[sheet_name]
+        # get the worksheet to use with the worksheet reader
+        ws = Worksheet(wb)
+        # Read the raw data
+        with ZipFile(fname) as z:
+            with z.open("xl/worksheets/{}.xml".format(sheet_name.lower())) as file:
+                file.seek(start)
+                bytes_data = file.read(end - start)
+
+        def parse1(match):
+            b = match.group(0)
+            return re.sub(
+                b"\d+",  # noqa: W605
+                lambda c: str(int(c.group(0).decode("utf-8")) - _skiprows).encode(
+                    "utf-8"
+                ),
+                b,
+            )
+
+        bytes_data = re.sub(b'r="[A-Z]*\d+"', parse1, bytes_data)  # noqa: W605
+        bytesio = BytesIO(header + bytes_data + footer)
+        # Use openpyxl to read/parse sheet data
+        reader = WorksheetReader(ws, bytesio, ex.shared_strings, False)
+        # Attach cells to worksheet object
+        reader.bind_cells()
+        data = PandasExcelParser.get_sheet_data(ws, kwargs.pop("convert_float", True))
+        kwargs["skiprows"] = None
+        usecols = _maybe_convert_usecols(kwargs.pop("usecols", None))
+        header = kwargs.pop("header", 0)
+        index_col = kwargs.pop("index_col", None)
+        skiprows = kwargs.pop("skiprows", None)
+
+        if is_list_like(header) and len(header) == 1:
+            header = header[0]
+        if header is not None and is_list_like(header):
+            header_names = []
+            control_row = [True] * len(data[0])
+
+            for row in header:
+                if is_integer(skiprows):
+                    row += skiprows
+
+                data[row], control_row = _fill_mi_header(data[row], control_row)
+
+                if index_col is not None:
+                    header_name, _ = _pop_header_name(data[row], index_col)
+                    header_names.append(header_name)
+
+        if is_list_like(index_col):
+            # Forward fill values for MultiIndex index.
+            if not is_list_like(header):
+                offset = 1 + header
+            else:
+                offset = 1 + max(header)
+
+            # Check if we have an empty dataset
+            # before trying to collect data.
+            if offset < len(data):
+                for col in index_col:
+                    last = data[offset][col]
+
+                    for row in range(offset + 1, len(data)):
+                        if data[row][col] == "" or data[row][col] is None:
+                            data[row][col] = last
+                        else:
+                            last = data[row][col]
+
+        has_index_names = is_list_like(header) and len(header) > 1
+
+        parser = TextParser(
+            data,
+            header=header,
+            index_col=index_col,
+            has_index_names=has_index_names,
+            skiprows=skiprows,
+            usecols=usecols,
+            **kwargs
+        )
+
+        pandas_df = parser.read()
+        # Since we know the number of rows that occur before this partition, we can
+        # correctly assign the index in cases of RangeIndex. If it is not a RangeIndex,
+        # the index is already correct because it came from the data.
+        if isinstance(pandas_df.index, pandas.RangeIndex):
+            pandas_df.index = pandas.RangeIndex(
+                start=_skiprows, stop=len(pandas_df.index) + _skiprows
+            )
+        # We return the length if it is a RangeIndex (common case) to reduce
+        # serialization cost.
         if index_col is not None:
             index = pandas_df.index
         else:

--- a/modin/engines/base/io/__init__.py
+++ b/modin/engines/base/io/__init__.py
@@ -15,6 +15,7 @@ from modin.engines.base.io.io import BaseIO
 from modin.engines.base.io.text.csv_reader import CSVReader
 from modin.engines.base.io.text.fwf_reader import FWFReader
 from modin.engines.base.io.text.json_reader import JSONReader
+from modin.engines.base.io.text.excel_reader import ExcelReader
 from modin.engines.base.io.file_reader import FileReader
 from modin.engines.base.io.text.text_file_reader import TextFileReader
 from modin.engines.base.io.column_stores.parquet_reader import ParquetReader
@@ -33,4 +34,5 @@ __all__ = [
     "HDFReader",
     "FeatherReader",
     "SQLReader",
+    "ExcelReader",
 ]

--- a/modin/engines/base/io/text/excel_reader.py
+++ b/modin/engines/base/io/text/excel_reader.py
@@ -20,6 +20,9 @@ from modin.data_management.utils import compute_chunksize
 from modin.engines.base.io.text.text_file_reader import TextFileReader
 
 
+EXCEL_READ_BLOCK_SIZE = 4096
+
+
 class ExcelReader(TextFileReader):
     @classmethod
     def _read(cls, io, **kwargs):
@@ -79,10 +82,10 @@ class ExcelReader(TextFileReader):
             # line. We need to make sure we get the first line of the data as well
             # because that is where the column names are. The header information will
             # be extracted and sent to all of the nodes.
-            sheet_block = f.read(4096)
+            sheet_block = f.read(EXCEL_READ_BLOCK_SIZE)
             end_of_row_tag = b"</row>"
             while end_of_row_tag not in sheet_block:
-                sheet_block += f.read(4096)
+                sheet_block += f.read(EXCEL_READ_BLOCK_SIZE)
             idx_of_header_end = sheet_block.index(end_of_row_tag) + len(end_of_row_tag)
             sheet_header = sheet_block[:idx_of_header_end]
             # Reset the file pointer to begin at the end of the header information.

--- a/modin/engines/base/io/text/excel_reader.py
+++ b/modin/engines/base/io/text/excel_reader.py
@@ -22,17 +22,13 @@ from modin.engines.base.io.text.text_file_reader import TextFileReader
 
 class ExcelReader(TextFileReader):
     @classmethod
-    def call_deploy(cls, f, chunk_size, num_return_vals, args, quotechar=b'"'):
-        return
-
-    @classmethod
     def _read(cls, io, **kwargs):
         if (
             kwargs.get("engine", None) is not None
             and kwargs.get("engine") != "openpyxl"
         ):
             warnings.warn(
-                "Modin only implements `read_excel` with `openpyxl` engine, "
+                "Modin only implements parallel `read_excel` with `openpyxl` engine, "
                 'please specify `engine=None` or `engine="openpyxl"` to '
                 "use Modin's parallel implementation."
             )
@@ -100,7 +96,7 @@ class ExcelReader(TextFileReader):
             # Attach cells to the worksheet
             reader.bind_cells()
             data = PandasExcelParser.get_sheet_data(
-                ws, kwargs.pop("convert_float", True)
+                ws, kwargs.get("convert_float", True)
             )
             # Extract column names from parsed data.
             column_names = pandas.Index(data[0])

--- a/modin/engines/base/io/text/excel_reader.py
+++ b/modin/engines/base/io/text/excel_reader.py
@@ -57,7 +57,7 @@ class ExcelReader(TextFileReader):
             return cls.single_worker_read(io, **kwargs)
 
         warnings.warn(
-            "Parallel `read_excel` is a new feature! Please email"
+            "Parallel `read_excel` is a new feature! Please email "
             "bug_reports@modin.org if you run into any problems."
         )
         wb = load_workbook(filename=io, read_only=True)

--- a/modin/engines/base/io/text/excel_reader.py
+++ b/modin/engines/base/io/text/excel_reader.py
@@ -1,0 +1,202 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pandas
+import re
+import sys
+import warnings
+
+from modin.data_management.utils import compute_chunksize
+from modin.engines.base.io.text.text_file_reader import TextFileReader
+
+
+class ExcelReader(TextFileReader):
+    @classmethod
+    def call_deploy(cls, f, chunk_size, num_return_vals, args, quotechar=b'"'):
+        return
+
+    @classmethod
+    def _read(cls, io, **kwargs):
+        if (
+            kwargs.get("engine", None) is not None
+            and kwargs.get("engine") != "openpyxl"
+        ):
+            warnings.warn(
+                "Modin only implements `read_excel` with `openpyxl` engine, "
+                'please specify `engine=None` or `engine="openpyxl"` to '
+                "use Modin's parallel implementation."
+            )
+            return cls.single_worker_read(io, **kwargs)
+        if sys.version_info < (3, 7):
+            warnings.warn("Python 3.7 or higher required for parallel `read_excel`.")
+            return cls.single_worker_read(io, **kwargs)
+
+        from zipfile import ZipFile
+        from openpyxl import load_workbook
+        from openpyxl.worksheet.worksheet import Worksheet
+        from openpyxl.worksheet._reader import WorksheetReader
+        from openpyxl.reader.excel import ExcelReader
+        from modin.backends.pandas.parsers import PandasExcelParser
+
+        sheet_name = kwargs.get("sheet_name", 0)
+        if sheet_name is None or isinstance(sheet_name, list):
+            warnings.warn(
+                "`read_excel` functionality is only implemented for a single sheet at a "
+                "time. Multiple sheet reading coming soon!"
+            )
+            return cls.single_worker_read(io, **kwargs)
+
+        warnings.warn(
+            "Parallel `read_excel` is a new feature! Please email"
+            "bug_reports@modin.org if you run into any problems."
+        )
+        wb = load_workbook(filename=io, read_only=True)
+        # Get shared strings
+        ex = ExcelReader(io, read_only=True)
+        ex.read_manifest()
+        ex.read_strings()
+        ws = Worksheet(wb)
+        # Convert string name 0 to string
+        if sheet_name == 0:
+            sheet_name = wb.sheetnames[sheet_name]
+        with ZipFile(io) as z:
+            from io import BytesIO
+
+            f = z.open("xl/worksheets/{}.xml".format(sheet_name.lower()))
+            f = BytesIO(f.read())
+            total_bytes = cls.file_size(f)
+
+            from modin.pandas import DEFAULT_NPARTITIONS
+
+            num_partitions = DEFAULT_NPARTITIONS
+            # Read some bytes from the sheet so we can extract the XML header and first
+            # line. We need to make sure we get the first line of the data as well
+            # because that is where the column names are. The header information will
+            # be extracted and sent to all of the nodes.
+            sheet_block = f.read(4096)
+            end_of_row_tag = b"</row>"
+            while end_of_row_tag not in sheet_block:
+                sheet_block += f.read(4096)
+            idx_of_header_end = sheet_block.index(end_of_row_tag) + len(end_of_row_tag)
+            sheet_header = sheet_block[:idx_of_header_end]
+            # Reset the file pointer to begin at the end of the header information.
+            f.seek(idx_of_header_end)
+            kwargs["_header"] = sheet_header
+            footer = b"</sheetData></worksheet>"
+            # Use openpyxml to parse the data
+            reader = WorksheetReader(
+                ws, BytesIO(sheet_header + footer), ex.shared_strings, False
+            )
+            # Attach cells to the worksheet
+            reader.bind_cells()
+            data = PandasExcelParser.get_sheet_data(
+                ws, kwargs.pop("convert_float", True)
+            )
+            # Extract column names from parsed data.
+            column_names = pandas.Index(data[0])
+            index_col = kwargs.get("index_col", None)
+            # Remove column names that are specified as `index_col`
+            if index_col is not None:
+                column_names = column_names.drop(column_names[index_col])
+            # Compute partition metadata upfront so it is uniform for all partitions
+            chunk_size = max(1, (total_bytes - f.tell()) // num_partitions)
+            num_splits = min(len(column_names), num_partitions)
+            kwargs["fname"] = io
+            # Skiprows will be used to inform a partition how many rows come before it.
+            kwargs["skiprows"] = 0
+            row_count = 0
+            data_ids = []
+            index_ids = []
+            dtypes_ids = []
+
+            # Compute column metadata
+            column_chunksize = compute_chunksize(
+                pandas.DataFrame(columns=column_names), num_splits, axis=1
+            )
+            if column_chunksize > len(column_names):
+                column_widths = [len(column_names)]
+                # This prevents us from unnecessarily serializing a bunch of empty
+                # objects.
+                num_splits = 1
+            else:
+                column_widths = [
+                    column_chunksize
+                    if len(column_names) > (column_chunksize * (i + 1))
+                    else 0
+                    if len(column_names) < (column_chunksize * i)
+                    else len(column_names) - (column_chunksize * i)
+                    for i in range(num_splits)
+                ]
+            kwargs["num_splits"] = num_splits
+
+            while f.tell() < total_bytes:
+                print(f.tell())
+                print(total_bytes)
+                args = kwargs
+                args["skiprows"] = row_count + args["skiprows"]
+                args["start"] = f.tell()
+                chunk = f.read(chunk_size)
+                # This edge case can happen when we have reached the end of the data
+                # but not the end of the file.
+                if b"<row" not in chunk:
+                    break
+                row_close_tag = b"</row>"
+                row_count = re.subn(row_close_tag, b"", chunk)[1]
+                break_condition = b"</sheetData>" in chunk
+
+                # Make sure we are reading at least one row.
+                while row_count == 0:
+                    chunk += f.read(chunk_size)
+                    row_count += re.subn(row_close_tag, b"", chunk)[1]
+
+                last_index = chunk.rindex(row_close_tag)
+                f.seek(-(len(chunk) - last_index) + len(row_close_tag), 1)
+                args["end"] = f.tell()
+                if break_condition:
+                    break
+                remote_results_list = cls.deploy(cls.parse, num_splits + 2, args)
+                data_ids.append(remote_results_list[:-2])
+                index_ids.append(remote_results_list[-2])
+                dtypes_ids.append(remote_results_list[-1])
+
+        # Compute the index based on a sum of the lengths of each partition (by default)
+        # or based on the column(s) that were requested.
+        if index_col is None:
+            row_lengths = cls.materialize(index_ids)
+            new_index = pandas.RangeIndex(sum(row_lengths))
+        else:
+            index_objs = cls.materialize(index_ids)
+            row_lengths = [len(o) for o in index_objs]
+            new_index = index_objs[0].append(index_objs[1:])
+
+        # Compute dtypes by getting collecting and combining all of the partitions. The
+        # reported dtypes from differing rows can be different based on the inference in
+        # the limited data seen by each worker. We use pandas to compute the exact dtype
+        # over the whole column for each column. The index is set below.
+        dtypes = cls.get_dtypes(dtypes_ids)
+
+        data_ids = cls.build_partition(data_ids, row_lengths, column_widths)
+        # Set the index for the dtypes to the column names
+        if isinstance(dtypes, pandas.Series):
+            dtypes.index = column_names
+        else:
+            dtypes = pandas.Series(dtypes, index=column_names)
+        new_frame = cls.frame_cls(
+            data_ids,
+            new_index,
+            column_names,
+            row_lengths,
+            column_widths,
+            dtypes=dtypes,
+        )
+        return cls.query_compiler_cls(new_frame)

--- a/modin/engines/base/io/text/excel_reader.py
+++ b/modin/engines/base/io/text/excel_reader.py
@@ -140,8 +140,6 @@ class ExcelReader(TextFileReader):
             kwargs["num_splits"] = num_splits
 
             while f.tell() < total_bytes:
-                print(f.tell())
-                print(total_bytes)
                 args = kwargs
                 args["skiprows"] = row_count + args["skiprows"]
                 args["start"] = f.tell()

--- a/modin/engines/dask/pandas_on_dask/io.py
+++ b/modin/engines/dask/pandas_on_dask/io.py
@@ -21,6 +21,7 @@ from modin.engines.base.io import (
     ParquetReader,
     FeatherReader,
     SQLReader,
+    ExcelReader,
 )
 from modin.backends.pandas.parsers import (
     PandasCSVParser,
@@ -28,6 +29,7 @@ from modin.backends.pandas.parsers import (
     PandasParquetParser,
     PandasFeatherParser,
     PandasSQLParser,
+    PandasExcelParser,
 )
 from modin.engines.dask.task_wrapper import DaskTask
 
@@ -53,3 +55,4 @@ class PandasOnDaskIO(BaseIO):
         "", (DaskTask, PandasFeatherParser, FeatherReader), build_args
     ).read
     read_sql = type("", (DaskTask, PandasSQLParser, SQLReader), build_args).read
+    read_excel = type("", (DaskTask, PandasExcelParser, ExcelReader), build_args).read

--- a/modin/engines/ray/pandas_on_ray/io.py
+++ b/modin/engines/ray/pandas_on_ray/io.py
@@ -20,6 +20,7 @@ from modin.engines.base.io import (
     ParquetReader,
     FeatherReader,
     SQLReader,
+    ExcelReader,
 )
 from modin.backends.pandas.parsers import (
     PandasCSVParser,
@@ -28,6 +29,7 @@ from modin.backends.pandas.parsers import (
     PandasParquetParser,
     PandasFeatherParser,
     PandasSQLParser,
+    PandasExcelParser,
 )
 from modin.engines.ray.task_wrapper import RayTask
 from modin.engines.ray.pandas_on_ray.frame.partition import PandasOnRayFramePartition
@@ -55,3 +57,4 @@ class PandasOnRayIO(RayIO):
         "", (RayTask, PandasFeatherParser, FeatherReader), build_args
     ).read
     read_sql = type("", (RayTask, PandasSQLParser, SQLReader), build_args).read
+    read_excel = type("", (RayTask, PandasExcelParser, ExcelReader), build_args).read

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -566,6 +566,30 @@ def test_from_excel():
     teardown_excel_file()
 
 
+def test_from_excel_engine():
+    setup_excel_file(SMALL_ROW_SIZE)
+
+    pandas_df = pandas.read_excel(TEST_EXCEL_FILENAME, engine="xlrd")
+    with pytest.warns(UserWarning):
+        modin_df = pd.read_excel(TEST_EXCEL_FILENAME, engine="xlrd")
+
+    df_equals(modin_df, pandas_df)
+
+    teardown_excel_file()
+
+
+def test_from_excel_index_col():
+    setup_excel_file(SMALL_ROW_SIZE)
+
+    pandas_df = pandas.read_excel(TEST_EXCEL_FILENAME, index_col=0)
+    with pytest.warns(UserWarning):
+        modin_df = pd.read_excel(TEST_EXCEL_FILENAME, index_col=0)
+
+    df_equals(modin_df, pandas_df)
+
+    teardown_excel_file()
+
+
 def test_from_excel_all_sheets():
     setup_excel_file(SMALL_ROW_SIZE)
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -259,7 +259,10 @@ def setup_excel_file(row_size, force=False):
 
 def teardown_excel_file():
     if os.path.exists(TEST_EXCEL_FILENAME):
-        os.remove(TEST_EXCEL_FILENAME)
+        try:
+            os.remove(TEST_EXCEL_FILENAME)
+        except PermissionError:
+            pass
 
 
 def setup_feather_file(row_size, force=False):


### PR DESCRIPTION
* Resovles #1298

Implementation at a high level:

* Parse header on driver.
* Compute partition offsets based on chunks. Ensure that entire rows are
  read by detecting `</row>` closing tag.
* Send header and args to each partition.
* Create fake spreadsheet with header and subset of rows.
* Parse with openpyxl.
* Create dataframe from parsed sheet with pandas.

Currently not implemented:

* Multiple sheets
* `engine` specified as anything but `openpyxl`
* Python 3.6 - need `Zipfile` capabilities only available in 3.7+

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1298 <!-- issue must be created for each patch -->
- [x] tests added and passing
