### PR TITLE
FIX-#1457: Series.reset_index considering 'name' fix

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1235,7 +1235,6 @@ class Series(BasePandasDataset):
             else:
                 result = self.copy()
                 result.index = new_idx
-                result.name = name or self.name
                 return result
         elif not drop and inplace:
             raise TypeError(
@@ -1247,9 +1246,7 @@ class Series(BasePandasDataset):
                 obj.name = name
             from .dataframe import DataFrame
 
-            return DataFrame(self.copy()).reset_index(
-                level=level, drop=drop, inplace=inplace
-            )
+            return DataFrame(obj).reset_index(level=level, drop=drop, inplace=inplace)
 
     def rdivmod(self, other, level=None, fill_value=None, axis=0):
         return self._default_to_pandas(

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2409,20 +2409,17 @@ def test_resample(closed, label, level):
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("drop", [True, False], ids=["True", "False"])
-def test_reset_index(data, drop):
-    modin_series, pandas_series = create_test_series(data)
-    df_equals(modin_series.reset_index(drop=drop), pandas_series.reset_index(drop=drop))
-
-    modin_series_cp = modin_series.copy()
-    pandas_series_cp = pandas_series.copy()
-    try:
-        pandas_result = pandas_series_cp.reset_index(drop=drop, inplace=True)
-    except Exception as e:
-        with pytest.raises(type(e)):
-            modin_series_cp.reset_index(drop=drop, inplace=True)
-    else:
-        modin_result = modin_series_cp.reset_index(drop=drop, inplace=True)
-        df_equals(pandas_result, modin_result)
+@pytest.mark.parametrize("name", [None, "Custom name"])
+@pytest.mark.parametrize("inplace", [True, False])
+def test_reset_index(data, drop, name, inplace):
+    eval_general(
+        *create_test_series(data),
+        lambda df, *args, **kwargs: df.reset_index(*args, **kwargs),
+        drop=drop,
+        name=name,
+        inplace=inplace,
+        __inplace__=inplace,
+    )
 
 
 @pytest.mark.skip(reason="Using pandas Series.")


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Fixing that `Series.reset_index` does not consider `name` parameter

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1457 <!-- issue must be created for each patch -->
- [x] tests added and passing
