### PR TITLE
FIX-#2134: Fix mismatch partitioning insertions with same index

### DIFF
--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1156,6 +1156,16 @@ def test___setitem__(data):
     df_equals(modin_df, pandas_df)
 
 
+def test___setitem__with_mismatched_partitions():
+    fname = "200kx99.csv"
+    np.savetxt(fname, np.random.randint(0, 100, size=(200_000, 99)), delimiter=",")
+    modin_df = pd.read_csv(fname)
+    pandas_df = pandas.read_csv(fname)
+    modin_df["new"] = pd.Series(list(range(len(modin_df))))
+    pandas_df["new"] = pandas.Series(list(range(len(pandas_df))))
+    df_equals(modin_df, pandas_df)
+
+
 def test___setitem__mask():
     # DataFrame mask:
     data = test_data["int_data"]


### PR DESCRIPTION
Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Add a simple shuffle internal mechanism to have more performant insertions and concatenation when index objects already match.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2134  <!-- issue must be created for each patch -->
- [x] tests added and passing
