### PR TITLE
FIX-#2074: CSVReader changes index_col if length names mismatch

### DIFF
--- a/modin/engines/base/io/text/csv_reader.py
+++ b/modin/engines/base/io/text/csv_reader.py
@@ -58,6 +58,7 @@ class CSVReader(TextFileReader):
         nrows = kwargs.pop("nrows", None)
         names = kwargs.get("names", None)
         index_col = kwargs.get("index_col", None)
+        usecols = kwargs.get("usecols", None)
         if names is None:
             # For the sake of the empty df, we assume no `index_col` to get the correct
             # column names before we build the index. Because we pass `names` in, this
@@ -67,13 +68,22 @@ class CSVReader(TextFileReader):
                 filepath_or_buffer,
                 **dict(kwargs, usecols=None, nrows=0, skipfooter=0, index_col=None),
             ).columns
+        elif index_col is None and not usecols:
+            # When names is set to some list that is smaller than the number of columns
+            # in the file, the first columns are built as a hierarchical index.
+            empty_pd_df = pandas.read_csv(filepath_or_buffer, nrows=0)
+            num_cols = len(empty_pd_df.columns)
+            if num_cols > len(names):
+                index_col = list(range(num_cols - len(names)))
+                if len(index_col) == 1:
+                    index_col = index_col[0]
+                kwargs["index_col"] = index_col
         empty_pd_df = pandas.read_csv(
             filepath_or_buffer, **dict(kwargs, nrows=0, skipfooter=0)
         )
         column_names = empty_pd_df.columns
         skipfooter = kwargs.get("skipfooter", None)
         skiprows = kwargs.pop("skiprows", None)
-        usecols = kwargs.get("usecols", None)
         usecols_md = _validate_usecols_arg(usecols)
         if usecols is not None and usecols_md[1] != "integer":
             del kwargs["usecols"]

--- a/modin/pandas/test/data/issue_2074.csv
+++ b/modin/pandas/test/data/issue_2074.csv
@@ -1,0 +1,12 @@
+one,two, three, five, six, seven, eight
+three,three, five, six, seven, eight, nine
+one,four, three, five, six, seven, eight
+one,two, three, five, six, seven, eight
+one,two, three, five, six, seven, eight
+one,two, three, five, six, seven, eight
+three,four, five, six, seven, eight, nine
+one,two, three, five, six, seven, eight
+three,four, five, six, seven, eight, nine
+three,four, five, six, seven, eight, nine
+three,four, five, six, seven, eight, nine
+three,four, five, six, seven, eight, nine

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1707,3 +1707,19 @@ def test_from_arrow():
     pandas_df = create_test_pandas_dataframe()
     modin_df = from_arrow(pa.Table.from_pandas(pandas_df))
     df_equals(modin_df, pandas_df)
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"names": [5, 1, 3, 4, 2, 6]},
+        {"names": [0]},
+        {"names": None, "usecols": [1, 0, 2]},
+        {"names": [3, 1, 2, 5], "usecols": [4, 1, 3, 2]},
+    ],
+)
+def test_csv_names_neq_num_cols(kwargs):
+    file_name = "modin/pandas/test/data/issue_2074.csv"
+    pandas_df = pandas.read_csv(file_name, **kwargs)
+    modin_df = pd.read_csv(file_name, **kwargs)
+    df_equals(modin_df, pandas_df)


### PR DESCRIPTION
#2074   What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2074 
- [x] tests added and passing
