### PR TITLE
Fix recursion in experimental mode in some cases

### DIFF
--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -94,10 +94,10 @@ _KNOWN_DUALS = {}
 
 def make_wrapped_class(local_cls: type, rpyc_wrapper_name: str):
     """
-    Replaces given local class in its module with a descendant class
-    which has __new__ overridden (a dual-nature class).
-    This new class is instantiated differently depending o
-     whether this is done in remote context or local.
+    Replaces given local class in its module with a replacement class
+    which has __new__ defined (a dual-nature class).
+    This new class is instantiated differently depending on
+    whether this is done in remote or local context.
 
     In local context we effectively get the same behaviour, but in remote
     context the created class is actually of separate type which
@@ -114,12 +114,12 @@ def make_wrapped_class(local_cls: type, rpyc_wrapper_name: str):
         installed, and not all users of Modin (even in experimental mode)
         need remote context.
     """
-    namespace = {
-        "__real_cls__": None,
-        "__new__": None,
-        "__module__": local_cls.__module__,
-    }
-    result = RemoteMeta(local_cls.__name__, (local_cls,), namespace)
+    namespace = dict(local_cls.__dict__)  # get a copy of local_cls attributes' dict
+    namespace["__real_cls__"] = None
+    namespace["__new__"] = None
+    # define a new class the same way original was defined but with replaced
+    # metaclass and a few more attributes in namespace
+    result = RemoteMeta(local_cls.__name__, local_cls.__bases__, namespace)
 
     def make_new(__class__):
         """

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -114,7 +114,14 @@ def make_wrapped_class(local_cls: type, rpyc_wrapper_name: str):
         installed, and not all users of Modin (even in experimental mode)
         need remote context.
     """
-    namespace = dict(local_cls.__dict__)  # get a copy of local_cls attributes' dict
+    # get a copy of local_cls attributes' dict but skip _very_ special attributes,
+    # because copying them to a different type leads to them not working.
+    # Python should create new descriptors automatically for us instead.
+    namespace = {
+        name: value
+        for name, value in local_cls.__dict__.items()
+        if not isinstance(value, types.GetSetDescriptorType)
+    }
     namespace["__real_cls__"] = None
     namespace["__new__"] = None
     # define a new class the same way original was defined but with replaced

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -227,7 +227,7 @@ class BasePandasDataset(object):
             # Broadcast is an internally used argument
             kwargs.pop("broadcast", None)
             return self._default_to_pandas(
-                getattr(getattr(pandas, self.__name__), op), other, **kwargs
+                getattr(getattr(pandas, type(self).__name__), op), other, **kwargs
             )
         other = self._validate_other(other, axis, numeric_or_object_only=True)
         new_query_compiler = getattr(self._query_compiler, op)(other, **kwargs)
