### PR TITLE
REFACTOR-#2221: Remove `PartitionIterator` methods related to the python 2.X iterator interface.

### DIFF
--- a/modin/pandas/iterator.py
+++ b/modin/pandas/iterator.py
@@ -43,9 +43,6 @@ class PartitionIterator(Iterator):
         return self
 
     def __next__(self):
-        return self.next()
-
-    def next(self):
         key = next(self.index_iter)
         df = self.df.iloc[key]
         return self.func(df)


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

We doesn't support python 2.X, so we can remove `next` method (For details see [PEP3114](https://www.python.org/dev/peps/pep-3114))

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2221<!-- issue must be created for each patch -->
- [ ] tests added and passing
