### PR TITLE
FIX-#911: Pin Dask Dependency for Python 3.8 compatiblity

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
 pandas==1.0.5
 numpy
 pyarrow<0.17
-dask[complete]>=2.1.0,<=2.19.0
-distributed>=2.3.2,<=2.19.0
+dask[complete]>=2.12.0,<=2.19.0
+distributed>=2.12.0,<=2.19.0
 ray==0.8.6
 psutil==5.6.6
 xarray

--- a/requirements/env_windows.yml
+++ b/requirements/env_windows.yml
@@ -15,8 +15,8 @@ dependencies:
     - pandas==1.0.5
     - numpy
     - pyarrow>=0.13.0
-    - dask[complete]>=2.1.0
-    - distributed>=2.3.2
+    - dask[complete]>=2.12.0
+    - distributed>=2.12.0
     - psutil==5.6.6
     - xarray
     - Jinja2

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ class ModinDistribution(Distribution):
         return False
 
 
-dask_deps = ["dask>=2.1.0", "distributed>=2.3.2"]
+dask_deps = ["dask>=2.12.0", "distributed>=2.12.0"]
 ray_deps = ["ray==0.8.6", "pyarrow<0.17"]
 
 all_deps = dask_deps + ray_deps


### PR DESCRIPTION
Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #911 <!-- issue must be created for each patch -->
- [ ] tests added and passing
