### PR TITLE
FIX-#1464: product/sum incorrect behavior of 'min_count' fixed

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1738,8 +1738,13 @@ class DataFrame(BasePandasDataset):
         **kwargs,
     ):
         axis = self._get_axis_number(axis)
-        new_index = self.columns if axis else self.index
-        if min_count > len(new_index):
+        axis_to_apply = self.columns if axis else self.index
+        if (
+            skipna is not False
+            and numeric_only is None
+            and min_count > len(axis_to_apply)
+        ):
+            new_index = self.columns if not axis else self.index
             return Series(
                 [np.nan] * len(new_index), index=new_index, dtype=np.dtype("object")
             )
@@ -2063,8 +2068,13 @@ class DataFrame(BasePandasDataset):
         **kwargs,
     ):
         axis = self._get_axis_number(axis)
-        new_index = self.columns if axis else self.index
-        if min_count > len(new_index):
+        axis_to_apply = self.columns if axis else self.index
+        if (
+            skipna is not False
+            and numeric_only is None
+            and min_count > len(axis_to_apply)
+        ):
+            new_index = self.columns if not axis else self.index
             return Series(
                 [np.nan] * len(new_index), index=new_index, dtype=np.dtype("object")
             )

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -54,6 +54,8 @@ from .utils import (
     encoding_types,
     categories_equals,
     eval_general,
+    test_data_small_values,
+    test_data_small_keys,
 )
 
 pd.DEFAULT_NPARTITIONS = 4
@@ -2086,19 +2088,53 @@ def test_pow(data):
     inter_df_math_helper(modin_series, pandas_series, "pow")
 
 
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_prod(data):
-    modin_series, pandas_series = create_test_series(data)
-    # Wrap in Series to test almost_equal because of overflow
-    df_equals(pd.Series([modin_series.prod()]), pandas.Series([pandas_series.prod()]))
-
-
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_product(data):
-    modin_series, pandas_series = create_test_series(data)
-    # Wrap in Series to test almost_equal because of overflow
-    df_equals(
-        pd.Series([modin_series.product()]), pandas.Series([pandas_series.product()])
+@pytest.mark.parametrize(
+    "data",
+    test_data_values + test_data_small_values,
+    ids=test_data_keys + test_data_small_keys,
+)
+@pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
+@pytest.mark.parametrize(
+    "skipna", bool_arg_values, ids=arg_keys("skipna", bool_arg_keys)
+)
+@pytest.mark.parametrize(
+    "numeric_only",
+    [
+        None,
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="numeric_only not implemented for pandas.Series"
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "min_count", int_arg_values, ids=arg_keys("min_count", int_arg_keys)
+)
+@pytest.mark.parametrize(
+    "operation",
+    [
+        "prod",
+        pytest.param(
+            "product",
+            marks=pytest.mark.skipif(
+                pandas.Series.product == pandas.Series.prod
+                and pd.Series.product == pd.Series.prod,
+                reason="That operation was already tested.",
+            ),
+        ),
+    ],
+)
+def test_prod(data, axis, skipna, numeric_only, min_count, operation):
+    eval_general(
+        *create_test_series(data),
+        lambda df, *args, **kwargs: type(df)([getattr(df, operation)(*args, **kwargs)]),
+        axis=axis,
+        skipna=skipna,
+        numeric_only=numeric_only,
+        min_count=min_count,
     )
 
 
@@ -2685,23 +2721,40 @@ def test_subtract(data):
     inter_df_math_helper(modin_series, pandas_series, "subtract")
 
 
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize(
+    "data",
+    test_data_values + test_data_small_values,
+    ids=test_data_keys + test_data_small_keys,
+)
+@pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
 @pytest.mark.parametrize(
     "skipna", bool_arg_values, ids=arg_keys("skipna", bool_arg_keys)
 )
 @pytest.mark.parametrize(
+    "numeric_only",
+    [
+        None,
+        False,
+        pytest.param(
+            True,
+            marks=pytest.mark.xfail(
+                reason="numeric_only not implemented for pandas.Series"
+            ),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
     "min_count", int_arg_values, ids=arg_keys("min_count", int_arg_keys)
 )
-def test_sum(data, skipna, min_count):
-    modin_series, pandas_series = create_test_series(data)
-    try:
-        pandas_result = pandas_series.sum(skipna=skipna, min_count=min_count)
-    except Exception:
-        with pytest.raises(TypeError):
-            modin_series.sum(skipna=skipna, min_count=min_count)
-    else:
-        modin_result = modin_series.sum(skipna=skipna, min_count=min_count)
-        df_equals(modin_result, pandas_result)
+def test_sum(data, axis, skipna, numeric_only, min_count):
+    eval_general(
+        *create_test_series(data),
+        lambda df, *args, **kwargs: df.sum(*args, **kwargs),
+        axis=axis,
+        skipna=skipna,
+        numeric_only=numeric_only,
+        min_count=min_count,
+    )
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -159,6 +159,17 @@ test_data_with_duplicates = {
     },
 }
 
+test_data_small = {
+    "small": {
+        "col0": [1, 2, 3, 4],
+        "col1": [8.0, 9.4, 10.1, 11.3],
+        "col2": [4, 5, 6, 7],
+    }
+}
+
+test_data_small_values = list(test_data_small.values())
+test_data_small_keys = list(test_data_small.keys())
+
 test_data_with_duplicates_values = list(test_data_with_duplicates.values())
 test_data_with_duplicates_keys = list(test_data_with_duplicates.keys())
 


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1464 <!-- issue must be created for each patch -->
- [x] tests added and passing
