### PR TITLE
Enable running remote Ray on spawned cluster

### DIFF
--- a/examples/cluster/mortgage-runner.py
+++ b/examples/cluster/mortgage-runner.py
@@ -24,7 +24,14 @@ from modin.experimental.cloud import create_cluster, get_connection
 from mortgage import run_benchmark
 from mortgage.mortgage_pandas import etl_pandas
 
-test_cluster = create_cluster("aws", "aws_credentials", cluster_name="rayscale-test", region="eu-north-1", zone="eu-north-1b", image="ami-00e1e82d7d4ca80d3")
+test_cluster = create_cluster(
+    "aws",
+    "aws_credentials",
+    cluster_name="rayscale-test",
+    region="eu-north-1",
+    zone="eu-north-1b",
+    image="ami-00e1e82d7d4ca80d3",
+)
 with test_cluster:
     conn = get_connection()
     np = conn.modules["numpy"]

--- a/examples/cluster/mortgage-runner.py
+++ b/examples/cluster/mortgage-runner.py
@@ -1,0 +1,57 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# pip install git+https://github.com/intel-go/ibis.git@develop
+
+# NOTE: expects https://github.com/intel-go/omniscripts/tree/modin-rpyc-test checked out and in PYTHONPATH
+
+import os
+os.environ["MODIN_ENGINE"] = "python"
+os.environ['MODIN_EXPERIMENTAL'] = 'True'
+
+# logging for Ray
+import logging
+logging.basicConfig(format='%(asctime)s %(message)s')
+logger = logging.getLogger()
+logger.setLevel(logging.INFO)
+
+import modin.pandas as pd
+
+from mortgage import run_benchmark
+from mortgage.mortgage_pandas import etl_pandas
+
+from modin.experimental.cloud import Provider, Cluster, get_connection
+
+aws = Provider(Provider.AWS, os.path.join(os.path.abspath(os.path.dirname(__file__)), 'aws_credentials'), 'us-west-1')
+cl = Cluster(aws, cluster_name='rayscale-test')
+
+with cl:
+    import rpyc
+    conn: rpyc.ClassicService = get_connection()
+    np = conn.modules["numpy"]
+    run_benchmark.__globals__["pd"] = pd
+    etl_pandas.__globals__["pd"] = pd
+    etl_pandas.__globals__["np"] = np
+
+    parameters = {}
+    #parameters["data_file"] = "/home/ubuntu/bench_data"
+    parameters["data_file"] = "https://modin-datasets.s3.amazonaws.com/mortgage"
+    parameters["dfiles_num"] = 1
+    parameters["no_ml"] = False
+    parameters["validation"] = False
+    parameters["no_ibis"] = True
+    parameters["no_pandas"] = False
+    parameters["pandas_mode"] = "Modin_on_ray"
+
+    run_benchmark(parameters)

--- a/examples/cluster/mortgage-runner.py
+++ b/examples/cluster/mortgage-runner.py
@@ -16,42 +16,32 @@
 
 # NOTE: expects https://github.com/intel-go/omniscripts/tree/modin-rpyc-test checked out and in PYTHONPATH
 
-import os
-os.environ["MODIN_ENGINE"] = "python"
-os.environ['MODIN_EXPERIMENTAL'] = 'True'
-
-# logging for Ray
-import logging
-logging.basicConfig(format='%(asctime)s %(message)s')
-logger = logging.getLogger()
-logger.setLevel(logging.INFO)
-
-import modin.pandas as pd
+# the following import turns on experimental mode in Modin,
+# including enabling running things in remote cloud
+import modin.experimental.pandas as pd  # noqa: F401
+from modin.experimental.cloud import create_cluster, get_connection
 
 from mortgage import run_benchmark
 from mortgage.mortgage_pandas import etl_pandas
 
-from modin.experimental.cloud import Provider, Cluster, get_connection
-
-aws = Provider(Provider.AWS, os.path.join(os.path.abspath(os.path.dirname(__file__)), 'aws_credentials'), 'us-west-1')
-cl = Cluster(aws, cluster_name='rayscale-test')
+cl = create_cluster("aws", "aws_credentials", cluster_name="rayscale-test")
 
 with cl:
-    import rpyc
-    conn: rpyc.ClassicService = get_connection()
+    conn = get_connection()
     np = conn.modules["numpy"]
-    run_benchmark.__globals__["pd"] = pd
-    etl_pandas.__globals__["pd"] = pd
     etl_pandas.__globals__["np"] = np
 
-    parameters = {}
-    #parameters["data_file"] = "/home/ubuntu/bench_data"
-    parameters["data_file"] = "https://modin-datasets.s3.amazonaws.com/mortgage"
-    parameters["dfiles_num"] = 1
-    parameters["no_ml"] = False
-    parameters["validation"] = False
-    parameters["no_ibis"] = True
-    parameters["no_pandas"] = False
-    parameters["pandas_mode"] = "Modin_on_ray"
+    parameters = {
+        "data_file": "https://modin-datasets.s3.amazonaws.com/mortgage",
+        # "data_file": "s3://modin-datasets/mortgage",
+        "dfiles_num": 1,
+        "no_ml": True,
+        "validation": False,
+        "no_ibis": True,
+        "no_pandas": False,
+        "pandas_mode": "Modin_on_ray",
+        "ray_tmpdir": "/tmp",
+        "ray_memory": 1024 * 1024 * 1024,
+    }
 
     run_benchmark(parameters)

--- a/examples/cluster/mortgage-runner.py
+++ b/examples/cluster/mortgage-runner.py
@@ -24,9 +24,9 @@ from modin.experimental.cloud import create_cluster, get_connection
 from mortgage import run_benchmark
 from mortgage.mortgage_pandas import etl_pandas
 
-cl = create_cluster("aws", "aws_credentials", cluster_name="rayscale-test")
+test_cluster = create_cluster("aws", "aws_credentials", cluster_name="rayscale-test")
 
-with cl:
+with test_cluster:
     conn = get_connection()
     np = conn.modules["numpy"]
     etl_pandas.__globals__["np"] = np

--- a/examples/cluster/mortgage-runner.py
+++ b/examples/cluster/mortgage-runner.py
@@ -14,7 +14,7 @@
 
 # pip install git+https://github.com/intel-go/ibis.git@develop
 
-# NOTE: expects https://github.com/intel-go/omniscripts/tree/modin-rpyc-test checked out and in PYTHONPATH
+# NOTE: expects https://github.com/intel-go/omniscripts/ checked out and in PYTHONPATH
 
 # the following import turns on experimental mode in Modin,
 # including enabling running things in remote cloud

--- a/examples/cluster/mortgage-runner.py
+++ b/examples/cluster/mortgage-runner.py
@@ -24,8 +24,7 @@ from modin.experimental.cloud import create_cluster, get_connection
 from mortgage import run_benchmark
 from mortgage.mortgage_pandas import etl_pandas
 
-test_cluster = create_cluster("aws", "aws_credentials", cluster_name="rayscale-test")
-
+test_cluster = create_cluster("aws", "aws_credentials", cluster_name="rayscale-test", region="eu-north-1", zone="eu-north-1b", image="ami-00e1e82d7d4ca80d3")
 with test_cluster:
     conn = get_connection()
     np = conn.modules["numpy"]

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -220,7 +220,6 @@ class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
         # upon checking its isinstance() or issubclass()
         import modin.backends.pandas.query_compiler  # noqa: F401
         from modin.experimental.cloud import get_connection
-        from rpyc.utils.classic import deliver
 
         class WrappedIo:
             def __init__(self, conn):

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -215,13 +215,15 @@ class ExperimentalPyarrowOnRayFactory(BaseFactory):  # pragma: no cover
 class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
     @classmethod
     def prepare(cls):
-        # query_compiler import is needed so remote PandasQueryCompiler has an imported local counterpart;
-        # if there isn't such counterpart rpyc generates some bogus class type which raises TypeError()
+        # query_compiler import is needed so remote PandasQueryCompiler
+        # has an imported local counterpart;
+        # if there isn't such counterpart rpyc generates some bogus
+        # class type which raises TypeError()
         # upon checking its isinstance() or issubclass()
         import modin.backends.pandas.query_compiler  # noqa: F401
         from modin.experimental.cloud import get_connection
 
-        class WrappedIo:
+        class WrappedIO:
             def __init__(self, conn):
                 self.__conn = conn
                 self.__io_cls = conn.modules[
@@ -248,4 +250,4 @@ class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
                     wrap = getattr(self.__io_cls, name)
                 return wrap
 
-        cls.io_cls = WrappedIo(get_connection())
+        cls.io_cls = WrappedIO(get_connection())

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -240,7 +240,8 @@ class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
                     except KeyError:
 
                         def wrap(*a, _original=getattr(self.__io_cls, name), **kw):
-                            a, kw = deliver(self.__conn, (a, kw))
+                            a = tuple(deliver(self.__conn, x) for x in a)
+                            kw = {k: deliver(self.__conn, v) for k, v in kw.items()}
                             return _original(*a, **kw)
 
                         self.__wrappers[name] = wrap

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -219,4 +219,23 @@ class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
         # upon checking its isinstance() or issubclass()
         import modin.backends.pandas.query_compiler
         from modin.experimental.cloud import get_connection
-        cls.io_cls = get_connection().modules["modin.engines.ray.pandas_on_ray.io"].PandasOnRayIO
+        from rpyc.utils.classic import deliver
+        class WrappedIo:
+            def __init__(self, conn):
+                self.__conn = conn
+                self.__io_cls = conn.modules["modin.engines.ray.pandas_on_ray.io"].PandasOnRayIO
+                self.__reads = {name for name in self.__io_cls.__dict__ if name.startswith('read_')}
+                self.__wrappers = {}
+            def __getattr__(self, name):
+                if name in self.__reads:
+                    try:
+                        wrap = self.__wrappers[name]
+                    except KeyError:
+                        def wrap(*a, _original=getattr(self.__io_cls, name), **kw):
+                            a, kw = deliver(self.__conn, (a, kw))
+                            return _original(*a, **kw)
+                        self.__wrappers[name] = wrap
+                else:
+                    wrap = getattr(self.__io_cls, name)
+                return wrap
+        cls.io_cls = WrappedIo(get_connection())

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -218,7 +218,7 @@ class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
         # query_compiler import is needed so remote PandasQueryCompiler has an imported local counterpart;
         # if there isn't such counterpart rpyc generates some bogus class type which raises TypeError()
         # upon checking its isinstance() or issubclass()
-        import modin.backends.pandas.query_compiler
+        import modin.backends.pandas.query_compiler  # noqa: F401
         from modin.experimental.cloud import get_connection
         from rpyc.utils.classic import deliver
 

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -229,7 +229,7 @@ class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
                     "modin.engines.ray.pandas_on_ray.io"
                 ].PandasOnRayIO
                 self.__reads = {
-                    name for name in self.__io_cls.__dict__ if name.startswith("read_")
+                    name for name in BaseIO.__dict__ if name.startswith("read_")
                 }
                 self.__wrappers = {}
 

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -210,3 +210,13 @@ class ExperimentalPyarrowOnRayFactory(BaseFactory):  # pragma: no cover
         from modin.experimental.engines.pyarrow_on_ray.io import PyarrowOnRayIO
 
         cls.io_cls = PyarrowOnRayIO
