### PR TITLE
Fix test_from_csv for simulated remote case

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -343,6 +343,40 @@ jobs:
       - shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash)
 
+  test-cloud:
+    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    runs-on: ubuntu-latest
+    env:
+      MODIN_ENGINE: "python"
+      MODIN_EXPERIMENTAL: "True"
+      MODIN_MEMORY: 1000000000
+    name: test cloud
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Cache pip
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-python-3.7-pip-${{ github.run_id }}-${{ hashFiles('environment.yml') }}
+      - uses: goanpeca/setup-miniconda@v1.6.0
+        with:
+          activate-environment: modin
+          environment-file: environment.yml
+          python-version: 3.7
+          channel-priority: strict
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+      - name: Conda environment
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+      - shell: bash -l {0}
+        run: python -m pytest --simulate-cloud=normal modin/pandas/test/test_io.py::test_from_csv
+      - shell: bash -l {0}
+        run: bash <(curl -s https://codecov.io/bash)
+
   test-windows:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
     runs-on: windows-latest

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -24,28 +24,62 @@ def pytest_addoption(parser):
     )
 
 
+class Patcher:
+    def __init__(self, conn, *pairs):
+        self.pairs = pairs
+        self.originals = None
+        self.conn = conn
+
+    def __wrap(self, func):
+        def wrapper(*a, **kw):
+            return func(
+                *(tuple(self.conn.obtain(x) for x in a)),
+                **({k: self.conn.obtain(v) for k, v in kw.items()}),
+            )
+
+        return func, wrapper
+
+    def __enter__(self):
+        self.originals = []
+        for module, attrname in self.pairs:
+            orig, wrapped = self.__wrap(getattr(module, attrname))
+            self.originals.append((module, attrname, orig))
+            setattr(module, attrname, wrapped)
+        return self
+
+    def __exit__(self, *a, **kw):
+        for module, attrname, orig in self.originals:
+            setattr(module, attrname, orig)
+
+
+def set_experimental_env(mode):
+    import os
+
+    os.environ["MODIN_EXPERIMENTAL"] = "True" if mode == "experimental" else "False"
+
+
 @pytest.fixture(scope="session", autouse=True)
 def simulate_cloud(request):
     mode = request.config.getoption("--simulate-cloud").lower()
     if mode == "off":
         yield
         return
+
     if mode not in ("normal", "experimental"):
         raise ValueError(f"Unsupported --simulate-cloud mode: {mode}")
     assert (
         os.environ.get("MODIN_EXPERIMENTAL", "").title() == "True"
-    ), "Simulated cloud must be stared in experimental mode"
+    ), "Simulated cloud must be started in experimental mode"
 
     from modin.experimental.cloud import create_cluster, get_connection
+    import pandas._testing
+    import pandas._libs.testing as cyx_testing
 
     with create_cluster("local", __spawner__="local"):
-
-        def set_env(mode):
-            import os
-
-            os.environ["MODIN_EXPERIMENTAL"] = (
-                "True" if mode == "experimental" else "False"
-            )
-
-        get_connection().teleport(set_env)(mode)
-        yield
+        get_connection().teleport(set_experimental_env)(mode)
+        with Patcher(
+            get_connection(),
+            (pandas._testing, "assert_class_equal"),
+            (cyx_testing, "assert_almost_equal"),
+        ):
+            yield

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -32,7 +32,9 @@ def simulate_cloud(request):
         return
     if mode not in ("normal", "experimental"):
         raise ValueError(f"Unsupported --simulate-cloud mode: {mode}")
-    os.environ["MODIN_EXPERIMENTAL"] = "True"
+    assert (
+        os.environ.get("MODIN_EXPERIMENTAL", "").title() == "True"
+    ), "Simulated cloud must be stared in experimental mode"
 
     from modin.experimental.cloud import create_cluster, get_connection
 

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -34,6 +34,10 @@ def _tuplize(arg):
     return tuple(arg)
 
 
+def _pickled_array(obj):
+    return pickle.dumps(obj.__array__())
+
+
 _TRACE_RPYC = os.environ.get("MODIN_TRACE_RPYC", "").title() == "True"
 
 
@@ -45,6 +49,7 @@ class WrappingConnection(rpyc.Connection):
         self._static_cache = collections.defaultdict(dict)
         self._remote_dumps = None
         self._remote_tuplize = None
+        self._remote_pickled_array = None
 
     def __wrap(self, local_obj):
         while True:
@@ -185,6 +190,9 @@ class WrappingConnection(rpyc.Connection):
 
         So we're patching RPyC netref __getattribute__ to keep a reference
         for certain read-only properties to better emulate local objects.
+
+        Also __array__() implementation works only for numpy arrays, but not other types,
+        like scalars (which should become arrays)
         """
         result = super()._netref_factory(id_pack)
         cls = type(result)
@@ -201,7 +209,11 @@ class WrappingConnection(rpyc.Connection):
                     return res
             return orig_getattribute(this, name)
 
+        def __array__(this):
+            return pickle.loads(self._remote_pickled_array(this))
+
         cls.__getattribute__ = __getattribute__
+        cls.__array__ = __array__
         return result
 
     def _netref_factory(self, id_pack):
@@ -256,13 +268,11 @@ class WrappingConnection(rpyc.Connection):
         return super()._box(obj)
 
     def _init_deliver(self):
-        self._remote_batch_loads = self.modules[
-            "modin.experimental.cloud.rpyc_proxy"
-        ]._batch_loads
+        remote_proxy = self.modules["modin.experimental.cloud.rpyc_proxy"]
+        self._remote_batch_loads = remote_proxy._batch_loads
         self._remote_dumps = self.modules["rpyc.lib.compat"].pickle.dumps
-        self._remote_tuplize = self.modules[
-            "modin.experimental.cloud.rpyc_proxy"
-        ]._tuplize
+        self._remote_tuplize = remote_proxy._tuplize
+        self._remote_pickled_array = remote_proxy._pickled_array
 
 
 class WrappingService(rpyc.ClassicService):

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -95,7 +95,9 @@ class WrappingConnection(rpyc.Connection):
                 remote = object.__getattribute__(remote, "__remote_end__")
             except AttributeError:
                 break
-        return pickle.loads(self._remote_dumps(remote))
+        if isinstance(remote, netref.BaseNetref) and remote.____conn__ is self:
+            return pickle.loads(self._remote_dumps(remote))
+        return remote
 
     def obtain_tuple(self, remote):
         while True:

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -198,9 +198,8 @@ class WrappingConnection(rpyc.Connection):
         """
         result = super()._netref_factory(id_pack)
         cls = type(result)
-        if not hasattr(cls, "__patched__"):
+        if not hasattr(cls, "__readonly_cache__"):
             orig_getattribute = cls.__getattribute__
-            # import pdb;pdb.set_trace()
             type.__setattr__(cls, "__readonly_cache__", {})
 
             def __getattribute__(this, name):
@@ -218,7 +217,6 @@ class WrappingConnection(rpyc.Connection):
 
             cls.__getattribute__ = __getattribute__
             cls.__array__ = __array__
-            cls.__patched__ = True
         return result
 
     def _netref_factory(self, id_pack):


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Both adapt local testing to possibility of having a remote proxy (by transferring the proxy by-value as low in the call hierarchy as possible) and by fixing `obj.__array__()` method.

With these changes applied, `python -m pytest --simulate-cloud=normal modin\pandas\test\test_io.py::test_from_csv` pass.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2100 
- [x] tests added and passing
