### PR TITLE
Implement numpy autowrapping in remote context

### DIFF
--- a/examples/cluster/mortgage-runner.py
+++ b/examples/cluster/mortgage-runner.py
@@ -19,10 +19,9 @@
 # the following import turns on experimental mode in Modin,
 # including enabling running things in remote cloud
 import modin.experimental.pandas as pd  # noqa: F401
-from modin.experimental.cloud import create_cluster, get_connection
+from modin.experimental.cloud import create_cluster
 
 from mortgage import run_benchmark
-from mortgage.mortgage_pandas import etl_pandas
 
 test_cluster = create_cluster(
     "aws",

--- a/examples/cluster/mortgage-runner.py
+++ b/examples/cluster/mortgage-runner.py
@@ -33,9 +33,6 @@ test_cluster = create_cluster(
     image="ami-00e1e82d7d4ca80d3",
 )
 with test_cluster:
-    conn = get_connection()
-    np = conn.modules["numpy"]
-    etl_pandas.__globals__["np"] = np
 
     parameters = {
         "data_file": "https://modin-datasets.s3.amazonaws.com/mortgage",

--- a/examples/cluster/taxi-runner.py
+++ b/examples/cluster/taxi-runner.py
@@ -19,10 +19,9 @@
 # the following import turns on experimental mode in Modin,
 # including enabling running things in remote cloud
 import modin.experimental.pandas as pd  # noqa: F401
-from modin.experimental.cloud import create_cluster, get_connection
+from modin.experimental.cloud import create_cluster
 
 from taxi import run_benchmark as run_benchmark
-from taxi.taxibench_pandas_ibis import etl_pandas
 
 test_cluster = create_cluster(
     "aws",
@@ -33,10 +32,6 @@ test_cluster = create_cluster(
     image="ami-00e1e82d7d4ca80d3",
 )
 with test_cluster:
-    conn = get_connection()
-    np = conn.modules["numpy"]
-    etl_pandas.__globals__["np"] = np
-
     parameters = {
         "data_file": "https://modin-datasets.s3.amazonaws.com/trips_data.csv",
         # "data_file": "s3://modin-datasets/trips_data.csv",

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -223,6 +223,9 @@ class ExperimentalPandasOnCloudrayFactory(ExperimentalBaseFactory):
         import modin.backends.pandas.query_compiler  # noqa: F401
         from modin.experimental.cloud import get_connection
 
+        # import a numpy overrider if it wasn't already imported
+        import modin.experimental.pandas.numpy_wrap  # noqa: F401
+
         class WrappedIO:
             def __init__(self, conn):
                 self.__conn = conn

--- a/modin/experimental/pandas/__init__.py
+++ b/modin/experimental/pandas/__init__.py
@@ -15,6 +15,8 @@ import os
 
 os.environ["MODIN_EXPERIMENTAL"] = "True"
 
+# import numpy_wrap as early as possible to intercept all "import numpy" statements
+# in the user code
 from .numpy_wrap import _CAUGHT_NUMPY  # noqa F401
 from modin.pandas import *  # noqa F401, F403
 from .io_exp import read_sql  # noqa F401

--- a/modin/experimental/pandas/__init__.py
+++ b/modin/experimental/pandas/__init__.py
@@ -15,7 +15,7 @@ import os
 
 os.environ["MODIN_EXPERIMENTAL"] = "True"
 
-from .numpy_wrap import _CAUGHT_NUMPY # noqa F401
+from .numpy_wrap import _CAUGHT_NUMPY  # noqa F401
 from modin.pandas import *  # noqa F401, F403
 from .io_exp import read_sql  # noqa F401
 import warnings

--- a/modin/experimental/pandas/__init__.py
+++ b/modin/experimental/pandas/__init__.py
@@ -14,6 +14,8 @@
 import os
 
 os.environ["MODIN_EXPERIMENTAL"] = "True"
+
+from .numpy_wrap import _CAUGHT_NUMPY # noqa F401
 from modin.pandas import *  # noqa F401, F403
 from .io_exp import read_sql  # noqa F401
 import warnings

--- a/modin/experimental/pandas/numpy_wrap.py
+++ b/modin/experimental/pandas/numpy_wrap.py
@@ -13,19 +13,19 @@
 
 import sys
 
-_CAUGHT_NUMPY = 'numpy' not in sys.modules
+_CAUGHT_NUMPY = "numpy" not in sys.modules
 try:
     import numpy as real_numpy
 except ImportError:
     pass
 else:
     import types
-    import collections
     import copyreg
     from modin import execution_engine
     import modin
     import pandas
     import os
+
     _EXCLUDE_MODULES = [modin, pandas]
     try:
         import rpyc
@@ -33,9 +33,12 @@ else:
         pass
     else:
         _EXCLUDE_MODULES.append(rpyc)
-    _EXCLUDE_PATHS = tuple(os.path.dirname(mod.__file__) + os.sep for mod in _EXCLUDE_MODULES)
+    _EXCLUDE_PATHS = tuple(
+        os.path.dirname(mod.__file__) + os.sep for mod in _EXCLUDE_MODULES
+    )
+
     class InterceptedNumpy(types.ModuleType):
-        __own_attrs__ = set(['__own_attrs__'])
+        __own_attrs__ = set(["__own_attrs__"])
 
         __spec__ = real_numpy.__spec__
         __current_numpy = real_numpy
@@ -46,27 +49,46 @@ else:
         def __init__(self):
             self.__own_attrs__ = set(type(self).__dict__.keys())
             execution_engine.subscribe(self.__update_engine)
+
         def __swap_numpy(self, other_numpy=None):
-            self.__current_numpy, self.__prev_numpy = other_numpy or self.__prev_numpy, self.__current_numpy
+            self.__current_numpy, self.__prev_numpy = (
+                other_numpy or self.__prev_numpy,
+                self.__current_numpy,
+            )
             if self.__current_numpy is not real_numpy and self.__has_to_warn:
                 import warnings
-                warnings.warn("Was not able to intercept all numpy imports. "
-                              "To intercept all of these please do 'import modin.experimental.pandas' as early as possible")
+
+                warnings.warn(
+                    "Was not able to intercept all numpy imports. "
+                    "To intercept all of these please do 'import modin.experimental.pandas' as early as possible"
+                )
                 self.__has_to_warn = False
+
         def __update_engine(self, _):
             if execution_engine.get() == "Cloudray":
                 from modin.experimental.cloud import get_connection
-                self.__swap_numpy(get_connection().modules['numpy'])
+
+                self.__swap_numpy(get_connection().modules["numpy"])
             else:
                 self.__swap_numpy()
+
         def __make_reducer(self, name):
             try:
                 reducer = self.__reducers[name]
             except KeyError:
-                def reducer(obj, obj_name=name, real_obj_reducer=getattr(real_numpy, name).__reduce__):
-                    return (getattr(self.__current_numpy, obj_name),) + real_obj_reducer(obj)[1:]
+
+                def reducer(
+                    obj,
+                    obj_name=name,
+                    real_obj_reducer=getattr(real_numpy, name).__reduce__,
+                ):
+                    return (
+                        getattr(self.__current_numpy, obj_name),
+                    ) + real_obj_reducer(obj)[1:]
+
                 self.__reducers[name] = reducer
             return reducer
+
         def __get_numpy(self):
             frame = sys._getframe()
             try:
@@ -78,18 +100,21 @@ else:
             if any(caller_file.startswith(p) for p in _EXCLUDE_PATHS):
                 return real_numpy
             return self.__current_numpy
+
         def __getattr__(self, name):
             obj = getattr(self.__get_numpy(), name)
             if isinstance(obj, type):
                 copyreg.pickle(obj, self.__make_reducer(name))
             return obj
+
         def __setattr__(self, name, value):
             if name in self.__own_attrs__:
                 super().__setattr__(name, value)
             else:
                 setattr(self.__get_numpy(), name, value)
+
         def __delattr__(self, name):
             if name not in self.__own_attrs__:
                 delattr(self.__get_numpy(), name)
-    sys.modules['numpy'] = InterceptedNumpy()
-    
+
+    sys.modules["numpy"] = InterceptedNumpy()

--- a/modin/experimental/pandas/numpy_wrap.py
+++ b/modin/experimental/pandas/numpy_wrap.py
@@ -1,0 +1,87 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import sys
+
+_CAUGHT_NUMPY = 'numpy' not in sys.modules
+try:
+    import numpy as real_numpy
+except ImportError:
+    pass
+else:
+    import types
+    import threading
+    import collections
+    import copyreg
+    from modin import execution_engine
+    class InterceptedNumpy(types.ModuleType):
+        __own_attrs__ = set(['__own_attrs__'])
+
+        __spec__ = real_numpy.__spec__
+        __current_numpy = real_numpy
+        __prev_numpy = real_numpy
+        __has_to_warn = not _CAUGHT_NUMPY
+        __recursive_guard = threading.local()
+        __recursive_guard.callers = collections.defaultdict(set)
+        __reducers = {}
+
+        def __init__(self):
+            self.__own_attrs__ = set(type(self).__dict__.keys())
+            execution_engine.subscribe(self.__update_engine)
+        def __swap_numpy(self, other_numpy=None):
+            self.__current_numpy, self.__prev_numpy = other_numpy or self.__prev_numpy, self.__current_numpy
+            if self.__current_numpy is not real_numpy and self.__has_to_warn:
+                import warnings
+                warnings.warn("Was not able to intercept all numpy imports. "
+                              "To intercept all of these please do 'import modin.experimental.pandas' as early as possible")
+                self.__has_to_warn = False
+        def __update_engine(self, _):
+            if execution_engine.get() == "Cloudray":
+                from modin.experimental.cloud import get_connection
+                self.__swap_numpy(get_connection().modules['numpy'])
+            else:
+                self.__swap_numpy()
+        def __guarded_call(self, func, name, *args):
+            guard = self.__recursive_guard.callers[func.__name__]
+            if name in guard:
+                # recursive call, call against the real numpy
+                return func(real_numpy, name, *args)
+            guard.add(name)
+            try:
+                return func(self.__current_numpy, name, *args)
+            finally:
+                guard.remove(name)
+        def __make_reducer(self, name):
+            try:
+                reducer = self.__reducers[name]
+            except KeyError:
+                def reducer(obj, obj_name=name, real_obj_reducer=getattr(real_numpy, name).__reduce__):
+                    return (getattr(self.__current_numpy, obj_name),) + real_obj_reducer(obj)[1:]
+                self.__reducers[name] = reducer
+            return reducer
+        def __getattr__(self, name):
+            obj = self.__guarded_call(getattr, name)
+            if isinstance(obj, type):
+                copyreg.pickle(obj, self.__make_reducer(name))
+            return obj
+        def __setattr__(self, name, value):
+            if name in self.__own_attrs__:
+                super().__setattr__(name, value)
+            else:
+                return self.__guarded_call(setattr, name, value)
+        def __delattr__(self, name):
+            if name not in self.__own_attrs__:
+                return getattr(real_numpy, name)
+            return self.__guarded_call(delattr, name)
+    sys.modules['numpy'] = InterceptedNumpy()
+    

--- a/modin/experimental/pandas/numpy_wrap.py
+++ b/modin/experimental/pandas/numpy_wrap.py
@@ -79,7 +79,6 @@ else:
 
                 def reducer(
                     obj,
-                    obj_name=name,
                     real_obj=getattr(real_numpy, name),
                     real_obj_reducer=getattr(real_numpy, name).__reduce__,
                 ):
@@ -87,18 +86,16 @@ else:
                     reduced = real_obj_reducer(obj)
                     if not isinstance(reduced, tuple):
                         return reduced
-                    if reduced[0] == real_obj:
-                        return (getattr(self.__current_numpy, obj_name),) + reduced[1:]
                     assert isinstance(
-                        reduced[0], (types.FunctionType, types.BuiltinFunctionType)
-                    ), "Do not know how to support this"
+                        reduced[0],
+                        (type, types.FunctionType, types.BuiltinFunctionType),
+                    ), "Do not know how to support this reconstructor"
 
                     modobj = self.__current_numpy
                     for submod in reduced[0].__module__.split(".")[1:]:
                         modobj = getattr(modobj, submod)
                     reconstruct = getattr(modobj, reduced[0].__name__)
-                    # FIXME: replace real numpy things in reduced[0] and all args in reduced[1:] with those from __current_numpy
-                    # TODO: see if all replacement is needed, maybe pickle calls __reduce__ recursievly?
+                    # TODO: see if replacing all "real numpy" things in reduced[1:] is needed
                     return (reconstruct,) + reduced[1:]
 
                 self.__reducers[name] = reducer


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
This replaces `numpy` module whenever a user code executes `import numpy` with a special class that returns different things in local and remote contexts.
It also registers special reducers (support for pickling), as, when trying to pickle an object from "local" numpy when "remote" is activated leads to `TypeError: different class` without special reducer.

Note that access to `numpy` is always local for `modin.*` and `pandas.*` packages, as NumPy is used internally there and is not needed to be proxied to the remote.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1819
- [ ] tests added and passing
