### PR TITLE
FEAT-#2154: generate MultiIndex for columns in groupby.agg

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -757,6 +757,12 @@ class TestGroupby:
 
         run_and_compare(std, data=self.skew_data, force_lazy=False)
 
+    def test_multilevel(self):
+        def groupby(df, **kwargs):
+            return df.groupby("a").agg({"b": "min", "c": ["min", "max", "sum", "skew"]})
+
+        run_and_compare(groupby, data=self.data)
+
 
 class TestMerge:
     data = {


### PR DESCRIPTION
## What do these changes do?
Add MultiIndex columns generation into OmniSci version of groupby.agg

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2154  <!-- issue must be created for each patch -->
- [x] tests added and passing
