### PR TITLE
FEAT-#2058: Improve how remote factories are defined

### DIFF
--- a/modin/data_management/__init__.py
+++ b/modin/data_management/__init__.py
@@ -10,3 +10,20 @@
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
+
+from . import factories
+
+
+def _get_remote_engines():
+    for name in dir(factories):
+        obj = getattr(factories, name)
+        if isinstance(obj, type) and issubclass(
+            obj, factories.ExperimentalRemoteFactory
+        ):
+            try:
+                yield obj.get_info().engine
+            except factories.NotRealFactory:
+                pass
+
+
+REMOTE_ENGINES = set(_get_remote_engines())

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -16,6 +16,7 @@ import inspect
 import types
 
 from modin import execution_engine
+from modin.data_management import REMOTE_ENGINES
 
 # the attributes that must be alwasy taken from a local part of dual-nature class,
 # never going to remote end
@@ -153,7 +154,7 @@ def make_wrapped_class(local_cls: type, rpyc_wrapper_name: str):
     _KNOWN_DUALS[local_cls] = result
 
     def update_class(_):
-        if execution_engine.get() == "Cloudray":
+        if execution_engine.get() in REMOTE_ENGINES:
             from . import rpyc_proxy
 
             result.__real_cls__ = getattr(rpyc_proxy, rpyc_wrapper_name)(result)

--- a/modin/experimental/pandas/numpy_wrap.py
+++ b/modin/experimental/pandas/numpy_wrap.py
@@ -27,6 +27,7 @@ else:
     import types
     import copyreg
     from modin import execution_engine
+    from modin.data_management import REMOTE_ENGINES
     import modin
     import pandas
     import os
@@ -78,7 +79,7 @@ else:
                 self.__has_to_warn = False
 
         def __update_engine(self, _):
-            if execution_engine.get() == "Cloudray":
+            if execution_engine.get() in REMOTE_ENGINES:
                 from modin.experimental.cloud import get_connection
 
                 self.__swap_numpy(get_connection().modules["numpy"])

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -134,9 +134,8 @@ def _update_engine(publisher: Publisher):
 
     elif publisher.get() == "Cloudray":
         from modin.experimental.cloud import get_connection
-        import rpyc
 
-        conn: rpyc.ClassicService = get_connection()
+        conn = get_connection()
         remote_ray = conn.modules["ray"]
         if _is_first_update.get("Cloudray", True):
 
@@ -159,7 +158,6 @@ def _update_engine(publisher: Publisher):
             import modin.data_management.dispatcher  # noqa: F401
 
         num_cpus = remote_ray.cluster_resources()["CPU"]
-
     elif publisher.get() not in _NOINIT_ENGINES:
         raise ImportError("Unrecognized execution engine: {}.".format(publisher.get()))
 


### PR DESCRIPTION
## What do these changes do?
* Extract common part of defining proxying factory to a separate class
* Change how other parts of code check for engine being a remote one
* Determine the list of remote engines from defined factories automatically

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2058
- [ ] tests added and passing
