### PR TITLE
FIX-#2110: get rid of 'NotImplementedError' at OmniSci query compiler

### DIFF
--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -219,7 +219,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
         Parameters
         ----------
-        by : PandasQueryCompiler
+        by : DFAlgQueryCompiler
             The column to group by
         func_dict : dict of str, callable/string
             The dictionary mapping of column to function
@@ -232,7 +232,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
         Returns
         -------
-        PandasQueryCompiler
+        DFAlgQueryCompiler
             The result of the per-column aggregations on the grouped dataframe.
         """
         # TODO: handle drop arg
@@ -342,7 +342,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
     def _bin_op(self, other, op_name, **kwargs):
         level = kwargs.get("level", None)
         if level is not None:
-            raise NotImplementedError(f"{op_name} doesn't support levels")
+            getattr(super(), op_name)(other=other, op_name=op_name, **kwargs)
 
         if isinstance(other, DFAlgQueryCompiler):
             shape_hint = (
@@ -391,7 +391,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
     def reset_index(self, **kwargs):
         level = kwargs.get("level", None)
         if level is not None:
-            raise NotImplementedError("reset_index doesn't support level arg yet")
+            return super().reset_index(**kwargs)
 
         drop = kwargs.get("drop", False)
         shape_hint = self._shape_hint if drop else None
@@ -424,11 +424,8 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         Returns:
              A new QueryCompiler
         """
-        if axis == 1:
-            raise NotImplementedError("setitem doesn't support axis 1")
-
-        if not isinstance(value, type(self)):
-            raise NotImplementedError("unsupported value for setitem")
+        if axis == 1 or not isinstance(value, type(self)):
+            super().setitem(axis=axis, key=key, value=value)
 
         return self._setitem(axis, key, value)
 
@@ -443,12 +440,10 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             value: Dtype object values to insert.
 
         Returns:
-            A new PandasQueryCompiler with new data inserted.
+            A new DFAlgQueryCompiler with new data inserted.
         """
         if is_list_like(value):
-            raise NotImplementedError(
-                "non-scalar values are not supported by insert yet"
-            )
+            super().insert(loc=loc, column=column, value=value)
 
         return self.__constructor__(self._modin_frame.insert(loc, column, value))
 
@@ -464,7 +459,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
         Returns
         -------
-        PandasQueryCompiler
+        DFAlgQueryCompiler
             A new query compiler that contains result of the sort
         """
         ignore_index = kwargs.get("ignore_index", False)
@@ -472,25 +467,6 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         return self.__constructor__(
             self._modin_frame.sort_rows(columns, ascending, ignore_index, na_position),
             self._shape_hint,
-        )
-
-    def sort_columns_by_row_values(self, rows, ascending=True, **kwargs):
-        """Reorder the columns based on the lexicographic order of the given rows.
-
-        Parameters
-        ----------
-        rows : scalar or list of scalar
-            The row or rows to sort by
-        ascending : bool
-            Sort in ascending order (True) or descending order (False)
-
-        Returns
-        -------
-        PandasQueryCompiler
-            A new query compiler that contains result of the sort
-        """
-        raise NotImplementedError(
-            "column sorting is not yet suported in DFAlgQueryCompiler"
         )
 
     def columnarize(self):

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -11,7 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from modin.backends.base.query_compiler import BaseQueryCompiler
+from modin.backends.base.query_compiler import (
+    BaseQueryCompiler,
+    _set_axis as default_axis_setter,
+)
 from modin.backends.pandas.query_compiler import PandasQueryCompiler
 
 import pandas
@@ -248,7 +251,9 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         return self._modin_frame.index
 
     def _set_index(self, index):
-        self._modin_frame.index = index
+        default_axis_setter(0)(self, index)
+        # NotImplementedError: OmnisciOnRayFrame._set_index is not yet suported
+        # self._modin_frame.index = index
 
     def _get_columns(self):
         return self._modin_frame.columns
@@ -342,7 +347,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
     def _bin_op(self, other, op_name, **kwargs):
         level = kwargs.get("level", None)
         if level is not None:
-            getattr(super(), op_name)(other=other, op_name=op_name, **kwargs)
+            return getattr(super(), op_name)(other=other, op_name=op_name, **kwargs)
 
         if isinstance(other, DFAlgQueryCompiler):
             shape_hint = (
@@ -425,7 +430,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
              A new QueryCompiler
         """
         if axis == 1 or not isinstance(value, type(self)):
-            super().setitem(axis=axis, key=key, value=value)
+            return super().setitem(axis=axis, key=key, value=value)
 
         return self._setitem(axis, key, value)
 
@@ -443,7 +448,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             A new DFAlgQueryCompiler with new data inserted.
         """
         if is_list_like(value):
-            super().insert(loc=loc, column=column, value=value)
+            return super().insert(loc=loc, column=column, value=value)
 
         return self.__constructor__(self._modin_frame.insert(loc, column, value))
 

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -409,8 +409,8 @@ class TestConcat:
             df.insert(0, "qc_column", df["new_int"])
             return df
 
-        # setting `force_laze=False`, because `to_pandas` is not supported
-        # in lazy frame mode
+        # setting `force_lazy=False`, because we're expecting to fallback
+        # to pandas in that case, which is not supported in lazy mode
         run_and_compare(applier, data=self.data, force_lazy=False)
 
     def test_concat_many(self):
@@ -952,6 +952,8 @@ class TestBinaryOp:
             df2.index = generate_multiindex(len(df2))
             return df1.add(df2, level=1)
 
+        # setting `force_lazy=False`, because we're expecting to fallback
+        # to pandas in that case, which is not supported in lazy mode
         run_and_compare(applier, data=self.data, data2=self.data, force_lazy=False)
 
     def test_add_cst(self):
@@ -1227,7 +1229,7 @@ class TestSort:
             ignore_index=ignore_index,
             index_cols=index_cols,
             ascending=ascending,
-            # we're excecting to fallback to pandas in that case,
+            # we're expecting to fallback to pandas in that case,
             # which is not supported in lazy mode
             force_lazy=(index_cols is None),
         )

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -727,9 +727,9 @@ def generate_multiindex(elements_number, nlevels=2, is_tree_like=False):
             )
         return result.sort_values()
     else:
-        base_level = ["first"] * (elements_number // 2) + ["second"] * (
-            elements_number // 2
-        )
+        base_level = ["first"] * (elements_number // 2 + elements_number % 2) + [
+            "second"
+        ] * (elements_number // 2)
         primary_levels = [generate_level(elements_number, i) for i in range(1, nlevels)]
         arrays = [base_level] + primary_levels
         return pd.MultiIndex.from_tuples(


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2110 <!-- issue must be created for each patch -->
- [x] tests added and passing
