### PR TITLE
Fix access to special attributes in experimental mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -171,3 +171,4 @@ cscope.out
 
 # Dask workspace
 dask-worker-space/
+node_modules

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -81,10 +81,7 @@ class RemoteMeta(type):
                     return super().__getattribute__(name)
                 else:
                     try:
-                        remote = object.__getattribute__(
-                            super().__getattribute__("__real_cls__"),
-                            "__wrapper_remote__",
-                        )
+                        remote = self.__real_cls__.__wrapper_remote__
                     except AttributeError:
                         # running in local mode, fall back
                         return super().__getattribute__(name)

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -46,47 +46,47 @@ class RemoteMeta(type):
     def __getattribute__(self, name):
         if name in _LOCAL_ATTRS:
             # never proxy special attributes, always get them from the class type
-            res = object.__getattribute__(self, name)
+            return super().__getattribute__(name)
         else:
             try:
                 # Go for proxying class-level attributes first;
                 # make sure to check for attribute in self.__dict__ to get the class-level
                 # attribute from the class itself, not from some of its parent classes.
-                # Also note we use object.__getattribute__() to skip any potential
-                # class-level __getattr__
-                res = object.__getattribute__(self, "__dict__")[name]
+                res = super().__getattribute__("__dict__")[name]
             except KeyError:
+                # Class-level attribute not found in the class itself; it might be present
+                # in its parents, but we must first see if we should go to a remote
+                # end, because in "remote context" local attributes are only those which
+                # are explicitly allowed by being defined in the class itself.
+                frame = sys._getframe()
                 try:
-                    res = object.__getattribute__(self, name)
+                    is_inspect = frame.f_back.f_code.co_filename == inspect.__file__
                 except AttributeError:
-                    frame = sys._getframe()
+                    is_inspect = False
+                finally:
+                    del frame
+                if is_inspect:
+                    # be always-local for inspect.* functions
+                    return super().__getattribute__(name)
+                else:
                     try:
-                        is_inspect = frame.f_back.f_code.co_filename == inspect.__file__
+                        remote = object.__getattribute__(
+                            super().__getattribute__("__real_cls__"),
+                            "__wrapper_remote__",
+                        )
                     except AttributeError:
-                        is_inspect = False
-                    finally:
-                        del frame
-                    if is_inspect:
-                        # be always-local for inspect.* functions
-                        res = super().__getattribute__(name)
-                    else:
-                        try:
-                            remote = object.__getattribute__(
-                                object.__getattribute__(self, "__real_cls__"),
-                                "__wrapper_remote__",
-                            )
-                        except AttributeError:
-                            # running in local mode, fall back
-                            res = super().__getattribute__(name)
-                        else:
-                            res = getattr(remote, name)
-        try:
-            # note that any attribute might be in fact a data descriptor,
-            # account for that
-            getter = res.__get__
-        except AttributeError:
-            return res
-        return getter(None, self)
+                        # running in local mode, fall back
+                        return super().__getattribute__(name)
+                    return getattr(remote, name)
+            else:
+                try:
+                    # note that any attribute might be in fact a data descriptor,
+                    # account for that; we only need it for attributes we get from __dict__[],
+                    # because other cases are handled by super().__getattribute__ for us
+                    getter = res.__get__
+                except AttributeError:
+                    return res
+                return getter(None, self)
 
 
 _KNOWN_DUALS = {}

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -17,7 +17,7 @@ import types
 
 from modin import execution_engine
 
-_LOCAL_ATTRS = frozenset(("__new__", "__dict__", "__wrapper_remote__"))
+_LOCAL_ATTRS = frozenset(("__new__", "__dict__", "__wrapper_remote__", "__real_cls__"))
 
 
 class RemoteMeta(type):

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -17,7 +17,18 @@ import types
 
 from modin import execution_engine
 
-_LOCAL_ATTRS = frozenset(("__new__", "__dict__", "__wrapper_remote__", "__real_cls__"))
+# the attributes that must be alwasy taken from a local part of dual-nature class,
+# never going to remote end
+_LOCAL_ATTRS = frozenset(
+    (
+        "__new__",
+        "__dict__",
+        "__wrapper_remote__",
+        "__real_cls__",
+        "__mro__",
+        "__class__",
+    )
+)
 
 
 class RemoteMeta(type):

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -417,6 +417,8 @@ def make_proxy_cls(
             4) check if type(self).__dict__[name] exists
             5) pass through to remote end
             """
+            if name == "__class__":
+                return object.__getattribute__(self, "__class__")
             dct = object.__getattribute__(self, "__dict__")
             if name == "__dict__":
                 return dct

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -384,9 +384,6 @@ def make_proxy_cls(
         __name__ = cls_name or origin_cls.__name__
         __wrapper_remote__ = remote_cls
 
-        def __new__(cls, *a, **kw):
-            return override.__new__(cls)
-
         def __init__(self, *a, __remote_end__=None, **kw):
             if __remote_end__ is None:
                 __remote_end__ = remote_cls(*a, **kw)


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
The root cause for #1873 was that `RemoteMeta` was returning wrongly-bound `__new__` method - `object.__new__` instead of `type.__new__` (because of it being retrieved via `object.__getattribute__(self, name)` instead of `type.__getattribute__(self, name)`).

As a metaclass (`RemoteMeta` in this case) is a descendant of `type` it should be using `type.__getattribute__()` to get attributes from itself, not `object.__getattribute__()`. To remove the ability to do wrongly in case it will ever be inherited from some `type` descendent instead of `type` itself, relevant calls were replaced with `super().__getattribute__(name)`.
Also the list of attributes that are always-local was expanded, both for performance reasons and to fix running it in remote context'

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1873
- [ ] tests added and passing
