### PR TITLE
FEAT-#1936: avoid empty frame checks for lazy backend

### DIFF
--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -45,6 +45,8 @@ class BaseQueryCompiler(abc.ABC):
     # some of these abstract methods, but for the sake of generality they are
     # treated differently.
 
+    lazy_execution = False
+
     # Metadata modification abstract methods
     @abc.abstractmethod
     def add_prefix(self, prefix, axis=1):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3438,7 +3438,7 @@ class BasePandasDataset(object):
         return self.ge(right)
 
     def __getitem__(self, key):
-        if len(self) == 0:
+        if not self._query_compiler.lazy_execution and len(self) == 0:
             return self._default_to_pandas("__getitem__", key)
         # see if we can slice the rows
         # This lets us reuse code in Pandas to error check
@@ -3569,7 +3569,7 @@ class BasePandasDataset(object):
             "_create_or_update_from_compiler",
             "_update_inplace",
         ]
-        if item not in default_behaviors:
+        if item not in default_behaviors and not self._query_compiler.lazy_execution:
             method = object.__getattribute__(self, item)
             is_callable = callable(method)
             # We default to pandas on empty DataFrames. This avoids a large amount of

--- a/modin/pandas/concat.py
+++ b/modin/pandas/concat.py
@@ -106,7 +106,8 @@ def concat(
     list_of_objs = [
         obj._query_compiler
         for obj in list_of_objs
-        if len(obj.index) or len(obj.columns)
+        if (not obj._query_compiler.lazy_execution and len(obj.index))
+        or len(obj.columns)
     ]
     if keys is not None:
         if all_series:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1134,7 +1134,7 @@ class DataFrame(BasePandasDataset):
             # TODO: Remove broadcast of Series
             value = value._to_pandas()
 
-        if len(self.index) == 0:
+        if not self._query_compiler.lazy_execution and len(self.index) == 0:
             try:
                 value = pandas.Series(value)
             except (TypeError, ValueError, IndexError):
@@ -2577,7 +2577,7 @@ class DataFrame(BasePandasDataset):
             if not isinstance(value, Series):
                 value = list(value)
 
-        if len(self.index) == 0:
+        if not self._query_compiler.lazy_execution and len(self.index) == 0:
             new_self = DataFrame({key: value}, columns=self.columns)
             self._update_inplace(new_self._query_compiler)
         else:


### PR DESCRIPTION
## What do these changes do?
Avoid checks for empty frames when lazy backend is used. This might affect semantics for lazy engines in corner cases, but we are OK with that.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1936  <!-- issue must be created for each patch -->
- [ ] tests added and passing
