### PR TITLE
FIX-#2237: use floordiv to get fragment size.

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py
@@ -109,7 +109,7 @@ class OmnisciServer:
         if fragment_size is None:
             cpu_count = os.cpu_count()
             if cpu_count is not None:
-                fragment_size = table.num_rows / cpu_count
+                fragment_size = table.num_rows // cpu_count
                 fragment_size = min(fragment_size, 2 ** 25)
                 fragment_size = max(fragment_size, 2 ** 18)
             else:


### PR DESCRIPTION
## What do these changes do?
Avoid float fragment size passed to DBE

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2237 <!-- issue must be created for each patch -->
- [ ] tests added and passing
