### PR TITLE
FIX-#1898: Support DataFrame.__setitem__ with boolean mask.

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2505,7 +2505,7 @@ class DataFrame(BasePandasDataset):
         object.__setattr__(self, key, value)
 
     def __setitem__(self, key, value):
-        if key not in self.columns:
+        if isinstance(key, str) and key not in self.columns:
             # Handle new column case first
             if isinstance(value, Series):
                 if len(self.columns) == 0:
@@ -2543,6 +2543,13 @@ class DataFrame(BasePandasDataset):
             return
 
         if not isinstance(key, str):
+
+            if isinstance(key, DataFrame) or isinstance(key, np.ndarray):
+                if isinstance(key, np.ndarray):
+                    if key.shape != self.shape:
+                        raise ValueError("Array must be same shape as DataFrame")
+                    key = DataFrame(key, columns=self.columns)
+                return self.mask(key, value, inplace=True)
 
             def setitem_without_string_columns(df):
                 # Arrow makes memory-mapped objects immutable, so copy will allow them

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -33,7 +33,13 @@ from typing import Tuple, Union
 import warnings
 
 from modin.error_message import ErrorMessage
-from .utils import from_pandas, from_non_pandas, to_pandas, _inherit_docstrings
+from .utils import (
+    from_pandas,
+    from_non_pandas,
+    to_pandas,
+    _inherit_docstrings,
+    hashable,
+)
 from .iterator import PartitionIterator
 from .series import Series
 from .base import BasePandasDataset
@@ -2505,7 +2511,7 @@ class DataFrame(BasePandasDataset):
         object.__setattr__(self, key, value)
 
     def __setitem__(self, key, value):
-        if isinstance(key, str) and key not in self.columns:
+        if hashable(key) and key not in self.columns:
             # Handle new column case first
             if isinstance(value, Series):
                 if len(self.columns) == 0:

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5370,6 +5370,7 @@ class TestDataFrameIndexing:
         df_equals(modin_df, pandas_df)
 
     def test___setitem__mask(self):
+        # DataFrame mask:
         data = test_data["int_data"]
         modin_df = pd.DataFrame(data)
         pandas_df = pandas.DataFrame(data)
@@ -5380,6 +5381,7 @@ class TestDataFrameIndexing:
 
         df_equals(modin_df, pandas_df)
 
+        # Array mask:
         pandas_df = pandas.DataFrame(data)
         modin_df = pd.DataFrame(data)
         array = (pandas_df > mean).to_numpy()
@@ -5388,6 +5390,11 @@ class TestDataFrameIndexing:
         pandas_df[array] = -50
 
         df_equals(modin_df, pandas_df)
+
+        # Array mask of wrong size:
+        with pytest.raises(ValueError):
+            array = np.array([[1, 2], [3, 4]])
+            modin_df[array] = 20
 
     @pytest.mark.parametrize(
         "data",

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5361,6 +5361,26 @@ class TestDataFrameIndexing:
 
         df_equals(modin_df, pandas_df)
 
+    def test___setitem__mask(self):
+        data = test_data["int_data"]
+        modin_df = pd.DataFrame(data)
+        pandas_df = pandas.DataFrame(data)
+
+        mean = int((RAND_HIGH + RAND_LOW) / 2)
+        pandas_df[pandas_df > mean] = -50
+        modin_df[modin_df > mean] = -50
+
+        df_equals(modin_df, pandas_df)
+
+        pandas_df = pandas.DataFrame(data)
+        modin_df = pd.DataFrame(data)
+        array = (pandas_df > mean).to_numpy()
+
+        modin_df[array] = -50
+        pandas_df[array] = -50
+
+        df_equals(modin_df, pandas_df)
+
     @pytest.mark.parametrize(
         "data",
         [

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -127,3 +127,12 @@ def wrap_udf_function(func):
 
     wrapper.__name__ = func.__name__
     return wrapper
+
+
+def hashable(obj):
+    """Return whether the object is hashable."""
+    try:
+        hash(obj)
+    except TypeError:
+        return False
+    return True


### PR DESCRIPTION
Signed-off-by: Itamar Turner-Trauring <itamar@itamarst.org>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Make `df[df > 2] = 3` work (previously it did not).

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1898
- [x] tests added and passing
