### PR TITLE
REFACTOR-#1917: move part of reset_index code to backend

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -472,6 +472,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
             A new QueryCompiler with updated data and reset index.
         """
         drop = kwargs.get("drop", False)
+        level = kwargs.get("level", None)
+        # TODO Implement level
+        if level is not None or isinstance(self.index, pandas.MultiIndex):
+            return self.default_to_pandas(pandas.DataFrame.reset_index, **kwargs)
         if not drop:
             new_column_name = (
                 self.index.name

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2289,20 +2289,10 @@ class BasePandasDataset(object):
             A new DataFrame if inplace is False, None otherwise.
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        # TODO Implement level
-        if level is not None or isinstance(self.index, pandas.MultiIndex):
-            new_query_compiler = self._default_to_pandas(
-                "reset_index",
-                level=level,
-                drop=drop,
-                inplace=False,
-                col_level=col_level,
-                col_fill=col_fill,
-            )._query_compiler
         # Error checking for matching Pandas. Pandas does not allow you to
         # insert a dropped index into a DataFrame if these columns already
         # exist.
-        elif (
+        if (
             not drop
             and not isinstance(self.index, pandas.MultiIndex)
             and all(n in self.columns for n in ["level_0", "index"])


### PR DESCRIPTION
## What do these changes do?
Move part of set_index implementation to a backend to allow other backends support multi-index reset.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1917  <!-- issue must be created for each patch -->
- [x] tests passing