@@ -238,7 +238,7 @@ class BasePandasDataset(object):
         empty_self_str = "" if not self.empty else " for empty DataFrame"
         ErrorMessage.default_to_pandas(
             "`{}.{}`{}".format(
-                self.__name__,
+                type(self).__name__,
                 op if isinstance(op, str) else op.__name__,
                 empty_self_str,
             )
@@ -254,7 +254,7 @@ class BasePandasDataset(object):
             # it is a DataFrame, Series, etc.) as a pandas object. The outer `getattr`
             # will get the operation (`op`) from the pandas version of the class and run
             # it on the object after we have converted it to pandas.
-            result = getattr(getattr(pandas, self.__name__), op)(
+            result = getattr(getattr(pandas, type(self).__name__), op)(
                 pandas_obj, *args, **kwargs
             )
         else:
@@ -307,7 +307,7 @@ class BasePandasDataset(object):
 
     def _get_axis_number(self, axis):
         return (
-            getattr(pandas, self.__name__)()._get_axis_number(axis)
+            getattr(pandas, type(self).__name__)()._get_axis_number(axis)
             if axis is not None
             else 0
         )
@@ -455,7 +455,7 @@ class BasePandasDataset(object):
                 if hasattr(self, "dtype"):
                     raise NotImplementedError(
                         "{}.{} does not implement numeric_only.".format(
-                            self.__name__, "all"
+                            type(self).__name__, "all"
                         )
                     )
                 data_for_compute = self[self.columns[self.dtypes == np.bool]]
@@ -512,7 +512,7 @@ class BasePandasDataset(object):
                 if hasattr(self, "dtype"):
                     raise NotImplementedError(
                         "{}.{} does not implement numeric_only.".format(
-                            self.__name__, "all"
+                            type(self).__name__, "all"
                         )
                     )
                 data_for_compute = self[self.columns[self.dtypes == np.bool]]
@@ -2117,9 +2117,9 @@ class BasePandasDataset(object):
             "copy": copy,
             "inplace": inplace,
         }
-        axes, kwargs = getattr(pandas, self.__name__)()._construct_axes_from_arguments(
-            (), kwargs, sentinel=sentinel
-        )
+        axes, kwargs = getattr(
+            pandas, type(self).__name__
+        )()._construct_axes_from_arguments((), kwargs, sentinel=sentinel)
         if axis is not None:
             axis = self._get_axis_number(axis)
         else:
@@ -3452,7 +3452,7 @@ class BasePandasDataset(object):
         # see if we can slice the rows
         # This lets us reuse code in Pandas to error check
         indexer = convert_to_index_sliceable(
-            getattr(pandas, self.__name__)(index=self.index), key
+            getattr(pandas, type(self).__name__)(index=self.index), key
         )
         if indexer is not None:
             return self._getitem_slice(indexer)
@@ -3553,10 +3553,6 @@ class BasePandasDataset(object):
             The numpy representation of this object.
         """
         return self.to_numpy()
-
-    @property
-    def __name__(self):
-        return type(self).__name__
 
     def __getattribute__(self, item):
         default_behaviors = [

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -354,7 +354,7 @@ class DataFrame(BasePandasDataset):
         # in pandas that verify that some results are created. This is a challenge for
         # empty DataFrames, but fortunately they only happen when the `func` type is
         # a list or a dictionary, which means that the return type won't change from
-        # type(self), so we catch that error and use `self.__name__` for the return
+        # type(self), so we catch that error and use `type(self).__name__` for the return
         # type.
         try:
             if axis == 0:
@@ -362,12 +362,12 @@ class DataFrame(BasePandasDataset):
             else:
                 init_kwargs = {"columns": self.columns}
             return_type = type(
-                getattr(pandas, self.__name__)(**init_kwargs).apply(
+                getattr(pandas, type(self).__name__)(**init_kwargs).apply(
                     func, axis=axis, raw=raw, result_type=result_type, args=args, **kwds
                 )
             ).__name__
         except Exception:
-            return_type = self.__name__
+            return_type = type(self).__name__
         if return_type not in ["DataFrame", "Series"]:
             return query_compiler.to_pandas().squeeze()
         else:
@@ -845,7 +845,7 @@ class DataFrame(BasePandasDataset):
             .astype(self.dtypes)
             .eval(expr, **kwargs)
         ).__name__
-        if return_type == self.__name__:
+        if return_type == type(self).__name__:
             return self._create_or_update_from_compiler(new_query_compiler, inplace)
         else:
             if inplace:

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -488,7 +488,7 @@ class Series(BasePandasDataset):
         # in pandas that verify that some results are created. This is a challenge for
         # empty DataFrames, but fortunately they only happen when the `func` type is
         # a list or a dictionary, which means that the return type won't change from
-        # type(self), so we catch that error and use `self.__name__` for the return
+        # type(self), so we catch that error and use `type(self).__name__` for the return
         # type.
         # Because a `Series` cannot be empty in pandas, we create a "dummy" `Series` to
         # do the error checking and determining the return type.
@@ -499,7 +499,7 @@ class Series(BasePandasDataset):
                 )
             ).__name__
         except Exception:
-            return_type = self.__name__
+            return_type = type(self).__name__
         if (
             isinstance(func, str)
             or is_list_like(func)


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Before the changes the wrappers needed to enable remote context were done as two classes named samely, one inheriting the other and replacing the other in globals of the module. This lead to `super(Class, self).method` recursing in itself, because both `Class` and parent of `Class` had the exact same method.

I'm changing the method to replacing the classes instead of inheriting.

I've also had to remove `BasePandasDataset.__name__` property, so `self.__name__` no longer works,  using `type(self).__name__` yields the same result.


<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1872
- [ ] tests added and passing
