### PR TITLE
REFACTOR-#1934: move MultiIndex checks to backend

### DIFF
--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -1226,3 +1226,20 @@ class BaseQueryCompiler(abc.ABC):
         return self.drop(columns=[key])
 
     # END __delitem__
+
+    @abc.abstractmethod
+    def has_multiindex(self, axis=0):
+        """
+        Check if specified axis is indexed by MultiIndex.
+
+        Parameters
+        ----------
+        axis : 0 or 1, default 0
+            The axis to check (0 - index, 1 - columns).
+
+        Returns
+        -------
+        bool
+            True if index at specified axis is MultiIndex and False otherwise.
+        """
+        pass

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -480,7 +480,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         drop = kwargs.get("drop", False)
         level = kwargs.get("level", None)
         # TODO Implement level
-        if level is not None or isinstance(self.index, pandas.MultiIndex):
+        if level is not None or self.has_multiindex():
             return self.default_to_pandas(pandas.DataFrame.reset_index, **kwargs)
         if not drop:
             new_column_name = (
@@ -1589,10 +1589,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         sort_remaining = kwargs.pop("sort_remaining", True)
         kwargs["inplace"] = False
 
-        if level is not None or (
-            (axis == 0 and isinstance(self.index, pandas.MultiIndex))
-            or (axis == 1 and isinstance(self.columns, pandas.MultiIndex))
-        ):
+        if level is not None or self.has_multiindex(axis=axis):
             return self.default_to_pandas(
                 pandas.DataFrame.sort_index,
                 axis=axis,
@@ -2278,3 +2275,22 @@ class PandasQueryCompiler(BaseQueryCompiler):
         return self.default_to_pandas(lambda df: df[df.columns[0]].cat.codes)
 
     # END Cat operations
+
+    def has_multiindex(self, axis=0):
+        """
+        Check if specified axis is indexed by MultiIndex.
+
+        Parameters
+        ----------
+        axis : 0 or 1, default 0
+            The axis to check (0 - index, 1 - columns).
+
+        Returns
+        -------
+        bool
+            True if index at specified axis is MultiIndex and False otherwise.
+        """
+        if axis == 0:
+            return isinstance(self.index, pandas.MultiIndex)
+        assert axis == 1
+        return isinstance(self.columns, pandas.MultiIndex)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -748,7 +748,7 @@ class BasePandasDataset(object):
             self._validate_dtypes(numeric_only=numeric_only)
 
         if level is not None:
-            if not isinstance(self.axes[axis], pandas.MultiIndex):
+            if not self._query_compiler.has_multiindex(axis=axis):
                 # error thrown by pandas
                 raise TypeError("Can only count levels on hierarchical columns.")
 
@@ -2042,11 +2042,11 @@ class BasePandasDataset(object):
             level is not None
             or (
                 (columns is not None or axis == 1)
-                and isinstance(self.columns, pandas.MultiIndex)
+                and self._query_compiler.has_multiindex(axis=1)
             )
             or (
                 (index is not None or axis == 0)
-                and isinstance(self.index, pandas.MultiIndex)
+                and self._query_compiler.has_multiindex()
             )
         ):
             return self._default_to_pandas(
@@ -2294,7 +2294,7 @@ class BasePandasDataset(object):
         # exist.
         if (
             not drop
-            and not isinstance(self.index, pandas.MultiIndex)
+            and not self._query_compiler.has_multiindex()
             and all(n in self.columns for n in ["level_0", "index"])
         ):
             raise ValueError("cannot insert level_0, already exists")

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -432,7 +432,7 @@ class DataFrame(BasePandasDataset):
             drop = by in self.columns
             idx_name = by
             if (
-                isinstance(self.axes[axis], pandas.MultiIndex)
+                self._query_compiler.has_multiindex(axis=axis)
                 and by in self.axes[axis].names
             ):
                 # In this case we pass the string value of the name through to the
@@ -2011,7 +2011,7 @@ class DataFrame(BasePandasDataset):
         names = []
         if append:
             names = [x for x in self.index.names]
-            if isinstance(self.index, pandas.MultiIndex):
+            if self._query_compiler.has_multiindex():
                 for i in range(self.index.nlevels):
                     arrays.append(self.index._get_level_values(i))
             else:
@@ -2423,7 +2423,7 @@ class DataFrame(BasePandasDataset):
         """
         key = apply_if_callable(key, self)
         # Shortcut if key is an actual column
-        is_mi_columns = isinstance(self.columns, pandas.MultiIndex)
+        is_mi_columns = self._query_compiler.has_multiindex(axis=1)
         try:
             if key in self.columns and not is_mi_columns:
                 return self._getitem_column(key)

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -338,7 +338,7 @@ class _LocIndexer(_LocationIndexerBase):
             row_lookup = self.qc.index.get_indexer_for(
                 self.qc.index.to_series().loc[row_loc]
             )
-        elif isinstance(self.qc.index, pandas.MultiIndex):
+        elif self.qc.has_multiindex():
             if isinstance(row_loc, pandas.MultiIndex):
                 row_lookup = self.qc.index.get_indexer_for(row_loc)
             else:
@@ -352,7 +352,7 @@ class _LocIndexer(_LocationIndexerBase):
             col_lookup = self.qc.columns.get_indexer_for(
                 self.qc.columns.to_series().loc[col_loc]
             )
-        elif isinstance(self.qc.columns, pandas.MultiIndex):
+        elif self.qc.has_multiindex(axis=1):
             if isinstance(col_loc, pandas.MultiIndex):
                 col_lookup = self.qc.columns.get_indexer_for(col_loc)
             else:


### PR DESCRIPTION
## What do these changes do?
Another refactoring to move index accesses to backend to enable lazy computations
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1934 <!-- issue must be created for each patch -->
- [x] tests passing
