### PR TITLE
FIX-#1803: Change the order of execution engine change callbacks

### DIFF
--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -85,11 +85,11 @@ class Publisher(object):
     def __init__(self, name, value):
         self.name = name
         self.__value = value.title()
-        self.__subs = set()
-        self.__once = collections.defaultdict(set)
+        self.__subs = []
+        self.__once = collections.defaultdict(list)
 
     def subscribe(self, callback):
-        self.__subs.add(callback)
+        self.__subs.append(callback)
         callback(self)
 
     def once(self, onvalue, callback):
@@ -97,7 +97,7 @@ class Publisher(object):
         if onvalue == self.__value:
             callback(self)
         else:
-            self.__once[onvalue].add(callback)
+            self.__once[onvalue].append(callback)
 
     def get(self):
         return self.__value


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
There are cases where callback order matters. For instance, whenever we import `pd.DataFrame` the engines must be initialized.
This is especially needed for implementing a "remote Ray" engine (which will be initialized separately).
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1803 <!-- issue must be created for each patch -->
- [ ] tests added and passing
