### PR TITLE
Fixed bug #1743. Inplace sort requires reset_index first

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2820,6 +2820,7 @@ class BasePandasDataset(object):
                 na_position=na_position,
             ).index
             if inplace:
+                self.reset_index(drop=True, inplace=True)
                 self.reindex(index=new_index2, copy=False)
                 self.index = new_index1
             else:

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5949,6 +5949,23 @@ class TestDataFrameJoinSort:
         pandas_result = pandas_df.sort_values(key, inplace=False,)
         df_equals(modin_result, pandas_result)
 
+        modin_df.sort_values(key, inplace=True)
+        pandas_df.sort_values(key, inplace=True)
+        df_equals(modin_df, pandas_df)
+
+    def test_sort_values_with_string_index(self):
+        modin_df = pd.DataFrame({"col": [25, 17, 1]}, index=["ccc", "bbb", "aaa"])
+        pandas_df = pandas.DataFrame({"col": [25, 17, 1]}, index=["ccc", "bbb", "aaa"])
+
+        key = modin_df.columns[0]
+        modin_result = modin_df.sort_values(key, inplace=False)
+        pandas_result = pandas_df.sort_values(key, inplace=False)
+        df_equals(modin_result, pandas_result)
+
+        modin_df.sort_values(key, inplace=True)
+        pandas_df.sort_values(key, inplace=True)
+        df_equals(modin_df, pandas_df)
+
     def test_where(self):
         frame_data = random_state.randn(100, 10)
         pandas_df = pandas.DataFrame(frame_data, columns=list("abcdefghij"))


### PR DESCRIPTION
Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1743  <!-- issue must be created for each patch -->
- [x] tests added and passing
