### PR TITLE
FEAT-#1925: add import from arrow table

### DIFF
--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -124,6 +124,28 @@ class BaseQueryCompiler(abc.ABC):
 
     # END To/From Pandas
 
+    # From Arrow
+    @classmethod
+    @abc.abstractmethod
+    def from_arrow(cls, at, data_cls):
+        """Improve simple Arrow Table to an advanced and superior Modin DataFrame.
+
+        Parameters
+        ----------
+        at : Arrow Table
+            The Arrow Table to convert from.
+        data_cls :
+            Modin DataFrame object to convert to.
+
+        Returns
+        -------
+        BaseQueryCompiler
+            QueryCompiler containing data from the Pandas DataFrame.
+        """
+        pass
+
+    # END From Arrow
+
     # To NumPy
     @abc.abstractmethod
     def to_numpy(self):

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -192,6 +192,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def from_pandas(cls, df, data_cls):
         return cls(data_cls.from_pandas(df))
 
+    @classmethod
+    def from_arrow(cls, at, data_cls):
+        return cls(data_cls.from_arrow(at))
+
     index = property(_get_axis(0), _set_axis(0))
     columns = property(_get_axis(1), _set_axis(1))
 

--- a/modin/data_management/dispatcher.py
+++ b/modin/data_management/dispatcher.py
@@ -99,6 +99,10 @@ class EngineDispatcher(object):
         return cls.__engine._from_pandas(df)
 
     @classmethod
+    def from_arrow(cls, at):
+        return cls.__engine._from_arrow(at)
+
+    @classmethod
     def from_non_pandas(cls, *args, **kwargs):
         return cls.__engine._from_non_pandas(*args, **kwargs)
 

--- a/modin/data_management/factories.py
+++ b/modin/data_management/factories.py
@@ -40,6 +40,10 @@ class BaseFactory(object):
         return cls.io_cls.from_pandas(df)
 
     @classmethod
+    def _from_arrow(cls, at):
+        return cls.io_cls.from_arrow(at)
+
+    @classmethod
     def _from_non_pandas(cls, *args, **kwargs):
         return cls.io_cls.from_non_pandas(*args, **kwargs)
 

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -399,6 +399,10 @@ class BaseFrameManager(object):
             return np.array(parts), row_lengths, col_widths
 
     @classmethod
+    def from_arrow(cls, at, return_dims=False):
+        return cls.from_pandas(at.to_pandas(), return_dims=return_dims)
+
+    @classmethod
     def get_indices(cls, axis, partitions, index_func=None):
         """This gets the internal indices stored in the partitions.
 

--- a/modin/engines/base/io/io.py
+++ b/modin/engines/base/io/io.py
@@ -30,6 +30,10 @@ class BaseIO(object):
         return cls.query_compiler_cls.from_pandas(df, cls.frame_cls)
 
     @classmethod
+    def from_arrow(cls, at):
+        return cls.query_compiler_cls.from_arrow(at, cls.frame_cls)
+
+    @classmethod
     def read_parquet(cls, path, engine, columns, **kwargs):
         """Load a parquet object from the file path, returning a Modin DataFrame.
            Modin only supports pyarrow engine for now.

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas
 from pandas.errors import ParserWarning
 from collections import OrderedDict
-from modin.pandas.utils import to_pandas
+from modin.pandas.utils import to_pandas, from_arrow
 from pathlib import Path
 import pyarrow as pa
 import pyarrow.parquet as pq
@@ -1643,3 +1643,9 @@ def test_cleanup():
                 os.remove(f)
             except PermissionError:
                 pass
+
+
+def test_from_arrow():
+    pandas_df = create_test_pandas_dataframe()
+    modin_df = from_arrow(pa.Table.from_pandas(pandas_df))
+    df_equals(modin_df, pandas_df)

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -39,6 +39,25 @@ def from_pandas(df):
     return DataFrame(query_compiler=EngineDispatcher.from_pandas(df))
 
 
+def from_arrow(at):
+    """Converts an Arrow Table to a Modin DataFrame.
+
+    Parameters
+    ----------
+        at : Arrow Table
+            The Arrow Table to convert from.
+
+    Returns
+    -------
+    DataFrame
+        A new Modin DataFrame object.
+    """
+    from modin.data_management.dispatcher import EngineDispatcher
+    from .dataframe import DataFrame
+
+    return DataFrame(query_compiler=EngineDispatcher.from_arrow(at))
+
+
 def to_pandas(modin_obj):
     """Converts a Modin DataFrame/Series to a pandas DataFrame/Series.
 


### PR DESCRIPTION
## What do these changes do?
Add API to build modin dataframes from arrow tables. This is an important feature for arrow based OmniSci backend. For pandas based backend we simple convert arrow table to pandas dataframe.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1925   <!-- issue must be created for each patch -->
- [x] tests added and passing
