### PR TITLE
Fixed #1675. Added setting parent in loc and iloc

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2329,6 +2329,7 @@ class DataFrame(BasePandasDataset):
         ).squeeze(axis=1)
         if isinstance(s, Series):
             s._parent = self
+            s._parent_axis = 1
         return s
 
     def _getitem_array(self, key):

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -233,6 +233,9 @@ class _LocIndexer(_LocationIndexerBase):
                 "supported, see https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#deprecate-loc-reindex-listlike"
             )
         result = super(_LocIndexer, self).__getitem__(row_lookup, col_lookup, ndim)
+        if isinstance(result, Series):
+            result._parent = self.df
+            result._parent_axis = 0
         # Pandas drops the levels that are in the `loc`, so we have to as well.
         if hasattr(result, "index") and isinstance(result.index, pandas.MultiIndex):
             if (
@@ -341,6 +344,9 @@ class _iLocIndexer(_LocationIndexerBase):
 
         row_lookup, col_lookup = self._compute_lookup(row_loc, col_loc)
         result = super(_iLocIndexer, self).__getitem__(row_lookup, col_lookup, ndim)
+        if isinstance(result, Series):
+            result._parent = self.df
+            result._parent_axis = 0
         return result
 
     def __setitem__(self, key, item):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -113,6 +113,12 @@ class Series(BasePandasDataset):
 
     name = property(_get_name, _set_name)
     _parent = None
+    # Parent axis denotes axis that was used to select series in a parent dataframe.
+    # If _parent_axis == 0, then it means that index axis was used via df.loc[row]
+    # indexing operations and assignments should be done to rows of parent.
+    # If _parent_axis == 1 it means that column axis was used via df[column] and assignments
+    # should be done to columns of parent.
+    _parent_axis = 0
 
     def _reduce_dimension(self, query_compiler):
         return query_compiler.to_pandas().squeeze()
@@ -325,7 +331,10 @@ class Series(BasePandasDataset):
         )
         # Propagate changes back to parent so that column in dataframe had the same contents
         if self._parent is not None:
-            self._parent[self.name] = self
+            if self._parent_axis == 0:
+                self._parent.loc[self.name] = self
+            else:
+                self._parent[self.name] = self
 
     def __sub__(self, right):
         return self.sub(right)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4456,6 +4456,48 @@ class TestDataFrameIndexing:
             transposed_pandas.loc[transposed_pandas.index[:-2], :],
         )
 
+    def test_loc_assignment(self):
+        modin_df = pd.DataFrame(
+            index=["row1", "row2", "row3"], columns=["col1", "col2"]
+        )
+        pandas_df = pandas.DataFrame(
+            index=["row1", "row2", "row3"], columns=["col1", "col2"]
+        )
+        modin_df.loc["row1"]["col1"] = 11
+        modin_df.loc["row2"]["col1"] = 21
+        modin_df.loc["row3"]["col1"] = 31
+        modin_df.loc["row1"]["col2"] = 12
+        modin_df.loc["row2"]["col2"] = 22
+        modin_df.loc["row3"]["col2"] = 32
+        pandas_df.loc["row1"]["col1"] = 11
+        pandas_df.loc["row2"]["col1"] = 21
+        pandas_df.loc["row3"]["col1"] = 31
+        pandas_df.loc["row1"]["col2"] = 12
+        pandas_df.loc["row2"]["col2"] = 22
+        pandas_df.loc["row3"]["col2"] = 32
+        df_equals(modin_df, pandas_df)
+
+    def test_iloc_assignment(self):
+        modin_df = pd.DataFrame(
+            index=["row1", "row2", "row3"], columns=["col1", "col2"]
+        )
+        pandas_df = pandas.DataFrame(
+            index=["row1", "row2", "row3"], columns=["col1", "col2"]
+        )
+        modin_df.iloc[0]["col1"] = 11
+        modin_df.iloc[1]["col1"] = 21
+        modin_df.iloc[2]["col1"] = 31
+        modin_df.iloc[0]["col2"] = 12
+        modin_df.iloc[1]["col2"] = 22
+        modin_df.iloc[2]["col2"] = 32
+        pandas_df.iloc[0]["col1"] = 11
+        pandas_df.iloc[1]["col1"] = 21
+        pandas_df.iloc[2]["col1"] = 31
+        pandas_df.iloc[0]["col2"] = 12
+        pandas_df.iloc[1]["col2"] = 22
+        pandas_df.iloc[2]["col2"] = 32
+        df_equals(modin_df, pandas_df)
+
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test_pop(self, request, data):
         modin_df = pd.DataFrame(data)


### PR DESCRIPTION
Implemented correct Series assignment to DataFrame parent depending on
which axis was used for indexing.

Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1675 <!-- issue must be created for each patch -->
- [x] tests added and passing
