### PR TITLE
FIX-#2115: Use `seek` when we don't need to check quotes for CSV

### DIFF
--- a/modin/engines/base/io/text/text_file_reader.py
+++ b/modin/engines/base/io/text/text_file_reader.py
@@ -100,18 +100,19 @@ class TextFileReader(FileReader):
 
         outside_quotes = True
 
-        chunk = f.read(chunk_size_bytes)
-        line = f.readline()  # Ensure we read up to a newline
-        # We need to ensure that one row isn't being split across different partitions
-
         if is_quoting:
+            chunk = f.read(chunk_size_bytes)
+            line = f.readline()  # Ensure we read up to a newline
+            # We need to ensure that one row isn't split across different partitions
             outside_quotes = not ((chunk.count(quotechar) + line.count(quotechar)) % 2)
             while not outside_quotes:
                 line = f.readline()
                 outside_quotes = line.count(quotechar) % 2
                 if not line:
                     break
-
+        else:
+            f.seek(chunk_size_bytes, os.SEEK_CUR)
+            f.readline()
         return outside_quotes
 
     @classmethod


### PR DESCRIPTION
Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2115 <!-- issue must be created for each patch -->
- [ ] tests added and passing
