### PR TITLE
FIX-#1679: Assignment df.loc["row"]["col"] fixed in case of one row

### DIFF
--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -302,6 +302,8 @@ class BaseFrameManager(object):
             A new BaseFrameManager object, the type of object that called this.
         """
         if type(right_parts) is list:
+            # filtering empty frames
+            right_parts = [o for o in right_parts if o.size != 0]
             return np.concatenate([left_parts] + right_parts, axis=axis)
         else:
             return np.append(left_parts, right_parts, axis=axis)

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -302,7 +302,9 @@ class BaseFrameManager(object):
             A new BaseFrameManager object, the type of object that called this.
         """
         if type(right_parts) is list:
-            # filtering empty frames
+            # `np.array` with partitions of empty ModinFrame has a shape (0,)
+            # but `np.concatenate` can concatenate arrays only if its shapes at
+            # specified axis are equals, so filtering empty frames to avoid concat error
             right_parts = [o for o in right_parts if o.size != 0]
             return np.concatenate([left_parts] + right_parts, axis=axis)
         else:

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -4677,26 +4677,16 @@ class TestDataFrameIndexing:
         df_equals(modin_df.loc[modin_df.index], pandas_df.loc[pandas_df.index])
         df_equals(modin_df.loc[modin_df.index[:7]], pandas_df.loc[pandas_df.index[:7]])
 
-    def test_loc_assignment(self):
-        modin_df = pd.DataFrame(
-            index=["row1", "row2", "row3"], columns=["col1", "col2"]
-        )
-        pandas_df = pandas.DataFrame(
-            index=["row1", "row2", "row3"], columns=["col1", "col2"]
-        )
-        modin_df.loc["row1"]["col1"] = 11
-        modin_df.loc["row2"]["col1"] = 21
-        modin_df.loc["row3"]["col1"] = 31
-        modin_df.loc["row1"]["col2"] = 12
-        modin_df.loc["row2"]["col2"] = 22
-        modin_df.loc["row3"]["col2"] = 32
-        pandas_df.loc["row1"]["col1"] = 11
-        pandas_df.loc["row2"]["col1"] = 21
-        pandas_df.loc["row3"]["col1"] = 31
-        pandas_df.loc["row1"]["col2"] = 12
-        pandas_df.loc["row2"]["col2"] = 22
-        pandas_df.loc["row3"]["col2"] = 32
-        df_equals(modin_df, pandas_df)
+    @pytest.mark.parametrize("index", [["row1", "row2", "row3"], ["row1"]])
+    @pytest.mark.parametrize("columns", [["col1", "col2"], ["col1"]])
+    def test_loc_assignment(self, index, columns):
+        md_df, pd_df = create_test_dfs(index=index, columns=columns)
+        for i, ind in enumerate(index):
+            for j, col in enumerate(columns):
+                value_to_assign = int(str(i) + str(j))
+                md_df.loc[ind][col] = value_to_assign
+                pd_df.loc[ind][col] = value_to_assign
+        df_equals(md_df, pd_df)
 
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test_loc_nested_assignment(self, data):


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1679 <!-- issue must be created for each patch -->
- [x] tests added and passing
