### PR TITLE
Implement cluster spawning API

### DIFF
--- a/examples/cluster/experimental_cloud.py
+++ b/examples/cluster/experimental_cloud.py
@@ -28,9 +28,9 @@ from modin.experimental.cloud import Provider, cluster, get_connection
 
 
 aws = Provider(Provider.AWS, os.path.join(os.path.abspath(os.path.dirname(__file__)), 'aws_credentials'), 'us-west-1')
-import pdb;pdb.set_trace()
 with cluster(aws, cluster_name='rayscale-test') as c:
     conn = get_connection()
     modin = conn.modules.modin
     print(modin)
     print(type(modin))
+    import pdb;pdb.set_trace()

--- a/examples/cluster/experimental_cloud.py
+++ b/examples/cluster/experimental_cloud.py
@@ -28,8 +28,9 @@ from modin.experimental.cloud import Provider, cluster, get_connection
 
 
 aws = Provider(Provider.AWS, os.path.join(os.path.abspath(os.path.dirname(__file__)), 'aws_credentials'), 'us-west-1')
+import pdb;pdb.set_trace()
 with cluster(aws, cluster_name='rayscale-test') as c:
     conn = get_connection()
     modin = conn.modules.modin
     print(modin)
-
+    print(type(modin))

--- a/examples/cluster/experimental_cloud.py
+++ b/examples/cluster/experimental_cloud.py
@@ -30,7 +30,7 @@ from modin.experimental.cloud import Provider, cluster, get_connection
 aws = Provider(Provider.AWS, os.path.join(os.path.abspath(os.path.dirname(__file__)), 'aws_credentials'), 'us-west-1')
 with cluster(aws, cluster_name='rayscale-test') as c:
     conn = get_connection()
+    import pdb;pdb.set_trace()
     modin = conn.modules.modin
     print(modin)
     print(type(modin))
-    import pdb;pdb.set_trace()

--- a/examples/cluster/experimental_cloud.py
+++ b/examples/cluster/experimental_cloud.py
@@ -13,24 +13,23 @@
 
 """
 This is a very basic sample script for running things remotely.
-It requires `aws_credentials` file to be present next to it.
+It requires `aws_credentials` file to be present in current working directory.
 
 On credentials file format see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where
 """
 
-import os
 import logging
-logging.basicConfig(format='%(asctime)s %(message)s')
+
+import modin.pandas as pd
+from modin.experimental.cloud import cluster
+
+# set up verbose logging so Ray autoscaler would print a lot of things
+# and we'll see that stuff is alive and kicking
+logging.basicConfig(format="%(asctime)s %(message)s")
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
-from modin.experimental.cloud import Provider, Cluster, get_connection
-
-
-aws = Provider(Provider.AWS, os.path.join(os.path.abspath(os.path.dirname(__file__)), 'aws_credentials'), 'us-west-1')
-with Cluster(aws, cluster_name='rayscale-test') as c:
-    conn = get_connection()
-    import pdb;pdb.set_trace()
-    modin = conn.modules.modin
-    print(modin)
-    print(type(modin))
+example_cluster = cluster.create("aws", "aws_credentials")
+with example_cluster:
+    remote_df = pd.DataFrame([1, 2, 3, 4])
+    print(len(remote_df))  # len() is executed remotely

--- a/examples/cluster/experimental_cloud.py
+++ b/examples/cluster/experimental_cloud.py
@@ -24,11 +24,11 @@ logging.basicConfig(format='%(asctime)s %(message)s')
 logger = logging.getLogger()
 logger.setLevel(logging.DEBUG)
 
-from modin.experimental.cloud import Provider, cluster, get_connection
+from modin.experimental.cloud import Provider, Cluster, get_connection
 
 
 aws = Provider(Provider.AWS, os.path.join(os.path.abspath(os.path.dirname(__file__)), 'aws_credentials'), 'us-west-1')
-with cluster(aws, cluster_name='rayscale-test') as c:
+with Cluster(aws, cluster_name='rayscale-test') as c:
     conn = get_connection()
     import pdb;pdb.set_trace()
     modin = conn.modules.modin

