### PR TITLE
FIX-#2172: support float32 in calcite serializer

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/frame/calcite_serializer.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/calcite_serializer.py
@@ -41,6 +41,7 @@ class CalciteSerializer:
         "int32": "INTEGER",
         "int64": "BIGINT",
         "bool": "BOOLEAN",
+        "float32": "FLOAT",
         "float64": "DOUBLE",
     }
 

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -275,6 +275,20 @@ class TestCSV:
 
         df_equals(modin_df, pandas_df)
 
+    @pytest.mark.skip(reason="https://github.com/modin-project/modin/issues/2174")
+    def test_float32(self):
+        csv_file = os.path.join(self.root, "modin/pandas/test/data", "test_usecols.csv")
+        kwargs = {
+            "dtype": {"a": "float32", "b": "float32"},
+        }
+
+        pandas_df = pandas.read_csv(csv_file, **kwargs)
+        pandas_df["a"] = pandas_df["a"] + pandas_df["b"]
+        modin_df = pd.read_csv(csv_file, **kwargs, engine="arrow")
+        modin_df["a"] = modin_df["a"] + modin_df["b"]
+
+        df_equals(modin_df, pandas_df)
+
 
 class TestMasks:
     data = {


### PR DESCRIPTION
## What do these changes do?
Support float32 in calcite serializer

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2172  <!-- issue must be created for each patch -->
- [x] tests added and passing
