### PR TITLE
FEAT-#1523: 'nrows' support to 'read_csv' added

### DIFF
--- a/modin/engines/base/io/file_reader.py
+++ b/modin/engines/base/io/file_reader.py
@@ -117,6 +117,17 @@ class FileReader:
         return size
 
     @classmethod
+    def lines_amount(cls, f, from_begin=False):
+        cur_pos = f.tell()
+        if from_begin:
+            f.seek(0, os.SEEK_SET)
+        nlines = 0
+        for _ in f:
+            nlines += 1
+        f.seek(cur_pos, os.SEEK_SET)
+        return nlines
+
+    @classmethod
     def file_exists(cls, file_path):
         if isinstance(file_path, str):
             match = S3_ADDRESS_REGEX.search(file_path)

--- a/modin/engines/base/io/file_reader.py
+++ b/modin/engines/base/io/file_reader.py
@@ -117,17 +117,6 @@ class FileReader:
         return size
 
     @classmethod
-    def lines_amount(cls, f, from_begin=False):
-        cur_pos = f.tell()
-        if from_begin:
-            f.seek(0, os.SEEK_SET)
-        nlines = 0
-        for _ in f:
-            nlines += 1
-        f.seek(cur_pos, os.SEEK_SET)
-        return nlines
-
-    @classmethod
     def file_exists(cls, file_path):
         if isinstance(file_path, str):
             match = S3_ADDRESS_REGEX.search(file_path)

--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -15,6 +15,7 @@ from modin.engines.base.io.text.text_file_reader import TextFileReader
 from modin.data_management.utils import compute_chunksize
 from pandas.io.parsers import _validate_usecols_arg
 import pandas
+import csv
 import sys
 
 
@@ -54,9 +55,7 @@ class CSVReader(TextFileReader):
         skiprows = kwargs.get("skiprows")
         if skiprows is not None and not isinstance(skiprows, int):
             return cls.single_worker_read(filepath_or_buffer, **kwargs)
-        # TODO: replace this by reading lines from file.
-        if kwargs.get("nrows") is not None:
-            return cls.single_worker_read(filepath_or_buffer, **kwargs)
+        nrows = kwargs.pop("nrows", None)
         names = kwargs.get("names", None)
         index_col = kwargs.get("index_col", None)
         if names is None:
@@ -110,8 +109,12 @@ class CSVReader(TextFileReader):
                     skiprows += header + 1
                 elif hasattr(header, "__iter__") and not isinstance(header, str):
                     skiprows += max(header) + 1
-                for _ in range(skiprows):
-                    f.readline()
+                cls.read_rows(
+                    f,
+                    skiprows,
+                    quotechar,
+                    is_quoting=(kwargs.get("quoting", "") != csv.QUOTE_NONE),
+                )
             if kwargs.get("encoding", None) is not None:
                 partition_kwargs["skiprows"] = 1
             # Launch tasks to read partitions
@@ -126,8 +129,10 @@ class CSVReader(TextFileReader):
             # This is the number of splits for the columns
             num_splits = min(len(column_names), num_partitions)
             # This is the chunksize each partition will read
