### PR TITLE
Fix CI failures on Dask/Windows

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 pandas==1.0.5
 numpy
 pyarrow<0.17
-dask[complete]>=2.1.0
-distributed>=2.3.2
+dask[complete]>=2.1.0,<=2.19.0
+distributed>=2.3.2,<=2.19.0
 ray==0.8.6
 psutil==5.6.6
 xarray


### PR DESCRIPTION
Signed-off-by: amyskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
The last versions of Distributed and Dask (versions 2.20.0) packages causes CI fails of Modin, so these packages were downgraded to the previous versions (2.19.0).

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1722  <!-- issue must be created for each patch -->
- [x] tests added and passing
