### PR TITLE
TEST-#1950: improve TestDataFrameIter test time

### DIFF
--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5424,10 +5424,9 @@ class TestDataFrameIndexing:
 
 
 class TestDataFrameIter:
-    @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-    def test_items(self, data):
-        modin_df = pd.DataFrame(data)
-        pandas_df = pandas.DataFrame(data)
+    def test_items(self):
+        modin_df = pd.DataFrame(test_data_values[0])
+        pandas_df = pandas.DataFrame(test_data_values[0])
 
         modin_items = modin_df.items()
         pandas_items = pandas_df.items()
@@ -5437,10 +5436,9 @@ class TestDataFrameIter:
             df_equals(pandas_series, modin_series)
             assert pandas_index == modin_index
 
-    @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-    def test_iteritems(self, data):
-        modin_df = pd.DataFrame(data)
-        pandas_df = pandas.DataFrame(data)
+    def test_iteritems(self):
+        modin_df = pd.DataFrame(test_data_values[0])
+        pandas_df = pandas.DataFrame(test_data_values[0])
 
         modin_items = modin_df.iteritems()
         pandas_items = pandas_df.iteritems()
@@ -5450,10 +5448,9 @@ class TestDataFrameIter:
             df_equals(pandas_series, modin_series)
             assert pandas_index == modin_index
 
-    @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-    def test_iterrows(self, data):
-        modin_df = pd.DataFrame(data)
-        pandas_df = pandas.DataFrame(data)
+    def test_iterrows(self):
+        modin_df = pd.DataFrame(test_data_values[0])
+        pandas_df = pandas.DataFrame(test_data_values[0])
 
         modin_iterrows = modin_df.iterrows()
         pandas_iterrows = pandas_df.iterrows()
@@ -5465,7 +5462,6 @@ class TestDataFrameIter:
 
     @pytest.mark.parametrize("name", [None, "NotPandas", "Pandas"])
     @pytest.mark.parametrize("index", [True, False])
-    # @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test_itertuples(self, name, index):
         modin_df = pd.DataFrame(test_data_values[0])
         pandas_df = pandas.DataFrame(test_data_values[0])
@@ -5488,10 +5484,9 @@ class TestDataFrameIter:
         for modin_row, pandas_row in zip(modin_it_custom, pandas_it_custom):
             np.testing.assert_equal(modin_row, pandas_row)
 
-    @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-    def test___iter__(self, data):
-        modin_df = pd.DataFrame(data)
-        pandas_df = pandas.DataFrame(data)
+    def test___iter__(self):
+        modin_df = pd.DataFrame(test_data_values[0])
+        pandas_df = pandas.DataFrame(test_data_values[0])
 
         modin_iterator = modin_df.__iter__()
 

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -5465,16 +5465,10 @@ class TestDataFrameIter:
 
     @pytest.mark.parametrize("name", [None, "NotPandas", "Pandas"])
     @pytest.mark.parametrize("index", [True, False])
-    @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-    def test_itertuples(self, name, index, data):
-        modin_df = pd.DataFrame(data)
-        pandas_df = pandas.DataFrame(data)
-
-        # test default
-        modin_it_default = modin_df.itertuples()
-        pandas_it_default = pandas_df.itertuples()
-        for modin_row, pandas_row in zip(modin_it_default, pandas_it_default):
-            np.testing.assert_equal(modin_row, pandas_row)
+    # @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+    def test_itertuples(self, name, index):
+        modin_df = pd.DataFrame(test_data_values[0])
+        pandas_df = pandas.DataFrame(test_data_values[0])
 
         modin_it_custom = modin_df.itertuples(index=index, name=name)
         pandas_it_custom = pandas_df.itertuples(index=index, name=name)
@@ -5489,11 +5483,6 @@ class TestDataFrameIter:
         )
         modin_df.columns = mi_index_modin
         pandas_df.columns = mi_index_pandas
-        modin_it_default = modin_df.itertuples()
-        pandas_it_default = pandas_df.itertuples()
-        for modin_row, pandas_row in zip(modin_it_default, pandas_it_default):
-            np.testing.assert_equal(modin_row, pandas_row)
-
         modin_it_custom = modin_df.itertuples(index=index, name=name)
         pandas_it_custom = pandas_df.itertuples(index=index, name=name)
         for modin_row, pandas_row in zip(modin_it_custom, pandas_it_custom):


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

1) Removed `itertuples` call with default values, because this set of parameters is specified explicitly.
2) Iteration should not depend on the type of values in the dataframe, so it is suggested to use only the first dataset from `test_data_values` variable. (test coverage did not decrease after these changes; these changes save **more than 6 hours for CI**)
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1950 <!-- issue must be created for each patch -->
- [x] tests added and passing
