### PR TITLE
FIX-1708: Don't sort indexes in Series functions with level parameter

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -124,7 +124,7 @@ class BasePandasDataset(object):
             level: The level of the axis to apply the operation on
             op: String representation of the operation to be performed on the level
         """
-        return getattr(self.groupby(level=level, axis=axis), op)(**kwargs)
+        return getattr(self.groupby(level=level, axis=axis, sort=False), op)(**kwargs)
 
     def _validate_other(
         self,


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1708 <!-- issue must be created for each patch -->
- [ ] tests added and passing