--- a/examples/cluster/experimental_cloud.py
+++ b/examples/cluster/experimental_cloud.py
@@ -1,0 +1,35 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""
+This is a very basic sample script for running things remotely.
+It requires `aws_credentials` file to be present next to it.
+
+On credentials file format see https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-where
+"""
+
+import os
+import logging
+logging.basicConfig(format='%(asctime)s %(message)s')
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)
+
+from modin.experimental.cloud import Provider, cluster, get_connection
+
+
+aws = Provider(Provider.AWS, os.path.join(os.path.abspath(os.path.dirname(__file__)), 'aws_credentials'), 'us-west-1')
+with cluster(aws, cluster_name='rayscale-test') as c:
+    conn = get_connection()
+    modin = conn.modules.modin
+    print(modin)
+

--- a/modin/experimental/cloud/__init__.py
+++ b/modin/experimental/cloud/__init__.py
@@ -29,7 +29,7 @@ def cluster(
         from .rayscale import RayCluster as Spawner
     else:
         raise ValueError(f"Unknown spawner: {spawner}")
-    return Spawner(
+    instance = Spawner(
         provider,
         project_name,
         cluster_name,
@@ -37,6 +37,8 @@ def cluster(
         head_node_type,
         worker_node_type,
     )
+    instance.spawn(wait=True)  # XXX for testing
+    return instance
 
 
 def get_connection():

--- a/modin/experimental/cloud/__init__.py
+++ b/modin/experimental/cloud/__init__.py
@@ -11,46 +11,46 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from typing import NamedTuple
-
-class ClusterError(Exception):
-    """
-    Generic cluster operating exception
-    """
-
-    def __init__(self, *args, cause=None, **kw):
-        self.cause = cause
-        super().__init__(*args, **kw)
-
-
-class CannotSpawnCluster(ClusterError):
-    """
-    Raised when cluster cannot be spawned in the cloud
-    """
-
-
-class CannotDestroyCluster(ClusterError):
-    """
-    Raised when cluster cannot be destroyed in the cloud
-    """
-
-
-class ConnectionDetails(NamedTuple):
-    user_name: str = "modin"
-    key_file: str = None
-    address: str = None
-    port: int = 22
-
+from .base import ClusterError, CannotSpawnCluster, CannotDestroyCluster
 from .cluster import Provider, Cluster
-def cluster(provider: Provider,
-        project_name: str = None,
-        cluster_name: str = "modin-cluster",
-        worker_count: int = 4,
-        head_node_type: str = None,
-        worker_node_type: str = None,
-        spawner: str = 'rayscale') -> Cluster:
-    if spawner == 'rayscale':
+from .connection import Connection
+
+
+def cluster(
+    provider: Provider,
+    project_name: str = None,
+    cluster_name: str = "modin-cluster",
+    worker_count: int = 4,
+    head_node_type: str = None,
+    worker_node_type: str = None,
+    spawner: str = "rayscale",
+) -> Cluster:
+    if spawner == "rayscale":
         from .rayscale import RayCluster as Spawner
     else:
-        raise ValueError(f'Unknown spawner: {spawner}')
-    return Spawner(provider, project_name, cluster_name, worker_count, head_node_type, worker_node_type)
+        raise ValueError(f"Unknown spawner: {spawner}")
+    return Spawner(
+        provider,
+        project_name,
+        cluster_name,
+        worker_count,
+        head_node_type,
+        worker_node_type,
+    )
+
+
+def get_connection():
+    """
+    Returns an RPyC connection object to execute Python code remotely.
+    """
+    return Connection.get()
+
+
+__all__ = [
+    "ClusterError",
+    "CannotSpawnCluster",
+    "CannotDestroyCluster",
+    "Provider",
+    "Cluster",
+    "get_connection",
+]

--- a/modin/experimental/cloud/__init__.py
+++ b/modin/experimental/cloud/__init__.py
@@ -12,11 +12,11 @@
 # governing permissions and limitations under the License.
 
 from .base import ClusterError, CannotSpawnCluster, CannotDestroyCluster
-from .cluster import Provider, Cluster
+from .cluster import Provider, BaseCluster
 from .connection import Connection
 
 
-def cluster(
+def Cluster(
     provider: Provider,
     project_name: str = None,
     cluster_name: str = "modin-cluster",
@@ -24,7 +24,7 @@ def cluster(
     head_node_type: str = None,
     worker_node_type: str = None,
     spawner: str = "rayscale",
-) -> Cluster:
+) -> BaseCluster:
     if spawner == "rayscale":
         from .rayscale import RayCluster as Spawner
     else:

--- a/modin/experimental/cloud/__init__.py
+++ b/modin/experimental/cloud/__init__.py
@@ -12,38 +12,13 @@
 # governing permissions and limitations under the License.
 
 from .base import ClusterError, CannotSpawnCluster, CannotDestroyCluster
-from .cluster import Provider, BaseCluster
+from .cluster import Provider, create as create_cluster
 from .connection import Connection
-
-
-def Cluster(
-    provider: Provider,
-    project_name: str = None,
-    cluster_name: str = "modin-cluster",
-    worker_count: int = 4,
-    head_node_type: str = None,
-    worker_node_type: str = None,
-    spawner: str = "rayscale",
-) -> BaseCluster:
-    if spawner == "rayscale":
-        from .rayscale import RayCluster as Spawner
-    else:
-        raise ValueError(f"Unknown spawner: {spawner}")
-    instance = Spawner(
-        provider,
-        project_name,
-        cluster_name,
-        worker_count,
-        head_node_type,
-        worker_node_type,
-    )
-    instance.spawn(wait=False)
-    return instance
 
 
 def get_connection():
     """
-    Returns an RPyC connection object to execute Python code remotely.
+    Returns an RPyC connection object to execute Python code remotely on the active cluster.
     """
     return Connection.get()
 
@@ -53,6 +28,6 @@ __all__ = [
     "CannotSpawnCluster",
     "CannotDestroyCluster",
     "Provider",
-    "Cluster",
+    "create_cluster",
     "get_connection",
 ]

--- a/modin/experimental/cloud/__init__.py
+++ b/modin/experimental/cloud/__init__.py
@@ -29,7 +29,7 @@ def cluster(
         from .rayscale import RayCluster as Spawner
     else:
         raise ValueError(f"Unknown spawner: {spawner}")
-    instance = Spawner(
+    return Spawner(
         provider,
         project_name,
         cluster_name,
@@ -37,8 +37,6 @@ def cluster(
         head_node_type,
         worker_node_type,
     )
-    instance.spawn(wait=True)  # XXX for testing
-    return instance
 
 
 def get_connection():

--- a/modin/experimental/cloud/__init__.py
+++ b/modin/experimental/cloud/__init__.py
@@ -1,0 +1,43 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+from typing import NamedTuple
+
+
+class ClusterError(Exception):
+    """
+    Generic cluster operating exception
+    """
+
+    def __init__(self, *args, cause=None, **kw):
+        self.cause = cause
+        super().__init__(*args, **kw)
+
+
+class CannotSpawnCluster(ClusterError):
+    """
+    Raised when cluster cannot be spawned in the cloud
+    """
+
+
+class CannotDestroyCluster(ClusterError):
+    """
+    Raised when cluster cannot be destroyed in the cloud
+    """
+
+
+class ConnectionDetails(NamedTuple):
+    user_name: str = "modin"
+    key_file: str = None
+    address: str = None
+    port: int = 22

--- a/modin/experimental/cloud/__init__.py
+++ b/modin/experimental/cloud/__init__.py
@@ -13,7 +13,6 @@
 
 from typing import NamedTuple
 
-
 class ClusterError(Exception):
     """
     Generic cluster operating exception
@@ -41,3 +40,17 @@ class ConnectionDetails(NamedTuple):
     key_file: str = None
     address: str = None
     port: int = 22
+
+from .cluster import Provider, Cluster
+def cluster(provider: Provider,
+        project_name: str = None,
+        cluster_name: str = "modin-cluster",
+        worker_count: int = 4,
+        head_node_type: str = None,
+        worker_node_type: str = None,
+        spawner: str = 'rayscale') -> Cluster:
+    if spawner == 'rayscale':
+        from .rayscale import RayCluster as Spawner
+    else:
+        raise ValueError(f'Unknown spawner: {spawner}')
+    return Spawner(provider, project_name, cluster_name, worker_count, head_node_type, worker_node_type)

