### PR TITLE
TEST-2022: speed up prepare-cache job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,19 +70,11 @@ jobs:
         with:
           path: ~\AppData\Local\pip\Cache
           key: ${{ runner.os }}-python-${{ matrix.python-version }}-pip-${{ github.run_id }}-${{ hashFiles('environment.yml') }}
-      - uses: goanpeca/setup-miniconda@v1.6.0
+      - uses: actions/setup-python@v2
         with:
           python-version: ${{matrix.python-version}}
-          channel-priority: strict
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          auto-update-conda: true
-      - shell: bash -l {0}
-        run: pip install ray==0.8.7
-      - name: Conda environment
-        shell: bash -l {0}
-        run: |
-          conda info
-          conda list
+          architecture: "x64"
+      - run: pip install ray==0.8.7
 
   test-api:
     needs: prepare-cache


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Speed up prepare-cache job by ~2 minutes.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2022  <!-- issue must be created for each patch -->
- [ ] tests added and passing
