### PR TITLE
REFACTOR-#1763: Move logic of `merge` into the query compiler

### DIFF
--- a/modin/data_management/utils.py
+++ b/modin/data_management/utils.py
@@ -106,9 +106,9 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
 
 def length_fn_pandas(df):
     assert isinstance(df, pandas.DataFrame)
-    return len(df) if len(df.columns) > 0 else 0
+    return len(df) if len(df) > 0 else 0
 
 
 def width_fn_pandas(df):
     assert isinstance(df, pandas.DataFrame)
-    return len(df.columns) if len(df) > 0 else 0
+    return len(df.columns) if len(df.columns) > 0 else 0

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2747,28 +2747,18 @@ class BasePandasDataset(object):
             A sorted DataFrame
         """
         axis = self._get_axis_number(axis)
-        if level is not None or (
-            (axis == 0 and isinstance(self.index, pandas.MultiIndex))
-            or (axis == 1 and isinstance(self.columns, pandas.MultiIndex))
-        ):
-            new_query_compiler = self._default_to_pandas(
-                "sort_index",
-                axis=axis,
-                level=level,
-                ascending=ascending,
-                inplace=False,
-                kind=kind,
-                na_position=na_position,
-                sort_remaining=sort_remaining,
-            )._query_compiler
-            return self._create_or_update_from_compiler(new_query_compiler, inplace)
+        inplace = validate_bool_kwarg(inplace, "inplace")
         new_query_compiler = self._query_compiler.sort_index(
-            axis=axis, ascending=ascending, kind=kind, na_position=na_position
+            axis=axis,
+            level=level,
+            ascending=ascending,
+            inplace=inplace,
+            kind=kind,
+            na_position=na_position,
+            sort_remaining=sort_remaining,
+            ignore_index=ignore_index,
         )
-        if inplace:
-            self._update_inplace(new_query_compiler=new_query_compiler)
-        else:
-            return self.__constructor__(query_compiler=new_query_compiler)
+        return self._create_or_update_from_compiler(new_query_compiler, inplace)
 
     def sort_values(
         self,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1491,57 +1491,8 @@ class DataFrame(BasePandasDataset):
                 right, how=how, lsuffix=suffixes[0], rsuffix=suffixes[1], sort=sort
             )
 
-        if how in ["left", "inner"] and left_index is False and right_index is False:
-            result = self.__constructor__(
-                query_compiler=self._query_compiler.merge(
-                    right._query_compiler,
-                    how=how,
-                    on=on,
-                    left_on=left_on,
-                    right_on=right_on,
-                    left_index=left_index,
-                    right_index=right_index,
-                    sort=sort,
-                    suffixes=suffixes,
-                    copy=copy,
-                    indicator=indicator,
-                    validate=validate,
-                )
-            )
-
-            is_reset_index = True
-            if left_on and right_on:
-                left_on = left_on if is_list_like(left_on) else [left_on]
-                right_on = right_on if is_list_like(right_on) else [right_on]
-                is_reset_index = (
-                    False
-                    if any(o in self.index.names for o in left_on)
-                    and any(o in right.index.names for o in right_on)
-                    else True
-                )
-                if sort:
-                    result = (
-                        result.sort_values(left_on.append(right_on))
-                        if is_reset_index
-                        else result.sort_index(axis=0, level=left_on.append(right_on))
-                    )
-            if on:
-                on = on if is_list_like(on) else [on]
-                is_reset_index = not any(
-                    o in self.index.names and o in right.index.names for o in on
-                )
-                if sort:
-                    result = (
-                        result.sort_values(on)
-                        if is_reset_index
-                        else result.sort_index(axis=0, level=on)
-                    )
-
-            return result.reset_index(drop=True) if is_reset_index else result
-
         return self.__constructor__(
-            query_compiler=self._query_compiler.default_to_pandas(
-                pandas.DataFrame.merge,
+            query_compiler=self._query_compiler.merge(
                 right._query_compiler,
                 how=how,
                 on=on,

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5782,6 +5782,15 @@ class TestDataFrameJoinSort:
                 )
                 df_equals(modin_result, pandas_result)
 
+        # Test for issue #1771
+        modin_df = pd.DataFrame({"name": np.arange(40)})
+        modin_df2 = pd.DataFrame({"name": [39], "position": [0]})
+        pandas_df = pandas.DataFrame({"name": np.arange(40)})
+        pandas_df2 = pandas.DataFrame({"name": [39], "position": [0]})
+        modin_result = modin_df.merge(modin_df2, on="name", how="inner")
+        pandas_result = pandas_df.merge(pandas_df2, on="name", how="inner")
+        df_equals(modin_result, pandas_result)
+
         frame_data = {
             "col1": [0, 1, 2, 3],
             "col2": [4, 5, 6, 7],


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

These changes move out the logic of `merge` and `sort_index` from API layer into the query compiler, fix incorrect computing of `row_lengths` and `column_widths` as well.

<!-- Please give a short brief about these changes. -->

- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1763, #1771  <!-- issue must be created for each patch -->
- [x] tests added and passing
