### PR TITLE
FIX-#1852: Add stub engines to known ones during test-internals

### DIFF
--- a/modin/data_management/test/test_dispatcher.py
+++ b/modin/data_management/test/test_dispatcher.py
@@ -18,6 +18,8 @@ from modin import execution_engine, partition_format, set_backends
 from modin.data_management.dispatcher import EngineDispatcher, FactoryNotFoundError
 from modin.data_management import factories
 
+import modin.pandas as pd
+
 
 class PandasOnTestFactory(factories.BaseFactory):
     """
@@ -62,6 +64,9 @@ class FooOnBarFactory(factories.BaseFactory):
 factories.PandasOnTestFactory = PandasOnTestFactory
 factories.TestOnPythonFactory = TestOnPythonFactory
 factories.FooOnBarFactory = FooOnBarFactory
+
+# register them as known "no init" engines for modin.pandas
+pd._NOINIT_ENGINES |= {"Test", "Bar"}
 
 
 def test_default_engine():

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -97,6 +97,9 @@ num_cpus = 1
 
 _is_first_update = {}
 dask_client = None
+_NOINIT_ENGINES = {
+    "Python"
+}  # engines that don't require initialization, useful for unit tests
 
 
 def _update_engine(publisher: Publisher):
@@ -157,7 +160,7 @@ def _update_engine(publisher: Publisher):
 
         num_cpus = remote_ray.cluster_resources()["CPU"]
 
-    elif publisher.get() != "Python":
+    elif publisher.get() not in _NOINIT_ENGINES:
         raise ImportError("Unrecognized execution engine: {}.".format(publisher.get()))
 
     _is_first_update[publisher.get()] = False


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
* Add a registry of known engines that don't require initialization.
* Register stub engines used in `test-internals` prior actually running the tests
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1852
- [ ] tests added and passing
