### PR TITLE
FIX-#2212: changed label to 'modin' in intel conda channel

### DIFF
--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -1,6 +1,6 @@
 name: modin_on_omnisci
 channels:
-  - intel/label/validation
+  - intel/label/modin
   - conda-forge
 dependencies:
   - pandas==1.1.2


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2212 <!-- issue must be created for each patch -->
- [x] tests passing
