### PR TITLE
REFACTOR-#2170: simplify concat of a single frame

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -562,6 +562,9 @@ class OmnisciOnRayFrame(BasePandasFrame):
     def _concat(
         self, axis, other_modin_frames, join="outer", sort=False, ignore_index=False
     ):
+        if not other_modin_frames:
+            return self
+
         if axis == 0:
             return self._union_all(axis, other_modin_frames, join, sort, ignore_index)
 

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -480,6 +480,31 @@ class TestConcat:
 
         run_and_compare(concat, data=self.data, data2=self.data2, allow_subqueries=True)
 
+    @pytest.mark.parametrize("join", ["inner", "outer"])
+    @pytest.mark.parametrize("sort", bool_arg_values)
+    @pytest.mark.parametrize("ignore_index", bool_arg_values)
+    def test_concat_single(self, join, sort, ignore_index):
+        def concat(lib, df, join, sort, ignore_index):
+            return lib.concat([df], join=join, sort=sort, ignore_index=ignore_index)
+
+        run_and_compare(
+            concat,
+            data=self.data,
+            join=join,
+            sort=sort,
+            ignore_index=ignore_index,
+        )
+
+    def test_groupby_concat_single(self):
+        def concat(lib, df):
+            df = lib.concat([df])
+            return df.groupby("a").agg({"b": "min"})
+
+        run_and_compare(
+            concat,
+            data=self.data,
+        )
+
 
 class TestGroupby:
     data = {


### PR DESCRIPTION
## What do these changes do?
Avoid useless projection for a `concat` of a single frame

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2170  <!-- issue must be created for each patch -->
- [x] tests added and passing
