### PR TITLE
FIX-#9999: test unicode_escape param

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1125,7 +1125,16 @@ def test_from_csv_skiprows(make_csv_file, nrows):
 
 
 @pytest.mark.parametrize(
-    "encoding", ["latin8", "ISO-8859-1", "latin1", "iso-8859-1", "cp1252", "utf8"]
+    "encoding",
+    [
+        "latin8",
+        "ISO-8859-1",
+        "latin1",
+        "iso-8859-1",
+        "cp1252",
+        "utf8",
+        "unicode_escape",
+    ],
 )
 def test_from_csv_encoding(make_csv_file, encoding):
     make_csv_file(encoding=encoding)


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
