### PR TITLE
DOCS-#1809 missing links in the architecture page

### DIFF
--- a/docs/architecture.rst
+++ b/docs/architecture.rst
@@ -202,8 +202,8 @@ documentation page on Contributing_.
 .. _Ray: https://github.com/ray-project/ray
 .. _code: https://github.com/modin-project/modin/blob/master/modin/engines/base/frame/data.py
 .. _Contributing: contributing.html
-.. _Pandas on Ray: UsingPandasonRay/optimizations.html
-.. _Pandas on Dask: UsingPandasonDask/optimizations.html
+.. _Pandas on Ray: UsingPandasonRay/index.html
+.. _Pandas on Dask: UsingPandasonDask/index.html
 .. _Dask Futures: https://docs.dask.org/en/latest/futures.html
 .. _issue: https://github.com/modin-project/modin/issues
 .. _Discourse: https://discuss.modin.org


### PR DESCRIPTION
Signed-off-by: ikedaosushi <ikeda.yutaro@gmail.com>

## What do these changes do?

I fixed the missing links in the documentation.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1809 <!-- issue must be created for each patch -->
