### PR TITLE
Fix pickle support for DataFrame and Series

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3257,9 +3257,6 @@ class BasePandasDataset(object):
             return self.copy()
         return self.iloc[key]
 
-    def __getstate__(self):
-        return self._default_to_pandas("__getstate__")
-
     def __gt__(self, right):
         return self.gt(right)
 
@@ -3351,6 +3348,8 @@ class BasePandasDataset(object):
         default_behaviors = [
             "__init__",
             "__class__",
+            "__reduce__",
+            "__inflate__",
             "_get_index",
             "_set_index",
             "empty",

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -3121,8 +3121,12 @@ class DataFrame(BasePandasDataset):
     def __round__(self, decimals=0):
         return self._default_to_pandas(pandas.DataFrame.__round__, decimals=decimals)
 
-    def __setstate__(self, state):
-        return self._default_to_pandas(pandas.DataFrame.__setstate__, state)
+    @classmethod
+    def __inflate__(self, pandas_df):
+        return from_pandas(pandas_df)
+
+    def __reduce__(self):
+        return self.__inflate__, (self._to_pandas(),)
 
     def __delitem__(self, key):
         """Delete a column by key. `del a[key]` for example.

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -62,7 +62,6 @@ matplotlib.use("Agg")
         ("lookup", lambda df: {"row_labels": [0], "col_labels": ["int_col"]}),
         ("mask", lambda df: {"cond": df != 0}),
         ("pct_change", None),
-        ("__getstate__", None),
         ("to_xarray", None),
         ("pivot_table", lambda df: {"values": "int_col", "index": ["float_col"]}),
     ],

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -82,15 +82,6 @@ def test_style():
         pd.DataFrame(data).style
 
 
-def test___setstate__():
-    data = test_data_values[0]
-    with pytest.warns(UserWarning):
-        try:
-            pd.DataFrame(data).__setstate__(None)
-        except TypeError:
-            pass
-
-
 def test_to_timestamp():
     idx = pd.date_range("1/1/2012", periods=5, freq="M")
     df = pd.DataFrame(np.random.randint(0, 100, size=(len(idx), 4)), index=idx)

--- a/modin/pandas/test/dataframe/test_pickle.py
+++ b/modin/pandas/test/dataframe/test_pickle.py
@@ -1,0 +1,39 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pytest
+import pickle
+
+import modin.pandas as pd
+
+from modin.pandas.test.utils import df_equals
+
+
+@pytest.fixture
+def modin_df():
+    return pd.DataFrame({"col1": [1, 2, 3], "col2": [3, 4, 5]})
+
+
+@pytest.fixture
+def modin_column(modin_df):
+    return modin_df["col1"]
+
+
+def test_dataframe_pickle(modin_df):
+    other = pickle.loads(pickle.dumps(modin_df))
+    df_equals(modin_df, other)
+
+
+def test_column_pickle(modin_column):
+    other = pickle.loads(pickle.dumps(modin_column))
+    df_equals(modin_column.to_frame(), other.to_frame())


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Implement fine-grained control over how `DataFrame` and `Series` objects are pickled and restored.
Main idea is to really pickle Pandas counterparts and restore Modin objects from them upon unpickling.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #672
- [x] tests added and passing