--- a/modin/experimental/cloud/__init__.py
+++ b/modin/experimental/cloud/__init__.py
@@ -29,7 +29,7 @@ def cluster(
         from .rayscale import RayCluster as Spawner
     else:
         raise ValueError(f"Unknown spawner: {spawner}")
-    return Spawner(
+    instance = Spawner(
         provider,
         project_name,
         cluster_name,
@@ -37,6 +37,8 @@ def cluster(
         head_node_type,
         worker_node_type,
     )
+    instance.spawn(wait=False)
+    return instance
 
 
 def get_connection():

--- a/modin/experimental/cloud/base.py
+++ b/modin/experimental/cloud/base.py
@@ -1,0 +1,43 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+from typing import NamedTuple
+
+
+class ClusterError(Exception):
+    """
+    Generic cluster operating exception
+    """
+
+    def __init__(self, *args, cause=None, **kw):
+        self.cause = cause
+        super().__init__(*args, **kw)
+
+
+class CannotSpawnCluster(ClusterError):
+    """
+    Raised when cluster cannot be spawned in the cloud
+    """
+
+
+class CannotDestroyCluster(ClusterError):
+    """
+    Raised when cluster cannot be destroyed in the cloud
+    """
+
+
+class ConnectionDetails(NamedTuple):
+    user_name: str = "modin"
+    key_file: str = None
+    address: str = None
+    port: int = 22

--- a/modin/experimental/cloud/base.py
+++ b/modin/experimental/cloud/base.py
@@ -21,8 +21,9 @@ class ClusterError(Exception):
     Generic cluster operating exception
     """
 
-    def __init__(self, *args, cause=None, **kw):
+    def __init__(self, *args, cause: BaseException = None, traceback: str = None, **kw):
         self.cause = cause
+        self.traceback = traceback
         super().__init__(*args, **kw)
 
 

--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -125,9 +125,10 @@ class Cluster:
         """
         raise NotImplementedError()
 
-    def destroy(self):
+    def destroy(self, wait=True):
         """
         Destroys the cluster. When already destroyed, should be a no-op.
+        When wait==False it destroys cluster asynchronously.
         """
         raise NotImplementedError()
 
@@ -157,4 +158,4 @@ class Cluster:
         self.old_backends = None
 
     def __del__(self):
-        self.destroy()
+        self.destroy(wait=True)

--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -14,6 +14,7 @@
 import os
 import errno
 from typing import NamedTuple
+import atexit
 
 from modin import set_backends
 
@@ -121,7 +122,6 @@ class Cluster:
 
         self.old_backends = None
         self.connection: Connection = None
-        self.spawn(wait=False)
 
     def spawn(self, wait=True):
         """
@@ -131,6 +131,7 @@ class Cluster:
         When wait==False it spawns cluster asynchronously.
         """
         self._spawn(wait=wait)
+        atexit.register(self.destroy, wait=True)
         if wait:
             # cluster is ready now
             if self.connection is None:
@@ -183,6 +184,3 @@ class Cluster:
         set_backends(*self.old_backends)
         self.connection.deactivate()
         self.old_backends = None
-
-    def __del__(self):
-        self.destroy(wait=True)

--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -123,7 +123,7 @@ class Cluster:
         self.old_backends = None
         self.connection: Connection = None
 
-    def spawn(self, wait=True):
+    def spawn(self, wait=False):
         """
         Actually spawns the cluster. When already spawned, should be a no-op.
         Always call .spawn(True) before assuming a cluster is ready.
@@ -139,7 +139,7 @@ class Cluster:
                     self._get_connection_details(), self._get_main_python()
                 )
 
-    def destroy(self, wait=True):
+    def destroy(self, wait=False):
         """
         Destroys the cluster. When already destroyed, should be a no-op.
         Always call .destroy(True) before assuming a cluster is dead.
@@ -152,13 +152,13 @@ class Cluster:
         if wait:
             atexit.unregister(self.destroy)
 
-    def _spawn(self, wait=True):
+    def _spawn(self, wait=False):
         """
         Subclass must implement the real spawning
         """
         raise NotImplementedError()
 
-    def _destroy(self, wait=True):
+    def _destroy(self, wait=False):
         """
         Subclass must implement the real destruction
         """

--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -34,18 +34,22 @@ class Provider:
     __DEFAULT_WORKER = {AWS: "m5.large"}
 
     def __init__(
-        self, name: str, credentials_file: str, region: str = None, zone: str = None
+        self,
+        name: str,
+        credentials_file: str = None,
+        region: str = None,
+        zone: str = None,
     ):
         """
         Class that holds all information about particular connection to cluster provider, namely
             * provider name (must be one of known ones)
-            * path to file with credentials (file format is provider-specific)
+            * path to file with credentials (file format is provider-specific); omit to use global provider-default credentials
             * region and zone where cluster is to be spawned (optional, would be deduced if omitted)
         """
 
         if name not in self.__KNOWN:
             raise ValueError(f"Unknown provider name: {name}")
-        if not os.path.exists(credentials_file):
+        if credentials_file is not None and not os.path.exists(credentials_file):
             raise OSError(
                 errno.ENOENT, "Credentials file does not exist", credentials_file
             )
@@ -68,7 +72,9 @@ class Provider:
         self.name = name
         self.region = region
         self.zone = zone
-        self.credentials_file = os.path.abspath(credentials_file)
+        self.credentials_file = (
+            os.path.abspath(credentials_file) if credentials_file is not None else None
+        )
 
     @property
     def default_head_type(self):

--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -149,6 +149,8 @@ class Cluster:
         if self.connection is not None:
             self.connection.stop()
         self._destroy(wait=wait)
+        if wait:
+            atexit.unregister(self.destroy)
 
     def _spawn(self, wait=True):
         """

--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -1,0 +1,160 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import os
+import errno
+from typing import NamedTuple
+
+from modin import set_backends
+
+from . import ConnectionDetails
+from .connection import Connection
+
+
+class _RegionZone(NamedTuple):
+    region: str
+    zone: str
+
+
+class Provider:
+    AWS = "aws"
+
+    __KNOWN = {AWS: [_RegionZone(region="us-west-1", zone="us-west-1a")]}
+    __DEFAULT_HEAD = {AWS: "m5.large"}
+    __DEFAULT_WORKER = {AWS: "m5.large"}
+
+    def __init__(
+        self, name: str, credentials_file: str, region: str = None, zone: str = None
+    ):
+        """
+        Class that holds all information about particular connection to cluster provider, namely
+            * provider name (must be one of known ones)
+            * path to file with credentials (file format is provider-specific)
+            * region and zone where cluster is to be spawned (optional, would be deduced if omitted)
+        """
+
+        if name not in self.__KNOWN:
+            raise ValueError(f"Unknown provider name: {name}")
+        if not os.path.exists(credentials_file):
+            raise OSError(
+                errno.ENOENT, "Credentials file does not exist", credentials_file
+            )
+
+        if region is None:
+            if zone is not None:
+                raise ValueError("Cannot specify a zone without specifying a region")
+            try:
+                region, zone = self.__KNOWN[name][0]
+            except IndexError:
+                raise ValueError(f"No defaults for provider {name}")
+        elif zone is None:
+            for regzone in self.__KNOWN[name]:
+                if regzone.region == region:
+                    zone = regzone.zone
+                    break
+            else:
+                raise ValueError(f"No default for region {region} for provider {name}")
+
+        self.name = name
+        self.region = region
+        self.zone = zone
+        self.credentials_file = os.path.abspath(credentials_file)
+
+    @property
+    def default_head_type(self):
+        return self.__DEFAULT_HEAD[self.name]
+
+    @property
+    def default_worker_type(self):
+        return self.__DEFAULT_WORKER[self.name]
+
+
+class Cluster:
+    """
+    Cluster manager for Modin. Knows how to use certain tools to spawn and destroy clusters,
+    can serve as context manager to switch execution engine and partition to remote.
+    """
+
+    target_engine = None
+    target_partition = None
+
+    def __init__(
+        self,
+        provider: Provider,
+        project_name: str = None,
+        cluster_name: str = "modin-cluster",
+        worker_count: int = 4,
+        head_node_type: str = None,
+        worker_node_type: str = None,
+    ):
+        """
+        Prepare the cluster manager. It needs to know a few things:
+            * which cloud provider to use
+            * what is project name (could be omitted to use default one for account used to connect)
+            * cluster name
+            * worker count
+            * head and worker node instance types (can be omitted to default to provider-defined)
+        """
+
+        self.provider = provider
+        self.project_name = project_name
+        self.cluster_name = cluster_name
+        self.worker_count = worker_count
+        self.head_node_type = head_node_type or provider.default_head_type
+        self.worker_node_type = worker_node_type or provider.default_worker_type
+
+        self.old_backends = None
+        self.connection = None
+        self.spawn(wait=False)
+
+    def spawn(self, wait=True):
+        """
+        Actually spawns the cluster. When already spawned, should be a no-op.
+
+        When wait==False it spawns cluster asynchronously.
+        """
+        raise NotImplementedError()
+
+    def destroy(self):
+        """
+        Destroys the cluster. When already destroyed, should be a no-op.
+        """
+        raise NotImplementedError()
+
+    def _get_connection_details(self) -> ConnectionDetails:
+        """
+        Gets the coordinates on how to connect to cluster frontend node.
+        """
+        raise NotImplementedError()
+
+    def _get_main_python(self) -> str:
+        """
+        Gets the path to 'main' interpreter (the one that houses created environment for running everything)
+        """
+        raise NotImplementedError()
+
+    def __enter__(self):
+        self.spawn(wait=True)  # make sure cluster is ready
+        self.connection = Connection(
+            self._get_connection_details(), self._get_main_python()
+        )
+        self.old_backends = set_backends(self.target_engine, self.target_partition)
+        return self
+
+    def __exit__(self, *a, **kw):
+        set_backends(*self.old_backends)
+        self.connection.stop()
+        self.old_backends = None
+
+    def __del__(self):
+        self.destroy()

--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -86,7 +86,7 @@ class Provider:
         return self.__DEFAULT_WORKER[self.name]
 
 
-class Cluster:
+class BaseCluster:
     """
     Cluster manager for Modin. Knows how to use certain tools to spawn and destroy clusters,
     can serve as context manager to switch execution engine and partition to remote.

--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -17,7 +17,7 @@ from typing import NamedTuple
 
 from modin import set_backends
 
-from . import ConnectionDetails
+from .base import ConnectionDetails
 from .connection import Connection
 
 

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -26,7 +26,7 @@ class Connection:
     rpyc_port = 18813
 
     @staticmethod
-    def __wait_noexc(proc:subprocess.Popen, timeout:float):
+    def __wait_noexc(proc: subprocess.Popen, timeout: float):
         try:
             return proc.wait(timeout=timeout)
         except subprocess.TimeoutExpired:
@@ -143,7 +143,10 @@ class Connection:
 
     @staticmethod
     def __run(sshcmd: list, cmd: list, capture_out: bool = True):
-        redirect = subprocess.PIPE if capture_out else None
+        redirect = subprocess.PIPE if capture_out else subprocess.DEVNULL
         return subprocess.Popen(
-            sshcmd + [subprocess.list2cmdline(cmd)], stdout=redirect, stderr=redirect
+            sshcmd + [subprocess.list2cmdline(cmd)],
+            stdin=subprocess.DEVNULL,
+            stdout=redirect,
+            stderr=redirect,
         )

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -97,7 +97,7 @@ class Connection:
             import rpyc
 
             self.__connection = rpyc.classic.connect(
-                "localhost", self.rpyc_port, keepalive=True
+                "127.0.0.1", self.rpyc_port, keepalive=True
             )
 
         Connection.__current = self
@@ -141,7 +141,9 @@ class Connection:
         for oname, ovalue in opts:
             cmdline.extend(["-o", f"{oname}={ovalue}"])
         if forward_port:
-            cmdline.extend(["-L", f"{forward_port}:localhost:{self.rpyc_port}"])
+            cmdline.extend(
+                ["-L", f"127.0.0.1:{forward_port}:127.0.0.1:{self.rpyc_port}"]
+            )
         cmdline.append(f"{details.user_name}@{details.address}")
 
         return cmdline

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -17,7 +17,7 @@ import os
 import random
 from shlex import quote
 
-from . import ClusterError, ConnectionDetails
+from .base import ClusterError, ConnectionDetails
 
 
 class Connection:
@@ -81,6 +81,7 @@ class Connection:
         ):
             raise ClusterError("SSH tunnel is not running")
         import rpyc
+
         return rpyc.classic.connect(
             "localhost", cls.__current.rpyc_port, keepalive=True
         )

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -1,0 +1,133 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import subprocess
+import signal
+import os
+import random
+from shlex import quote
+
+import rpyc
+
+from . import ClusterError, ConnectionDetails
+
+
+class Connection:
+    __current = None
+    connect_timeout = 5
+    tries = 10
+    rpyc_port = 18813
+
+    def __init__(self, details: ConnectionDetails, main_python: str, log_rpyc=None):
+        if log_rpyc is None:
+            log_rpyc = os.environ.get("MODIN_LOG_RPYC", "").title() == "True"
+        self.proc = None
+
+        # find where rpyc_classic is located
+        locator = self.__run(
+            self.__build_opts(details)
+            + [
+                main_python,
+                "-c",
+                "import os; from distutils.dist import Distribution; from distutils.command.install import install; cmd = install(Distribution()); cmd.finalize_options(); print(os.path.join(cmd.install_scripts, 'rpyc_classic.py'))",
+            ]
+        )
+        out, err = locator.communicate(timeout=5)
+        if locator.returncode != 0:
+            raise ClusterError(
+                f"Cannot get path to rpyc_classic, return code: {locator.returncode}"
+            )
+        rpyc_classic = out.splitlines()[0].strip()
+        if not rpyc_classic:
+            raise ClusterError("Got empty path to rpyc_classic")
+
+        port = self.rpyc_port
+        for _ in range(self.tries):
+            cmd = self.__build_opts(details, forward_port=port) + [
+                main_python,
+                rpyc_classic,
+                "--port",
+                str(self.rpyc_port),
+            ]
+            if log_rpyc:
+                cmd.extend(["--logfile", "/tmp/rpyc.log"])
+            proc = self.__run(cmd, capture_out=False)
+            if proc.wait(1) is None:
+                # started successfully
+                self.proc = proc
+                self.rpyc_port = port
+                break
+            # most likely port is busy, pick random one
+            port = random.randint(1024, 65000)
+        else:
+            raise ClusterError("Unable to bind a local port when forwarding")
+
+        Connection.__current = self
+
+    @classmethod
+    def get(cls) -> rpyc.core.protocol.Connection:
+        if (
+            not cls.__current
+            or not cls.__current.proc
+            or cls.__current.proc.poll() is not None
+        ):
+            raise ClusterError("SSH tunnel is not running")
+        return rpyc.classic.connect(
+            "localhost", cls.__current.rpyc_port, keepalive=True
+        )
+
+    def stop(self):
+        if self.proc and self.proc.poll() is None:
+            self.proc.send_signal(signal.SIGINT)
+            if self.proc.wait(self.connect_timeout) is None:
+                self.proc.terminate()
+                if self.proc.wait(self.connect_timeout) is None:
+                    self.proc.kill()
+        self.proc = None
+        if Connection.__current is self:
+            Connection.__current = None
+
+    def __del__(self):
+        self.stop()
+
+    def __build_opts(self, details: ConnectionDetails, forward_port: int = None):
+        socks_proxy = os.environ.get("MODIN_SOCKS_PROXY", None)
+
+        opts = [
+            ("ConnectTimeout", "{}s".format(self.connect_timeout)),
+            ("StrictHostKeyChecking", "no"),
+            # Try fewer extraneous key pairs.
+            ("IdentitiesOnly", "yes"),
+            # Abort if port forwarding fails (instead of just printing to stderr).
+            ("ExitOnForwardFailure", "yes"),
+            # Quickly kill the connection if network connection breaks (as opposed to hanging/blocking).
+            ("ServerAliveInterval", 5),
+            ("ServerAliveCountMax", 3),
+        ]
+
+        if socks_proxy:
+            opts += [("ProxyCommand", f"nc -x {quote(socks_proxy)} %h %p")]
+
+        cmdline = ["ssh", "-i", details.key_file]
+        for oname, ovalue in opts:
+            cmdline.extend(["-o", f"{oname}={ovalue}"])
+        if forward_port:
+            cmdline.extend(["-L", f"{forward_port}:localhost:{self.rpyc_port}"])
+        cmdline.append(f"{details.user_name}@{details.address}")
+
+        return cmdline
+
+    @staticmethod
+    def __run(cmd: list, capture_out: bool = True):
+        redirect = subprocess.PIPE if capture_out else None
+        return subprocess.Popen(cmd, stdout=redirect, stderr=redirect)

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -17,8 +17,6 @@ import os
 import random
 from shlex import quote
 
-import rpyc
-
 from . import ClusterError, ConnectionDetails
 
 
@@ -75,13 +73,14 @@ class Connection:
         Connection.__current = self
 
     @classmethod
-    def get(cls) -> rpyc.core.protocol.Connection:
+    def get(cls):
         if (
             not cls.__current
             or not cls.__current.proc
             or cls.__current.proc.poll() is not None
         ):
             raise ClusterError("SSH tunnel is not running")
+        import rpyc
         return rpyc.classic.connect(
             "localhost", cls.__current.rpyc_port, keepalive=True
         )

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -19,6 +19,8 @@ import time
 
 from .base import ClusterError, ConnectionDetails, _get_ssh_proxy_command
 
+RPYC_REQUEST_TIMEOUT = 2400
+
 
 class Connection:
     __current = None
@@ -105,8 +107,12 @@ class Connection:
 
             while time.time() < self.__started + self.connect_timeout + 1.0:
                 try:
-                    self.__connection = rpyc.classic.connect(
-                        "127.0.0.1", self.rpyc_port, keepalive=True
+                    self.__connection = rpyc.connect(
+                        "127.0.0.1",
+                        self.rpyc_port,
+                        rpyc.ClassicService,
+                        config={"sync_request_timeout": RPYC_REQUEST_TIMEOUT},
+                        keepalive=True,
                     )
                 except (ConnectionRefusedError, EOFError):
                     if self.proc.poll() is not None:

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -46,7 +46,12 @@ class Connection:
                 "import os; from distutils.dist import Distribution; from distutils.command.install import install; cmd = install(Distribution()); cmd.finalize_options(); print(os.path.join(cmd.install_scripts, 'rpyc_classic.py'))",
             ],
         )
-        out, err = locator.communicate(timeout=5)
+        try:
+            out, err = locator.communicate(timeout=self.connect_timeout)
+        except subprocess.TimeoutExpired as ex:
+            raise ClusterError(
+                "Cannot get path to rpyc_classic: cannot connect to host", cause=ex
+            )
         if locator.returncode != 0:
             raise ClusterError(
                 f"Cannot get path to rpyc_classic, return code: {locator.returncode}"

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -103,6 +103,7 @@ class Connection:
 
     def __try_connect(self):
         import rpyc
+
         try:
             self.__connection = rpyc.connect(
                 "127.0.0.1",
@@ -120,7 +121,10 @@ class Connection:
     def activate(self):
         if self.__connection is None:
             self.__try_connect()
-            while self.__connection is None and time.time() < self.__started + self.connect_timeout + 1.0:
+            while (
+                self.__connection is None
+                and time.time() < self.__started + self.connect_timeout + 1.0
+            ):
                 time.sleep(1.0)
                 self.__try_connect()
             if self.__connection is None:

--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -136,7 +136,7 @@ head_setup_commands:
     - |
         source ~/.bashrc
         conda activate modin
-        pip install boto3==1.4.8 rpyc
+        pip install boto3==1.4.8 rpyc==4.1.5
         echo 'export MODIN_REDIS_ADDRESS="localhost:6379"' >> ~/.bashrc
 
 # Custom commands that will be run on worker nodes after common setup.

--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -116,14 +116,14 @@ setup_commands:
     - |
         # need to install python 3.7.6
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
-        bash ~/miniconda.sh -b -p ~/miniconda
+        bash ~/miniconda.sh -b -p ~/miniconda -f -u
         $HOME/miniconda/bin/conda init bash
         source ~/.bashrc
         conda create --clone base --name modin
         conda activate modin
         conda install python==3.7.6
 
-        pip install modin "ray==0.8.6" rpyc
+        pip install modin "ray==0.8.6"
         echo 'export MODIN_RAY_CLUSTER=True' >> ~/.bashrc
 
     # Consider uncommenting these if you also want to run apt-get commands during setup
@@ -136,7 +136,7 @@ head_setup_commands:
     - |
         source ~/.bashrc
         conda activate modin
-        pip install boto3==1.4.8
+        pip install boto3==1.4.8 rpyc
         echo 'export MODIN_REDIS_ADDRESS="localhost:6379"' >> ~/.bashrc
 
 # Custom commands that will be run on worker nodes after common setup.

--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -149,12 +149,12 @@ head_start_ray_commands:
         conda activate modin
         ray stop
 
-        export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024}" /proc/meminfo)
+        export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024*0.8}" /proc/meminfo)
         export TMPDIR="$(dirname $(mktemp tmp.XXXXXXXXXX -ut))"
-        echo 'export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024}" /proc/meminfo)' >> ~/.bashrc
+        echo 'export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024*0.8}" /proc/meminfo)' >> ~/.bashrc
         echo 'export TMPDIR="$(dirname $(mktemp tmp.XXXXXXXXXX -ut))"' >> ~/.bashrc
 
-        ulimit -n 65536; ray start --head --num-redis-shards=1 --redis-shard-ports=6380 --redis-port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml --object-store-memory=$MEMORY_STORE_SIZE --plasma-directory=$TMPDIR
+        ulimit -n 65536; ray start --head --num-redis-shards=1 --redis-shard-ports=6380 --port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml --object-store-memory=$MEMORY_STORE_SIZE --plasma-directory=$TMPDIR
 
 # Command to start ray on worker nodes. You don't need to change this.
 worker_start_ray_commands:
@@ -163,9 +163,9 @@ worker_start_ray_commands:
         conda activate modin
         ray stop
 
-        export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024}" /proc/meminfo)
+        export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024*0.8}" /proc/meminfo)
         export TMPDIR="$(dirname $(mktemp tmp.XXXXXXXXXX -ut))"
