### PR TITLE
Implement a method to switch a pair of engine and partition

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -137,7 +137,7 @@ def set_backends(engine=None, partition=None):
     if engine is not None:
         old_engine = execution_engine._put_nocallback(engine)
     if partition is not None:
-        old_partition = partition_format._put_nocallback(engine)
+        old_partition = partition_format._put_nocallback(partition)
     # execute callbacks if something was changed
     if old_engine is not None:
         execution_engine._check_callbacks(old_engine)

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -102,24 +102,50 @@ class Publisher(object):
     def get(self):
         return self.__value
 
-    def put(self, value):
+    def _put_nocallback(self, value):
         value = value.title()  # normalize the value
         oldvalue, self.__value = self.__value, value
-        if oldvalue != value:
-            for callback in self.__subs:
-                callback(self)
-            try:
-                once = self.__once[value]
-            except KeyError:
-                return
-            if once:
-                for callback in once:
-                    callback(self)
-            del self.__once[value]
+        return oldvalue
+
+    def _check_callbacks(self, oldvalue):
+        if oldvalue == self.__value:
+            return
+        for callback in self.__subs:
+            callback(self)
+        once = self.__once.pop(self.__value, ())
+        for callback in once:
+            callback(self)
+
+    def put(self, value):
+        self._check_callbacks(self._put_nocallback(value))
 
 
 execution_engine = Publisher(name="execution_engine", value=get_execution_engine())
 partition_format = Publisher(name="partition_format", value=get_partition_format())
+
+
+def set_backends(engine=None, partition=None):
+    """
+    Method to set the _pair_ of execution engine and partition format simultaneously.
+    This is needed because there might be cases where switching one by one would be
+    impossible, as not all pairs of values are meaningful.
+
+    The method returns pair of old values, so it is easy to return back.
+    """
+    old_engine, old_partition = None, None
+    # defer callbacks until both entities are set
+    if engine is not None:
+        old_engine = execution_engine._put_nocallback(engine)
+    if partition is not None:
+        old_partition = partition_format._put_nocallback(engine)
+    # execute callbacks if something was changed
+    if old_engine is not None:
+        execution_engine._check_callbacks(old_engine)
+    if old_partition is not None:
+        partition_format._check_callbacks(old_partition)
+
+    return old_engine, old_partition
+
 
 # We don't want these used outside of this file.
 del get_execution_engine

--- a/modin/data_management/test/test_dispatcher.py
+++ b/modin/data_management/test/test_dispatcher.py
@@ -13,7 +13,7 @@
 
 import pytest
 
-from modin import execution_engine, partition_format
+from modin import execution_engine, partition_format, set_backends
 
 from modin.data_management.dispatcher import EngineDispatcher, FactoryNotFoundError
 from modin.data_management import factories
@@ -45,9 +45,23 @@ class TestOnPythonFactory(factories.BaseFactory):
         cls.io_cls = "Bar"
 
 
+class FooOnBarFactory(factories.BaseFactory):
+    """
+    Stub factory to ensure we can switch engine and partition to 'Foo' and 'Bar'
+    """
+
+    @classmethod
+    def prepare(cls):
+        """
+        Fills in .io_cls class attribute lazily
+        """
+        cls.io_cls = "Zug-zug"
+
+
 # inject the stubs
 factories.PandasOnTestFactory = PandasOnTestFactory
 factories.TestOnPythonFactory = TestOnPythonFactory
+factories.FooOnBarFactory = FooOnBarFactory
 
 
 def test_default_engine():
@@ -71,3 +85,8 @@ def test_engine_wrong_factory():
     with pytest.raises(FactoryNotFoundError):
         execution_engine.put("BadEngine")
     execution_engine.put("Python")  # revert engine to default
+
+
+def test_set_backends():
+    set_backends("Bar", "Foo")
+    assert EngineDispatcher.get_engine() == FooOnBarFactory


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Previously added `Publusher` mechanism lacked the ability to change the _pair_ of engine and partition, which might lead to a case when changing from one pair to another is impossible (each pair must have a corresponding factory, which means that to switch from pair AxB to CxD either AxD must exist or CxB, and user must know which exists).

This newly added method defers callbacks execution until both elements are changed, thus we only require that final pair is valid.

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves https://github.com/modin-project/modin/issues/1540
- [x] tests added and passing
