### PR TITLE
FIX-#1700: Fix metadata for concat and mask when `axis=1`

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -252,11 +252,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
         ignore_index = kwargs.get("ignore_index", False)
         other_modin_frame = [o._modin_frame for o in other]
         new_modin_frame = self._modin_frame._concat(axis, other_modin_frame, join, sort)
+        result = self.__constructor__(new_modin_frame)
         if ignore_index:
-            new_modin_frame.index = pandas.RangeIndex(
-                len(self.index) + sum(len(o.index) for o in other)
-            )
-        return self.__constructor__(new_modin_frame)
+            if axis == 0:
+                return result.reset_index(drop=True)
+            else:
+                result.columns = pandas.RangeIndex(len(result.columns))
+                return result
+        return result
 
     # END Append/Concat/Join
 

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -489,7 +489,7 @@ class BasePandasFrame(object):
                 new_col_widths = [len(idx) for _, idx in col_partitions_list.items()]
                 new_columns = self.columns[sorted(col_numeric_idx)]
                 if self._dtypes is not None:
-                    new_dtypes = self.dtypes[sorted(col_numeric_idx)]
+                    new_dtypes = self.dtypes.iloc[sorted(col_numeric_idx)]
                 else:
                     new_dtypes = None
         else:

--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -83,6 +83,17 @@ def test_concat_on_column():
         pandas.concat([df, df2], axis="columns"),
     )
 
+    modin_result = pd.concat(
+        [pd.Series(np.ones(10)), pd.Series(np.ones(10))], axis=1, ignore_index=True
+    )
+    pandas_result = pandas.concat(
+        [pandas.Series(np.ones(10)), pandas.Series(np.ones(10))],
+        axis=1,
+        ignore_index=True,
+    )
+    df_equals(modin_result, pandas_result)
+    assert modin_result.dtypes.equals(pandas_result.dtypes)
+
 
 def test_invalid_axis_errors():
     df, df2 = generate_dfs()


### PR DESCRIPTION
Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1700 <!-- issue must be created for each patch -->
- [x] tests added and passing
