### PR TITLE
FIX-#2249: changed 'return' -> 'assert' in df_equals

### DIFF
--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -390,6 +390,9 @@ def test_loc_multi_index():
 @pytest.mark.parametrize("index", [["row1", "row2", "row3"], ["row1"]])
 @pytest.mark.parametrize("columns", [["col1", "col2"], ["col1"]])
 def test_loc_assignment(index, columns):
+    if len(index) == 1 and len(columns) == 1:
+        pytest.skip("See Modin issue #2253 for details")
+
     md_df, pd_df = create_test_dfs(index=index, columns=columns)
     for i, ind in enumerate(index):
         for j, col in enumerate(columns):

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1109,6 +1109,7 @@ def test_groupby_multiindex():
     df_equals(modin_df.groupby(by=by).count(), pandas_df.groupby(by=by).count())
 
 
+@pytest.mark.skip("See Modin issue #2254 for details")
 def test_agg_func_None_rename():
     pandas_df = pandas.DataFrame(
         {
@@ -1131,7 +1132,17 @@ def test_agg_func_None_rename():
 
 
 @pytest.mark.parametrize(
-    "operation", ["quantile", "mean", "sum", "median", "unique", "cumprod"]
+    "operation",
+    [
+        "quantile",
+        "mean",
+        pytest.param(
+            "sum", marks=pytest.mark.skip("See Modin issue #2255 for details")
+        ),
+        "median",
+        "unique",
+        "cumprod",
+    ],
 )
 def test_agg_exceptions(operation):
     N = 256

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -505,9 +505,9 @@ def df_equals(df1, df2):
 
     if isinstance(df1, pandas.DataFrame) and isinstance(df2, pandas.DataFrame):
         if (df1.empty and not df2.empty) or (df2.empty and not df1.empty):
-            return False
+            assert False
         elif df1.empty and df2.empty and type(df1) != type(df2):
-            return False
+            assert False
 
     if isinstance(df1, pandas.DataFrame) and isinstance(df2, pandas.DataFrame):
         assert_frame_equal(

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -505,9 +505,11 @@ def df_equals(df1, df2):
 
     if isinstance(df1, pandas.DataFrame) and isinstance(df2, pandas.DataFrame):
         if (df1.empty and not df2.empty) or (df2.empty and not df1.empty):
-            assert False
+            assert False, "One of the passed frames is empty, when other isn't"
         elif df1.empty and df2.empty and type(df1) != type(df2):
-            assert False
+            assert (
+                False
+            ), f"Empty frames have different types: {type(df1)} != {type(df2)}"
 
     if isinstance(df1, pandas.DataFrame) and isinstance(df2, pandas.DataFrame):
         assert_frame_equal(


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2249 <!-- issue must be created for each patch -->
- [x] tests passing
