### PR TITLE
FIX-#1857: make 'sort_index' consider axis parameter

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1562,6 +1562,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         ):
             return self.default_to_pandas(
                 pandas.DataFrame.sort_index,
+                axis=axis,
                 level=level,
                 sort_remaining=sort_remaining,
                 **kwargs

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5970,11 +5970,19 @@ class TestDataFrameJoinSort:
         pandas_df.index = pandas.MultiIndex.from_tuples(
             [(i // 10, i // 5, i) for i in range(len(pandas_df))]
         )
+        modin_df.columns = pd.MultiIndex.from_tuples(
+            [(i // 10, i // 5, i) for i in range(len(modin_df.columns))]
+        )
+        pandas_df.columns = pd.MultiIndex.from_tuples(
+            [(i // 10, i // 5, i) for i in range(len(pandas_df.columns))]
+        )
 
         with pytest.warns(UserWarning):
             df_equals(modin_df.sort_index(level=0), pandas_df.sort_index(level=0))
         with pytest.warns(UserWarning):
             df_equals(modin_df.sort_index(axis=0), pandas_df.sort_index(axis=0))
+        with pytest.warns(UserWarning):
+            df_equals(modin_df.sort_index(axis=1), pandas_df.sort_index(axis=1))
 
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1857 <!-- issue must be created for each patch -->
- [x] tests added and passing