-        echo 'export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024}" /proc/meminfo)' >> ~/.bashrc
+        echo 'export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024*0.8}" /proc/meminfo)' >> ~/.bashrc
         echo 'export TMPDIR="$(dirname $(mktemp tmp.XXXXXXXXXX -ut))"' >> ~/.bashrc
 
         ulimit -n 65536; ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076 --object-store-memory=$MEMORY_STORE_SIZE --plasma-directory=$TMPDIR

--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -1,0 +1,171 @@
+# An unique identifier for the head node and workers of this cluster.
+cluster_name: default
+
+# The minimum number of workers nodes to launch in addition to the head
+# node. This number should be >= 0.
+min_workers: 2
+
+# The maximum number of workers nodes to launch in addition to the head
+# node. This takes precedence over min_workers.
+max_workers: 2
+
+# The initial number of worker nodes to launch in addition to the head
+# node. When the cluster is first brought up (or when it is refreshed with a
+# subsequent `ray up`) this number of nodes will be started.
+initial_workers: 2
+
+autoscaling_mode: aggressive
+
+# This executes all commands on all nodes in the docker container,
+# and opens all the necessary ports to support the Ray cluster.
+# Empty string means disabled.
+docker:
+    image: "" # e.g., tensorflow/tensorflow:1.5.0-py3
+    container_name: "" # e.g. ray_docker
+    run_options: []  # Extra options to pass into "docker run"
+
+    # Example of running a GPU head with CPU workers
+    # head_image: "tensorflow/tensorflow:1.13.1-py3"
+    # head_run_options:
+    #     - --runtime=nvidia
+
+    # worker_image: "ubuntu:18.04"
+    # worker_run_options: []
+
+# The autoscaler will scale up the cluster to this target fraction of resource
+# usage. For example, if a cluster of 10 nodes is 100% busy and
+# target_utilization is 0.8, it would resize the cluster to 13. This fraction
+# can be decreased to increase the aggressiveness of upscaling.
+# This value must be less than 1.0 for scaling to happen.
+target_utilization_fraction: 1.0
+
+# If a node is idle for this many minutes, it will be removed.
+idle_timeout_minutes: 60
+
+# Cloud-provider specific configuration.
+provider:
+    type: aws
+    region: us-west-1
+    # Availability zone(s), comma-separated, that nodes may be launched in.
+    # Nodes are currently spread between zones by a round-robin approach,
+    # however this implementation detail should not be relied upon.
+    availability_zone: us-west-1a,us-west-1c
+    # use_internal_ips: True
+
+# How Ray will authenticate with newly launched nodes.
+auth:
+    ssh_user: ubuntu
+# By default Ray creates a new private keypair, but you can also use your own.
+# If you do so, make sure to also set "KeyName" in the head and worker node
+# configurations below.
+#    ssh_private_key: /path/to/your/key.pem
+
+# Provider-specific config for the head node, e.g. instance type. By default
+# Ray will auto-configure unspecified fields such as SubnetId and KeyName.
+# For more documentation on available fields, see:
+# http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
+head_node:
+    InstanceType: m5.large
+    ImageId: ami-0f56279347d2fa43e
+
+    # You can provision additional disk space with a conf as follows
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+              VolumeSize: 40
+
+    # NetworkInterfaces:
+    #     - AssociatePublicIpAddress: True
+    # Additional options in the boto docs.
+
+# Provider-specific config for worker nodes, e.g. instance type. By default
+# Ray will auto-configure unspecified fields such as SubnetId and KeyName.
+# For more documentation on available fields, see:
+# http://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.ServiceResource.create_instances
+worker_nodes:
+    InstanceType: m5.large
+    ImageId: ami-0f56279347d2fa43e
+
+    BlockDeviceMappings:
+        - DeviceName: /dev/sda1
+          Ebs:
+              VolumeSize: 40
+    # Run workers on spot by default. Comment this out to use on-demand.
+    # InstanceMarketOptions:
+    #    MarketType: spot
+        # Additional options can be found in the boto docs, e.g.
+        #   SpotOptions:
+        #       MaxPrice: MAX_HOURLY_PRICE
+
+    # Additional options in the boto docs.
+
+# Files or directories to copy to the head and worker nodes. The format is a
+# dictionary from REMOTE_PATH: LOCAL_PATH, e.g.
+file_mounts: {
+#    "/path1/on/remote/machine": "/path1/on/local/machine",
+#    "/path2/on/remote/machine": "/path2/on/local/machine",
+}
+
+# List of commands that will be run before `setup_commands`. If docker is
+# enabled, these commands will run outside the container and before docker
+# is setup.
+initialization_commands: []
+
+# List of shell commands to run to set up nodes.
+setup_commands:
+    - |
+        # need to install python 3.7.6
+        wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
+        bash ~/miniconda.sh -b -p ~/miniconda
+        $HOME/miniconda/bin/conda init bash
+        source ~/.bashrc
+        conda create --clone base --name modin
+        conda activate modin
+        conda install python==3.7.6
+
+        pip install modin "ray==0.8.6" rpyc
+        echo 'export MODIN_RAY_CLUSTER=True' >> ~/.bashrc
+
+    # Consider uncommenting these if you also want to run apt-get commands during setup
+    # - sudo pkill -9 apt-get || true
+    # - sudo pkill -9 dpkg || true
+    # - sudo dpkg --configure -a
+
+# Custom commands that will be run on the head node after common setup.
+head_setup_commands:
+    - |
+        source ~/.bashrc
+        conda activate modin
+        pip install boto3==1.4.8
+        echo 'export MODIN_REDIS_ADDRESS="localhost:6379"' >> ~/.bashrc
+
+# Custom commands that will be run on worker nodes after common setup.
+worker_setup_commands: []
+
+# Command to start ray on the head node. You don't need to change this.
+head_start_ray_commands:
+    - |
+        source ~/.bashrc
+        conda activate modin
+        ray stop
+
+        export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024}" /proc/meminfo)
+        export TMPDIR="$(dirname $(mktemp tmp.XXXXXXXXXX -ut))"
+        echo 'export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024}" /proc/meminfo)' >> ~/.bashrc
+        echo 'export TMPDIR="$(dirname $(mktemp tmp.XXXXXXXXXX -ut))"' >> ~/.bashrc
+
+        ulimit -n 65536; ray start --head --num-redis-shards=1 --redis-shard-ports=6380 --redis-port=6379 --object-manager-port=8076 --autoscaling-config=~/ray_bootstrap_config.yaml --object-store-memory=$MEMORY_STORE_SIZE --plasma-directory=$TMPDIR
+
+# Command to start ray on worker nodes. You don't need to change this.
+worker_start_ray_commands:
+    - |
+        source ~/.bashrc
+        conda activate modin
+        ray stop
+
+        export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024}" /proc/meminfo)
+        export TMPDIR="$(dirname $(mktemp tmp.XXXXXXXXXX -ut))"
+        echo 'export MEMORY_STORE_SIZE=$(awk "/MemFree/ { printf \"%d \\n\", \$2*1024}" /proc/meminfo)' >> ~/.bashrc
+        echo 'export TMPDIR="$(dirname $(mktemp tmp.XXXXXXXXXX -ut))"' >> ~/.bashrc
+
+        ulimit -n 65536; ray start --address=$RAY_HEAD_IP:6379 --object-manager-port=8076 --object-store-memory=$MEMORY_STORE_SIZE --plasma-directory=$TMPDIR

