### PR TITLE
REFACTOR-#1938: avoid index access in a simple column reference

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3442,9 +3442,14 @@ class BasePandasDataset(object):
             return self._default_to_pandas("__getitem__", key)
         # see if we can slice the rows
         # This lets us reuse code in Pandas to error check
-        indexer = convert_to_index_sliceable(
-            getattr(pandas, type(self).__name__)(index=self.index), key
-        )
+        indexer = None
+        if isinstance(key, slice) or (
+            isinstance(key, str)
+            and (not hasattr(self, "columns") or key not in self.columns)
+        ):
+            indexer = convert_to_index_sliceable(
+                getattr(pandas, type(self).__name__)(index=self.index), key
+            )
         if indexer is not None:
             return self._getitem_slice(indexer)
         else:


### PR DESCRIPTION
## What do these changes do?
This patch allows column references without index access which is essential for lazy engine.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1938  <!-- issue must be created for each patch -->
- [x] tests passing
