### PR TITLE
FIX-#1965: Fix `count` func in case `numeric_only`==True

### DIFF
--- a/modin/pandas/test/dataframe/test_reduction.py
+++ b/modin/pandas/test/dataframe/test_reduction.py
@@ -101,14 +101,7 @@ def test_count(data, axis):
     )
 
 
-@pytest.mark.parametrize(
-    "numeric_only",
-    [
-        pytest.param(True, marks=pytest.mark.xfail(reason="See #1965 for details")),
-        False,
-        None,
-    ],
-)
+@pytest.mark.parametrize("numeric_only", [True, False, None])
 def test_count_specific(numeric_only):
     eval_general(
         *create_test_dfs(test_data_diff_dtype),


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
In previous implementation parameter `numeric_only` was needed only for checking that `dtypes` is numeric else it was raising an exception. This changes make possible work with this parameter according pandas.
- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1965  <!-- issue must be created for each patch -->
- [x] tests added and passing
