### PR TITLE
FEAT-#2138: sync modin version between local and remote contexts

### DIFF
--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -120,7 +120,7 @@ setup_commands:
         source ~/.bashrc
         conda create --name modin --yes
         conda activate modin
-        conda install --yes --override-channels -c intel/label/validation -c conda-forge {{CONDA_PACKAGES}}
+        conda install --yes -c intel/label/validation -c conda-forge {{CONDA_PACKAGES}}
         {{INSTALL_MODIN_COMMAND}}
 
         pip install colorful cloudpickle

--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -121,7 +121,6 @@ setup_commands:
         conda create --name modin --yes
         conda activate modin
         conda install --yes -c intel/label/validation -c conda-forge {{CONDA_PACKAGES}}
-        {{INSTALL_MODIN_COMMAND}}
 
         pip install colorful cloudpickle
         # ray now executes "ray stop" which expects "ray" to be in $PATH

--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -120,7 +120,8 @@ setup_commands:
         source ~/.bashrc
         conda create --name modin --yes
         conda activate modin
-        conda install --yes --override-channels -c intel/label/validation -c conda-forge modin {{CONDA_PACKAGES}}
+        conda install --yes --override-channels -c intel/label/validation -c conda-forge {{CONDA_PACKAGES}}
+        {{INSTALL_MODIN_COMMAND}}
 
         pip install colorful cloudpickle
         # ray now executes "ray stop" which expects "ray" to be in $PATH
@@ -138,7 +139,6 @@ head_setup_commands:
     - |
         source ~/.bashrc
         conda activate modin
-        pip install boto3==1.4.8 rpyc==4.1.5
         echo 'export MODIN_REDIS_ADDRESS="localhost:6379"' >> ~/.bashrc
 
 # Custom commands that will be run on worker nodes after common setup.

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -236,7 +236,7 @@ class RayCluster(BaseCluster):
 
         if len(__version__.split("+")) == 1:
             # example version: 0.8.0
-            return f"conda install --yes --override-channels -c intel/label/validation \
+            return f"conda install --yes -c intel/label/validation \
                 -c conda-forge modin=={__version__}"
         else:
             # example version: 0.8.0+103.gfe0afed.dirty
@@ -248,7 +248,7 @@ class RayCluster(BaseCluster):
                 warnings.warn(
                     "failed get git repo and branch; installing latest release of modin"
                 )
-                return "conda install --yes --override-channels -c intel/label/validation -c conda-forge modin"
+                return "conda install --yes -c intel/label/validation -c conda-forge modin"
 
             modin_install = f"""
         sudo apt-get update -y

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -244,11 +244,11 @@ class RayCluster(BaseCluster):
             try:
                 repo, branch = RayCluster._git_state()
             except Exception as er:
-                print(er)
+                warnings.warn(str(er))
                 warnings.warn(
                     "failed get git repo and branch; installing latest release of modin"
                 )
-                return f"conda install --yes --override-channels -c intel/label/validation -c conda-forge modin"
+                return "conda install --yes --override-channels -c intel/label/validation -c conda-forge modin"
 
             modin_install = f"""
         sudo apt-get update -y

--- a/modin/experimental/cloud/test/test_cloud.py
+++ b/modin/experimental/cloud/test/test_cloud.py
@@ -50,31 +50,3 @@ def test_update_conda_requirements(setup_commands_source):
     )
     assert "scikit-learn>=0.23" in setup_commands_result
     assert "{{CONDA_PACKAGES}}" not in setup_commands_result
