### PR TITLE
Speed up RPyC connection

### DIFF
--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -241,8 +241,7 @@ class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
                     except KeyError:
 
                         def wrap(*a, _original=getattr(self.__io_cls, name), **kw):
-                            a = tuple(self.__conn.deliver(x) for x in a)
-                            kw = {k: self.__conn.deliver(v) for k, v in kw.items()}
+                            a, kw = self.__conn.deliver(a, kw)
                             return _original(*a, **kw)
 
                         self.__wrappers[name] = wrap

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -106,11 +106,12 @@ class Connection:
         from .rpyc_proxy import WrappingService
 
         try:
-            self.__connection = rpyc.connect(
-                "127.0.0.1",
-                self.rpyc_port,
+            stream = rpyc.SocketStream.connect(
+                host="127.0.0.1", port=self.rpyc_port, nodelay=True, keepalive=True
+            )
+            self.__connection = rpyc.connect_stream(
+                stream,
                 WrappingService,
-                keepalive=True,
                 config={"sync_request_timeout": RPYC_REQUEST_TIMEOUT},
             )
         except (ConnectionRefusedError, EOFError):

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -15,7 +15,9 @@ import types
 
 import rpyc
 from rpyc.lib.compat import pickle
-from rpyc.core import netref
+from rpyc.lib import get_methods
+
+from rpyc.core import netref, AsyncResult
 
 from . import get_connection
 from .meta_magic import _LOCAL_ATTRS, RemoteMeta, _KNOWN_DUALS
@@ -126,6 +128,29 @@ class WrappingConnection(rpyc.Connection):
                 return result
 
         return super().sync_request(handler, *args)
+
+    def async_request(self, handler, *args, **kw):
+        if handler == consts.HANDLE_DEL:
+            obj, refcount = args
+            try:
+                obj_class = object.__getattribute__(obj, '__class__')
+            except AttributeError:
+                obj_class = None
+            if type(obj).__name__ in ('numpy',) or (getattr(obj_class, '__module__', None) in ('numpy',) and obj_class.__name__ in ('dtype',)):
+                """
+                # we have this cached, but a deletion is requested, remove the from cache
+                self._static_cache.pop(obj.____id_pack__, None)
+                """
+                try:
+                    cache = self._static_cache[obj.____id_pack__]
+                except KeyError:
+                    pass
+                else:
+                    # object is cached by us, so ignore the request or remote end dies and cache is suddenly stale
+                    res = AsyncResult(self)
+                    res._is_ready = True
+                    return res
+        return super().async_request(handler, *args, **kw)
 
     def _netref_factory(self, id_pack):
         id_name, cls_id, inst_id = id_pack
@@ -518,6 +543,8 @@ def make_dataframe_wrapper(DataFrame):
     class ObtainingItems:
         def items(self):
             return conn.obtain_tuple(self.__remote_end__.items())
+        def iteritems(self):
+            return conn.obtain_tuple(self.__remote_end__.iteritems())
     ObtainingItems = _deliveringWrapper(Series, mixin=ObtainingItems)
 
 

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -43,7 +43,8 @@ class WrappingConnection(rpyc.Connection):
     def _netref_factory(self, id_pack):
         id_name, cls_id, inst_id = id_pack
         id_name = str(id_name)
-        if id_name.startswith('modin.') and inst_id:
+        first = id_name.split('.', 1)[0]
+        if first in ('modin', 'numpy', 'pandas') and inst_id:
             try:
                 cached_cls = self._remote_cls_cache[(id_name, cls_id)]
             except KeyError:

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -107,11 +107,13 @@ class WrappingConnection(rpyc.Connection):
                     pass
                 else:
                     return get_methods(netref.LOCAL_ATTRS, clsobj)
-        elif handler in (consts.HANDLE_GETATTR, consts.HANDLE_STR):
+        elif handler in (consts.HANDLE_GETATTR, consts.HANDLE_STR, consts.HANDLE_HASH):
             if handler == consts.HANDLE_GETATTR:
                 obj, attr = args
+                key = (attr, handler)
             else:
-                obj, attr = args[0], '__str__'
+                obj = args[0]
+                key = handler
 
             if str(obj.____id_pack__[0]) in {'numpy', 'numpy.dtype'}:
                 try:
@@ -119,9 +121,9 @@ class WrappingConnection(rpyc.Connection):
                 except KeyError:
                     cache = self._static_cache[obj.____id_pack__] = {}
                 try:
-                    result = cache[(attr, handler)]
+                    result = cache[key]
                 except KeyError:
-                    result = cache[(attr, handler)] = super().sync_request(handler, *args)
+                    result = cache[key] = super().sync_request(handler, *args)
                 return result
 
         return super().sync_request(handler, *args)

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -18,7 +18,7 @@ import rpyc
 from rpyc.lib.compat import pickle
 from rpyc.lib import get_methods
 
-from rpyc.core import netref, AsyncResult
+from rpyc.core import netref, AsyncResult, consts
 
 from . import get_connection
 from .meta_magic import _LOCAL_ATTRS, RemoteMeta, _KNOWN_DUALS

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -224,9 +224,9 @@ def make_proxy_cls(
                             try:
                                 remote = cache[__method_name__]
                             except KeyError:
-                                cache[__method_name__] = remote = getattr(
-                                    remote_cls, __method_name__
-                                )
+                                # use remote_cls.__getattr__ to force RPyC return us
+                                # a proxy for remote method call instead of its local wrapper
+                                cache[__method_name__] = remote = remote_cls.__getattr__(__method_name__)
                             return remote(_self.__remote_end__, *_args, **_kw)
 
                         method.__name__ = name

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -12,6 +12,7 @@
 # governing permissions and limitations under the License.
 
 import types
+import collections
 
 import rpyc
 from rpyc.lib.compat import pickle
@@ -34,7 +35,11 @@ class WrappingConnection(rpyc.Connection):
         super().__init__(*a, **kw)
         self._remote_batch_loads = None
         self._remote_cls_cache = {}
-        self._static_cache = {}
+        self._static_cache = collections.defaultdict(dict)
+        self._remote_dumps = None
+        self._remote_tuplize = None
+
+
 
     def __wrap(self, local_obj):
         while True:
@@ -116,14 +121,14 @@ class WrappingConnection(rpyc.Connection):
                 key = handler
 
             if str(obj.____id_pack__[0]) in {'numpy', 'numpy.dtype'}:
-                try:
-                    cache = self._static_cache[obj.____id_pack__]
-                except KeyError:
-                    cache = self._static_cache[obj.____id_pack__] = {}
+                cache = self._static_cache[obj.____id_pack__]
                 try:
                     result = cache[key]
                 except KeyError:
                     result = cache[key] = super().sync_request(handler, *args)
+                    if handler == consts.HANDLE_GETATTR:
+                        # save an entry in our cache telling that we get this attribute cached
+                        self._static_cache[result.____id_pack__]['__getattr__'] = True
                 return result
 
         return super().sync_request(handler, *args)
@@ -132,10 +137,6 @@ class WrappingConnection(rpyc.Connection):
         if handler == consts.HANDLE_DEL:
             obj, _ = args
             if str(obj.____id_pack__[0]) in {'numpy', 'numpy.dtype'}:
-                """
-                # we have this cached, but a deletion is requested, remove the from cache
-                self._static_cache.pop(obj.____id_pack__, None)
-                """
                 if obj.____id_pack__ in self._static_cache:
                     # object is cached by us, so ignore the request or remote end dies and cache is suddenly stale;
                     # we shouldn't remove item from cache as it would reduce performance

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -26,7 +26,6 @@ def _batch_loads(items):
 class WrappingConnection(rpyc.Connection):
     def __init__(self, *a, **kw):
         super().__init__(*a, **kw)
-        self._remote_pickle_loads = None
         self._remote_batch_loads = None
         self._remote_cls_cache = {}
     def __wrap(self, local_obj):
@@ -115,7 +114,6 @@ class WrappingConnection(rpyc.Connection):
         return super()._box(obj)
 
     def _init_deliver(self):
-        self._remote_pickle_loads = self.modules["rpyc.lib.compat"].pickle.loads
         self._remote_batch_loads = self.modules["modin.experimental.cloud.rpyc_proxy"]._batch_loads
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
* Cache remote class types of known classes (RPyC by default reconstructs them upon each call)
* Use more efficient "batching" `.deliver()` which transfers all arguments in a single RPyC call instead of one call per argument
* Override inspecting certain classes, cache some getting attributes, hashes and strings for known static-ish items in `numpy`
* Obtain as local tuple the results of calling `DF.dtypes.items()` and `DF.dtypes.iteritems()`, as iterating over a remote connection introduces a lot of latency.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1821
- [ ] tests added and passing
