### PR TITLE
FIX-#1953: Fix computing of reduced indices for reduction operation

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1655,29 +1655,6 @@ class BasePandasDataset(object):
             )
         )
 
-    def median(self, axis=None, skipna=None, level=None, numeric_only=None, **kwargs):
-        """Computes median across the DataFrame.
-
-        Args:
-            axis (int): The axis to take the median on.
-            skipna (bool): True to skip NA values, false otherwise.
-
-        Returns:
-            The median of the DataFrame. (Pandas series)
-        """
-        axis = self._get_axis_number(axis) if axis is not None else 0
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
-        return self._reduce_dimension(
-            self._query_compiler.median(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                numeric_only=numeric_only,
-                **kwargs,
-            )
-        )
-
     def memory_usage(self, index=True, deep=False):
         """Returns the memory usage of each column in bytes
 
@@ -1862,52 +1839,6 @@ class BasePandasDataset(object):
             "pow", other, axis=axis, level=level, fill_value=fill_value
         )
 
-    def prod(
-        self,
-        axis=None,
-        skipna=None,
-        level=None,
-        numeric_only=None,
-        min_count=0,
-        **kwargs,
-    ):
-        """Return the product of the values for the requested axis
-
-        Args:
-            axis : {index (0), columns (1)}
-            skipna : boolean, default True
-            level : int or level name, default None
-            numeric_only : boolean, default None
-            min_count : int, default 0
-
-        Returns:
-            prod : Series or DataFrame (if level specified)
-        """
-        axis = self._get_axis_number(axis) if axis is not None else 0
-        data = self._validate_dtypes_sum_prod_mean(axis, numeric_only, ignore_axis=True)
-        if min_count > 1:
-            return data._reduce_dimension(
-                query_compiler=data._query_compiler.prod_min_count(
-                    axis=axis,
-                    skipna=skipna,
-                    level=level,
-                    numeric_only=numeric_only,
-                    min_count=min_count,
-                    **kwargs,
-                )
-            )
-        return data._reduce_dimension(
-            data._query_compiler.prod(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                numeric_only=numeric_only,
-                min_count=min_count,
-                **kwargs,
-            )
-        )
-
-    product = prod
     radd = add
 
     def quantile(self, q=0.5, axis=0, numeric_only=True, interpolation="linear"):
@@ -2733,32 +2664,6 @@ class BasePandasDataset(object):
         else:
             return self.tshift(periods, freq)
 
-    def skew(self, axis=None, skipna=None, level=None, numeric_only=None, **kwargs):
-        """Return unbiased skew over requested axis Normalized by N-1
-
-        Args:
-            axis : {index (0), columns (1)}
-            skipna : boolean, default True
-            Exclude NA/null values when computing the result.
-            level : int or level name, default None
-            numeric_only : boolean, default None
-
-        Returns:
-            skew : Series or DataFrame (if level specified)
-        """
-        axis = self._get_axis_number(axis) if axis is not None else 0
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
-        return self._reduce_dimension(
-            self._query_compiler.skew(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                numeric_only=numeric_only,
-                **kwargs,
-            )
-        )
-
     def sort_index(
         self,
         axis=0,
@@ -2842,33 +2747,6 @@ class BasePandasDataset(object):
             )
         return self._create_or_update_from_compiler(result, inplace)
 
-    def std(
-        self, axis=None, skipna=None, level=None, ddof=1, numeric_only=None, **kwargs
-    ):
-        """Computes standard deviation across the DataFrame.
-
-        Args:
-            axis (int): The axis to take the std on.
-            skipna (bool): True to skip NA values, false otherwise.
-            ddof (int): degrees of freedom
-
-        Returns:
-            The std of the DataFrame (Pandas Series)
-        """
-        axis = self._get_axis_number(axis) if axis is not None else 0
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
-        return self._reduce_dimension(
-            self._query_compiler.std(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                ddof=ddof,
-                numeric_only=numeric_only,
-                **kwargs,
-            )
-        )
-
     def sub(self, other, axis="columns", level=None, fill_value=None):
         """Subtract a DataFrame/Series/scalar from this DataFrame.
 
@@ -2886,50 +2764,6 @@ class BasePandasDataset(object):
         )
 
     subtract = sub
