### PR TITLE
TEST-#1961: speed up TestDataFrameReduction_* test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: "3.7.x"
           architecture: "x64"
-      - run: pip install "black==19.10b0"
+      - run: pip install black
       - run: black --check --diff modin/
 
   lint-flake8:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,7 +180,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
         engine: ["python", "ray", "dask"]
-        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        part: ["Reduction", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000
@@ -284,7 +284,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
         engine: ["ray", "dask"]
-        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        part: ["Reduction", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           python-version: "3.7.x"
           architecture: "x64"
-      - run: pip install black
+      - run: pip install "black==19.10b0"
       - run: black --check --diff modin/
 
   lint-flake8:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -44,7 +44,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
         engine: ["python", "ray", "dask"]
-        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        part: ["Reduction", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000
@@ -110,7 +110,7 @@ jobs:
       matrix:
         python-version: ["3.6", "3.7", "3.8"]
         engine: ["ray", "dask"]
-        part: ["Reduction_A", "Reduction_B", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
+        part: ["Reduction", "Binary", "MapMetadata", "UDF", "Default", "Window", "Indexing", "Iter", "JoinSort", 3]
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -3004,7 +3004,7 @@ class TestDataFrameDefault:
             assert modin_result == pandas_result
 
 
-class TestDataFrameReduction_A:
+class TestDataFrameReduction:
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     @pytest.mark.parametrize("axis", [None, 0, 1])
     @pytest.mark.parametrize("method", ["all", "any"])
@@ -3058,13 +3058,11 @@ class TestDataFrameReduction_A:
             modin_df, pandas_df, lambda df: getattr(df, method)(axis=axis, level=level),
         )
 
-
-class TestDataFrameReduction_B:
     @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
     @pytest.mark.parametrize(
         "numeric_only",
         [
-            pytest.param(True, marks=pytest.mark.xfail(reason="See #1965")),
+            pytest.param(True, marks=pytest.mark.xfail(reason="See #1965 for details")),
             False,
             None,
         ],
@@ -3085,7 +3083,7 @@ class TestDataFrameReduction_B:
             lambda df: df.count(axis=axis, numeric_only=numeric_only),
         )
 
-        '''
+        """
             @pytest.mark.parametrize(
         "numeric_only", bool_arg_values, ids=arg_keys("numeric_only", bool_arg_keys)
     )
@@ -3137,7 +3135,7 @@ class TestDataFrameReduction_B:
                     axis=axis, numeric_only=numeric_only, level=level
                 )
                 df_equals(modin_multi_level_result, pandas_multi_level_result)
-        '''
+        """
 
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
     def test_describe(self, data):

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -3321,34 +3321,39 @@ class TestDataFrameReduction:
             min_count=min_count,
         )
 
-    @pytest.mark.parametrize(
-        "data",
-        test_data_values + test_data_small_values,
-        ids=test_data_keys + test_data_small_keys,
-    )
-    @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
+    @pytest.mark.parametrize("is_transposed", [False, True])
     @pytest.mark.parametrize(
         "skipna", bool_arg_values, ids=arg_keys("skipna", bool_arg_keys)
     )
-    @pytest.mark.parametrize(
-        "numeric_only", bool_arg_values, ids=arg_keys("numeric_only", bool_arg_keys)
-    )
-    @pytest.mark.parametrize(
-        "min_count", int_arg_values, ids=arg_keys("min_count", int_arg_keys)
-    )
-    @pytest.mark.parametrize("is_transposed", [False, True])
-    def test_sum(
-        self, request, data, axis, skipna, numeric_only, min_count, is_transposed
-    ):
+    @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
+    @pytest.mark.parametrize("data", [test_data["dense_nan_data"]])
+    def test_sum(self, data, axis, skipna, is_transposed):
         eval_general(
             *create_test_dfs(data),
-            lambda df, *args, **kwargs: (df.T if is_transposed else df).sum(
-                *args, **kwargs
+            lambda df: (df.T if is_transposed else df).sum(
+                axis=axis,
+                skipna=skipna,
             ),
-            axis=axis,
-            skipna=skipna,
-            numeric_only=numeric_only,
-            min_count=min_count,
+        )
+
+    @pytest.mark.parametrize(
+        "numeric_only",
+        [
+            pytest.param(None, marks=pytest.mark.xfail(reason="See #1976 for details")),
+            False,
+            True,
+        ],
+    )
+    @pytest.mark.parametrize("min_count", int_arg_values)
+    def test_sum_specific(self, min_count, numeric_only):
+        data = {
+            "float_col": [np.NaN, 9.4, 10.1, np.NaN],
+            "str_col": ["a", np.NaN, "c", "d"],
+            "bool_col": [False, True, True, False],
+        }
+        eval_general(
+            *create_test_dfs(data),
+            lambda df: df.sum(min_count=min_count, numeric_only=numeric_only),
         )
 
     @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -3191,6 +3191,10 @@ class TestDataFrameReduction:
             ),
         )
 
+    @pytest.mark.skipif(
+        os.name == "nt",
+        reason="Windows has a memory issue for large numbers on this test",
+    )
     @pytest.mark.parametrize(
         "method",
         [

--- a/modin/pandas/test/test_dataframe.py
+++ b/modin/pandas/test/test_dataframe.py
@@ -60,6 +60,7 @@ from .utils import (
     udf_func_values,
     udf_func_keys,
     generate_multiindex,
+    test_data_diff_dtype,
 )
 
 pd.DEFAULT_NPARTITIONS = 4
@@ -3022,13 +3023,9 @@ class TestDataFrameReduction:
         "bool_only", bool_arg_values, ids=arg_keys("bool_only", bool_arg_keys)
     )
     def test_all_any_specific(self, bool_only, method):
-        data = {
-            "float_col": [np.NaN, 9.4, 10.1, np.NaN],
-            "str_col": ["a", np.NaN, "c", "d"],
-            "bool_col": [False, True, True, False],
-        }
         eval_general(
-            *create_test_dfs(data), lambda df: getattr(df, method)(bool_only=bool_only)
+            *create_test_dfs(test_data_diff_dtype),
+            lambda df: getattr(df, method)(bool_only=bool_only),
         )
 
     @pytest.mark.parametrize("method", ["all", "any"])
@@ -3070,13 +3067,8 @@ class TestDataFrameReduction:
         ],
     )
     def test_count_specific(self, numeric_only):
-        data = {
-            "float_col": [np.NaN, 9.4, 10.1, np.NaN],
-            "str_col": ["a", np.NaN, "c", "d"],
-            "bool_col": [False, True, True, False],
-        }
         eval_general(
-            *create_test_dfs(data),
+            *create_test_dfs(test_data_diff_dtype),
             lambda df: df.count(numeric_only=numeric_only),
         )
 
@@ -3120,13 +3112,11 @@ class TestDataFrameReduction:
         ],
     )
     def test_describe_specific(self, exclude, include):
-        data = {
-            "float_col": [np.NaN, 9.4, 10.1, np.NaN],
-            "bool_col": [False, True, True, False],
-        }
         eval_general(
-            *create_test_dfs(data),
-            lambda df: df.describe(exclude=exclude, include=include),
+            *create_test_dfs(test_data_diff_dtype),
+            lambda df: df.drop("str_col", axis=1).describe(
+                exclude=exclude, include=include
+            ),
         )
 
     @pytest.mark.parametrize("data", [test_data["int_data"]])
@@ -3251,14 +3241,8 @@ class TestDataFrameReduction:
     def test_prod_specific(self, min_count, numeric_only):
         if min_count == 5 and numeric_only:
             pytest.xfail("see #1953 for details")
-
-        data = {
-            "float_col": [np.NaN, 9.4, 10.1, np.NaN],
-            "str_col": ["a", np.NaN, "c", "d"],
-            "bool_col": [False, True, True, False],
-        }
         eval_general(
-            *create_test_dfs(data),
+            *create_test_dfs(test_data_diff_dtype),
             lambda df: df.prod(min_count=min_count, numeric_only=numeric_only),
         )
 
@@ -3287,13 +3271,8 @@ class TestDataFrameReduction:
     )
     @pytest.mark.parametrize("min_count", int_arg_values)
     def test_sum_specific(self, min_count, numeric_only):
-        data = {
-            "float_col": [np.NaN, 9.4, 10.1, np.NaN],
-            "str_col": ["a", np.NaN, "c", "d"],
-            "bool_col": [False, True, True, False],
-        }
         eval_general(
-            *create_test_dfs(data),
+            *create_test_dfs(test_data_diff_dtype),
             lambda df: df.sum(min_count=min_count, numeric_only=numeric_only),
         )
 
@@ -4111,7 +4090,6 @@ class TestDataFrameWindow:
             modin_result = modin_df.T.var(
                 axis=axis, skipna=skipna, numeric_only=numeric_only, ddof=ddof
             )
-            df_equals(modin_result, pandas_result)
 
 
 class TestDataFrameIndexing:

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -174,6 +174,13 @@ test_data_small = {
     }
 }
 
+test_data_diff_dtype = {
+    "int_col": [-5, 2, 7, 16],
+    "float_col": [np.NaN, -9.4, 10.1, np.NaN],
+    "str_col": ["a", np.NaN, "c", "d"],
+    "bool_col": [False, True, True, False],
+}
+
 test_data_small_values = list(test_data_small.values())
 test_data_small_keys = list(test_data_small.keys())
 

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -127,6 +127,13 @@ test_data["with_index_column"]["index"] = test_data["with_index_column"].pop(
 test_data_values = list(test_data.values())
 test_data_keys = list(test_data.keys())
 
+test_bool_data = {
+    "col{}".format(int((i - NCOLS / 2) % NCOLS + 1)): random_state.choice(
+        [True, False], size=(NROWS)
+    )
+    for i in range(NCOLS)
+}
+
 test_data_with_duplicates = {
     "no_duplicates": {
         "col{}".format(int((i - NCOLS / 2) % NCOLS + 1)): range(NROWS)
@@ -681,10 +688,10 @@ def generate_multiindex_dfs(axis=1):
     return df1, df2
 
 
-def generate_multiindex(cols_number):
+def generate_multiindex(elements_number):
     arrays = [
-        random_state.choice(["bar", "baz", "foo", "qux"], cols_number),
-        random_state.choice(["one", "two"], cols_number),
+        random_state.choice(["bar", "baz", "foo", "qux"], elements_number),
+        random_state.choice(["one", "two"], elements_number),
     ]
     return pd.MultiIndex.from_tuples(list(zip(*arrays)), names=["first", "second"])
 


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1961 <!-- issue must be created for each patch -->
- [x] tests added and passing
