### PR TITLE
REFACTOR-#1929: avoid unnecessary index access in groupby

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -49,7 +49,6 @@ class DataFrameGroupBy(object):
         self._idx_name = idx_name
         self._df = df
         self._query_compiler = self._df._query_compiler
-        self._index = self._query_compiler.index
         self._columns = self._query_compiler.columns
         self._by = by
         self._drop = drop
@@ -82,6 +81,10 @@ class DataFrameGroupBy(object):
             "squeeze": squeeze,
         }
         self._kwargs.update(kwargs)
+
+    @property
+    def _index(self):
+        return self._query_compiler.index
 
     @property
     def _sort(self):


### PR DESCRIPTION
Signed-off-by: ienkovich <ilya.enkovich@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Avoid unconditional index access in each groupby statement. This helps lazy engines to be lazier.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1929   <!-- issue must be created for each patch -->
- [x] tests passing