-
-    def sum(
-        self,
-        axis=None,
-        skipna=None,
-        level=None,
-        numeric_only=None,
-        min_count=0,
-        **kwargs,
-    ):
-        """Perform a sum across the DataFrame.
-
-        Args:
-            axis (int): The axis to sum on.
-            skipna (bool): True to skip NA values, false otherwise.
-
-        Returns:
-            The sum of the DataFrame.
-        """
-        axis = self._get_axis_number(axis) if axis is not None else 0
-        data = self._validate_dtypes_sum_prod_mean(
-            axis, numeric_only, ignore_axis=False
-        )
-        if min_count > 1:
-            return data._reduce_dimension(
-                query_compiler=data._query_compiler.sum_min_count(
-                    axis=axis,
-                    skipna=skipna,
-                    level=level,
-                    numeric_only=numeric_only,
-                    min_count=min_count,
-                    **kwargs,
-                )
-            )
-        return data._reduce_dimension(
-            data._query_compiler.sum(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                numeric_only=numeric_only,
-                min_count=min_count,
-                **kwargs,
-            )
-        )
 
     def swapaxes(self, axis1, axis2, copy=True):
         axis1 = self._get_axis_number(axis1)
@@ -3332,33 +3166,6 @@ class BasePandasDataset(object):
             .index
         )
         return self.set_axis(labels=new_labels, axis=axis, inplace=not copy)
