### PR TITLE
Enable OmniSci on cloud

### DIFF
--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -75,7 +75,7 @@ def simulate_cloud(request):
     import pandas._testing
     import pandas._libs.testing as cyx_testing
 
-    with create_cluster("local", __spawner__="local"):
+    with create_cluster("local", cluster_type="local"):
         get_connection().teleport(set_experimental_env)(mode)
         with Patcher(
             get_connection(),

--- a/modin/data_management/factories/dispatcher.py
+++ b/modin/data_management/factories/dispatcher.py
@@ -25,12 +25,10 @@ class StubIoEngine(object):
     def __init__(self, factory_name=""):
         self.factory_name = factory_name or "Unknown"
 
-    def __getattribute__(self, name):
-        factory_name = self.factory_name  # for closure to bind the value
-
+    def __getattr__(self, name):
         def stub(*args, **kw):
             raise NotImplementedError(
-                "Method {}.{} is not implemented".format(factory_name, name)
+                f"Method {self.factory_name}.{name} is not implemented"
             )
 
         return stub

--- a/modin/data_management/factories/factories.py
+++ b/modin/data_management/factories/factories.py
@@ -311,3 +311,7 @@ class ExperimentalOmnisciOnRayFactory(BaseFactory):
         from modin.experimental.engines.omnisci_on_ray.io import OmnisciOnRayIO
 
         cls.io_cls = OmnisciOnRayIO
+
+
+class ExperimentalOmnisciOnCloudrayFactory(ExperimentalRemoteFactory):
+    wrapped_factory = ExperimentalOmnisciOnRayFactory

--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -208,7 +208,7 @@ def create(
     workers: int = 4,
     head_node: str = None,
     worker_node: str = None,
-    __spawner__: str = "rayscale",
+    cluster_type: str = "rayscale",
 ) -> BaseCluster:
     """
     Creates an instance of a cluster with desired characteristics in a cloud.
@@ -243,9 +243,9 @@ def create(
         What machine type to use for head node in the cluster.
     worker_node : str, optional
         What machine type to use for worker nodes in the cluster.
-    __spawner__ : str, optional, internal
+    cluster_type : str, optional
         How to spawn the cluster.
-        Currently only spawning by Ray autoscaler ("rayscale") is supported
+        Currently spawning by Ray autoscaler ("rayscale" for general and "omnisci" for Omnisci-based) is supported
 
     Returns
     -------
@@ -262,7 +262,7 @@ def create(
 
     Using SOCKS proxy requires Ray newer than 0.8.6, which might need to be installed manually.
     """
-    if not isinstance(provider, Provider) and __spawner__ != "local":
+    if not isinstance(provider, Provider) and cluster_type != "local":
         provider = Provider(
             name=provider,
             credentials_file=credentials,
@@ -276,12 +276,14 @@ def create(
                 "Ignoring credentials, region, zone and image parameters because provider is specified as Provider descriptor, not as name",
                 UserWarning,
             )
-    if __spawner__ == "rayscale":
+    if cluster_type == "rayscale":
         from .rayscale import RayCluster as Spawner
-    elif __spawner__ == "local":
+    elif cluster_type == "omnisci":
+        from .omnisci import RemoteOmnisci as Spawner
+    elif cluster_type == "local":
         from .local_cluster import LocalCluster as Spawner
     else:
-        raise ValueError(f"Unknown spawner: {__spawner__}")
+        raise ValueError(f"Unknown cluster type: {cluster_type}")
     instance = Spawner(
         provider,
         project_name,

--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -99,6 +99,7 @@ class BaseCluster:
 
     target_engine = None
     target_partition = None
+    wrap_cmd = None
     Connector = Connection
 
     def __init__(
@@ -142,7 +143,9 @@ class BaseCluster:
             # cluster is ready now
             if self.connection is None:
                 self.connection = self.Connector(
-                    self._get_connection_details(), self._get_main_python()
+                    self._get_connection_details(),
+                    self._get_main_python(),
+                    self.wrap_cmd,
                 )
 
     def destroy(self, wait=False):

--- a/modin/experimental/cloud/connection.py
+++ b/modin/experimental/cloud/connection.py
@@ -37,13 +37,16 @@ class Connection:
         except subprocess.TimeoutExpired:
             return None
 
-    def __init__(self, details: ConnectionDetails, main_python: str, log_rpyc=None):
+    def __init__(
+        self, details: ConnectionDetails, main_python: str, wrap_cmd=None, log_rpyc=None
+    ):
         self.log_rpyc = (
             log_rpyc
             if log_rpyc is not None
             else os.environ.get("MODIN_LOG_RPYC", "").title() == "True"
         )
         self.proc = None
+        self.wrap_cmd = wrap_cmd or subprocess.list2cmdline
 
         # find where rpyc_classic is located
         locator = self._run(
@@ -199,7 +202,7 @@ class Connection:
     def _run(self, sshcmd: list, cmd: list, capture_out: bool = True):
         redirect = self._redirect(capture_out)
         return subprocess.Popen(
-            sshcmd + [subprocess.list2cmdline(cmd)],
+            sshcmd + [self.wrap_cmd(cmd)],
             stdin=subprocess.DEVNULL,
             stdout=redirect,
             stderr=redirect,

--- a/modin/experimental/cloud/omnisci.py
+++ b/modin/experimental/cloud/omnisci.py
@@ -1,0 +1,39 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import warnings
+
+from .rayscale import RayCluster
+from .cluster import Provider
+
+
+class RemoteOmnisci(RayCluster):
+    target_engine = "Cloudray"
+    target_partition = "Omnisci"
+
+    def __init__(
+        self,
+        provider: Provider,
+        project_name: str = None,
+        cluster_name: str = "modin-cluster",
+        worker_count: int = 0,
+        head_node_type: str = None,
+        worker_node_type: str = None,
+    ):
+        if worker_count != 0:
+            warnings.warn(
+                "Current Omnisci on cloud does not support multi-node setups, not requesting worker nodes"
+            )
+        super().__init__(
+            provider, project_name, cluster_name, 0, head_node_type, worker_node_type
+        )

--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -114,16 +114,15 @@ initialization_commands: []
 # List of shell commands to run to set up nodes.
 setup_commands:
     - |
-        # need to install python 3.7.6
         wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O ~/miniconda.sh
         bash ~/miniconda.sh -b -p ~/miniconda -f -u
         $HOME/miniconda/bin/conda init bash
         source ~/.bashrc
         conda create --name modin --yes
         conda activate modin
-        conda install --yes {{CONDA_PACKAGES}}
+        conda install --yes --override-channels -c intel/label/validation -c conda-forge modin {{CONDA_PACKAGES}}
 
-        pip install modin "ray==0.8.7" cloudpickle
+        pip install colorful cloudpickle
         # ray now executes "ray stop" which expects "ray" to be in $PATH
         # so place a symlink to current "ray" binary to /usr/local/bin
         sudo ln -s `which ray` /usr/local/bin/ray

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -17,6 +17,7 @@ import traceback
 import sys
 from hashlib import sha1
 from typing import Callable
+import subprocess
 
 import yaml
 from ray.autoscaler.commands import (
@@ -235,3 +236,16 @@ class RayCluster(BaseCluster):
         Gets the path to 'main' interpreter (the one that houses created environment for running everything)
         """
         return "~/miniconda/envs/modin/bin/python"
+
+    def wrap_cmd(self, cmd: list):
+        """
+        Wraps command into required incantation for bash to read ~/.bashrc which is needed
+        to make "conda foo" commands work
+        """
+        return subprocess.list2cmdline(
+            [
+                "bash",
+                "-ic",
+                subprocess.list2cmdline(["conda", "run", "-n", "modin"] + cmd),
+            ]
+        )

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -145,22 +145,26 @@ def _update_engine(publisher: Publisher):
         if _is_first_update.get("Cloudray", True):
 
             @conn.teleport
-            def init_remote_ray():
+            def init_remote_ray(partition):
                 from ray import ray_constants
                 import modin
                 from modin.engines.ray.utils import initialize_ray
 
-                modin.set_backends("Ray")
+                modin.set_backends("Ray", partition)
                 initialize_ray(
                     override_is_cluster=True,
                     override_redis_address=f"localhost:{ray_constants.DEFAULT_PORT}",
                     override_redis_password=ray_constants.REDIS_DEFAULT_PASSWORD,
                 )
 
-            init_remote_ray()
+            init_remote_ray(partition_format.get())
             # import EngineDispatcher here to initialize IO class
             # so it doesn't skew read_csv() timings later on
             import modin.data_management.factories.dispatcher  # noqa: F401
+        else:
+            get_connection().modules["modin"].set_backends(
+                "Ray", partition_format.get()
+            )
 
         num_cpus = remote_ray.cluster_resources()["CPU"]
     elif publisher.get() == "Cloudpython":

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -41,7 +41,7 @@ from .utils import (
 )
 from .iterator import PartitionIterator
 from .series import Series
-from .base import BasePandasDataset
+from .base import BasePandasDataset, _ATTRS_NO_LOOKUP
 from .groupby import DataFrameGroupBy
 
 
@@ -3082,7 +3082,7 @@ class DataFrame(BasePandasDataset):
         try:
             return object.__getattribute__(self, key)
         except AttributeError as e:
-            if key in self.columns:
+            if key not in _ATTRS_NO_LOOKUP and key in self.columns:
                 return self[key]
             raise e
 

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -27,7 +27,7 @@ from typing import Union, Optional
 import warnings
 
 from modin.utils import _inherit_docstrings, to_pandas
-from .base import BasePandasDataset
+from .base import BasePandasDataset, _ATTRS_NO_LOOKUP
 from .iterator import PartitionIterator
 from .utils import from_pandas, is_scalar
 
@@ -270,7 +270,7 @@ class Series(BasePandasDataset):
         try:
             return object.__getattribute__(self, key)
         except AttributeError as e:
-            if key in self.index:
+            if key not in _ATTRS_NO_LOOKUP and key in self.index:
                 return self[key]
             raise e
 


### PR DESCRIPTION
<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
**Note**: this changes API of `create_cluster()` by renaming `__spawner__` (considered internal) to `cluster_type` (considered public).

This enables running workloads remotely on Omnisci-enabled Modin.
This also changes Modin installation to be `conda`-based (because OmniSci Python engine is published only in conda for now).

With those changes, `taxi-runner.py --omnisci` runs fine.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1991 
- [ ] tests added and passing
