### PR TITLE
Fixed #1678. Added missing default case in dtypes translation

### DIFF
--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -553,6 +553,8 @@ class BasePandasFrame(object):
                 elif isinstance(new_dtype, str) and new_dtype == "category":
                     new_dtypes = None
                     break
+                else:
+                    new_dtypes[column] = new_dtype
 
         def astype_builder(df):
             return df.astype({k: v for k, v in col_dtypes.items() if k in df})

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -809,6 +809,14 @@ class TestDataFrameMapMetadata:
         expected_df_casted = expected_df.astype(bad_dtype_dict)
         df_equals(modin_df_casted, expected_df_casted)
 
+        modin_df = pd.DataFrame(index=["row1"], columns=["col1"])
+        modin_df["col1"]["row1"] = 11
+        modin_df_casted = modin_df.astype(int)
+        expected_df = pandas.DataFrame(index=["row1"], columns=["col1"])
+        expected_df["col1"]["row1"] = 11
+        expected_df_casted = expected_df.astype(int)
+        df_equals(modin_df_casted, expected_df_casted)
+
         with pytest.raises(KeyError):
             modin_df.astype({"not_exists": np.uint8})
 


### PR DESCRIPTION
Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1678 <!-- issue must be created for each patch -->
- [x] tests added and passing