-
-    def var(
-        self, axis=None, skipna=None, level=None, ddof=1, numeric_only=None, **kwargs
-    ):
-        """Computes variance across the DataFrame.
-
-        Args:
-            axis (int): The axis to take the variance on.
-            skipna (bool): True to skip NA values, false otherwise.
-            ddof (int): degrees of freedom
-
-        Returns:
-            The variance of the DataFrame.
-        """
-        axis = self._get_axis_number(axis) if axis is not None else 0
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
-        return self._reduce_dimension(
-            self._query_compiler.var(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                ddof=ddof,
-                numeric_only=numeric_only,
-                **kwargs,
-            )
-        )
 
     def __abs__(self):
         """Creates a modified DataFrame by taking the absolute value.

--- a/modin/pandas/test/dataframe/test_reduction.py
+++ b/modin/pandas/test/dataframe/test_reduction.py
@@ -279,6 +279,18 @@ def test_prod(
         ),
     )
 
+    # test for issue #1953
+    arrays = [["1", "1", "2", "2"], ["1", "2", "3", "4"]]
+    modin_df = pd.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    pandas_df = pandas.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    modin_result = modin_df.prod(level=0)
+    pandas_result = pandas_df.prod(level=0)
+    df_equals(modin_result, pandas_result)
+
 
 @pytest.mark.parametrize(
     "numeric_only",
@@ -314,6 +326,18 @@ def test_sum(data, axis, skipna, is_transposed):
             skipna=skipna,
         ),
     )
+
+    # test for issue #1953
+    arrays = [["1", "1", "2", "2"], ["1", "2", "3", "4"]]
+    modin_df = pd.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    pandas_df = pandas.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    modin_result = modin_df.sum(level=0)
+    pandas_result = pandas_df.sum(level=0)
+    df_equals(modin_result, pandas_result)
 
 
 @pytest.mark.parametrize(

--- a/modin/pandas/test/dataframe/test_window.py
+++ b/modin/pandas/test/dataframe/test_window.py
@@ -570,6 +570,18 @@ def test_median(request, data, axis, skipna, numeric_only):
         )
         df_equals(modin_result, pandas_result)
 
+    # test for issue #1953
+    arrays = [["1", "1", "2", "2"], ["1", "2", "3", "4"]]
+    modin_df = pd.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    pandas_df = pandas.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    modin_result = modin_df.median(level=0)
+    pandas_result = pandas_df.median(level=0)
+    df_equals(modin_result, pandas_result)
+
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
@@ -782,6 +794,18 @@ def test_skew(request, data, axis, skipna, numeric_only):
         )
         df_equals(modin_result, pandas_result)
 
+    # test for issue #1953
+    arrays = [["1", "1", "2", "2"], ["1", "2", "3", "4"]]
+    modin_df = pd.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    pandas_df = pandas.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    modin_result = modin_df.skew(level=0)
+    pandas_result = pandas_df.skew(level=0)
+    df_equals(modin_result, pandas_result)
+
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
@@ -823,6 +847,18 @@ def test_std(request, data, axis, skipna, numeric_only, ddof):
             axis=axis, skipna=skipna, numeric_only=numeric_only, ddof=ddof
         )
         df_equals(modin_result, pandas_result)
+
+    # test for issue #1953
+    arrays = [["1", "1", "2", "2"], ["1", "2", "3", "4"]]
+    modin_df = pd.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    pandas_df = pandas.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    modin_result = modin_df.std(level=0)
+    pandas_result = pandas_df.std(level=0)
+    df_equals(modin_result, pandas_result)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
@@ -872,3 +908,15 @@ def test_var(request, data, axis, skipna, numeric_only, ddof):
         modin_result = modin_df.T.var(
             axis=axis, skipna=skipna, numeric_only=numeric_only, ddof=ddof
         )
+
+    # test for issue #1953
+    arrays = [["1", "1", "2", "2"], ["1", "2", "3", "4"]]
+    modin_df = pd.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    pandas_df = pandas.DataFrame(
+        [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]], index=arrays
+    )
+    modin_result = modin_df.var(level=0)
+    pandas_result = pandas_df.var(level=0)
+    df_equals(modin_result, pandas_result)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1971,6 +1971,17 @@ def test_median(data, skipna):
     modin_series, pandas_series = create_test_series(data)
     df_equals(modin_series.median(skipna=skipna), pandas_series.median(skipna=skipna))
 
+    # test for issue #1953
+    arrays = [
+        ["1", "1", "1", "2", "2", "2", "3", "3", "3"],
+        ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    ]
+    modin_series = pd.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    pandas_series = pandas.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    modin_result = modin_series.median(level=0)
+    pandas_result = pandas_series.median(level=0)
+    df_equals(modin_result, pandas_result)
+
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("index", [True, False], ids=["True", "False"])
@@ -2199,6 +2210,17 @@ def test_prod(data, axis, skipna, numeric_only, min_count, operation):
         numeric_only=numeric_only,
         min_count=min_count,
     )
+
+    # test for issue #1953
+    arrays = [
+        ["1", "1", "1", "2", "2", "2", "3", "3", "3"],
+        ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    ]
+    modin_series = pd.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    pandas_series = pandas.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    modin_result = modin_series.prod(level=0)
+    pandas_result = pandas_series.prod(level=0)
+    df_equals(modin_result, pandas_result)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
@@ -2660,6 +2682,17 @@ def test_skew(data, skipna):
     modin_series, pandas_series = create_test_series(data)
     df_equals(modin_series.skew(skipna=skipna), pandas_series.skew(skipna=skipna))
 
+    # test for issue #1953
+    arrays = [
+        ["1", "1", "1", "2", "2", "2", "3", "3", "3"],
+        ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    ]
+    modin_series = pd.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    pandas_series = pandas.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    modin_result = modin_series.skew(level=0)
+    pandas_result = pandas_series.skew(level=0)
+    df_equals(modin_result, pandas_result)
+
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("index", ["default", "ndarray"])
@@ -2778,6 +2811,17 @@ def test_std(request, data, skipna, ddof):
         modin_result = modin_series.std(skipna=skipna, ddof=ddof)
         df_equals(modin_result, pandas_result)
 
+    # test for issue #1953
+    arrays = [
+        ["1", "1", "1", "2", "2", "2", "3", "3", "3"],
+        ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    ]
+    modin_series = pd.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    pandas_series = pandas.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    modin_result = modin_series.std(level=0)
+    pandas_result = pandas_series.std(level=0)
+    df_equals(modin_result, pandas_result)
+
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_sub(data):
@@ -2825,6 +2869,17 @@ def test_sum(data, axis, skipna, numeric_only, min_count):
         numeric_only=numeric_only,
         min_count=min_count,
     )
+
+    # test for issue #1953
+    arrays = [
+        ["1", "1", "1", "2", "2", "2", "3", "3", "3"],
+        ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    ]
+    modin_series = pd.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    pandas_series = pandas.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    modin_result = modin_series.sum(level=0)
+    pandas_result = pandas_series.sum(level=0)
+    df_equals(modin_result, pandas_result)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
@@ -3203,6 +3258,17 @@ def test_var(data, skipna, ddof):
     else:
         modin_result = modin_series.var(skipna=skipna, ddof=ddof)
         df_equals(modin_result, pandas_result)
+
+    # test for issue #1953
+    arrays = [
+        ["1", "1", "1", "2", "2", "2", "3", "3", "3"],
+        ["1", "2", "3", "4", "5", "6", "7", "8", "9"],
+    ]
+    modin_series = pd.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    pandas_series = pandas.Series([3, 3, 3, 3, 3, 3, 3, 3, 3], index=arrays)
+    modin_result = modin_series.var(level=0)
+    pandas_result = pandas_series.var(level=0)
+    df_equals(modin_result, pandas_result)
 
 
 def test_view():


### PR DESCRIPTION
Signed-off-by: Igoshev, Yaroslav <yaroslav.igoshev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1953  <!-- issue must be created for each patch -->
- [x] tests added and passing
