### PR TITLE
Add tests running under experimental mode

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,27 @@ jobs:
       - run: python -m pytest modin/experimental/pandas/test/test_io_exp.py
         if: matrix.part == 3
       - run: bash <(curl -s https://codecov.io/bash)
+  test-experimental:
+    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    runs-on: ubuntu-latest
+    env:
+      MODIN_ENGINE: "python"
+      MODIN_EXPERIMENTAL: "True"
+      MODIN_MEMORY: 1000000000
+    name: test experimental
+    steps:
+      - uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - uses: actions/setup-python@v1
+        with:
+          python-version: "3.7.x"
+          architecture: "x64"
+      - run: pip install -r requirements.txt
+      - run: python -m pytest modin/pandas/test/test_dataframe.py::TestDataFrameMapMetadata
+      - run: python -m pytest modin/pandas/test/test_series.py
+      - run: python -m pytest modin/pandas/test/test_io.py
+      - run: bash <(curl -s https://codecov.io/bash)
   test-windows:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
     runs-on: windows-latest


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Add one more test group that runs ordinary non-experimental Modin tests with `MODIN_EXPERIMENTAL` set to `True`.
This should prevent accidental breakage of at least basic functionality in experimental mode in the future.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1876
- [ ] tests added and passing