-            chunk_size = max(1, (total_bytes - f.tell()) // num_partitions)
-
+            if nrows is None:
+                part_size = max(1, total_bytes // num_partitions)
+            else:
+                part_size = max(1, (nrows - skiprows) // num_partitions)
             # Metadata
             column_chunksize = compute_chunksize(empty_pd_df, num_splits, axis=1)
             if column_chunksize > len(column_names):
@@ -145,18 +150,27 @@ class CSVReader(TextFileReader):
                     for i in range(num_splits)
                 ]
 
-            while f.tell() < total_bytes:
+            deploy_kwargs = {
+                "chunk_size_bytes" if nrows is None else "nrows": part_size
+            }
+
+            readed = f.tell() if nrows is None else 0
+            read_limit = total_bytes if nrows is None else nrows
+            while readed < read_limit:
                 args = {
                     "fname": filepath_or_buffer,
                     "num_splits": num_splits,
                     **partition_kwargs,
                 }
+                if (readed + part_size) > read_limit:
+                    deploy_kwargs[list(deploy_kwargs.keys())[0]] = read_limit - readed
                 partition_id = cls.call_deploy(
-                    f, chunk_size, num_splits + 2, args, quotechar=quotechar
+                    f, num_splits + 2, args, quotechar=quotechar, **deploy_kwargs
                 )
                 partition_ids.append(partition_id[:-2])
                 index_ids.append(partition_id[-2])
                 dtypes_ids.append(partition_id[-1])
+                readed = f.tell() if nrows is None else readed + part_size
 
         # Compute the index based on a sum of the lengths of each partition (by default)
         # or based on the column(s) that were requested.

--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -154,7 +154,6 @@ class CSVReader(TextFileReader):
             splits = cls.partitioned_file(
                 f,
                 nrows=nrows,
-                skiprows=skiprows,
                 num_partitions=num_partitions,
                 quotechar=quotechar,
                 is_quoting=is_quoting,

--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -96,6 +96,7 @@ class CSVReader(TextFileReader):
         quotechar = kwargs.get("quotechar", '"').encode(
             encoding if encoding is not None else "UTF-8"
         )
+        is_quoting = kwargs.get("quoting", "") != csv.QUOTE_NONE
         with cls.file_open(filepath_or_buffer, "rb", compression_type) as f:
             # Skip the header since we already have the header information and skip the
             # rows we are told to skip.
@@ -111,9 +112,9 @@ class CSVReader(TextFileReader):
                     skiprows += max(header) + 1
                 cls.read_rows(
                     f,
-                    skiprows,
-                    quotechar,
-                    is_quoting=(kwargs.get("quoting", "") != csv.QUOTE_NONE),
+                    nrows=skiprows,
+                    quotechar=quotechar,
+                    is_quoting=is_quoting,
                 )
             if kwargs.get("encoding", None) is not None:
                 partition_kwargs["skiprows"] = 1
@@ -121,20 +122,12 @@ class CSVReader(TextFileReader):
             partition_ids = []
             index_ids = []
             dtypes_ids = []
-            total_bytes = cls.file_size(f)
             # Max number of partitions available
             from modin.pandas import DEFAULT_NPARTITIONS
 
             num_partitions = DEFAULT_NPARTITIONS
             # This is the number of splits for the columns
             num_splits = min(len(column_names), num_partitions)
-            # This is the chunksize each partition will read
-            if nrows is None:
-                chunk_size_bytes = max(1, num_partitions, total_bytes // num_partitions)
-                rows_per_part = None
-            else:
-                chunk_size_bytes = None
-                rows_per_part = max(1, num_partitions, nrows // num_partitions)
             # Metadata
             column_chunksize = compute_chunksize(empty_pd_df, num_splits, axis=1)
             if column_chunksize > len(column_names):
@@ -152,32 +145,26 @@ class CSVReader(TextFileReader):
                     for i in range(num_splits)
                 ]
 
-            rows_readed = 0
-            rows_limit = float("inf") if nrows is None else nrows
-            while f.tell() < total_bytes and rows_readed < rows_limit:
-                args = {
-                    "fname": filepath_or_buffer,
-                    "num_splits": num_splits,
-                    **partition_kwargs,
-                }
-                if (
-                    rows_per_part is not None
-                    and rows_readed + rows_per_part > rows_limit
-                ):
-                    rows_per_part = rows_limit - rows_readed
-                partition_id = cls.call_deploy(
-                    f,
-                    num_splits + 2,
-                    args,
-                    quotechar=quotechar,
-                    chunk_size_bytes=chunk_size_bytes,
-                    nrows=rows_per_part,
-                )
+            args = {
+                "fname": filepath_or_buffer,
+                "num_splits": num_splits,
+                **partition_kwargs,
+            }
+
+            splits = cls.partitioned_file(
+                f,
+                nrows=nrows,
+                skiprows=skiprows,
+                num_partitions=num_partitions,
+                quotechar=quotechar,
+                is_quoting=is_quoting,
+            )
+            for start, end in splits:
+                args.update({"start": start, "end": end})
+                partition_id = cls.deploy(cls.parse, num_splits + 2, args)
                 partition_ids.append(partition_id[:-2])
                 index_ids.append(partition_id[-2])
                 dtypes_ids.append(partition_id[-1])
-                if nrows is not None:
-                    rows_readed += rows_per_part
 
         # Compute the index based on a sum of the lengths of each partition (by default)
         # or based on the column(s) that were requested.

--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -110,7 +110,7 @@ class CSVReader(TextFileReader):
                     skiprows += header + 1
                 elif hasattr(header, "__iter__") and not isinstance(header, str):
                     skiprows += max(header) + 1
-                cls.read_rows(
+                cls.offset(
                     f,
                     nrows=skiprows,
                     quotechar=quotechar,

--- a/modin/engines/base/io/text/fwf_reader.py
+++ b/modin/engines/base/io/text/fwf_reader.py
@@ -116,7 +116,7 @@ class FWFReader(TextFileReader):
                     skiprows += header + 1
                 elif hasattr(header, "__iter__") and not isinstance(header, str):
                     skiprows += max(header) + 1
-                cls.read_rows(
+                cls.offset(
                     f,
                     nrows=skiprows,
                     quotechar=quotechar,

--- a/modin/engines/base/io/text/fwf_reader.py
+++ b/modin/engines/base/io/text/fwf_reader.py
@@ -160,7 +160,6 @@ class FWFReader(TextFileReader):
             splits = cls.partitioned_file(
                 f,
                 nrows=nrows,
-                skiprows=skiprows,
                 num_partitions=num_partitions,
                 quotechar=quotechar,
                 is_quoting=is_quoting,

--- a/modin/engines/base/io/text/json_reader.py
+++ b/modin/engines/base/io/text/json_reader.py
@@ -41,7 +41,7 @@ class JSONReader(TextFileReader):
 
             num_partitions = DEFAULT_NPARTITIONS
             num_splits = min(len(columns), num_partitions)
-            chunk_size = max(1, (total_bytes - f.tell()) // num_partitions)
+            part_size = max(1, total_bytes // num_partitions)
 
             partition_ids = []
             index_ids = []
@@ -63,7 +63,9 @@ class JSONReader(TextFileReader):
                 start = f.tell()
                 args = {"fname": path_or_buf, "num_splits": num_splits, "start": start}
                 args.update(kwargs)
-                partition_id = cls.call_deploy(f, chunk_size, num_splits + 3, args)
+                partition_id = cls.call_deploy(
+                    f, num_splits + 3, args, chunk_size_bytes=part_size
+                )
                 partition_ids.append(partition_id[:-3])
                 index_ids.append(partition_id[-3])
                 dtypes_ids.append(partition_id[-2])

--- a/modin/engines/base/io/text/text_file_reader.py
+++ b/modin/engines/base/io/text/text_file_reader.py
@@ -95,6 +95,21 @@ class TextFileReader(FileReader):
 
     @classmethod
     def read_rows(cls, f, nrows, quotechar=b'"', is_quoting=True):
+        """
+        Moves the file offset at the specified amount of rows
+
+        Parameters
+        ----------
+            f: file object
+            nrows: int, number of rows to read
+            quotechar: char that indicates quote in a file (optional, by default is '\"')
+            is_quoting: bool, Whether or not to consider quotes
+
+        Returns
+        -------
+            bool, If file pointer reached the end of the file, but did not find
+            closing quote returns `False`. `True` in any other case.
+        """
         if nrows <= 0:
             return
         rows_readed = 0

--- a/modin/engines/base/io/text/text_file_reader.py
+++ b/modin/engines/base/io/text/text_file_reader.py
@@ -72,8 +72,7 @@ class TextFileReader(FileReader):
                 consider `chunk_size_bytes` parameter.
             chunk_size_bytes: int, Will read new rows while file pointer
                 is less than `chunk_size_bytes`. Optional, if not specified will only
-                consider `nrows` parameter, if both not specified will read till
-                the end of the file.
+                consider `nrows` parameter.
             skiprows: array or callable (optional), specifies rows to skip
             quotechar: char that indicates quote in a file
                 (optional, by default it's '\"')
@@ -85,6 +84,10 @@ class TextFileReader(FileReader):
             bool: If file pointer reached the end of the file, but did not find
             closing quote returns `False`. `True` in any other case.
         """
+        assert (
+            nrows is not None or chunk_size_bytes is not None
+        ), "`nrows` and `chunk_size_bytes` can't be None at the same time"
+
         if nrows is not None or skiprows is not None:
             return cls._read_rows(
                 f,
@@ -94,9 +97,6 @@ class TextFileReader(FileReader):
                 is_quoting=is_quoting,
                 max_bytes=chunk_size_bytes,
             )[0]
-
-        if chunk_size_bytes is None:
-            chunk_size_bytes = -1
 
         outside_quotes = True
 

--- a/modin/engines/base/io/text/text_file_reader.py
+++ b/modin/engines/base/io/text/text_file_reader.py
@@ -216,7 +216,7 @@ class TextFileReader(FileReader):
             f: file object
             nrows: int, number of rows to read. Optional, if not specified will only
                 consider `max_bytes` parameter.
-            skiprows: array or callable (optional), specifies rows to skip
+            skiprows: int, array or callable (optional), specifies rows to skip
             quotechar: char that indicates quote in a file
                 (optional, by default it's '\"')
             is_quoting: bool, Whether or not to consider quotes

--- a/modin/pandas/test/data/newlines.csv
+++ b/modin/pandas/test/data/newlines.csv
@@ -11,7 +11,15 @@ reproduce the issue",2,3,4
 "H",2,3,4
 "I",2,3,4
 "J",2,3,4
-"H",2,3,4
+"And there is another
+string with several
+newline characters
+that will probably cause some
+problem for Modin
+and I suspect that
+we
+will hopefully
+reproduce the issue",2,3,4
 "I",2,3,4
 "J",2,3,4
 "H",2,3,4
@@ -19,4 +27,40 @@ reproduce the issue",2,3,4
 "J",2,3,4
 "H",2,3,4
 "I",2,3,4
+"And there is another
+string with several
+newline characters
+that will probably cause some
+problem for Modin
+and I suspect that
+we
+will hopefully
+reproduce the issue",2,3,4
+"H",2,3,4
+"I",2,3,4
 "J",2,3,4
+"And there is another
+string with several
+newline characters
+that will probably cause some
+problem for Modin
+and I suspect that
+we
+will hopefully
+reproduce the issue",2,3,4
+"I",2,3,4
+"J",2,3,4
+"H",2,3,4
+"I",2,3,4
+"J",2,3,4
+"H",2,3,4
+"I",2,3,4
+"And there is another
+string with several
+newline characters
+that will probably cause some
+problem for Modin
+and I suspect that
+we
+will hopefully
+reproduce the issue",2,3,4

--- a/modin/pandas/test/data/newlines.csv
+++ b/modin/pandas/test/data/newlines.csv
@@ -35,11 +35,8 @@ problem for Modin
 and I suspect that
 we
 will hopefully
-reproduce the issue",2,3,4
-"H",2,3,4
-"I",2,3,4
-"J",2,3,4
-"And there is another
+reproduce the issue",2,"And
+there is another
 string with several
 newline characters
 that will probably cause some
@@ -47,7 +44,7 @@ problem for Modin
 and I suspect that
 we
 will hopefully
-reproduce the issue",2,3,4
+reproduce the issue",4
 "I",2,3,4
 "J",2,3,4
 "H",2,3,4

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -728,31 +728,34 @@ def test_from_sas():
     df_equals(modin_df, pandas_df)
 
 
-def test_from_csv(make_csv_file):
+@pytest.mark.parametrize("nrows", [123, None])
+def test_from_csv(make_csv_file, nrows):
     make_csv_file()
 
-    pandas_df = pandas.read_csv(TEST_CSV_FILENAME)
-    modin_df = pd.read_csv(TEST_CSV_FILENAME)
+    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, nrows=nrows)
+    modin_df = pd.read_csv(TEST_CSV_FILENAME, nrows=nrows)
 
     df_equals(modin_df, pandas_df)
 
-    pandas_df = pandas.read_csv(Path(TEST_CSV_FILENAME))
-    modin_df = pd.read_csv(Path(TEST_CSV_FILENAME))
+    pandas_df = pandas.read_csv(Path(TEST_CSV_FILENAME), nrows=nrows)
+    modin_df = pd.read_csv(Path(TEST_CSV_FILENAME), nrows=nrows)
 
     df_equals(modin_df, pandas_df)
 
 
-def test_from_csv_sep_none(make_csv_file):
+@pytest.mark.parametrize("nrows", [123, None])
+def test_from_csv_sep_none(make_csv_file, nrows):
     make_csv_file()
 
     with pytest.warns(ParserWarning):
-        pandas_df = pandas.read_csv(TEST_CSV_FILENAME, sep=None)
+        pandas_df = pandas.read_csv(TEST_CSV_FILENAME, sep=None, nrows=nrows)
     with pytest.warns(ParserWarning):
-        modin_df = pd.read_csv(TEST_CSV_FILENAME, sep=None)
+        modin_df = pd.read_csv(TEST_CSV_FILENAME, sep=None, nrows=nrows)
     df_equals(modin_df, pandas_df)
 
 
-def test_from_csv_bad_quotes():
+@pytest.mark.parametrize("nrows", [2, None])
+def test_from_csv_bad_quotes(nrows):
     csv_bad_quotes = """1, 2, 3, 4
 one, two, three, four
 five, "six", seven, "eight
@@ -761,13 +764,14 @@ five, "six", seven, "eight
     with open(TEST_CSV_FILENAME, "w") as f:
         f.write(csv_bad_quotes)
 
-    pandas_df = pandas.read_csv(TEST_CSV_FILENAME)
-    modin_df = pd.read_csv(TEST_CSV_FILENAME)
+    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, nrows=nrows)
+    modin_df = pd.read_csv(TEST_CSV_FILENAME, nrows=nrows)
 
     df_equals(modin_df, pandas_df)
 
 
-def test_from_csv_quote_none():
+@pytest.mark.parametrize("nrows", [2, None])
+def test_from_csv_quote_none(nrows):
     csv_bad_quotes = """1, 2, 3, 4
 one, two, three, four
 five, "six", seven, "eight
@@ -775,8 +779,8 @@ five, "six", seven, "eight
     with open(TEST_CSV_FILENAME, "w") as f:
         f.write(csv_bad_quotes)
 
-    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, quoting=csv.QUOTE_NONE)
-    modin_df = pd.read_csv(TEST_CSV_FILENAME, quoting=csv.QUOTE_NONE)
+    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, quoting=csv.QUOTE_NONE, nrows=nrows)
+    modin_df = pd.read_csv(TEST_CSV_FILENAME, quoting=csv.QUOTE_NONE, nrows=nrows)
 
     df_equals(modin_df, pandas_df)
 
@@ -1058,26 +1062,33 @@ def test_from_csv_chunksize(make_csv_file):
     df_equals(modin_df, pd_df)
 
 
-def test_from_csv_skiprows(make_csv_file):
+@pytest.mark.parametrize("nrows", [123, None])
+def test_from_csv_skiprows(make_csv_file, nrows):
     make_csv_file()
 
-    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, skiprows=2)
-    modin_df = pd.read_csv(TEST_CSV_FILENAME, skiprows=2)
+    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, skiprows=2, nrows=nrows)
+    modin_df = pd.read_csv(TEST_CSV_FILENAME, skiprows=2, nrows=nrows)
     df_equals(modin_df, pandas_df)
 
     pandas_df = pandas.read_csv(
-        TEST_CSV_FILENAME, names=["c1", "c2", "c3", "c4"], skiprows=2
+        TEST_CSV_FILENAME, names=["c1", "c2", "c3", "c4"], skiprows=2, nrows=nrows
     )
     modin_df = pd.read_csv(
-        TEST_CSV_FILENAME, names=["c1", "c2", "c3", "c4"], skiprows=2
+        TEST_CSV_FILENAME, names=["c1", "c2", "c3", "c4"], skiprows=2, nrows=nrows
     )
     df_equals(modin_df, pandas_df)
 
     pandas_df = pandas.read_csv(
-        TEST_CSV_FILENAME, names=["c1", "c2", "c3", "c4"], skiprows=lambda x: x % 2
+        TEST_CSV_FILENAME,
+        names=["c1", "c2", "c3", "c4"],
+        skiprows=lambda x: x % 2,
+        nrows=nrows,
     )
     modin_df = pd.read_csv(
-        TEST_CSV_FILENAME, names=["c1", "c2", "c3", "c4"], skiprows=lambda x: x % 2
+        TEST_CSV_FILENAME,
+        names=["c1", "c2", "c3", "c4"],
+        skiprows=lambda x: x % 2,
+        nrows=nrows,
     )
     df_equals(modin_df, pandas_df)
 
@@ -1098,10 +1109,6 @@ def test_from_csv_default_to_pandas_behavior(make_csv_file):
     make_csv_file()
 
     with pytest.warns(UserWarning):
-        # Test nrows
-        pd.read_csv(TEST_CSV_FILENAME, nrows=10)
-
-    with pytest.warns(UserWarning):
         # This tests that we default to pandas on a buffer
         from io import StringIO
 
@@ -1111,11 +1118,12 @@ def test_from_csv_default_to_pandas_behavior(make_csv_file):
         pd.read_csv(TEST_CSV_FILENAME, skiprows=lambda x: x in [0, 2])
 
 
-def test_from_csv_index_col(make_csv_file):
+@pytest.mark.parametrize("nrows", [123, None])
+def test_from_csv_index_col(make_csv_file, nrows):
     make_csv_file()
 
-    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, index_col="col1")
-    modin_df = pd.read_csv(TEST_CSV_FILENAME, index_col="col1")
+    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, index_col="col1", nrows=nrows)
+    modin_df = pd.read_csv(TEST_CSV_FILENAME, index_col="col1", nrows=nrows)
     df_equals(modin_df, pandas_df)
 
 
@@ -1142,9 +1150,15 @@ def test_from_csv_parse_dates(make_csv_file):
     df_equals(modin_df, pandas_df)
 
 
-def test_from_csv_newlines_in_quotes():
-    pandas_df = pandas.read_csv("modin/pandas/test/data/newlines.csv")
-    modin_df = pd.read_csv("modin/pandas/test/data/newlines.csv")
+@pytest.mark.parametrize("nrows", [14, None])
+@pytest.mark.parametrize("skiprows", [3, None])
+def test_from_csv_newlines_in_quotes(nrows, skiprows):
+    pandas_df = pandas.read_csv(
+        "modin/pandas/test/data/newlines.csv", nrows=nrows, skiprows=skiprows
+    )
+    modin_df = pd.read_csv(
+        "modin/pandas/test/data/newlines.csv", nrows=nrows, skiprows=skiprows
+    )
     df_equals(modin_df, pandas_df)
 
 
@@ -1537,15 +1551,20 @@ def test_fwf_file_chunksize():
     df_equals(modin_df, pd_df)
 
 
-def test_fwf_file_skiprows():
+@pytest.mark.parametrize("nrows", [13, None])
+def test_fwf_file_skiprows(nrows):
     setup_fwf_file(overwrite=True)
 
-    pandas_df = pandas.read_fwf(TEST_FWF_FILENAME, skiprows=2)
-    modin_df = pd.read_fwf(TEST_FWF_FILENAME, skiprows=2)
+    pandas_df = pandas.read_fwf(TEST_FWF_FILENAME, skiprows=2, nrows=nrows)
+    modin_df = pd.read_fwf(TEST_FWF_FILENAME, skiprows=2, nrows=nrows)
     df_equals(modin_df, pandas_df)
 
-    pandas_df = pandas.read_fwf(TEST_FWF_FILENAME, usecols=[0, 4, 7], skiprows=[2, 5])
-    modin_df = pd.read_fwf(TEST_FWF_FILENAME, usecols=[0, 4, 7], skiprows=[2, 5])
+    pandas_df = pandas.read_fwf(
+        TEST_FWF_FILENAME, usecols=[0, 4, 7], skiprows=[2, 5], nrows=nrows
+    )
+    modin_df = pd.read_fwf(
+        TEST_FWF_FILENAME, usecols=[0, 4, 7], skiprows=[2, 5], nrows=nrows
+    )
     df_equals(modin_df, pandas_df)
 
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -31,6 +31,7 @@ from .utils import (
     json_short_bytes,
     json_long_string,
     json_long_bytes,
+    eval_general,
 )
 
 from modin import execution_engine
@@ -57,6 +58,17 @@ TEST_SAS_FILENAME = os.getcwd() + "/data/test1.sas7bdat"
 TEST_FWF_FILENAME = "test_fwf.txt"
 TEST_GBQ_FILENAME = "test_gbq."
 SMALL_ROW_SIZE = 2000
+
+
+def eval_io(path, fn_name, comparator=df_equals, *args, **kwargs):
+    eval_general(
+        pd,
+        pandas,
+        lambda module, *args, **kwargs: getattr(module, fn_name)(*args, **kwargs),
+        path=path,
+        *args,
+        **kwargs,
+    )
 
 
 @pytest.fixture
@@ -1150,16 +1162,15 @@ def test_from_csv_parse_dates(make_csv_file):
     df_equals(modin_df, pandas_df)
 
 
-@pytest.mark.parametrize("nrows", [14, None])
-@pytest.mark.parametrize("skiprows", [3, None])
+@pytest.mark.parametrize("nrows", [21, 5, None])
+@pytest.mark.parametrize("skiprows", [4, 1, 500, None])
 def test_from_csv_newlines_in_quotes(nrows, skiprows):
-    pandas_df = pandas.read_csv(
-        "modin/pandas/test/data/newlines.csv", nrows=nrows, skiprows=skiprows
+    eval_io(
+        path="modin/pandas/test/data/newlines.csv",
+        fn_name="read_csv",
+        nrows=nrows,
+        skiprows=skiprows,
     )
-    modin_df = pd.read_csv(
-        "modin/pandas/test/data/newlines.csv", nrows=nrows, skiprows=skiprows
-    )
-    df_equals(modin_df, pandas_df)
 
 
 @pytest.mark.skip(reason="No clipboard on Travis")

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -60,11 +60,20 @@ TEST_GBQ_FILENAME = "test_gbq."
 SMALL_ROW_SIZE = 2000
 
 
-def eval_io(path, fn_name, comparator=df_equals, *args, **kwargs):
+def eval_io(path, fn_name, comparator=df_equals, cast_to_str=False, *args, **kwargs):
+    def applyier(module, *args, **kwargs):
+        result = getattr(module, fn_name)(*args, **kwargs)
+        # There could be some missmatches in dtypes, so we're
+        # casting the whole frame to `str` before comparison.
+        # See issue #1931 for details.
+        if cast_to_str:
+            result = result.astype(str)
+        return result
+
     eval_general(
         pd,
         pandas,
-        lambda module, *args, **kwargs: getattr(module, fn_name)(*args, **kwargs),
+        applyier,
         path=path,
         *args,
         **kwargs,
@@ -1170,6 +1179,7 @@ def test_from_csv_newlines_in_quotes(nrows, skiprows):
         fn_name="read_csv",
         nrows=nrows,
         skiprows=skiprows,
+        cast_to_str=True,
     )
 
 


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1523, #1924 <!-- issue must be created for each patch -->
- [x] tests added and passing
