### PR TITLE
REFACTOR-#2035: move getitem_array to the backend

### DIFF
--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -834,6 +834,23 @@ class BaseQueryCompiler(abc.ABC):
 
     # Abstract __getitem__ methods
     @abc.abstractmethod
+    def getitem_array(self, key):
+        """
+        Get column or row data specified by key.
+
+        Parameters
+        ----------
+        key : BaseQueryCompiler, numpy.ndarray, pandas.Index or list
+            Target numeric indices or labels by which to retrieve data.
+
+        Returns
+        -------
+        BaseQueryCompiler
+            A new Query Compiler.
+        """
+        pass
+
+    @abc.abstractmethod
     def getitem_column_array(self, key):
         """Get column data for target labels.
 


### PR DESCRIPTION
## What do these changes do?
This patch moves `getitem_array` implementation from API level to the backend. This allows OmniSci backend to have its own implementation with a lazy bool indexer support.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2035  <!-- issue must be created for each patch -->
- [x] tests passing