-
-
-@pytest.mark.parametrize(
-    "git_output",
-    [
-        {
-            "remote": """
-modin   https://github.com/modin-project/modin.git (fetch)
-modin   https://github.com/modin-project/modin.git (push)
-origin  https://github.com/username/modin.git (fetch)
-origin  https://github.com/username/modin.git (push)""",
-            "branch": """
-* sync-modin-between-contexts 8503e3b [origin/sync-modin-between-contexts: ahead 1] FEAT-#2138: sync modin from custom branch
-  taxi-runner                 f9bc050 [origin/taxi-runner: gone] DOCS-#1835: add runner of taxi benchmark as example
-  teamcity-coverage           3ad1674 [origin/teamcity-coverage] FIX-#9999: remove env_windows.yml
-  test-autoscaler             7d0e006 [origin/test-autoscaler: gone] add missing ray
-  update-docstrings           985adb0 Mad function implementation (#1430)""",
-        }
-    ],
-)
-def test__git_state(git_output):
-    with mock.patch(
-        "subprocess.check_output", lambda *args, **kwargs: git_output[args[0][1]]
-    ):
-        repo, branch = RayCluster._git_state()
-
-    assert repo == "https://github.com/username/modin.git"
-    assert branch == "sync-modin-between-contexts"

--- a/modin/experimental/cloud/test/test_cloud.py
+++ b/modin/experimental/cloud/test/test_cloud.py
@@ -56,12 +56,6 @@ def test_update_conda_requirements(setup_commands_source):
     "git_output",
     [
         {
-            "log": """
-commit cefabbc97698145223e1f93c6caece0fbd807feb (HEAD -> sync-modin-between-contexts, origin/sync-modin-between-contexts)
-Author: USER NAME <mail>
-Date:   Fri Sep 25 11:46:46 2020 +0300
-FEAT-#2138: simple sync modin
-Signed-off-by: USER NAME <mail>""",
             "remote": """
 modin   https://github.com/modin-project/modin.git (fetch)
 modin   https://github.com/modin-project/modin.git (push)
@@ -77,7 +71,9 @@ origin  https://github.com/username/modin.git (push)""",
     ],
 )
 def test__git_state(git_output):
-    with mock.patch("subprocess.check_output", lambda *args: git_output[args[0][1]]):
+    with mock.patch(
+        "subprocess.check_output", lambda *args, **kwargs: git_output[args[0][1]]
+    ):
         repo, branch = RayCluster._git_state()
 
     assert repo == "https://github.com/username/modin.git"

--- a/modin/experimental/cloud/test/test_cloud.py
+++ b/modin/experimental/cloud/test/test_cloud.py
@@ -50,3 +50,35 @@ def test_update_conda_requirements(setup_commands_source):
     )
     assert "scikit-learn>=0.23" in setup_commands_result
     assert "{{CONDA_PACKAGES}}" not in setup_commands_result
+
+
+@pytest.mark.parametrize(
+    "git_output",
+    [
+        {
+            "log": """
+commit cefabbc97698145223e1f93c6caece0fbd807feb (HEAD -> sync-modin-between-contexts, origin/sync-modin-between-contexts)
+Author: USER NAME <mail>
+Date:   Fri Sep 25 11:46:46 2020 +0300
+FEAT-#2138: simple sync modin
+Signed-off-by: USER NAME <mail>""",
+            "remote": """
+modin   https://github.com/modin-project/modin.git (fetch)
+modin   https://github.com/modin-project/modin.git (push)
+origin  https://github.com/username/modin.git (fetch)
+origin  https://github.com/username/modin.git (push)""",
+            "branch": """
+* sync-modin-between-contexts 8503e3b [origin/sync-modin-between-contexts: ahead 1] FEAT-#2138: sync modin from custom branch
+  taxi-runner                 f9bc050 [origin/taxi-runner: gone] DOCS-#1835: add runner of taxi benchmark as example
+  teamcity-coverage           3ad1674 [origin/teamcity-coverage] FIX-#9999: remove env_windows.yml
+  test-autoscaler             7d0e006 [origin/test-autoscaler: gone] add missing ray
+  update-docstrings           985adb0 Mad function implementation (#1430)""",
+        }
+    ],
+)
+def test__git_state(git_output):
+    with mock.patch("subprocess.check_output", lambda *args: git_output[args[0][1]]):
+        repo, branch = RayCluster._git_state()
+
+    assert repo == "https://github.com/username/modin.git"
+    assert branch == "sync-modin-between-contexts"


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2138 <!-- issue must be created for each patch -->
- [ ] tests added and passing
