### PR TITLE
Do not always require pyarrow

### DIFF
--- a/modin/backends/__init__.py
+++ b/modin/backends/__init__.py
@@ -16,7 +16,7 @@ from .pandas import PandasQueryCompiler
 
 __all__ = ["BaseQueryCompiler", "PandasQueryCompiler"]
 try:
-    from .pyarrow import PyarrowQueryCompiler
+    from .pyarrow import PyarrowQueryCompiler  # noqa: F401
 except ImportError:
     pass
 else:

--- a/modin/backends/__init__.py
+++ b/modin/backends/__init__.py
@@ -13,6 +13,11 @@
 
 from .base import BaseQueryCompiler
 from .pandas import PandasQueryCompiler
-from .pyarrow import PyarrowQueryCompiler
 
-__all__ = ["BaseQueryCompiler", "PandasQueryCompiler", "PyarrowQueryCompiler"]
+__all__ = ["BaseQueryCompiler", "PandasQueryCompiler"]
+try:
+    from .pyarrow import PyarrowQueryCompiler
+except ImportError:
+    pass
+else:
+    __all__.append("PyarrowQueryCompiler")


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Relax requirements on having `pyarrow` installed.
After these changes if there is `pyarrow` is only required to have `modin.backends.PyarrowQueryCompiler`, base and Pandas backends always exist.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2090 
- [ ] tests added and passing
