### PR TITLE
TEST-#1119: Re-enable skipped Windows tests for `DataFrame.prod`

### DIFF
--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -15,7 +15,6 @@ import pytest
 import numpy as np
 import pandas
 import pandas.util.testing as tm
-import os
 import matplotlib
 import modin.pandas as pd
 from modin.pandas.utils import to_pandas
@@ -3374,10 +3373,6 @@ class TestDataFrameReduction_B:
             )
             df_equals(modin_result, pandas_result)
 
-    @pytest.mark.skipif(
-        os.name == "nt",
-        reason="Windows has a memory issue for large numbers on this test",
-    )
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
     @pytest.mark.parametrize(
@@ -3429,10 +3424,6 @@ class TestDataFrameReduction_B:
             )
             df_equals(modin_result, pandas_result)
 
-    @pytest.mark.skipif(
-        os.name == "nt",
-        reason="Windows has a memory issue for large numbers on this test",
-    )
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
     @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1119 <!-- issue must be created for each patch -->
- [x] tests added and passing