--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -119,7 +119,7 @@ setup_commands:
         bash ~/miniconda.sh -b -p ~/miniconda -f -u
         $HOME/miniconda/bin/conda init bash
         source ~/.bashrc
-        conda create --clone base --name modin
+        conda create --clone base --name modin --yes
         conda activate modin
         conda install python==3.7.6
 

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -23,7 +23,7 @@ from ray.autoscaler.commands import (
     get_head_node_ip,
 )
 
-from . import CannotSpawnCluster, CannotDestroyCluster, ConnectionDetails
+from .base import CannotSpawnCluster, CannotDestroyCluster, ConnectionDetails
 from .cluster import Cluster, Provider
 
 

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -43,6 +43,7 @@ class RayCluster(Cluster):
         os.path.abspath(os.path.dirname(__file__)), "ray-autoscaler.yml"
     )
     __instance_key = {Provider.AWS: "InstanceType"}
+    __credentials_env = {Provider.AWS: "AWS_CONFIG_FILE"}
 
     def __init__(self, *a, **kw):
         self.spawner = _ThreadTask(self.__spawn)
@@ -50,6 +51,14 @@ class RayCluster(Cluster):
 
         self.ready = False
         super().__init__(self, *a, **kw)
+
+        if self.provider.credentials_file is not None:
+            try:
+                config_key = self.__credentials_env[self.provider.name]
+            except KeyError:
+                raise ValueError(f"Unsupported provider: {self.provider.name}")
+            os.environ[config_key] = self.provider.credentials_file
+
         self.config = self.__make_config()
         self.config_file = self.__save_config(self.config)
 

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -32,7 +32,7 @@ from .base import (
     ConnectionDetails,
     _get_ssh_proxy_command,
 )
