### PR TITLE
REFACTOR-#1941: move index access from DataFrame.insert to backend

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -1898,6 +1898,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 value = value.reindex(self.index)
             else:
                 value = list(value)
+        else:
+            value = [value] * len(self.index)
 
         def insert(df, internal_indices=[]):
             internal_idx = int(internal_indices[0])

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1159,9 +1159,11 @@ class DataFrame(BasePandasDataset):
                 data=value, columns=[column], index=self.index
             )._query_compiler
         else:
-            if not is_list_like(value):
-                value = np.full(len(self.index), value)
-            if not isinstance(value, pandas.Series) and len(value) != len(self.index):
+            if (
+                is_list_like(value)
+                and not isinstance(value, pandas.Series)
+                and len(value) != len(self.index)
+            ):
                 raise ValueError("Length of values does not match length of index")
             if not allow_duplicates and column in self.columns:
                 raise ValueError("cannot insert {0}, already exists".format(column))


### PR DESCRIPTION
## What do these changes do?
Avoid index access in API layer when scalar is inserted as a new column.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1941  <!-- issue must be created for each patch -->
- [x] tests passing
