### PR TITLE
FIX-#1997 #2084: Fix `unstack` for case when columns are non-tree MultiIndex

### DIFF
--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -717,11 +717,13 @@ def generate_multiindex(elements_number, nlevels=2, is_tree_like=False):
 
         lvl_len = int(lvl_len_d)
         result = pd.MultiIndex.from_product(
-            [generate_level(lvl_len, i) for i in range(nlevels - penalty_level)]
+            [generate_level(lvl_len, i) for i in range(nlevels - penalty_level)],
+            names=[f"level-{i}" for i in range(nlevels - penalty_level)],
         )
         if penalty_level:
             result = pd.MultiIndex.from_tuples(
-                [("base_level", *ml_tuple) for ml_tuple in result]
+                [("base_level", *ml_tuple) for ml_tuple in result],
+                names=[f"level-{i}" for i in range(nlevels)],
             )
         return result.sort_values()
     else:


### PR DESCRIPTION
Fix `unstack` for case when columns are non-tree MultiIndex

Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1997 and #2084  <!-- issue must be created for each patch -->
- [x] tests added and passing