-from .cluster import Cluster, Provider
+from .cluster import BaseCluster, Provider
 
 
 class _ThreadTask:
@@ -54,7 +54,7 @@ class _Immediate:
         pass
 
 
-class RayCluster(Cluster):
+class RayCluster(BaseCluster):
     __base_config = os.path.join(
         os.path.abspath(os.path.dirname(__file__)), "ray-autoscaler.yml"
     )

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -1,0 +1,163 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import threading
+import os
+from shlex import quote
+from hashlib import sha1
+
+import yaml
+from ray.autoscaler.commands import (
+    create_or_update_cluster,
+    teardown_cluster,
+    get_head_node_ip,
+)
+
+from . import CannotSpawnCluster, CannotDestroyCluster, ConnectionDetails
+from .cluster import Cluster, Provider
+
+
+class RayCluster(Cluster):
+    __base_config = os.path.join(
+        os.path.abspath(os.path.dirname(__file__)), "ray-autoscaler.yml"
+    )
+    __instance_key = {Provider.AWS: "InstanceType"}
+
+    def __init__(self, *a, **kw):
+        self.spawner, self.destroyer = None, None
+        self.spawn_exc, self.destroy_exc = None, None
+        self.ready = False
+        super().__init__(self, *a, **kw)
+        self.config = self.__make_config()
+        self.config_file = self.__save_config(self.config)
+
+    def spawn(self, wait=True):
+        """
+        Actually spawns the cluster. When already spawned, should be a no-op.
+
+        When wait==False it spawns cluster asynchronously.
+        """
+        self.__run_thread(wait, "spawner", self.__spawn, "spawn_exc")
+
+    def destroy(self, wait=True):
+        """
+        Destroys the cluster. When already destroyed, should be a no-op.
+        """
+        self.__run_thread(wait, "destroyer", self.__destroy, "destroy_exc")
+
+    def __run_thread(self, wait, name, target, exc_name):
+        if not getattr(self, name):
+            setattr(self, name, threading.Thread(target=target))
+
+        if wait:
+            getattr(self, name).join()
+            exc = getattr(self, exc_name)
+            setattr(self, exc_name, None)
+            if exc:
+                raise exc
+
+    def __make_config(self):
+        with open(self.__base_config) as inp:
+            config = yaml.safe_load(inp.read())
+
+        # cluster and provider details
+        config["cluster_name"] = self.cluster_name
+        config["min_workers"] = self.worker_count
+        config["max_workers"] = self.worker_count
+        config["initial_workers"] = self.worker_count
+        config["provider"]["type"] = self.provider.name
+        if self.provider.region:
+            config["provider"]["region"] = self.provider.region
+        if self.provider.zone:
+            config["provider"]["zone"] = self.provider.zone
+
+        # connection details
+        socks_proxy = os.environ.get("MODIN_SOCKS_PROXY", None)
+        config["auth"]["ssh_user"] = "modin"
+        if socks_proxy:
+            config["auth"]["ssh_proxy_command"] = f"nc -x {quote(socks_proxy)} %h %p"
+
+        # instance types
+        try:
+            instance_key = self.__instance_key[self.provider.name]
+        except KeyError:
+            raise ValueError(f"Unsupported provider: {self.provider.name}")
+        config["head_node"][instance_key] = self.head_node_type
+        config["worker_nodes"][instance_key] = self.worker_node_type
+
+        return config
+
+    @staticmethod
+    def __save_config(config):
+        cfgdir = os.path.abspath(os.path.expanduser("~/.modin/cloud"))
+        os.makedirs(cfgdir, mode=0o700, exist_ok=True)
+        namehash = sha1(repr(config).encode("utf8")).hexdigest()
+        for stop in range(4, len(namehash)):
+            entry = os.path.join(cfgdir, f"config-{namehash[:stop]}.yml")
+            if not os.path.exists(entry):
+                break
+        else:
+            entry = os.path.join(cfgdir, f"config-{namehash}.yml")
+
+        with open(entry, "w") as out:
+            out.write(yaml.dump(config))
+        return entry
+
+    def __spawn(self):
+        try:
+            create_or_update_cluster(
+                self.config_file,
+                override_min_workers=None,
+                override_max_workers=None,
+                no_restart=False,
+                restart_only=False,
+                yes=True,
+                override_cluster_name=None,
+            )
+            # need to re-load the config, as create_or_update_cluster() modifies it
+            with open(self.config_file) as inp:
+                self.config = yaml.safe_load(inp.read())
+            self.ready = True
+        except BaseException as ex:
+            self.spawn_exc = CannotSpawnCluster("Cannot spawn cluster", cause=ex)
+
+    def __destroy(self):
+        try:
+            teardown_cluster(
+                self.config_file,
+                yes=True,
+                workers_only=False,
+                override_cluster_name=None,
+                keep_min_workers=0,
+            )
+            self.ready = False
+            self.config = None
+        except BaseException as ex:
+            self.destroy_exc = CannotDestroyCluster("Cannot destroy cluster", cause=ex)
+
+    def _get_connection_details(self) -> ConnectionDetails:
+        """
+        Gets the coordinates on how to connect to cluster frontend node.
+        """
+        assert self.ready, "Cluster is not ready, cannot get connection details"
+        return ConnectionDetails(
+            user_name=self.config["auth"]["ssh_user"],
+            key_file=self.config["auth"]["ssh_private_key"],
+            address=get_head_node_ip(self.config_file, override_cluster_name=None),
+        )
+
+    def _get_main_python(self) -> str:
+        """
+        Gets the path to 'main' interpreter (the one that houses created environment for running everything)
+        """
+        return "~/miniconda/envs/modin/bin/python"


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
* Add `modin.experimental.cloud` package that will be dealing with spawning clusters in a cloud
* Implement spawning a cluster using Ray autoscaler (based on https://github.com/modin-project/modin/pull/1659)
* Implement making an RPyC connection to spawned cluster to enable running things remotely

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves https://github.com/modin-project/modin/issues/1538
- [ ] tests added and passing

**Notes**:
- Requires https://github.com/ray-project/ray/pull/8833 to be merged if SSH through proxy is needed
- Merging it alone won't complete the "Modin in the cloud" story, there is a separate tracker for that: https://github.com/modin-project/modin/issues/1701