### PR TITLE
FIX-#2147: return interval for python micro version - *.*.X

### DIFF
--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -167,7 +167,7 @@ class RayCluster(BaseCluster):
         major = sys.version_info.major
         minor = sys.version_info.minor
         micro = sys.version_info.micro
-        return [f"python>{major}.{minor}", f"python<={major}.{minor}.{micro}"]
+        return [f"python>={major}.{minor}", f"python<={major}.{minor}.{micro}"]
 
     @staticmethod
     def __save_config(config):

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -146,7 +146,7 @@ class RayCluster(BaseCluster):
 
         reqs = []
 
-        reqs.append(f"python=={self._get_python_version()}")
+        reqs.extend(self._get_python_version())
 
         if self.add_conda_packages:
             reqs.extend(self.add_conda_packages)
@@ -167,7 +167,7 @@ class RayCluster(BaseCluster):
         major = sys.version_info.major
         minor = sys.version_info.minor
         micro = sys.version_info.micro
-        return f"{major}.{minor}.{micro}"
+        return [f"python>{major}.{minor}", f"python<={major}.{minor}.{micro}"]
 
     @staticmethod
     def __save_config(config):

--- a/modin/experimental/cloud/test/test_cloud.py
+++ b/modin/experimental/cloud/test/test_cloud.py
@@ -11,9 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-import sys
 import unittest.mock as mock
 import pytest
+from collections import namedtuple
 from modin.experimental.cloud.rayscale import RayCluster
 from modin.experimental.cloud.cluster import Provider
 
@@ -30,11 +30,8 @@ from modin.experimental.cloud.cluster import Provider
     ],
 )
 def test_update_conda_requirements(setup_commands_source):
-    major = sys.version_info.major
-    minor = sys.version_info.minor
-    micro = sys.version_info.micro
-    python_version_lower = f"python>{major}.{minor}"
-    python_version_higher = f"python<={major}.{minor}.{micro}"
+    major, minor, micro = 7, 12, 45
+    version_info = {"major": major, "minor": minor, "micro": micro}
 
     with mock.patch(
         "modin.experimental.cloud.rayscale._bootstrap_config", lambda config: config
@@ -43,11 +40,14 @@ def test_update_conda_requirements(setup_commands_source):
             Provider(name="aws"), add_conda_packages=["scikit-learn>=0.23"]
         )
 
-    setup_commands_result = ray_cluster._update_conda_requirements(
-        setup_commands_source
-    )
+    with mock.patch(
+        "sys.version_info", namedtuple("mock", version_info.keys())(**version_info)
+    ):
+        setup_commands_result = ray_cluster._update_conda_requirements(
+            setup_commands_source
+        )
 
-    assert python_version_lower in setup_commands_result
-    assert python_version_higher in setup_commands_result
+    assert f"python>={major}.{minor}" in setup_commands_result
+    assert f"python<={major}.{minor}.{micro}" in setup_commands_result
     assert "scikit-learn>=0.23" in setup_commands_result
     assert "{{CONDA_PACKAGES}}" not in setup_commands_result

--- a/modin/experimental/cloud/test/test_cloud.py
+++ b/modin/experimental/cloud/test/test_cloud.py
@@ -30,9 +30,6 @@ from modin.experimental.cloud.cluster import Provider
     ],
 )
 def test_update_conda_requirements(setup_commands_source):
-    major, minor, micro = 7, 12, 45
-    version_info = {"major": major, "minor": minor, "micro": micro}
-
     with mock.patch(
         "modin.experimental.cloud.rayscale._bootstrap_config", lambda config: config
     ):
@@ -40,14 +37,16 @@ def test_update_conda_requirements(setup_commands_source):
             Provider(name="aws"), add_conda_packages=["scikit-learn>=0.23"]
         )
 
-    with mock.patch(
-        "sys.version_info", namedtuple("mock", version_info.keys())(**version_info)
-    ):
+    fake_version = namedtuple("FakeVersion", "major minor micro")(7, 12, 45)
+    with mock.patch("sys.version_info", fake_version):
         setup_commands_result = ray_cluster._update_conda_requirements(
             setup_commands_source
         )
 
-    assert f"python>={major}.{minor}" in setup_commands_result
-    assert f"python<={major}.{minor}.{micro}" in setup_commands_result
+    assert f"python>={fake_version.major}.{fake_version.minor}" in setup_commands_result
+    assert (
+        f"python<={fake_version.major}.{fake_version.minor}.{fake_version.micro}"
+        in setup_commands_result
+    )
     assert "scikit-learn>=0.23" in setup_commands_result
     assert "{{CONDA_PACKAGES}}" not in setup_commands_result

--- a/modin/experimental/cloud/test/test_cloud.py
+++ b/modin/experimental/cloud/test/test_cloud.py
@@ -33,7 +33,8 @@ def test_update_conda_requirements(setup_commands_source):
     major = sys.version_info.major
     minor = sys.version_info.minor
     micro = sys.version_info.micro
-    python_version = f"python=={major}.{minor}.{micro}"
+    python_version_lower = f"python>{major}.{minor}"
+    python_version_higher = f"python<={major}.{minor}.{micro}"
 
     with mock.patch(
         "modin.experimental.cloud.rayscale._bootstrap_config", lambda config: config
@@ -46,6 +47,7 @@ def test_update_conda_requirements(setup_commands_source):
         setup_commands_source
     )
 
-    assert python_version in setup_commands_result
+    assert python_version_lower in setup_commands_result
+    assert python_version_higher in setup_commands_result
     assert "scikit-learn>=0.23" in setup_commands_result
     assert "{{CONDA_PACKAGES}}" not in setup_commands_result


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
For RPyC to work correctly, the micro part of the python version may not match, so we can specify an interval from which the conda will choose the appropriate one. (for example 3.7.*)

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2147 <!-- issue must be created for each patch -->
- [ ] tests added and passing