+
+class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
+    @classmethod
+    def prepare(cls):
+        # query_compiler import is needed so remote PandasQueryCompiler has an imported local counterpart;
+        # if there isn't such counterpart rpyc generates some bogus class type which raises TypeError()
+        # upon checking its isinstance() or issubclass()
+        import modin.backends.pandas.query_compiler
+        from modin.experimental.cloud import get_connection
+        cls.io_cls = get_connection().modules["modin.engines.ray.pandas_on_ray.io"].PandasOnRayIO

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -240,8 +240,8 @@ class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
                     except KeyError:
 
                         def wrap(*a, _original=getattr(self.__io_cls, name), **kw):
-                            a = tuple(deliver(self.__conn, x) for x in a)
-                            kw = {k: deliver(self.__conn, v) for k, v in kw.items()}
+                            a = tuple(self.__conn.deliver(x) for x in a)
+                            kw = {k: self.__conn.deliver(v) for k, v in kw.items()}
                             return _original(*a, **kw)
 
                         self.__wrappers[name] = wrap

--- a/modin/engines/ray/utils.py
+++ b/modin/engines/ray/utils.py
@@ -62,9 +62,28 @@ def _import_pandas(*args):
 
 
 def initialize_ray(
-    override_is_cluster=False, override_redis_address=None, override_redis_password=None
+    override_is_cluster=False,
+    override_redis_address: str = None,
+    override_redis_password: str = None,
 ):
-    """Initializes ray based on environment variables and internal defaults."""
+    """
+    Initializes ray based on parameters, environment variables and internal defaults.
+
+    Parameters
+    ----------
+    override_is_cluster: bool, optional
+        Whether to override the detection of Moding being run in a cluster
+        and always assume this runs on cluster head node.
+        This also overrides Ray worker detection and always runs the function,
+        not only from main thread.
+        If not specified, $MODIN_RAY_CLUSTER env variable is used.
+    override_redis_address: str, optional
+        What Redis address to connect to when running in Ray cluster.
+        If not specified, $MODIN_REDIS_ADDRESS is used.
+    override_redis_password: str, optional
+        What password to use when connecting to Redis.
+        If not specified, a new random one is generated.
+    """
     import ray
 
     if threading.current_thread().name == "MainThread" or override_is_cluster:

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -106,7 +106,7 @@ class Connection:
         from .rpyc_proxy import WrappingService
 
         try:
