### PR TITLE
FIX-#2145: add cloud dependencies to conda dev environment

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -30,7 +30,7 @@ dependencies:
   - coverage<5.0
   - pygithub==1.53
   - rpyc==4.1.5
-  - cloudpickle
+  - cloudpickle==1.4.1
   - boto3
   - pip:
     - ray==0.8.7

--- a/environment.yml
+++ b/environment.yml
@@ -29,6 +29,8 @@ dependencies:
   - pytest-xdist>=2.1.0
   - coverage<5.0
   - pygithub==1.53
+  - rpyc==4.1.5
+  - cloudpickle
+  - boto3
   - pip:
     - ray==0.8.7
-    - rpyc==4.1.5

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ class ModinDistribution(Distribution):
 
 dask_deps = ["dask>=2.12.0", "distributed>=2.12.0"]
 ray_deps = ["ray==0.8.7", "pyarrow<0.17"]
-remote_deps = ["rpyc==4.1.5", "cloudpickle", "boto3==1.4.8"]
+remote_deps = ["rpyc==4.1.5", "cloudpickle==1.4.1", "boto3==1.4.8"]
 
 all_deps = dask_deps + ray_deps + remote_deps
 


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
* Pin cloudpickle to 1.4.1 to avoid `ValueError: pickle protocol must be <= 4` problem for mortgage-runner.py.
* Add boto3 to dev environment.
* Move rpyc from pip section to avoid conflicts of versions of packages installed with conda.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2145 <!-- issue must be created for each patch -->
- [ ] tests added and passing
