### PR TITLE
FIX-#1709: Fix support for `level` parameter in reductions

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2073,6 +2073,7 @@ class DataFrame(BasePandasDataset):
             skipna is not False
             and numeric_only is None
             and min_count > len(axis_to_apply)
+            and level is None
         ):
             new_index = self.columns if not axis else self.index
             return Series(

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -517,6 +517,7 @@ def df_equals(df1, df2):
         assert isinstance(df2, pandas.core.arrays.numpy_.PandasArray)
         assert df1 == df2
     else:
+        assert type(df1) == type(df2), "Mismatched type: {} != {}".format(type(df1), type(df2))
         if df1 != df2:
             np.testing.assert_almost_equal(df1, df2)
 


### PR DESCRIPTION
Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
