### PR TITLE
FEAT-#2232: add way to specify modin version in the cloud

### DIFF
--- a/modin/experimental/cloud/cluster.py
+++ b/modin/experimental/cloud/cluster.py
@@ -251,7 +251,8 @@ def create(
     worker_node : str, optional
         What machine type to use for worker nodes in the cluster.
     add_conda_packages : list, optional
-        Custom conda packages for remote environments.
+        Custom conda packages for remote environments. By default remote modin version is
+        the same as local version.
     cluster_type : str, optional
         How to spawn the cluster.
         Currently spawning by Ray autoscaler ("rayscale" for general and "omnisci" for Omnisci-based) is supported

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -13,6 +13,7 @@
 
 import threading
 import os
+import re
 import traceback
 import sys
 from hashlib import sha1
@@ -148,7 +149,9 @@ class RayCluster(BaseCluster):
 
         reqs.extend(self._get_python_version())
 
-        if not any(map(lambda pkg: pkg.startswith("modin"), self.add_conda_packages)):
+        if not any(
+            map(lambda pkg: re.match(r"modin(\W|$)", pkg), self.add_conda_packages)
+        ):
             # user didn't define modin release;
             # use automatically detected modin release from local context
             reqs.append(self._get_modin_version())

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -149,9 +149,7 @@ class RayCluster(BaseCluster):
 
         reqs.extend(self._get_python_version())
 
-        if not any(
-            map(lambda pkg: re.match(r"modin(\W|$)", pkg), self.add_conda_packages)
-        ):
+        if not any(re.match(r"modin(\W|$)", p) for p in self.add_conda_packages):
             # user didn't define modin release;
             # use automatically detected modin release from local context
             reqs.append(self._get_modin_version())

--- a/modin/experimental/cloud/rayscale.py
+++ b/modin/experimental/cloud/rayscale.py
@@ -148,7 +148,10 @@ class RayCluster(BaseCluster):
 
         reqs.extend(self._get_python_version())
 
-        reqs.append(self._get_modin_version())
+        if not any(map(lambda pkg: pkg.startswith("modin"), self.add_conda_packages)):
+            # user didn't define modin release;
+            # use automatically detected modin release from local context
+            reqs.append(self._get_modin_version())
 
         if self.add_conda_packages:
             reqs.extend(self.add_conda_packages)

--- a/modin/experimental/cloud/test/test_cloud.py
+++ b/modin/experimental/cloud/test/test_cloud.py
@@ -63,7 +63,8 @@ def make_ray_cluster(make_bootstrap_config_mock):
             make_bootstrap_config_mock,
         ):
             ray_cluster = RayCluster(
-                Provider(name="aws"), add_conda_packages=["scikit-learn>=0.23"]
+                Provider(name="aws"),
+                add_conda_packages=["scikit-learn>=0.23", "modin==0.8.0"],
             )
         return ray_cluster
 
@@ -124,4 +125,5 @@ def test_update_conda_requirements(setup_commands_source, make_ray_cluster):
         in setup_commands_result
     )
     assert "scikit-learn>=0.23" in setup_commands_result
+    assert "modin==0.8.0" in setup_commands_result
     assert "{{CONDA_PACKAGES}}" not in setup_commands_result


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2232 <!-- issue must be created for each patch -->
- [ ] tests added and passing