-            self.__connection = self.__connection = rpyc.connect(
+            self.__connection = rpyc.connect(
                 "127.0.0.1",
                 self.rpyc_port,
                 WrappingService,

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -106,12 +106,12 @@ class Connection:
         from .rpyc_proxy import WrappingService
 
         try:
-            self.__connection = rpyc.connect(
+            self.__connection = self.__connection = rpyc.connect(
                 "127.0.0.1",
                 self.rpyc_port,
                 WrappingService,
-                config={"sync_request_timeout": RPYC_REQUEST_TIMEOUT},
                 keepalive=True,
+                config={"sync_request_timeout": RPYC_REQUEST_TIMEOUT},
             )
         except (ConnectionRefusedError, EOFError):
             if self.proc.poll() is not None:

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -103,12 +103,13 @@ class Connection:
 
     def __try_connect(self):
         import rpyc
+        from .rpyc_proxy import WrappingService
 
         try:
             self.__connection = rpyc.connect(
                 "127.0.0.1",
                 self.rpyc_port,
-                rpyc.ClassicService,
+                WrappingService,
                 config={"sync_request_timeout": RPYC_REQUEST_TIMEOUT},
                 keepalive=True,
             )

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -17,7 +17,12 @@ _SPECIAL = frozenset(("__new__", "__dict__"))
 _WRAP_ATTRS = ("__wrapper_local__", "__wrapper_remote__")
 
 
-class RemoteMeta(type):
+class MetaComparer(type):
+    def __instancecheck__(self, instance):
+        return issubclass(instance.__class__, self.__real_cls__)
+
+
+class RemoteMeta(MetaComparer):
     """
     Metaclass that relays getting non-existing attributes from
     a proxying object *CLASS* to a remote end transparently.
@@ -53,11 +58,6 @@ class RemoteMeta(type):
         except AttributeError:
             return res
         return getter(self)
-
-
-class MetaComparer(type):
-    def __instancecheck__(self, instance):
-        return issubclass(instance.__class__, self.__real_cls__)
 
 
 def make_wrapped_class(local_cls, cls_name, rpyc_wrapper_name):

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -52,7 +52,8 @@ class RemoteMeta(type):
                 # Go for proxying class-level attributes first;
                 # make sure to check for attribute in self.__dict__ to get the class-level
                 # attribute from the class itself, not from some of its parent classes.
-                # Also note we use object.__getattribute__() to skip any potential class-level __getattr__
+                # Also note we use object.__getattribute__() to skip any potential
+                # class-level __getattr__
                 res = object.__getattribute__(self, "__dict__")[name]
             except KeyError:
                 try:

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -60,6 +60,9 @@ class RemoteMeta(MetaComparer):
         return getter(self)
 
 
+_KNOWN_DUALS = {}
+
+
 def make_wrapped_class(local_cls, cls_name, rpyc_wrapper_name):
     from modin import execution_engine
 
@@ -93,4 +96,6 @@ def make_wrapped_class(local_cls, cls_name, rpyc_wrapper_name):
     }
     result = MetaComparer(cls_name, (local_cls,), namespace)
     execution_engine.subscribe(result._update_engine)
+
+    _KNOWN_DUALS[local_cls] = result
     return result

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -38,10 +38,7 @@ class MetaComparer(type):
     def __instancecheck__(self, instance):
         # see if self is a type that has __real_cls__ defined,
         # as if it's a dual-nature class we need to use its internal class to compare
-        try:
-            my_cls = self.__dict__["__real_cls__"]
-        except KeyError:
-            my_cls = self
+        my_cls = self.__dict__.get("__real_cls__", self)
         try:
             # see if it's a proxying wrapper, in which case
             # use wrapped local class as a comparison base
@@ -65,7 +62,10 @@ class RemoteMeta(MetaComparer):
             res = object.__getattribute__(self, name)
         else:
             try:
-                # go for proxying class-level attributes first
+                # Go for proxying class-level attributes first;
+                # make sure to check for attribute in self.__dict__ to get the class-level
+                # attribute from the class itself, not from some of its parent classes.
+                # Also note we use object.__getattribute__() to skip any potential class-level __getattr__
                 res = object.__getattribute__(self, "__dict__")[name]
             except KeyError:
                 attr_ex = None

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -19,7 +19,7 @@ _WRAP_ATTRS = ("__wrapper_local__", "__wrapper_remote__")
 
 class MetaComparer(type):
     def __instancecheck__(self, instance):
-        return issubclass(instance.__class__, self.__real_cls__)
+        return issubclass(instance.__class__, self.__dict__.get("__real_cls__", self))
 
 
 class RemoteMeta(MetaComparer):

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -1,0 +1,96 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import sys
+
+_SPECIAL = frozenset(("__new__", "__dict__"))
+_WRAP_ATTRS = ("__wrapper_local__", "__wrapper_remote__")
+
+
+class RemoteMeta(type):
+    """
+    Metaclass that relays getting non-existing attributes from
+    a proxying object *CLASS* to a remote end transparently.
+
+    Attributes existing on a proxying object are retrieved locally.
+    """
+
+    def __getattribute__(self, name):
+        if name in _SPECIAL:
+            # never proxy special attributes, always get them from the class type
+            res = object.__getattribute__(self, name)
+        else:
+            try:
+                # go for proxying class-level attributes first
+                res = object.__getattribute__(self, "__dict__")[name]
+            except KeyError:
+                attr_ex = None
+                for wrap_name in _WRAP_ATTRS:
+                    # now try getting an attribute from an overriding object first,
+                    # and only if it fails resort to getting from the remote end
+                    try:
+                        res = getattr(object.__getattribute__(self, wrap_name), name)
+                        break
+                    except AttributeError as ex:
+                        attr_ex = ex
+                        continue
+                else:
+                    raise attr_ex
+        try:
+            # note that any attribute might be in fact a data descriptor,
+            # account for that
+            getter = res.__get__
+        except AttributeError:
+            return res
+        return getter(self)
+
+
+class MetaComparer(type):
+    def __instancecheck__(self, instance):
+        return issubclass(instance.__class__, self.__real_cls__)
+
+
+def make_wrapped_class(local_cls, cls_name, rpyc_wrapper_name):
+    from modin import execution_engine
+
+    current_frame = sys._getframe()
+    try:
+        module_name = current_frame.f_back.f_globals["__name__"]
+    except (AttributeError, KeyError):
+        module_name = __name__
+    finally:
+        del current_frame  # avoid reference cycles
+
+    @classmethod
+    def _update_engine(cls, _):
+        if execution_engine.get() == "Cloudray":
+            from . import rpyc_proxy
+
+            cls.__real_cls__ = getattr(rpyc_proxy, rpyc_wrapper_name)()
+        else:
+            cls.__real_cls__ = local_cls
+
+    def __new__(cls, *a, **kw):
+        if cls.__name__ == cls_name:
+            return cls.__real_cls__(*a, **kw)
+        return local_cls.__new__(cls)
+
+    namespace = {
+        "__real_cls__": None,
+        "_update_engine": _update_engine,
+        "__new__": __new__,
+        "__module__": module_name,
+    }
+    result = MetaComparer(cls_name, (local_cls,), namespace)
+    execution_engine.subscribe(result._update_engine)
+    return result

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -15,7 +15,7 @@ import sys
 import inspect
 import types
 
-_SPECIAL = frozenset(("__new__", "__dict__"))
+_LOCAL_ATTRS = frozenset(("__new__", "__dict__"))
 _WRAP_ATTRS = ("__wrapper_local__", "__wrapper_remote__")
 
 
@@ -60,7 +60,7 @@ class RemoteMeta(MetaComparer):
     """
 
     def __getattribute__(self, name):
-        if name in _SPECIAL:
+        if name in _LOCAL_ATTRS:
             # never proxy special attributes, always get them from the class type
             res = object.__getattribute__(self, name)
         else:

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -92,7 +92,28 @@ class RemoteMeta(type):
 _KNOWN_DUALS = {}
 
 
-def make_wrapped_class(local_cls, rpyc_wrapper_name):
+def make_wrapped_class(local_cls: type, rpyc_wrapper_name: str):
+    """
+    Replaces given local class in its module with a descendant class
+    which has __new__ overridden (a dual-nature class).
+    This new class is instantiated differently depending o
+     whether this is done in remote context or local.
+
+    In local context we effectively get the same behaviour, but in remote
+    context the created class is actually of separate type which
+    proxies most requests to a remote end.
+
+    Parameters
+    ----------
+    local_cls: class
+        The class to replace with a dual-nature class
+    rpyc_wrapper_name: str
+        The function *name* to make a proxy class type.
+        Note that this is specifically taken as string to not import
+        "rpyc_proxy" module in top-level, as it requires RPyC to be
+        installed, and not all users of Modin (even in experimental mode)
+        need remote context.
+    """
     namespace = {
         "__real_cls__": None,
         "__new__": None,

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -55,8 +55,8 @@ class _Immediate:
 
 
 class RayCluster(BaseCluster):
-    target_engine = 'Cloudray'
-    target_partition = 'Pandas'
+    target_engine = "Cloudray"
+    target_partition = "Pandas"
 
     __base_config = os.path.join(
         os.path.abspath(os.path.dirname(__file__)), "ray-autoscaler.yml"

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -55,6 +55,9 @@ class _Immediate:
 
 
 class RayCluster(BaseCluster):
+    target_engine = 'Cloudray'
+    target_partition = 'Pandas'
+
     __base_config = os.path.join(
         os.path.abspath(os.path.dirname(__file__)), "ray-autoscaler.yml"
     )

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -145,7 +145,11 @@ def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
                         namespace[name] = method
             return namespace
 
-    class Wrapper(override, metaclass=ProxyMeta):
+    class Wrapper(override, origin_cls, metaclass=ProxyMeta):
+        __name__ = cls_name or origin_cls.__name__
+        __wrapper_remote__ = remote_cls
+        __wrapper_local__ = Wrapper
+
         def __init__(self, *a, __remote_end__=None, **kw):
             if __remote_end__ is None:
                 __remote_end__ = remote_cls(*a, **kw)
@@ -184,18 +188,7 @@ def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
                 if name not in _PROXY_LOCAL_ATTRS:
                     delattr(self.__remote_end__, name)
 
-    class Wrapped(origin_cls, metaclass=RemoteMeta):
-        __name__ = cls_name or origin_cls.__name__
-        __wrapper_remote__ = remote_cls
-        __wrapper_local__ = Wrapper
-        __class__ = Wrapper
-
-        def __new__(cls, *a, **kw):
-            return Wrapper(*a, **kw)
-
-    Wrapper.__name__ = Wrapped.__name__
-
-    return Wrapped
+    return Wrapper
 
 
 def _deliveringWrapper(origin_cls, methods=(), mixin=None, target_name=None):

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -133,7 +133,7 @@ def make_proxy_cls(
         The mixin providing methods and attributes to overlay on top of remote values and methods.
     cls_name: str, optional
         The name to give to the resulting class.
-    
+
     Returns
     -------
     type

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -1,0 +1,96 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+_SPECIAL = frozenset(("__new__", "__dict__"))
+_WRAP_ATTRS = ("__wrapper_local__", "__wrapper_remote__")
+
+
+class RemoteMeta(type):
+    """
+    Metaclass that relays getting non-existing attributes from
+    a proxying object *CLASS* to a remote end transparently.
+
+    Attributes existing on a proxying object are retrieved locally.
+    """
+
+    def __getattribute__(self, name):
+        if name in _SPECIAL:
+            # never proxy special attributes, always get them from the class type
+            res = object.__getattribute__(self, name)
+        else:
+            try:
+                # go for proxying class-level attributes first
+                res = object.__getattribute__(self, "__dict__")[name]
+            except KeyError:
+                attr_ex = None
+                for wrap_name in _WRAP_ATTRS:
+                    # now try getting an attribute from an overriding object first,
+                    # and only if it fails resort to getting from the remote end
+                    try:
+                        res = getattr(object.__getattribute__(self, wrap_name), name)
+                        break
+                    except AttributeError as ex:
+                        attr_ex = ex
+                        continue
+                else:
+                    raise attr_ex
+        try:
+            # note that any attribute might be in fact a data descriptor,
+            # account for that
+            getter = res.__get__
+        except AttributeError:
+            return res
+        return getter(self)
+
+
+_SPECIAL_ATTRS = frozenset(["__name__", "__remote_end__"])
+
+
+def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
+    class Wrapper(override):
+        def __init__(self, *a, **kw):
+            object.__setattr__(self, "__remote_end__", remote_cls(*a, **kw))
+
+        def __getattr__(self, name):
+            """
+            Any attributes not currently known to Wrapper (i.e. not defined here
+            or in override class) will be retrieved from the remote end
+            """
+            return getattr(self.__remote_end__, name)
+
+        if override.__setattr__ == object.__setattr__:
+            # no custom attribute setting, define our own relaying to remote end
+            def __setattr__(self, name, value):
+                if name not in _SPECIAL_ATTRS:
+                    setattr(self.__remote_end__, name, value)
+                else:
+                    object.__setattr__(self, name, value)
+
+        if override.__delattr__ == object.__delattr__:
+            # no custom __delattr__, define our own
+            def __delattr__(self, name):
+                if name not in _SPECIAL_ATTRS:
+                    delattr(self.__remote_end__, name)
+
+    class Wrapped(origin_cls, metaclass=RemoteMeta):
+        __name__ = cls_name or origin_cls.__name__
+        __wrapper_remote__ = remote_cls
+        __wrapper_local__ = Wrapper
+        __class__ = Wrapper
+
+        def __new__(cls, *a, **kw):
+            return Wrapper(*a, **kw)
+
+    Wrapper.__name__ = Wrapped.__name__
+
+    return Wrapped

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -39,6 +39,10 @@ class WrappingConnection(rpyc.Connection):
         except KeyError:
             pass
         try:
+            # Try to get local_cls.__real_cls__ but look it up within
+            # local_cls.__dict__ to not grab it from any parent class.
+            # Also get the __dict__ by using low-level __getattribute__
+            # to override any potential __getattr__ callbacks on the class.
             wrapping_cls = object.__getattribute__(local_cls, "__dict__")[
                 "__real_cls__"
             ]
@@ -193,7 +197,10 @@ def make_dataframe_wrapper():
     from modin.pandas.dataframe import _DataFrame
 
     DeliveringDataFrame = _deliveringWrapper(
-        _DataFrame, ["groupby", "agg", "aggregate"], _prepare_loc_mixin(), "DataFrame"
+        _DataFrame,
+        ["groupby", "agg", "aggregate", "__getitem__", "astype"],
+        _prepare_loc_mixin(),
+        "DataFrame",
     )
     return DeliveringDataFrame
 

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -85,7 +85,9 @@ def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
                     ):
 
                         def method(_self, *_args, __method_name__=name, **_kw):
-                            return getattr(remote_cls, __method_name__)(*_args, **_kw)
+                            return getattr(_self.__remote_end__, __method_name__)(
+                                *_args, **_kw
+                            )
 
                         method.__name__ = name
                         namespace[name] = method

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -13,12 +13,24 @@
 
 from rpyc.utils.classic import deliver
 import rpyc
+from rpyc.lib.compat import pickle
+
+from rpyc.core import brine, consts
 
 from . import get_connection
 from .meta_magic import _LOCAL_ATTRS, _WRAP_ATTRS, RemoteMeta, _KNOWN_DUALS
 
-
 class WrappingConnection(rpyc.Connection):
+    def __init__(self, *a, **kw):
+        super().__init__(*a, **kw)
+        self._remote_pickle_loads = None
+
+    def deliver(self, local_obj):
+        """
+        More caching version of rpyc.classic.deliver()
+        """
+        return self._remote_pickle_loads(bytes(pickle.dumps(local_obj)))
+
     def _netref_factory(self, id_pack):
         result = super()._netref_factory(id_pack)
         # try getting __real_cls__ from result.__class__ BUT make sure to
@@ -57,9 +69,16 @@ class WrappingConnection(rpyc.Connection):
             remote_obj = obj
         return super()._box(remote_obj)
 
+    def _init_deliver(self):
+        self._remote_pickle_loads = self.modules["rpyc.lib.compat"].pickle.loads
+
 
 class WrappingService(rpyc.ClassicService):
     _protocol = WrappingConnection
+
+    def on_connect(self, conn):
+        super().on_connect(conn)
+        conn._init_deliver()
 
 
 _PROXY_LOCAL_ATTRS = frozenset(["__name__", "__remote_end__"])
@@ -160,8 +179,8 @@ def _deliveringWrapper(origin_cls, methods, mixin=None, target_name=None):
     for method in methods:
 
         def wrapper(self, *args, __remote_conn__=conn, __method_name__=method, **kw):
-            args = tuple(deliver(__remote_conn__, x) for x in args)
-            kw = {k: deliver(__remote_conn__, v) for k, v in kw.items()}
+            args = tuple(__remote_conn__.deliver(x) for x in args)
+            kw = {k: __remote_conn__.deliver(v) for k, v in kw.items()}
             return getattr(self.__remote_end__, __method_name__)(*args, **kw)
 
         wrapper.__name__ = method
@@ -184,11 +203,11 @@ def _prepare_loc_mixin():
     class DeliveringMixin:
         @property
         def loc(self):
-            return DeliveringLocIndexer(self)
+            return DeliveringLocIndexer(self.__remote_end__)
 
         @property
         def iloc(self):
-            return DeliveringILocIndexer(self)
+            return DeliveringILocIndexer(self.__remote_end__)
 
     return DeliveringMixin
 

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -78,6 +78,7 @@ def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
                 for name, entry in base.__dict__.items():
                     if (
                         name not in namespace
+                        and name not in override.__dict__
                         and name.startswith("__")
                         and name.endswith("__")
                         and name not in _NO_OVERRIDE
@@ -204,3 +205,14 @@ def make_base_dataset_wrapper():
         "BasePandasDataset",
     )
     return DeliveringBasePandasDataset
+
+
+def make_dataframe_groupby_wrapper():
+    from modin.pandas.groupby import _DataFrameGroupBy
+
+    DeliveringDataFrameGroupBy = _deliveringWrapper(
+        _DataFrameGroupBy,
+        ["agg", "aggregate", "apply"],
+        target_name="DataFrameGroupBy",
+    )
+    return DeliveringDataFrameGroupBy

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -11,14 +11,11 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-
 import types
 
-from rpyc.utils.classic import deliver
 import rpyc
 from rpyc.lib.compat import pickle
-
-from rpyc.core import brine, consts, netref
+from rpyc.core import netref
 
 from . import get_connection
 from .meta_magic import _LOCAL_ATTRS, RemoteMeta, _KNOWN_DUALS

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -92,6 +92,15 @@ class WrappingService(rpyc.ClassicService):
         conn._init_deliver()
 
 
+def _in_empty_class():
+    class Empty:
+        pass
+
+    return frozenset(Empty.__dict__.keys())
+
+
+_EMPTY_CLASS_ATTRS = _in_empty_class()
+
 _PROXY_LOCAL_ATTRS = frozenset(["__name__", "__remote_end__"])
 _NO_OVERRIDE = (
     _LOCAL_ATTRS
@@ -99,22 +108,33 @@ _NO_OVERRIDE = (
     | frozenset(_WRAP_ATTRS)
     | rpyc.core.netref.DELETED_ATTRS
     | frozenset(["__getattribute__"])
+    | _EMPTY_CLASS_ATTRS
 )
 
 
 def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
-    class ProxyMeta(type):
+    class ProxyMeta(RemoteMeta):
         def __repr__(self):
             return f"<proxy for {origin_cls.__module__}.{origin_cls.__name__}:{cls_name or origin_cls.__name__}>"
 
         def __prepare__(*args, **kw):
             namespace = type.__prepare__(*args, **kw)
 
-            overridden = {
-                name
-                for (name, func) in override.__dict__.items()
-                if getattr(object, name, None) != func
-            }
+            # try computing overridden differently to allow subclassing one override from another
+            no_override = set(_NO_OVERRIDE)
+            for base in override.__mro__:
+                if base == object:
+                    continue
+                for attr_name, attr_value in base.__dict__.items():
+                    if (
+                        attr_name not in namespace
+                        and attr_name not in no_override
+                        and getattr(object, attr_name, None) != attr_value
+                    ):
+                        namespace[
+                            attr_name
+                        ] = attr_value  # force-inherit an attribute manually
+                        no_override.add(attr_name)
 
             for base in origin_cls.__mro__:
                 if base == object:
@@ -131,8 +151,7 @@ def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
                 for name, entry in base.__dict__.items():
                     if (
                         name not in namespace
-                        and name not in overridden
-                        and name not in _NO_OVERRIDE
+                        and name not in no_override
                         and isinstance(entry, types.FunctionType)
                     ):
 
@@ -148,7 +167,10 @@ def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
     class Wrapper(override, origin_cls, metaclass=ProxyMeta):
         __name__ = cls_name or origin_cls.__name__
         __wrapper_remote__ = remote_cls
-        __wrapper_local__ = Wrapper
+        __wrapper_local__ = None
+
+        def __new__(cls, *a, **kw):
+            return override.__new__(cls, *a, **kw)
 
         def __init__(self, *a, __remote_end__=None, **kw):
             if __remote_end__ is None:
@@ -188,6 +210,7 @@ def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
                 if name not in _PROXY_LOCAL_ATTRS:
                     delattr(self.__remote_end__, name)
 
+    Wrapper.__wrapper_local__ = Wrapper
     return Wrapper
 
 
@@ -238,11 +261,9 @@ def _prepare_loc_mixin():
     return DeliveringMixin
 
 
-def make_dataframe_wrapper():
-    from modin.pandas.dataframe import _DataFrame
-
+def make_dataframe_wrapper(DataFrame):
     DeliveringDataFrame = _deliveringWrapper(
-        _DataFrame,
+        DataFrame,
         ["groupby", "agg", "aggregate", "__getitem__", "astype", "drop", "merge"],
         _prepare_loc_mixin(),
         "DataFrame",
@@ -250,11 +271,9 @@ def make_dataframe_wrapper():
     return DeliveringDataFrame
 
 
-def make_base_dataset_wrapper():
-    from modin.pandas.base import _BasePandasDataset
-
+def make_base_dataset_wrapper(BasePandasDataset):
     DeliveringBasePandasDataset = _deliveringWrapper(
-        _BasePandasDataset,
+        BasePandasDataset,
         ["agg", "aggregate"],
         _prepare_loc_mixin(),
         "BasePandasDataset",
@@ -262,18 +281,12 @@ def make_base_dataset_wrapper():
     return DeliveringBasePandasDataset
 
 
-def make_dataframe_groupby_wrapper():
-    from modin.pandas.groupby import _DataFrameGroupBy
-
+def make_dataframe_groupby_wrapper(DataFrameGroupBy):
     DeliveringDataFrameGroupBy = _deliveringWrapper(
-        _DataFrameGroupBy,
-        ["agg", "aggregate", "apply"],
-        target_name="DataFrameGroupBy",
+        DataFrameGroupBy, ["agg", "aggregate", "apply"], target_name="DataFrameGroupBy",
     )
     return DeliveringDataFrameGroupBy
 
 
-def make_series_wrapper():
-    from modin.pandas.series import _Series
-
-    return _deliveringWrapper(_Series, target_name="Series")
+def make_series_wrapper(Series):
+    return _deliveringWrapper(Series, target_name="Series")

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -105,7 +105,6 @@ _PROXY_LOCAL_ATTRS = frozenset(["__name__", "__remote_end__"])
 _NO_OVERRIDE = (
     _LOCAL_ATTRS
     | _PROXY_LOCAL_ATTRS
-
     | rpyc.core.netref.DELETED_ATTRS
     | frozenset(["__getattribute__"])
     | _EMPTY_CLASS_ATTRS
@@ -204,10 +203,10 @@ def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
             4) check if type(self).__dict__[name] exists
             5) pass through to remote end
             """
-            dct = object.__getattribute__(self, '__dict__')
-            if name == '__dict__':
+            dct = object.__getattribute__(self, "__dict__")
+            if name == "__dict__":
                 return dct
-            cls_dct = object.__getattribute__(type(self), '__dict__')
+            cls_dct = object.__getattribute__(type(self), "__dict__")
             try:
                 cls_attr, has_cls_attr = cls_dct[name], True
             except KeyError:
@@ -215,10 +214,10 @@ def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
             else:
                 oget = None
                 try:
-                    oget = object.__getattribute__(cls_attr, '__get__')
-                    object.__getattribute__(cls_attr, '__set__')
+                    oget = object.__getattribute__(cls_attr, "__get__")
+                    object.__getattribute__(cls_attr, "__set__")
                 except AttributeError:
-                    pass # not a get/set data descriptor, go next
+                    pass  # not a get/set data descriptor, go next
                 else:
                     return oget(self, type(self))
             # type(self).name is not a get/set data descriptor
@@ -231,10 +230,10 @@ def make_proxy_cls(remote_cls, origin_cls, override, cls_name=None):
                     if oget:
                         # this attribute is a get data descriptor
                         return oget(self, type(self))
-                    return cls_attr # not a data descriptor whatsoever
+                    return cls_attr  # not a data descriptor whatsoever
 
             # this instance/class does not have this attribute, pass it through to remote end
-            return getattr(dct['__remote_end__'], name)
+            return getattr(dct["__remote_end__"], name)
 
         if override.__setattr__ == object.__setattr__:
             # no custom attribute setting, define our own relaying to remote end

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -153,7 +153,7 @@ def _update_engine(publisher: Publisher):
             init_remote_ray()
             # import EngineDispatcher here to initialize IO class
             # so it doesn't skew read_csv() timings later on
-            import modin.data_management.dispatcher # noqa: F401
+            import modin.data_management.dispatcher  # noqa: F401
 
         num_cpus = remote_ray.cluster_resources()["CPU"]
 

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -151,6 +151,9 @@ def _update_engine(publisher: Publisher):
                 )
 
             init_remote_ray()
+            # import EngineDispatcher here to initialize IO class
+            # so it doesn't skew read_csv() timings later on
+            import modin.data_management.dispatcher # noqa: F401
 
         num_cpus = remote_ray.cluster_resources()["CPU"]
 

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -89,6 +89,8 @@ import multiprocessing
 
 from .. import execution_engine, Publisher
 
+# Set this so that Pandas doesn't try to multithread by itself
+os.environ["OMP_NUM_THREADS"] = "1"
 DEFAULT_NPARTITIONS = 4
 num_cpus = 1
 
@@ -127,12 +129,14 @@ def _update_engine(publisher: Publisher):
                 )
                 dask_client = Client(n_workers=int(num_cpus))
 
-    elif publisher.get() == 'Cloudray':
+    elif publisher.get() == "Cloudray":
         from modin.experimental.cloud import get_connection
         import rpyc
-        conn : rpyc.ClassicService = get_connection()
-        remote_ray = conn.modules['ray']
-        if _is_first_update.get('Cloudray', True):
+
+        conn: rpyc.ClassicService = get_connection()
+        remote_ray = conn.modules["ray"]
+        if _is_first_update.get("Cloudray", True):
+
             @conn.teleport
             def init_remote_ray():
                 # XXX hack alert! things being monkey-patched below should be not needed when initialize_ray() accepts parameters
@@ -141,23 +145,26 @@ def _update_engine(publisher: Publisher):
                 import secrets
                 import threading
 
-                os.environ['MODIN_ENGINE'] = 'Ray'
-                os.environ['MODIN_RAY_CLUSTER'] = 'True'
-                os.environ['MODIN_REDIS_ADDRESS'] = 'localhost:6379'
+                os.environ["MODIN_ENGINE"] = "Ray"
+                os.environ["MODIN_RAY_CLUSTER"] = "True"
+                os.environ["MODIN_REDIS_ADDRESS"] = "localhost:6379"
 
                 old_name = threading.current_thread().name
-                threading.current_thread().name = 'MainThread'
+                threading.current_thread().name = "MainThread"
 
                 old_token = secrets.token_hex
-                secrets.token_hex = lambda *a, **kw: ray.ray_constants.REDIS_DEFAULT_PASSWORD
+                secrets.token_hex = (
+                    lambda *a, **kw: ray.ray_constants.REDIS_DEFAULT_PASSWORD
+                )
                 try:
-                    import modin.pandas # this would initialize remote ray
+                    import modin.pandas  # this would initialize remote ray
                 finally:
                     threading.current_thread().name = old_name
                     secrets.token_hex = old_token
+
             init_remote_ray()
 
-        num_cpus = remote_ray.cluster_resources()['CPU']
+        num_cpus = remote_ray.cluster_resources()["CPU"]
 
     elif publisher.get() != "Python":
         raise ImportError("Unrecognized execution engine: {}.".format(publisher.get()))
@@ -215,8 +222,6 @@ from .general import (
 )
 from .plotting import Plotting as plotting
 
-# Set this so that Pandas doesn't try to multithread by itself
-os.environ["OMP_NUM_THREADS"] = "1"
 __all__ = [
     "DataFrame",
     "Series",

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -157,7 +157,8 @@ def _update_engine(publisher: Publisher):
                     lambda *a, **kw: ray.ray_constants.REDIS_DEFAULT_PASSWORD
                 )
                 try:
-                    import modin.pandas  # this would initialize remote ray
+                    # this would initialize remote ray
+                    import modin.pandas  # noqa" F401
                 finally:
                     threading.current_thread().name = old_name
                     secrets.token_hex = old_token

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -127,6 +127,38 @@ def _update_engine(publisher: Publisher):
                 )
                 dask_client = Client(n_workers=int(num_cpus))
 
+    elif publisher.get() == 'Cloudray':
+        from modin.experimental.cloud import get_connection
+        import rpyc
+        conn : rpyc.ClassicService = get_connection()
+        remote_ray = conn.modules['ray']
+        if _is_first_update.get('Cloudray', True):
+            @conn.teleport
+            def init_remote_ray():
+                # XXX hack alert! things being monkey-patched below should be not needed when initialize_ray() accepts parameters
+                import os
+                import ray.ray_constants
+                import secrets
+                import threading
+
+                os.environ['MODIN_ENGINE'] = 'Ray'
+                os.environ['MODIN_RAY_CLUSTER'] = 'True'
+                os.environ['MODIN_REDIS_ADDRESS'] = 'localhost:6379'
+
+                old_name = threading.current_thread().name
+                threading.current_thread().name = 'MainThread'
+
+                old_token = secrets.token_hex
+                secrets.token_hex = lambda *a, **kw: ray.ray_constants.REDIS_DEFAULT_PASSWORD
+                try:
+                    import modin.pandas # this would initialize remote ray
+                finally:
+                    threading.current_thread().name = old_name
+                    secrets.token_hex = old_token
+            init_remote_ray()
+
+        num_cpus = remote_ray.cluster_resources()['CPU']
+
     elif publisher.get() != "Python":
         raise ImportError("Unrecognized execution engine: {}.".format(publisher.get()))
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3913,6 +3913,7 @@ BasePandasDataset = make_wrapped_class(
     _BasePandasDataset, "BasePandasDataset", "make_base_dataset_wrapper"
 )
 
+
 class Window(object):
     def __init__(
         self,

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3592,9 +3592,11 @@ class BasePandasDataset(object):
 
                 return default_handler
         return object.__getattribute__(self, item)
-    
-if os.environ.get('MODIN_EXPERIMENTAL', "").title() == 'True':
+
+
+if os.environ.get("MODIN_EXPERIMENTAL", "").title() == "True":
     from modin.experimental.cloud.meta_magic import make_wrapped_class
+
     make_wrapped_class(BasePandasDataset, "make_base_dataset_wrapper")
 
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3623,7 +3623,6 @@ class Resampler(object):
             on,
             level,
         ]
-
         self.__groups = self.__get_groups(*self.resample_args)
 
     def __get_groups(
@@ -3910,26 +3909,11 @@ class Resampler(object):
         )
 
 
-class BasePandasDataset(_BasePandasDataset):
-    __real_cls__: _BasePandasDataset = None
+from modin.experimental.cloud.meta_magic import make_wrapped_class
 
-    @classmethod
-    def _update_engine(cls, publisher: Publisher):
-        if publisher.get() == "Cloudray":
-            from modin.experimental.cloud.rpyc_proxy import make_base_dataset_wrapper
-
-            cls.__real_cls__ = make_base_dataset_wrapper()
-        else:
-            cls.__real_cls__ = _BasePandasDataset
-
-    def __new__(cls, *a, **kw):
-        if cls is BasePandasDataset:
-            return cls.__real_cls__(*a, **kw)
-        return super().__new__(cls)
-
-
-execution_engine.subscribe(BasePandasDataset._update_engine)
-
+BasePandasDataset = make_wrapped_class(
+    _BasePandasDataset, "BasePandasDataset", "make_base_dataset_wrapper"
+)
 
 class Window(object):
     def __init__(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3923,7 +3923,9 @@ class BasePandasDataset(_BasePandasDataset):
             cls.__real_cls__ = _BasePandasDataset
 
     def __new__(cls, *a, **kw):
-        return cls.__real_cls__(*a, **kw)
+        if cls is BasePandasDataset:
+            return cls.__real_cls__(*a, **kw)
+        return super().__new__(cls)
 
 
 execution_engine.subscribe(BasePandasDataset._update_engine)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -31,8 +31,8 @@ import re
 import warnings
 import pickle as pkl
 
-from modin import execution_engine, Publisher
 from modin.error_message import ErrorMessage
+from modin.experimental.cloud.meta_magic import make_wrapped_class
 
 # Similar to pandas, sentinel value to use as kwarg in place of None when None has
 # special meaning and needs to be distinguished from a user explicitly passing None.
@@ -3908,8 +3908,6 @@ class Resampler(object):
             )
         )
 
-
-from modin.experimental.cloud.meta_magic import make_wrapped_class
 
 BasePandasDataset = make_wrapped_class(
     _BasePandasDataset, "BasePandasDataset", "make_base_dataset_wrapper"

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3911,19 +3911,19 @@ class Resampler(object):
 
 
 class BasePandasDataset(_BasePandasDataset):
-    __real_cls: _BasePandasDataset = None
+    __real_cls__: _BasePandasDataset = None
 
     @classmethod
     def _update_engine(cls, publisher: Publisher):
         if publisher.get() == "Cloudray":
             from modin.experimental.cloud.rpyc_proxy import make_base_dataset_wrapper
 
-            cls.__real_cls = make_base_dataset_wrapper()
+            cls.__real_cls__ = make_base_dataset_wrapper()
         else:
-            cls.__real_cls = _BasePandasDataset
+            cls.__real_cls__ = _BasePandasDataset
 
     def __new__(cls, *a, **kw):
-        return cls.__real_cls(*a, **kw)
+        return cls.__real_cls__(*a, **kw)
 
 
 execution_engine.subscribe(BasePandasDataset._update_engine)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3592,11 +3592,9 @@ class BasePandasDataset(object):
 
                 return default_handler
         return object.__getattribute__(self, item)
-
-
-if os.environ.get("MODIN_EXPERIMENTAL", "").title() == "True":
+    
+if os.environ.get('MODIN_EXPERIMENTAL', "").title() == 'True':
     from modin.experimental.cloud.meta_magic import make_wrapped_class
-
     make_wrapped_class(BasePandasDataset, "make_base_dataset_wrapper")
 
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3585,7 +3585,7 @@ class BasePandasDataset(object):
             # We default to pandas on empty DataFrames. This avoids a large amount of
             # pain in underlying implementation and returns a result immediately rather
             # than dealing with the edge cases that empty DataFrames have.
-            if self.empty and is_callable:
+            if is_callable and self.empty:
 
                 def default_handler(*args, **kwargs):
                     return self._default_to_pandas(item, *args, **kwargs)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import os
 import numpy as np
 from numpy import nan
 import pandas
@@ -32,14 +33,13 @@ import warnings
 import pickle as pkl
 
 from modin.error_message import ErrorMessage
-from modin.experimental.cloud.meta_magic import make_wrapped_class
 
 # Similar to pandas, sentinel value to use as kwarg in place of None when None has
 # special meaning and needs to be distinguished from a user explicitly passing None.
 sentinel = object()
 
 
-class _BasePandasDataset(object):
+class BasePandasDataset(object):
     """This object is the base for most of the common code that exists in
         DataFrame/Series. Since both objects share the same underlying representation,
         and the algorithms are the same, we use this object to define the general
@@ -3594,6 +3594,12 @@ class _BasePandasDataset(object):
         return object.__getattribute__(self, item)
 
 
+if os.environ.get("MODIN_EXPERIMENTAL", "").title() == "True":
+    from modin.experimental.cloud.meta_magic import make_wrapped_class
+
+    make_wrapped_class(BasePandasDataset, "make_base_dataset_wrapper")
+
+
 class Resampler(object):
     def __init__(
         self,
@@ -3907,11 +3913,6 @@ class Resampler(object):
                 self.resample_args, q, **kwargs
             )
         )
-
-
-BasePandasDataset = make_wrapped_class(
-    _BasePandasDataset, "BasePandasDataset", "make_base_dataset_wrapper"
-)
 
 
 class Window(object):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -43,7 +43,8 @@ from .base import BasePandasDataset
     pandas.DataFrame, excluded=[pandas.DataFrame, pandas.DataFrame.__init__]
 )
 class _DataFrame(BasePandasDataset):
-    __name__ = "DataFrame" # for compat with .default_to_pandas()
+    __name__ = "DataFrame"  # for compat with .default_to_pandas()
+
     def __init__(
         self,
         data=None,
@@ -2798,13 +2799,16 @@ class _DataFrame(BasePandasDataset):
     def _to_pandas(self):
         return self._query_compiler.to_pandas()
 
+
 class DataFrame(_DataFrame):
-    __real_cls :_DataFrame = None
+    __real_cls: _DataFrame = None
+
     @classmethod
     def _update_engine(cls, publisher: Publisher):
-        if publisher.get() == 'Cloudray':
+        if publisher.get() == "Cloudray":
             from modin.experimental.cloud import get_connection
-            remote_module = get_connection().modules['modin.pandas.dataframe']
+
+            remote_module = get_connection().modules["modin.pandas.dataframe"]
             try:
                 cls.__real_cls = remote_module._DataFrame
             except AttributeError:
@@ -2812,8 +2816,9 @@ class DataFrame(_DataFrame):
                 cls.__real_cls = remote_module.DataFrame
         else:
             cls.__real_cls = _DataFrame
-    
+
     def __new__(cls, *a, **kw):
         return cls.__real_cls(*a, **kw)
+
 
 execution_engine.subscribe(DataFrame._update_engine)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2813,7 +2813,9 @@ class DataFrame(_DataFrame):
             cls.__real_cls__ = _DataFrame
 
     def __new__(cls, *a, **kw):
-        return cls.__real_cls__(*a, **kw)
+        if cls is DataFrame:
+            return cls.__real_cls__(*a, **kw)
+        return super().__new__(cls)
 
 
 execution_engine.subscribe(DataFrame._update_engine)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -45,8 +45,6 @@ from modin.experimental.cloud.meta_magic import make_wrapped_class
     pandas.DataFrame, excluded=[pandas.DataFrame, pandas.DataFrame.__init__]
 )
 class _DataFrame(BasePandasDataset):
-    __name__ = "DataFrame"  # for compat with .default_to_pandas()
-
     def __init__(
         self,
         data=None,
@@ -2799,5 +2797,8 @@ class _DataFrame(BasePandasDataset):
     def _to_pandas(self):
         return self._query_compiler.to_pandas()
 
+
+# disguise _DataFrame as much as possible for compat with .default_to_pandas() and some tests
+_DataFrame.__name__ = "DataFrame"
 
 DataFrame = make_wrapped_class(_DataFrame, "DataFrame", "make_dataframe_wrapper")

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -36,6 +36,7 @@ from .utils import from_pandas, from_non_pandas, to_pandas, _inherit_docstrings
 from .iterator import PartitionIterator
 from .series import Series
 from .base import BasePandasDataset
+from .groupby import DataFrameGroupBy
 
 from modin.experimental.cloud.meta_magic import make_wrapped_class
 
@@ -461,8 +462,6 @@ class _DataFrame(BasePandasDataset):
                     pass
                 elif mismatch:
                     raise KeyError(next(x for x in by if x not in self))
-
-        from .groupby import DataFrameGroupBy
 
         return DataFrameGroupBy(
             self,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2806,14 +2806,9 @@ class DataFrame(_DataFrame):
     @classmethod
     def _update_engine(cls, publisher: Publisher):
         if publisher.get() == "Cloudray":
-            from modin.experimental.cloud import get_connection
+            from modin.experimental.cloud.rpyc_proxy import make_dataframe_wrapper
 
-            remote_module = get_connection().modules["modin.pandas.dataframe"]
-            try:
-                cls.__real_cls = remote_module._DataFrame
-            except AttributeError:
-                # older version of Modin there
-                cls.__real_cls = remote_module.DataFrame
+            cls.__real_cls = make_dataframe_wrapper()
         else:
             cls.__real_cls = _DataFrame
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -31,12 +31,13 @@ import sys
 from typing import Tuple, Union
 import warnings
 
-from modin import execution_engine, Publisher
 from modin.error_message import ErrorMessage
 from .utils import from_pandas, from_non_pandas, to_pandas, _inherit_docstrings
 from .iterator import PartitionIterator
 from .series import Series
 from .base import BasePandasDataset
+
+from modin.experimental.cloud.meta_magic import make_wrapped_class
 
 
 @_inherit_docstrings(
@@ -2799,7 +2800,5 @@ class _DataFrame(BasePandasDataset):
     def _to_pandas(self):
         return self._query_compiler.to_pandas()
 
-
-from modin.experimental.cloud.meta_magic import make_wrapped_class
 
 DataFrame = make_wrapped_class(_DataFrame, "DataFrame", "make_dataframe_wrapper")

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -980,7 +980,9 @@ class _DataFrame(BasePandasDataset):
 
         output = []
 
-        type_line = str(type(self))
+        # disguise as DataFrame if we're its implementation
+        own_cls = type(self)
+        type_line = str(own_cls if own_cls is not _DataFrame else DataFrame)
         index_line = self.index._summary()
         columns = self.columns
         columns_len = len(columns)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2800,22 +2800,6 @@ class _DataFrame(BasePandasDataset):
         return self._query_compiler.to_pandas()
 
 
-class DataFrame(_DataFrame):
-    __real_cls__: _DataFrame = None
+from modin.experimental.cloud.meta_magic import make_wrapped_class
 
-    @classmethod
-    def _update_engine(cls, publisher: Publisher):
-        if publisher.get() == "Cloudray":
-            from modin.experimental.cloud.rpyc_proxy import make_dataframe_wrapper
-
-            cls.__real_cls__ = make_dataframe_wrapper()
-        else:
-            cls.__real_cls__ = _DataFrame
-
-    def __new__(cls, *a, **kw):
-        if cls is DataFrame:
-            return cls.__real_cls__(*a, **kw)
-        return super().__new__(cls)
-
-
-execution_engine.subscribe(DataFrame._update_engine)
+DataFrame = make_wrapped_class(_DataFrame, "DataFrame", "make_dataframe_wrapper")

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -28,6 +28,7 @@ import itertools
 import functools
 import numpy as np
 import sys
+import os
 from typing import Tuple, Union
 import warnings
 
@@ -38,13 +39,11 @@ from .series import Series
 from .base import BasePandasDataset
 from .groupby import DataFrameGroupBy
 
-from modin.experimental.cloud.meta_magic import make_wrapped_class
-
 
 @_inherit_docstrings(
     pandas.DataFrame, excluded=[pandas.DataFrame, pandas.DataFrame.__init__]
 )
-class _DataFrame(BasePandasDataset):
+class DataFrame(BasePandasDataset):
     def __init__(
         self,
         data=None,
@@ -980,9 +979,7 @@ class _DataFrame(BasePandasDataset):
 
         output = []
 
-        # disguise as DataFrame if we're its implementation
-        own_cls = type(self)
-        type_line = str(own_cls if own_cls is not _DataFrame else DataFrame)
+        type_line = str(type(self))
         index_line = self.index._summary()
         columns = self.columns
         columns_len = len(columns)
@@ -2800,7 +2797,7 @@ class _DataFrame(BasePandasDataset):
         return self._query_compiler.to_pandas()
 
 
-# disguise _DataFrame as much as possible for compat with .default_to_pandas() and some tests
-_DataFrame.__name__ = "DataFrame"
+if os.environ.get("MODIN_EXPERIMENTAL", "").title() == "True":
+    from modin.experimental.cloud.meta_magic import make_wrapped_class
 
-DataFrame = make_wrapped_class(_DataFrame, "DataFrame", "make_dataframe_wrapper")
+    make_wrapped_class(DataFrame, "make_dataframe_wrapper")

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2801,19 +2801,19 @@ class _DataFrame(BasePandasDataset):
 
 
 class DataFrame(_DataFrame):
-    __real_cls: _DataFrame = None
+    __real_cls__: _DataFrame = None
 
     @classmethod
     def _update_engine(cls, publisher: Publisher):
         if publisher.get() == "Cloudray":
             from modin.experimental.cloud.rpyc_proxy import make_dataframe_wrapper
 
-            cls.__real_cls = make_dataframe_wrapper()
+            cls.__real_cls__ = make_dataframe_wrapper()
         else:
-            cls.__real_cls = _DataFrame
+            cls.__real_cls__ = _DataFrame
 
     def __new__(cls, *a, **kw):
-        return cls.__real_cls(*a, **kw)
+        return cls.__real_cls__(*a, **kw)
 
 
 execution_engine.subscribe(DataFrame._update_engine)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -43,6 +43,7 @@ from .base import BasePandasDataset
     pandas.DataFrame, excluded=[pandas.DataFrame, pandas.DataFrame.__init__]
 )
 class _DataFrame(BasePandasDataset):
+    __name__ = "DataFrame" # for compat with .default_to_pandas()
     def __init__(
         self,
         data=None,

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -11,13 +11,13 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import os
 import pandas
 import pandas.core.groupby
 from pandas.core.dtypes.common import is_list_like
 import pandas.core.common as com
 
 from modin.error_message import ErrorMessage
-from modin.experimental.cloud.meta_magic import make_wrapped_class
 
 from .utils import _inherit_docstrings
 from .series import Series
@@ -30,7 +30,7 @@ from .series import Series
         pandas.core.groupby.DataFrameGroupBy.__init__,
     ],
 )
-class _DataFrameGroupBy(object):
+class DataFrameGroupBy(object):
     def __init__(
         self,
         df,
@@ -685,9 +685,10 @@ class _DataFrameGroupBy(object):
         return self._df._default_to_pandas(groupby_on_multiple_columns)
 
 
-DataFrameGroupBy = make_wrapped_class(
-    _DataFrameGroupBy, "DataFrameGroupBy", "make_dataframe_groupby_wrapper"
-)
+if os.environ.get("MODIN_EXPERIMENTAL", "").title() == "True":
+    from modin.experimental.cloud.meta_magic import make_wrapped_class
+
+    make_wrapped_class(DataFrameGroupBy, "make_dataframe_groupby_wrapper")
 
 
 class SeriesGroupBy(DataFrameGroupBy):

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -17,6 +17,8 @@ from pandas.core.dtypes.common import is_list_like
 import pandas.core.common as com
 
 from modin.error_message import ErrorMessage
+from modin.experimental.cloud.meta_magic import make_wrapped_class
+
 from .utils import _inherit_docstrings
 from .series import Series
 
@@ -28,7 +30,7 @@ from .series import Series
         pandas.core.groupby.DataFrameGroupBy.__init__,
     ],
 )
-class DataFrameGroupBy(object):
+class _DataFrameGroupBy(object):
     def __init__(
         self,
         df,
@@ -681,6 +683,11 @@ class DataFrameGroupBy(object):
             return f(df.groupby(by=by, axis=self._axis, **self._kwargs), **kwargs)
 
         return self._df._default_to_pandas(groupby_on_multiple_columns)
+
+
+DataFrameGroupBy = make_wrapped_class(
+    _DataFrameGroupBy, "DataFrameGroupBy", "make_dataframe_groupby_wrapper"
+)
 
 
 class SeriesGroupBy(DataFrameGroupBy):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -28,6 +28,8 @@ from .iterator import PartitionIterator
 from .utils import _inherit_docstrings
 from .utils import from_pandas, to_pandas
 
+from modin.experimental.cloud.meta_magic import make_wrapped_class
+
 if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
     # Python >= 3.7
     from re import Pattern as _pattern_type
@@ -37,7 +39,7 @@ else:
 
 
 @_inherit_docstrings(pandas.Series, excluded=[pandas.Series, pandas.Series.__init__])
-class Series(BasePandasDataset):
+class _Series(BasePandasDataset):
     def __init__(
         self,
         data=None,
@@ -178,10 +180,10 @@ class Series(BasePandasDataset):
 
     def __and__(self, other):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).__and__(new_other)
+        return super(_Series, new_self).__and__(new_other)
 
     def __array__(self, dtype=None):
-        return super(Series, self).__array__(dtype).flatten()
+        return super().__array__(dtype).flatten()
 
     @property
     def __array_priority__(self):  # pragma: no cover
@@ -297,7 +299,7 @@ class Series(BasePandasDataset):
 
     def __or__(self, other):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).__or__(new_other)
+        return super(_Series, new_self).__or__(new_other)
 
     def __pow__(self, right):
         return self.pow(right)
@@ -364,15 +366,15 @@ class Series(BasePandasDataset):
         Returns:
             The NumPy representation of this object.
         """
-        return super(Series, self).to_numpy().flatten()
+        return super().to_numpy().flatten()
 
     def __xor__(self, other):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).__xor__(new_other)
+        return super(_Series, new_self).__xor__(new_other)
 
     def add(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).add(
+        return super(_Series, new_self).add(
             new_other, level=level, fill_value=fill_value, axis=axis
         )
 
@@ -504,7 +506,7 @@ class Series(BasePandasDataset):
             or is_list_like(func)
             or return_type not in ["DataFrame", "Series"]
         ):
-            query_compiler = super(Series, self).apply(func, *args, **kwds)
+            query_compiler = super().apply(func, *args, **kwds)
         else:
             # handle ufuncs and lambdas
             if kwds or args and not isinstance(func, np.ufunc):
@@ -576,7 +578,7 @@ class Series(BasePandasDataset):
         )
 
     def combine(self, other, func, fill_value=None):
-        return super(Series, self).combine(
+        return super().combine(
             other, lambda s1, s2: s1.combine(s2, func, fill_value=fill_value)
         )
 
@@ -662,7 +664,7 @@ class Series(BasePandasDataset):
         )
 
     def count(self, level=None):
-        return super(Series, self).count(level=level)
+        return super().count(level=level)
 
     def cov(self, other, min_periods=None):
         """
@@ -718,10 +720,10 @@ class Series(BasePandasDataset):
 
     def describe(self, percentiles=None, include=None, exclude=None):
         # Pandas ignores the `include` and `exclude` for Series for some reason.
-        return super(Series, self).describe(percentiles=percentiles)
+        return super().describe(percentiles=percentiles)
 
     def diff(self, periods=1):
-        return super(Series, self).diff(periods=periods, axis=0)
+        return super().diff(periods=periods, axis=0)
 
     def divmod(self, other, level=None, fill_value=None, axis=0):
         return self._default_to_pandas(
@@ -796,17 +798,17 @@ class Series(BasePandasDataset):
         )
 
     def drop_duplicates(self, keep="first", inplace=False):
-        return super(Series, self).drop_duplicates(keep=keep, inplace=inplace)
+        return super().drop_duplicates(keep=keep, inplace=inplace)
 
     def dropna(self, axis=0, inplace=False, how=None):
-        return super(Series, self).dropna(axis=axis, inplace=inplace)
+        return super().dropna(axis=axis, inplace=inplace)
 
     def duplicated(self, keep="first"):
         return self.to_frame().duplicated(keep=keep)
 
     def eq(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).eq(new_other, level=level, axis=axis)
+        return super(_Series, new_self).eq(new_other, level=level, axis=axis)
 
     def equals(self, other):
         return (
@@ -825,13 +827,13 @@ class Series(BasePandasDataset):
 
     def floordiv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).floordiv(
+        return super(_Series, new_self).floordiv(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def ge(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).ge(new_other, level=level, axis=axis)
+        return super(_Series, new_self).ge(new_other, level=level, axis=axis)
 
     def groupby(
         self,
@@ -871,7 +873,7 @@ class Series(BasePandasDataset):
 
     def gt(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).gt(new_other, level=level, axis=axis)
+        return super(_Series, new_self).gt(new_other, level=level, axis=axis)
 
     def hist(
         self,
@@ -903,12 +905,12 @@ class Series(BasePandasDataset):
     def idxmax(self, axis=0, skipna=True, *args, **kwargs):
         if skipna is None:
             skipna = True
-        return super(Series, self).idxmax(axis=axis, skipna=skipna, *args, **kwargs)
+        return super().idxmax(axis=axis, skipna=skipna, *args, **kwargs)
 
     def idxmin(self, axis=0, skipna=True, *args, **kwargs):
         if skipna is None:
             skipna = True
-        return super(Series, self).idxmin(axis=axis, skipna=skipna, *args, **kwargs)
+        return super().idxmin(axis=axis, skipna=skipna, *args, **kwargs)
 
     def interpolate(
         self,
@@ -952,11 +954,11 @@ class Series(BasePandasDataset):
 
     def le(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).le(new_other, level=level, axis=axis)
+        return super(_Series, new_self).le(new_other, level=level, axis=axis)
 
     def lt(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).lt(new_other, level=level, axis=axis)
+        return super(_Series, new_self).lt(new_other, level=level, axis=axis)
 
     def map(self, arg, na_action=None):
         if not callable(arg) and hasattr(arg, "get"):
@@ -980,20 +982,20 @@ class Series(BasePandasDataset):
             )
             index_value = self.index.memory_usage(deep=deep)
             return result + index_value
-        return super(Series, self).memory_usage(index=index, deep=deep)
+        return super().memory_usage(index=index, deep=deep)
 
     def mod(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).mod(
+        return super(_Series, new_self).mod(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def mode(self, dropna=True):
-        return super(Series, self).mode(numeric_only=False, dropna=dropna)
+        return super().mode(numeric_only=False, dropna=dropna)
 
     def mul(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).mul(
+        return super(_Series, new_self).mul(
             new_other, level=level, fill_value=None, axis=axis
         )
 
@@ -1001,7 +1003,7 @@ class Series(BasePandasDataset):
 
     def ne(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).ne(new_other, level=level, axis=axis)
+        return super(_Series, new_self).ne(new_other, level=level, axis=axis)
 
     def nlargest(self, n=5, keep="first"):
         return self._default_to_pandas(pandas.Series.nlargest, n=n, keep=keep)
@@ -1099,7 +1101,7 @@ class Series(BasePandasDataset):
 
     def pow(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).pow(
+        return super(_Series, new_self).pow(
             new_other, level=level, fill_value=None, axis=axis
         )
 
@@ -1116,7 +1118,7 @@ class Series(BasePandasDataset):
         new_index = self.columns if axis else self.index
         if min_count > len(new_index):
             return np.nan
-        return super(Series, self).prod(
+        return super().prod(
             axis=axis,
             skipna=skipna,
             level=level,
@@ -1160,7 +1162,7 @@ class Series(BasePandasDataset):
                 "reindex() got an unexpected keyword "
                 'argument "{0}"'.format(list(kwargs.keys())[0])
             )
-        return super(Series, self).reindex(
+        return super().reindex(
             index=index,
             method=method,
             level=level,
@@ -1258,43 +1260,43 @@ class Series(BasePandasDataset):
 
     def rfloordiv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).rfloordiv(
+        return super(_Series, new_self).rfloordiv(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def rmod(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).rmod(
+        return super(_Series, new_self).rmod(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def rpow(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).rpow(
+        return super(_Series, new_self).rpow(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def rsub(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).rsub(
+        return super(_Series, new_self).rsub(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def rtruediv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).rtruediv(
+        return super(_Series, new_self).rtruediv(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     rdiv = rtruediv
 
     def quantile(self, q=0.5, interpolation="linear"):
-        return super(Series, self).quantile(
+        return super().quantile(
             q=q, numeric_only=False, interpolation=interpolation
         )
 
     def reorder_levels(self, order):
-        return super(Series, self).reorder_levels(order)
+        return super().reorder_levels(order)
 
     def searchsorted(self, value, side="left", sorter=None):
         return self._default_to_pandas(
@@ -1346,7 +1348,7 @@ class Series(BasePandasDataset):
 
     def sub(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).sub(
+        return super(_Series, new_self).sub(
             new_other, level=level, fill_value=None, axis=axis
         )
 
@@ -1365,7 +1367,7 @@ class Series(BasePandasDataset):
         new_index = self.columns if axis else self.index
         if min_count > len(new_index):
             return np.nan
-        return super(Series, self).sum(
+        return super().sum(
             axis=axis,
             skipna=skipna,
             level=level,
@@ -1378,7 +1380,7 @@ class Series(BasePandasDataset):
         return self._default_to_pandas("swaplevel", i=i, j=j, copy=copy)
 
     def take(self, indices, axis=0, is_copy=None, **kwargs):
-        return super(Series, self).take(indices, axis=axis, is_copy=is_copy, **kwargs)
+        return super().take(indices, axis=axis, is_copy=is_copy, **kwargs)
 
     def _to_datetime(self, **kwargs):
         """
@@ -1431,7 +1433,7 @@ class Series(BasePandasDataset):
         Returns:
             A NumPy array.
         """
-        return super(Series, self).to_numpy(dtype, copy).flatten()
+        return super().to_numpy(dtype, copy).flatten()
 
     tolist = to_list
 
@@ -1478,7 +1480,7 @@ class Series(BasePandasDataset):
 
     def truediv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).truediv(
+        return super(_Series, new_self).truediv(
             new_other, level=level, fill_value=None, axis=axis
         )
 
@@ -1685,7 +1687,7 @@ class Series(BasePandasDataset):
         return 1
 
     def nunique(self, dropna=True):
-        return super(Series, self).nunique(dropna=dropna)
+        return super().nunique(dropna=dropna)
 
     @property
     def shape(self):
@@ -1702,6 +1704,7 @@ class Series(BasePandasDataset):
             series.name = None
         return series
 
+Series = make_wrapped_class(_Series, "Series", "make_series_wrapper")
 
 class DatetimeProperties(object):
     def __init__(self, series):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1291,9 +1291,7 @@ class _Series(BasePandasDataset):
     rdiv = rtruediv
 
     def quantile(self, q=0.5, interpolation="linear"):
-        return super().quantile(
-            q=q, numeric_only=False, interpolation=interpolation
-        )
+        return super().quantile(q=q, numeric_only=False, interpolation=interpolation)
 
     def reorder_levels(self, order):
         return super().reorder_levels(order)
@@ -1704,7 +1702,10 @@ class _Series(BasePandasDataset):
             series.name = None
         return series
 
+
+_Series.__name__ = "Series"
 Series = make_wrapped_class(_Series, "Series", "make_series_wrapper")
+
 
 class DatetimeProperties(object):
     def __init__(self, series):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -182,7 +182,7 @@ class Series(BasePandasDataset):
         return super(Series, new_self).__and__(new_other)
 
     def __array__(self, dtype=None):
-        return super().__array__(dtype).flatten()
+        return super(Series, self).__array__(dtype).flatten()
 
     @property
     def __array_priority__(self):  # pragma: no cover
@@ -365,7 +365,7 @@ class Series(BasePandasDataset):
         Returns:
             The NumPy representation of this object.
         """
-        return super().to_numpy().flatten()
+        return super(Series, self).to_numpy().flatten()
 
     def __xor__(self, other):
         new_self, new_other = self._prepare_inter_op(other)
@@ -505,7 +505,7 @@ class Series(BasePandasDataset):
             or is_list_like(func)
             or return_type not in ["DataFrame", "Series"]
         ):
-            query_compiler = super().apply(func, *args, **kwds)
+            query_compiler = super(Series, self).apply(func, *args, **kwds)
         else:
             # handle ufuncs and lambdas
             if kwds or args and not isinstance(func, np.ufunc):
@@ -577,7 +577,7 @@ class Series(BasePandasDataset):
         )
 
     def combine(self, other, func, fill_value=None):
-        return super().combine(
+        return super(Series, self).combine(
             other, lambda s1, s2: s1.combine(s2, func, fill_value=fill_value)
         )
 
@@ -663,7 +663,7 @@ class Series(BasePandasDataset):
         )
 
     def count(self, level=None):
-        return super().count(level=level)
+        return super(Series, self).count(level=level)
 
     def cov(self, other, min_periods=None):
         """
@@ -719,10 +719,10 @@ class Series(BasePandasDataset):
 
     def describe(self, percentiles=None, include=None, exclude=None):
         # Pandas ignores the `include` and `exclude` for Series for some reason.
-        return super().describe(percentiles=percentiles)
+        return super(Series, self).describe(percentiles=percentiles)
 
     def diff(self, periods=1):
-        return super().diff(periods=periods, axis=0)
+        return super(Series, self).diff(periods=periods, axis=0)
 
     def divmod(self, other, level=None, fill_value=None, axis=0):
         return self._default_to_pandas(
@@ -797,10 +797,10 @@ class Series(BasePandasDataset):
         )
 
     def drop_duplicates(self, keep="first", inplace=False):
-        return super().drop_duplicates(keep=keep, inplace=inplace)
+        return super(Series, self).drop_duplicates(keep=keep, inplace=inplace)
 
     def dropna(self, axis=0, inplace=False, how=None):
-        return super().dropna(axis=axis, inplace=inplace)
+        return super(Series, self).dropna(axis=axis, inplace=inplace)
 
     def duplicated(self, keep="first"):
         return self.to_frame().duplicated(keep=keep)
@@ -904,12 +904,12 @@ class Series(BasePandasDataset):
     def idxmax(self, axis=0, skipna=True, *args, **kwargs):
         if skipna is None:
             skipna = True
-        return super().idxmax(axis=axis, skipna=skipna, *args, **kwargs)
+        return super(Series, self).idxmax(axis=axis, skipna=skipna, *args, **kwargs)
 
     def idxmin(self, axis=0, skipna=True, *args, **kwargs):
         if skipna is None:
             skipna = True
-        return super().idxmin(axis=axis, skipna=skipna, *args, **kwargs)
+        return super(Series, self).idxmin(axis=axis, skipna=skipna, *args, **kwargs)
 
     def interpolate(
         self,
@@ -981,7 +981,7 @@ class Series(BasePandasDataset):
             )
             index_value = self.index.memory_usage(deep=deep)
             return result + index_value
-        return super().memory_usage(index=index, deep=deep)
+        return super(Series, self).memory_usage(index=index, deep=deep)
 
     def mod(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
@@ -990,7 +990,7 @@ class Series(BasePandasDataset):
         )
 
     def mode(self, dropna=True):
-        return super().mode(numeric_only=False, dropna=dropna)
+        return super(Series, self).mode(numeric_only=False, dropna=dropna)
 
     def mul(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
@@ -1117,7 +1117,7 @@ class Series(BasePandasDataset):
         new_index = self.columns if axis else self.index
         if min_count > len(new_index):
             return np.nan
-        return super().prod(
+        return super(Series, self).prod(
             axis=axis,
             skipna=skipna,
             level=level,
@@ -1161,7 +1161,7 @@ class Series(BasePandasDataset):
                 "reindex() got an unexpected keyword "
                 'argument "{0}"'.format(list(kwargs.keys())[0])
             )
-        return super().reindex(
+        return super(Series, self).reindex(
             index=index,
             method=method,
             level=level,
@@ -1290,10 +1290,12 @@ class Series(BasePandasDataset):
     rdiv = rtruediv
 
     def quantile(self, q=0.5, interpolation="linear"):
-        return super().quantile(q=q, numeric_only=False, interpolation=interpolation)
+        return super(Series, self).quantile(
+            q=q, numeric_only=False, interpolation=interpolation
+        )
 
     def reorder_levels(self, order):
-        return super().reorder_levels(order)
+        return super(Series, self).reorder_levels(order)
 
     def searchsorted(self, value, side="left", sorter=None):
         return self._default_to_pandas(
@@ -1364,7 +1366,7 @@ class Series(BasePandasDataset):
         new_index = self.columns if axis else self.index
         if min_count > len(new_index):
             return np.nan
-        return super().sum(
+        return super(Series, self).sum(
             axis=axis,
             skipna=skipna,
             level=level,
@@ -1377,7 +1379,7 @@ class Series(BasePandasDataset):
         return self._default_to_pandas("swaplevel", i=i, j=j, copy=copy)
 
     def take(self, indices, axis=0, is_copy=None, **kwargs):
-        return super().take(indices, axis=axis, is_copy=is_copy, **kwargs)
+        return super(Series, self).take(indices, axis=axis, is_copy=is_copy, **kwargs)
 
     def _to_datetime(self, **kwargs):
         """
@@ -1430,7 +1432,7 @@ class Series(BasePandasDataset):
         Returns:
             A NumPy array.
         """
-        return super().to_numpy(dtype, copy).flatten()
+        return super(Series, self).to_numpy(dtype, copy).flatten()
 
     tolist = to_list
 
@@ -1684,7 +1686,7 @@ class Series(BasePandasDataset):
         return 1
 
     def nunique(self, dropna=True):
-        return super().nunique(dropna=dropna)
+        return super(Series, self).nunique(dropna=dropna)
 
     @property
     def shape(self):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import os
 import numpy as np
 import pandas
 from pandas.core.common import apply_if_callable, is_bool_indexer
@@ -28,8 +29,6 @@ from .iterator import PartitionIterator
 from .utils import _inherit_docstrings
 from .utils import from_pandas, to_pandas
 
-from modin.experimental.cloud.meta_magic import make_wrapped_class
-
 if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
     # Python >= 3.7
     from re import Pattern as _pattern_type
@@ -39,7 +38,7 @@ else:
 
 
 @_inherit_docstrings(pandas.Series, excluded=[pandas.Series, pandas.Series.__init__])
-class _Series(BasePandasDataset):
+class Series(BasePandasDataset):
     def __init__(
         self,
         data=None,
@@ -180,7 +179,7 @@ class _Series(BasePandasDataset):
 
     def __and__(self, other):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).__and__(new_other)
+        return super(Series, new_self).__and__(new_other)
 
     def __array__(self, dtype=None):
         return super().__array__(dtype).flatten()
@@ -299,7 +298,7 @@ class _Series(BasePandasDataset):
 
     def __or__(self, other):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).__or__(new_other)
+        return super(Series, new_self).__or__(new_other)
 
     def __pow__(self, right):
         return self.pow(right)
@@ -370,11 +369,11 @@ class _Series(BasePandasDataset):
 
     def __xor__(self, other):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).__xor__(new_other)
+        return super(Series, new_self).__xor__(new_other)
 
     def add(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).add(
+        return super(Series, new_self).add(
             new_other, level=level, fill_value=fill_value, axis=axis
         )
 
@@ -808,7 +807,7 @@ class _Series(BasePandasDataset):
 
     def eq(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).eq(new_other, level=level, axis=axis)
+        return super(Series, new_self).eq(new_other, level=level, axis=axis)
 
     def equals(self, other):
         return (
@@ -827,13 +826,13 @@ class _Series(BasePandasDataset):
 
     def floordiv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).floordiv(
+        return super(Series, new_self).floordiv(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def ge(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).ge(new_other, level=level, axis=axis)
+        return super(Series, new_self).ge(new_other, level=level, axis=axis)
 
     def groupby(
         self,
@@ -873,7 +872,7 @@ class _Series(BasePandasDataset):
 
     def gt(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).gt(new_other, level=level, axis=axis)
+        return super(Series, new_self).gt(new_other, level=level, axis=axis)
 
     def hist(
         self,
@@ -954,11 +953,11 @@ class _Series(BasePandasDataset):
 
     def le(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).le(new_other, level=level, axis=axis)
+        return super(Series, new_self).le(new_other, level=level, axis=axis)
 
     def lt(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).lt(new_other, level=level, axis=axis)
+        return super(Series, new_self).lt(new_other, level=level, axis=axis)
 
     def map(self, arg, na_action=None):
         if not callable(arg) and hasattr(arg, "get"):
@@ -986,7 +985,7 @@ class _Series(BasePandasDataset):
 
     def mod(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).mod(
+        return super(Series, new_self).mod(
             new_other, level=level, fill_value=None, axis=axis
         )
 
@@ -995,7 +994,7 @@ class _Series(BasePandasDataset):
 
     def mul(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).mul(
+        return super(Series, new_self).mul(
             new_other, level=level, fill_value=None, axis=axis
         )
 
@@ -1003,7 +1002,7 @@ class _Series(BasePandasDataset):
 
     def ne(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).ne(new_other, level=level, axis=axis)
+        return super(Series, new_self).ne(new_other, level=level, axis=axis)
 
     def nlargest(self, n=5, keep="first"):
         return self._default_to_pandas(pandas.Series.nlargest, n=n, keep=keep)
@@ -1101,7 +1100,7 @@ class _Series(BasePandasDataset):
 
     def pow(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).pow(
+        return super(Series, new_self).pow(
             new_other, level=level, fill_value=None, axis=axis
         )
 
@@ -1260,31 +1259,31 @@ class _Series(BasePandasDataset):
 
     def rfloordiv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).rfloordiv(
+        return super(Series, new_self).rfloordiv(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def rmod(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).rmod(
+        return super(Series, new_self).rmod(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def rpow(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).rpow(
+        return super(Series, new_self).rpow(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def rsub(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).rsub(
+        return super(Series, new_self).rsub(
             new_other, level=level, fill_value=None, axis=axis
         )
 
     def rtruediv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).rtruediv(
+        return super(Series, new_self).rtruediv(
             new_other, level=level, fill_value=None, axis=axis
         )
 
@@ -1346,7 +1345,7 @@ class _Series(BasePandasDataset):
 
     def sub(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).sub(
+        return super(Series, new_self).sub(
             new_other, level=level, fill_value=None, axis=axis
         )
 
@@ -1478,7 +1477,7 @@ class _Series(BasePandasDataset):
 
     def truediv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
-        return super(_Series, new_self).truediv(
+        return super(Series, new_self).truediv(
             new_other, level=level, fill_value=None, axis=axis
         )
 
@@ -1703,8 +1702,10 @@ class _Series(BasePandasDataset):
         return series
 
 
-_Series.__name__ = "Series"
-Series = make_wrapped_class(_Series, "Series", "make_series_wrapper")
+if os.environ.get("MODIN_EXPERIMENTAL", "").title() == "True":
+    from modin.experimental.cloud.meta_magic import make_wrapped_class
+
+    make_wrapped_class(Series, "make_series_wrapper")
 
 
 class DatetimeProperties(object):

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -51,6 +51,7 @@ def test_top_level_api_equality():
         "base",
         "utils",
         "dataframe",
+        "groupby",
         "threading",
         "general",
         "datetimes",


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
This enables the story of scaling out Modin on cloud-based clusters.
Mortgage benchmark from https://github.com/intel-go/omniscripts/ could now be run using provided runner.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves  https://github.com/modin-project/modin/issues/1701
- [x] tests added and passing

**Note**: this is a replacement for https://github.com/modin-project/modin/pull/1750