### PR TITLE
FIX-#1976: indices matching at reduction functions fixed

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -159,8 +159,10 @@ def _numeric_only_reduce_fn(applier: Type[Function], *funcs) -> Callable:
 
     Parameters
     ----------
-    applier : Function object to register `funcs`
-    *funcs : list of functions to register in `applier`
+    applier: Callable
+        Function object to register `funcs`
+    *funcs: list
+        List of functions to register in `applier`
 
     Returns
     -------
@@ -665,18 +667,43 @@ class PandasQueryCompiler(BaseQueryCompiler):
         lambda x, *args, **kwargs: pandas.DataFrame.sum(x),
         axis=0,
     )
-    mean = MapReduceFunction.register(
-        lambda df, **kwargs: df.apply(
-            lambda x: (x.sum(skipna=kwargs.get("skipna", True)), x.count()),
-            axis=kwargs.get("axis", 0),
-            result_type="reduce",
-        ).set_axis(df.axes[kwargs.get("axis", 0) ^ 1], axis=0),
-        lambda df, **kwargs: df.apply(
-            lambda x: x.apply(lambda d: d[0]).sum(skipna=kwargs.get("skipna", True))
-            / x.apply(lambda d: d[1]).sum(skipna=kwargs.get("skipna", True)),
-            axis=kwargs.get("axis", 0),
-        ).set_axis(df.axes[kwargs.get("axis", 0) ^ 1], axis=0),
-    )
+
+    def mean(self, axis, **kwargs):
+        if kwargs.get("level") is not None:
+            return self.default_to_pandas(pandas.DataFrame.mean, axis=axis, **kwargs)
+
+        skipna = kwargs.get("skipna", True)
+
+        def map_apply_fn(ser, **kwargs):
+            try:
+                sum_result = ser.sum(skipna=skipna)
+                count_result = ser.count()
+            except TypeError:
+                return None
+            else:
+                return (sum_result, count_result)
+
+        def reduce_apply_fn(ser, **kwargs):
+            sum_result = ser.apply(lambda x: x[0]).sum(skipna=skipna)
+            count_result = ser.apply(lambda x: x[1]).sum(skipna=skipna)
+            return sum_result / count_result
+
+        def reduce_fn(df, **kwargs):
+            df.dropna(axis=1, inplace=True, how="any")
+            return build_applyier(reduce_apply_fn, axis=axis)(df)
+
+        def build_applyier(func, **applyier_kwargs):
+            def applyier(df, **kwargs):
+                result = df.apply(func, **applyier_kwargs)
+                return result.set_axis(df.axes[axis ^ 1], axis=0)
+
+            return applyier
+
+        return MapReduceFunction.register(
+            build_applyier(map_apply_fn, axis=axis, result_type="reduce"),
+            reduce_fn,
+            preserve_index=(kwargs.get("numeric_only") is not None),
+        )(self, axis=axis, **kwargs)
 
     def value_counts(self, **kwargs):
         """

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -768,9 +768,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
             return sort_index_for_equal_values(result, ascending)
 
-        return MapReduceFunction.register(map_func, reduce_func, axis=1, preserve_index=False)(
-            self, **kwargs
-        )
+        return MapReduceFunction.register(
+            map_func, reduce_func, axis=1, preserve_index=False
+        )(self, **kwargs)
 
     # END MapReduce operations
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -693,7 +693,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             return self.__constructor__(new_modin_frame)
 
         def map_func(df, *args, **kwargs):
-            return df.squeeze(axis=1).value_counts(**kwargs)
+            return df.squeeze(axis=1).value_counts(**kwargs).to_frame()
 
         def reduce_func(df, *args, **kwargs):
             normalize = kwargs.get("normalize", False)
@@ -764,12 +764,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     else:
                         new_index[j] = result.index[j]
                     i += 1
-                return pandas.DataFrame(result, index=new_index)
+                return pandas.DataFrame(
+                    result, index=new_index, columns=["__reduced__"]
+                )
 
             return sort_index_for_equal_values(result, ascending)
 
         return MapReduceFunction.register(
-            map_func, reduce_func, axis=1, preserve_index=False
+            map_func, reduce_func, axis=0, preserve_index=False
         )(self, **kwargs)
 
     # END MapReduce operations

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -768,7 +768,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
             return sort_index_for_equal_values(result, ascending)
 
-        return MapReduceFunction.register(map_func, reduce_func, preserve_index=False)(
+        return MapReduceFunction.register(map_func, reduce_func, axis=1, preserve_index=False)(
             self, **kwargs
         )
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -150,6 +150,16 @@ def copy_df_for_func(func, display_name: str = None):
     return caller
 
 
+def _numeric_only_reduce_fn(applier, *fns):
+    def caller(self, *args, **kwargs):
+        preserve_index = kwargs.get("numeric_only", None) is not None
+        return applier.register(*fns, preserve_index=preserve_index)(
+            self, *args, **kwargs
+        )
+
+    return caller
+
+
 class PandasQueryCompiler(BaseQueryCompiler):
     """This class implements the logic necessary for operating on partitions
     with a Pandas backend. This logic is specific to Pandas."""
@@ -625,10 +635,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
     is_monotonic = _is_monotonic
 
     count = MapReduceFunction.register(pandas.DataFrame.count, pandas.DataFrame.sum)
-    max = MapReduceFunction.register(pandas.DataFrame.max, pandas.DataFrame.max)
-    min = MapReduceFunction.register(pandas.DataFrame.min, pandas.DataFrame.min)
-    sum = MapReduceFunction.register(pandas.DataFrame.sum, pandas.DataFrame.sum)
-    prod = MapReduceFunction.register(pandas.DataFrame.prod, pandas.DataFrame.prod)
+    max = _numeric_only_reduce_fn(MapReduceFunction, pandas.DataFrame.max)
+    min = _numeric_only_reduce_fn(MapReduceFunction, pandas.DataFrame.min)
+    sum = _numeric_only_reduce_fn(MapReduceFunction, pandas.DataFrame.sum)
+    prod = _numeric_only_reduce_fn(MapReduceFunction, pandas.DataFrame.prod)
     any = MapReduceFunction.register(pandas.DataFrame.any, pandas.DataFrame.any)
     all = MapReduceFunction.register(pandas.DataFrame.all, pandas.DataFrame.all)
     memory_usage = MapReduceFunction.register(
@@ -748,15 +758,15 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # Reduction operations
     idxmax = ReductionFunction.register(pandas.DataFrame.idxmax)
     idxmin = ReductionFunction.register(pandas.DataFrame.idxmin)
-    median = ReductionFunction.register(pandas.DataFrame.median)
+    median = _numeric_only_reduce_fn(ReductionFunction, pandas.DataFrame.median)
     nunique = ReductionFunction.register(pandas.DataFrame.nunique)
-    skew = ReductionFunction.register(pandas.DataFrame.skew)
-    kurt = ReductionFunction.register(pandas.DataFrame.kurt)
-    sem = ReductionFunction.register(pandas.DataFrame.sem)
-    std = ReductionFunction.register(pandas.DataFrame.std)
-    var = ReductionFunction.register(pandas.DataFrame.var)
-    sum_min_count = ReductionFunction.register(pandas.DataFrame.sum)
-    prod_min_count = ReductionFunction.register(pandas.DataFrame.prod)
+    skew = _numeric_only_reduce_fn(ReductionFunction, pandas.DataFrame.skew)
+    kurt = _numeric_only_reduce_fn(ReductionFunction, pandas.DataFrame.kurt)
+    sem = _numeric_only_reduce_fn(ReductionFunction, pandas.DataFrame.sem)
+    std = _numeric_only_reduce_fn(ReductionFunction, pandas.DataFrame.std)
+    var = _numeric_only_reduce_fn(ReductionFunction, pandas.DataFrame.var)
+    sum_min_count = _numeric_only_reduce_fn(ReductionFunction, pandas.DataFrame.sum)
+    prod_min_count = _numeric_only_reduce_fn(ReductionFunction, pandas.DataFrame.prod)
     quantile_for_single_value = ReductionFunction.register(pandas.DataFrame.quantile)
     mad = ReductionFunction.register(pandas.DataFrame.mad)
     to_datetime = ReductionFunction.register(

--- a/modin/data_management/functions/__init__.py
+++ b/modin/data_management/functions/__init__.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+from .function import Function
 from .mapfunction import MapFunction
 from .mapreducefunction import MapReduceFunction
 from .reductionfunction import ReductionFunction
@@ -19,6 +20,7 @@ from .binary_function import BinaryFunction
 from .groupby_function import GroupbyReduceFunction
 
 __all__ = [
+    "Function",
     "MapFunction",
     "MapReduceFunction",
     "ReductionFunction",

--- a/modin/data_management/functions/foldfunction.py
+++ b/modin/data_management/functions/foldfunction.py
@@ -18,11 +18,10 @@ class FoldFunction(Function):
     @classmethod
     def call(cls, fold_function, **call_kwds):
         def caller(query_compiler, *args, **kwargs):
+            axis = call_kwds.get("axis") if "axis" in call_kwds else kwargs.get("axis")
             return query_compiler.__constructor__(
                 query_compiler._modin_frame._fold(
-                    call_kwds.get("axis")
-                    if "axis" in call_kwds
-                    else kwargs.get("axis"),
+                    cls.validate_axis(axis),
                     lambda x: fold_function(x, *args, **kwargs),
                 )
             )

--- a/modin/data_management/functions/foldfunction.py
+++ b/modin/data_management/functions/foldfunction.py
@@ -18,7 +18,7 @@ class FoldFunction(Function):
     @classmethod
     def call(cls, fold_function, **call_kwds):
         def caller(query_compiler, *args, **kwargs):
-            axis = call_kwds.get("axis") if "axis" in call_kwds else kwargs.get("axis")
+            axis = call_kwds.get("axis", kwargs.get("axis"))
             return query_compiler.__constructor__(
                 query_compiler._modin_frame._fold(
                     cls.validate_axis(axis),

--- a/modin/data_management/functions/function.py
+++ b/modin/data_management/functions/function.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+from typing import Optional
+
 
 class Function(object):
     def __init__(self):
@@ -27,3 +29,7 @@ class Function(object):
     @classmethod
     def register(cls, func, **kwargs):
         return cls.call(func, **kwargs)
+
+    @classmethod
+    def validate_axis(cls, axis: Optional[int]) -> int:
+        return 0 if axis is None else axis

--- a/modin/data_management/functions/mapreducefunction.py
+++ b/modin/data_management/functions/mapreducefunction.py
@@ -19,7 +19,7 @@ class MapReduceFunction(Function):
     def call(cls, map_function, reduce_function, **call_kwds):
         def caller(query_compiler, *args, **kwargs):
             preserve_index = call_kwds.pop("preserve_index", True)
-            axis = call_kwds.get("axis") if "axis" in call_kwds else kwargs.get("axis")
+            axis = call_kwds.get("axis", kwargs.get("axis"))
             return query_compiler.__constructor__(
                 query_compiler._modin_frame._map_reduce(
                     cls.validate_axis(axis),

--- a/modin/data_management/functions/mapreducefunction.py
+++ b/modin/data_management/functions/mapreducefunction.py
@@ -33,5 +33,7 @@ class MapReduceFunction(Function):
         return caller
 
     @classmethod
-    def register(cls, map_function, reduce_function, **kwargs):
+    def register(cls, map_function, reduce_function=None, **kwargs):
+        if reduce_function is None:
+            reduce_function = map_function
         return cls.call(map_function, reduce_function, **kwargs)

--- a/modin/data_management/functions/mapreducefunction.py
+++ b/modin/data_management/functions/mapreducefunction.py
@@ -19,11 +19,10 @@ class MapReduceFunction(Function):
     def call(cls, map_function, reduce_function, **call_kwds):
         def caller(query_compiler, *args, **kwargs):
             preserve_index = call_kwds.pop("preserve_index", True)
+            axis = call_kwds.get("axis") if "axis" in call_kwds else kwargs.get("axis")
             return query_compiler.__constructor__(
                 query_compiler._modin_frame._map_reduce(
-                    call_kwds.get("axis")
-                    if "axis" in call_kwds
-                    else kwargs.get("axis"),
+                    cls.validate_axis(axis),
                     lambda x: map_function(x, *args, **kwargs),
                     lambda y: reduce_function(y, *args, **kwargs),
                     preserve_index=preserve_index,

--- a/modin/data_management/functions/reductionfunction.py
+++ b/modin/data_management/functions/reductionfunction.py
@@ -19,7 +19,7 @@ class ReductionFunction(Function):
     def call(cls, reduction_function, **call_kwds):
         def caller(query_compiler, *args, **kwargs):
             preserve_index = call_kwds.pop("preserve_index", True)
-            axis = call_kwds.get("axis") if "axis" in call_kwds else kwargs.get("axis")
+            axis = call_kwds.get("axis", kwargs.get("axis"))
             return query_compiler.__constructor__(
                 query_compiler._modin_frame._fold_reduce(
                     cls.validate_axis(axis),

--- a/modin/data_management/functions/reductionfunction.py
+++ b/modin/data_management/functions/reductionfunction.py
@@ -18,12 +18,14 @@ class ReductionFunction(Function):
     @classmethod
     def call(cls, reduction_function, **call_kwds):
         def caller(query_compiler, *args, **kwargs):
+            preserve_index = call_kwds.pop("preserve_index", True)
             return query_compiler.__constructor__(
                 query_compiler._modin_frame._fold_reduce(
                     call_kwds.get("axis")
                     if "axis" in call_kwds
                     else kwargs.get("axis"),
                     lambda x: reduction_function(x, *args, **kwargs),
+                    preserve_index=preserve_index,
                 )
             )
 

--- a/modin/data_management/functions/reductionfunction.py
+++ b/modin/data_management/functions/reductionfunction.py
@@ -19,11 +19,10 @@ class ReductionFunction(Function):
     def call(cls, reduction_function, **call_kwds):
         def caller(query_compiler, *args, **kwargs):
             preserve_index = call_kwds.pop("preserve_index", True)
+            axis = call_kwds.get("axis") if "axis" in call_kwds else kwargs.get("axis")
             return query_compiler.__constructor__(
                 query_compiler._modin_frame._fold_reduce(
-                    call_kwds.get("axis")
-                    if "axis" in call_kwds
-                    else kwargs.get("axis"),
+                    cls.validate_axis(axis),
                     lambda x: reduction_function(x, *args, **kwargs),
                     preserve_index=preserve_index,
                 )

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1141,9 +1141,9 @@ class BasePandasFrame(object):
 
         axis_validate_mask = [validate_index, validate_columns]
         new_axes = [
-            self.axes[axis]
+            self._compute_axis_labels(axis, new_partitions)
             if should_validate
-            else self._compute_axis_labels(axis, new_partitions)
+            else self.axes[axis]
             for axis, should_validate in enumerate(axis_validate_mask)
         ]
 
@@ -1611,7 +1611,7 @@ class BasePandasFrame(object):
             dtypes = self._dtypes
         elif dtypes is not None:
             dtypes = pandas.Series(
-                [np.dtype(dtypes)] * len(new_columns), index=new_columns
+                [np.dtype(dtypes)] * len(new_axes[1]), index=new_axes[1]
             )
         return self.__constructor__(
             new_partitions,

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -255,13 +255,15 @@ class BasePandasFrame(object):
 
         Parameters
         ----------
-        axis : int, axis to compute labels along
-        partitions : numpy 2D array (optional), partitions from which labels will
-            be grabbed, if no specified, partitions will be considered as `self._partitions`
+        axis: int
+            Axis to compute labels along
+        partitions: numpy 2D array (optional)
+            Partitions from which labels will be grabbed,
+            if no specified, partitions will be considered as `self._partitions`
 
         Returns
         -------
-        Pandas.index
+        Pandas.Index
             Labels for the specified `axis`
         """
         if partitions is None:
@@ -1009,12 +1011,12 @@ class BasePandasFrame(object):
 
         Parameters
         ----------
-            axis : int,
-                The axis on which reduce function was applied
-            new_parts : numpy 2D array
-                Partitions with the result of applied function
-            preserve_index : boolean
-                The flag to preserve labels for the reduced axis.
+        axis: int,
+            The axis on which reduce function was applied
+        new_parts: numpy 2D array
+            Partitions with the result of applied function
+        preserve_index: boolean
+            The flag to preserve labels for the reduced axis.
 
         Returns
         -------

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -114,6 +114,10 @@ class BasePandasFrame(object):
         return self._column_widths_cache
 
     @property
+    def _axis_lengths(self):
+        return [self._row_lengths, self._column_widths]
+
+    @property
     def dtypes(self):
         """Compute the data types if they are not cached.
 
@@ -244,6 +248,13 @@ class BasePandasFrame(object):
         """The index, columns that can be accessed with an `axis` integer."""
         return [self.index, self.columns]
 
+    def _compute_axis(self, axis, partitions=None):
+        if partitions is None:
+            partitions = self._partitions
+        return self._frame_mgr_cls.get_indices(
+            axis, partitions, lambda df: df.axes[axis]
+        )
+
     def _filter_empties(self):
         """Removes empty partitions to avoid triggering excess computation."""
         if len(self.axes[0]) == 0 or len(self.axes[1]) == 0:
@@ -278,9 +289,7 @@ class BasePandasFrame(object):
                 Whether to update external indices with internal if their lengths
                 do not match or raise an exception in that case.
         """
-        internal_axis = self._frame_mgr_cls.get_indices(
-            axis, self._partitions, lambda df: df.axes[axis]
-        )
+        internal_axis = self._compute_axis(axis)
         self_axis = self.axes[axis]
         is_equals = self_axis.equals(internal_axis)
         if (
@@ -979,36 +988,39 @@ class BasePandasFrame(object):
 
         return _map_reduce_func
 
-    def _compute_map_reduce_metadata(self, axis, new_parts):
-        if axis == 0:
-            columns = self.columns
-            index = ["__reduced__"]
-            new_lengths = [1]
-            new_widths = self._column_widths
+    def _compute_map_reduce_metadata(self, axis, new_parts, preserve_index=True):
+        new_axes, new_axes_lengths = [0, 0], [0, 0]
+
+        new_axes[axis] = ["__reduced__"]
+        new_axes[axis ^ 1] = (
+            self.axes[axis ^ 1]
+            if preserve_index
+            else self._compute_axis(axis ^ 1, new_parts)
+        )
+
+        new_axes_lengths[axis] = [1]
+        new_axes_lengths[axis ^ 1] = (
+            self._axis_lengths[axis ^ 1] if preserve_index else None
+        )
+
+        if (axis == 0 or self._dtypes is None) and preserve_index:
             new_dtypes = self._dtypes
+        elif preserve_index:
+            new_dtypes = pandas.Series(
+                [find_common_type(self.dtypes.values)], index=new_axes[axis]
+            )
         else:
-            columns = ["__reduced__"]
-            index = self.index
-            new_lengths = self._row_lengths
-            new_widths = [1]
-            if self._dtypes is not None:
-                new_dtypes = pandas.Series(
-                    np.full(1, find_common_type(self.dtypes.values)),
-                    index=["__reduced__"],
-                )
-            else:
-                new_dtypes = self._dtypes
+            new_dtypes = None
+
         return self.__constructor__(
             new_parts,
-            index,
-            columns,
-            new_lengths,
-            new_widths,
+            *new_axes,
+            *new_axes_lengths,
             new_dtypes,
             validate_axes="reduced",
         )
 
-    def _fold_reduce(self, axis, func):
+    def _fold_reduce(self, axis, func, preserve_index=True):
         """
         Apply function that reduce Manager to series but require knowledge of full axis.
 
@@ -1028,7 +1040,9 @@ class BasePandasFrame(object):
         new_parts = self._frame_mgr_cls.map_axis_partitions(
             axis, self._partitions, func
         )
-        return self._compute_map_reduce_metadata(axis, new_parts)
+        return self._compute_map_reduce_metadata(
+            axis, new_parts, preserve_index=preserve_index
+        )
 
     def _map_reduce(self, axis, map_func, reduce_func=None, preserve_index=True):
         """
@@ -1062,22 +1076,9 @@ class BasePandasFrame(object):
         reduce_parts = self._frame_mgr_cls.map_axis_partitions(
             axis, map_parts, reduce_func
         )
-        if preserve_index:
-            return self._compute_map_reduce_metadata(axis, reduce_parts)
-        else:
-            if axis == 0:
-                new_index = ["__reduced__"]
-                new_columns = self._frame_mgr_cls.get_indices(
-                    1, reduce_parts, lambda df: df.columns
-                )
-            else:
-                new_index = self._frame_mgr_cls.get_indices(
-                    0, reduce_parts, lambda df: df.index
-                )
-                new_columns = ["__reduced__"]
-            return self.__constructor__(
-                reduce_parts, new_index, new_columns, validate_axes="reduced"
-            )
+        return self._compute_map_reduce_metadata(
+            axis, reduce_parts, preserve_index=preserve_index
+        )
 
     def _map(self, func, dtypes=None, validate_index=False, validate_columns=False):
         """Perform a function that maps across the entire dataset.
@@ -1103,33 +1104,26 @@ class BasePandasFrame(object):
             dtypes = pandas.Series(
                 [np.dtype(dtypes)] * len(self.columns), index=self.columns
             )
-        if validate_index:
-            new_index = self._frame_mgr_cls.get_indices(
-                0, new_partitions, lambda df: df.index
-            )
-        else:
-            new_index = self.index
-        if len(new_index) != len(self.index):
-            new_row_lengths = None
-        else:
-            new_row_lengths = self._row_lengths
 
-        if validate_columns:
-            new_columns = self._frame_mgr_cls.get_indices(
-                1, new_partitions, lambda df: df.columns
-            )
-        else:
-            new_columns = self.columns
-        if len(new_columns) != len(self.columns):
-            new_column_widths = None
-        else:
-            new_column_widths = self._column_widths
+        axis_validate_mask = [validate_index, validate_columns]
+        new_axes = [
+            self.axes[axis]
+            if should_validate
+            else self._compute_axis(axis, new_partitions)
+            for axis, should_validate in enumerate(axis_validate_mask)
+        ]
+
+        new_lengths = [
+            self._axis_lengths[axis]
+            if len(new_axes[axis]) == len(self.axes[axis])
+            else None
+            for axis in [0, 1]
+        ]
+
         return self.__constructor__(
             new_partitions,
-            new_index,
-            new_columns,
-            new_row_lengths,
-            new_column_widths,
+            *new_axes,
+            *new_lengths,
             dtypes=dtypes,
         )
 
@@ -1170,26 +1164,18 @@ class BasePandasFrame(object):
         new_partitions = self._frame_mgr_cls.map_axis_partitions(
             axis, self._partitions, func, keep_partitioning=True
         )
-        if axis == 0:
-            new_index = self.index
-            new_lengths = self._row_lengths
-            new_widths = None  # We do not know what the resulting widths will be
-            new_columns = self._frame_mgr_cls.get_indices(
-                1, new_partitions, lambda df: df.columns
-            )
-        else:
-            new_columns = self.columns
-            new_lengths = None  # We do not know what the resulting lengths will be
-            new_widths = self._column_widths
-            new_index = self._frame_mgr_cls.get_indices(
-                0, new_partitions, lambda df: df.index
-            )
+        new_axes, new_lengths = [0, 0], [0, 0]
+
+        new_axes[axis] = self.axes[axis]
+        new_axes[axis ^ 1] = self._compute_axis(axis ^ 1, new_partitions)
+
+        new_lengths[axis] = self._axis_lengths[axis]
+        new_lengths[axis ^ 1] = None  # We do not know what the resulting widths will be
+
         return self.__constructor__(
             new_partitions,
-            new_index,
-            new_columns,
-            new_lengths,
-            new_widths,
+            *new_axes,
+            *new_lengths,
             self.dtypes if axis == 0 else None,
         )
 
@@ -1530,15 +1516,13 @@ class BasePandasFrame(object):
             broadcasted_dict,
             keep_remaining,
         )
-        if new_index is None:
-            new_index = self._frame_mgr_cls.get_indices(
-                0, new_partitions, lambda df: df.index
-            )
-        if new_columns is None:
-            new_columns = self._frame_mgr_cls.get_indices(
-                1, new_partitions, lambda df: df.columns
-            )
-        return self.__constructor__(new_partitions, new_index, new_columns)
+
+        new_axes = [
+            self._compute_axis(i, new_partitions) if new_axis is None else new_axis
+            for i, new_axis in enumerate([new_index, new_columns])
+        ]
+
+        return self.__constructor__(new_partitions, *new_axes)
 
     def broadcast_apply_full_axis(
         self,
@@ -1581,14 +1565,10 @@ class BasePandasFrame(object):
             keep_partitioning=True,
         )
         # Index objects for new object creation. This is shorter than if..else
-        if new_columns is None:
-            new_columns = self._frame_mgr_cls.get_indices(
-                1, new_partitions, lambda df: df.columns
-            )
-        if new_index is None:
-            new_index = self._frame_mgr_cls.get_indices(
-                0, new_partitions, lambda df: df.index
-            )
+        new_axes = [
+            self._compute_axis(i, new_partitions) if new_axis is None else new_axis
+            for i, new_axis in enumerate([new_index, new_columns])
+        ]
         if dtypes == "copy":
             dtypes = self._dtypes
         elif dtypes is not None:
@@ -1597,8 +1577,7 @@ class BasePandasFrame(object):
             )
         return self.__constructor__(
             new_partitions,
-            new_index,
-            new_columns,
+            *new_axes,
             None,
             None,
             dtypes,
@@ -1808,15 +1787,12 @@ class BasePandasFrame(object):
         new_partitions = self._frame_mgr_cls.groupby_reduce(
             axis, self._partitions, by._partitions, map_func, reduce_func
         )
-        if new_columns is None:
-            new_columns = self._frame_mgr_cls.get_indices(
-                1, new_partitions, lambda df: df.columns
-            )
-        if new_index is None:
-            new_index = self._frame_mgr_cls.get_indices(
-                0, new_partitions, lambda df: df.index
-            )
-        return self.__constructor__(new_partitions, new_index, new_columns)
+        new_axes = [
+            self._compute_axis(i, new_partitions) if new_axis is None else new_axis
+            for i, new_axis in enumerate([new_index, new_columns])
+        ]
+
+        return self.__constructor__(new_partitions, *new_axes)
 
     @classmethod
     def from_pandas(cls, df):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1334,10 +1334,13 @@ class BasePandasDataset(object):
                 query_compiler=self._query_compiler.apply("kurt", axis, **func_kwargs)
             )
 
-        if numeric_only:
+        if numeric_only is not None and not numeric_only:
             self._validate_dtypes(numeric_only=True)
+
+        data = self._numeric_data(axis) if numeric_only else self
+
         return self._reduce_dimension(
-            self._query_compiler.kurt(
+            data._query_compiler.kurt(
                 axis=axis,
                 skipna=skipna,
                 level=level,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1634,7 +1634,7 @@ class DataFrame(BasePandasDataset):
         **kwargs,
     ):
         """
-        Common function to do statistic reduce operations on frame
+        Do common statistic reduce operations under frame.
 
         Parameters
         ----------

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -40,7 +40,7 @@ import itertools
 import functools
 import numpy as np
 import sys
-from typing import Optional, Sequence, Tuple, Union, Mapping, Type
+from typing import Optional, Sequence, Tuple, Union, Mapping
 import warnings
 
 from modin.error_message import ErrorMessage

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1625,7 +1625,13 @@ class DataFrame(BasePandasDataset):
             return self.copy()
 
     def _stat_operation(
-        self, op_name: str, axis: int, numeric_only: Optional[bool] = None, **kwargs
+        self,
+        op_name: str,
+        axis: int,
+        skipna: bool,
+        level: Optional[Union[int, str]],
+        numeric_only: Optional[bool] = None,
+        **kwargs,
     ):
         """
         Common function to do statistic reduce operations on frame
@@ -1636,6 +1642,11 @@ class DataFrame(BasePandasDataset):
                 Name of method to apply.
             axis : int,
                 Axis to apply method on.
+            skipna : bool,
+                Exclude NA/null values when computing the result.
+            level : int or level name,
+                If specified `axis` is a MultiIndex, applying method along a particular
+                level, collapsing into a Series
             numeric_only : bool
                 Include only float, int, boolean columns. If None, will attempt
                 to use everything, then use only numeric data.
@@ -1653,10 +1664,12 @@ class DataFrame(BasePandasDataset):
 
         result_qc = getattr(data._query_compiler, op_name)(
             axis=axis,
+            skipna=skipna,
+            level=level,
             numeric_only=numeric_only,
             **kwargs,
         )
-        if kwargs.get("level", None) is not None:
+        if level is not None:
             return self.__constructor__(query_compiler=result_qc)
         return self._reduce_dimension(result_qc)
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1624,7 +1624,27 @@ class DataFrame(BasePandasDataset):
         else:
             return self.copy()
 
-    def _stat_operation(self, op_name, axis, skipna, level, numeric_only, **kwargs):
+    def _stat_operation(
+        self, op_name: str, axis: int, numeric_only: Optional[bool] = None, **kwargs
+    ):
+        """
+        Common function to do statistic reduce operations on frame
+
+        Parameters
+        ----------
+            op_name : str,
+                Name of method to apply.
+            axis : int,
+                Axis to apply method on.
+            numeric_only : bool
+                Include only float, int, boolean columns. If None, will attempt
+                to use everything, then use only numeric data.
+
+        Returns
+        -------
+        Series of DataFrame (if level specified)
+
+        """
         axis = self._get_axis_number(axis)
         if numeric_only is not None and not numeric_only:
             self._validate_dtypes(numeric_only=True)
@@ -1633,12 +1653,10 @@ class DataFrame(BasePandasDataset):
 
         result_qc = getattr(data._query_compiler, op_name)(
             axis=axis,
-            skipna=skipna,
-            level=level,
             numeric_only=numeric_only,
             **kwargs,
         )
-        if level is not None:
+        if kwargs.get("level", None) is not None:
             return self.__constructor__(query_compiler=result_qc)
         return self._reduce_dimension(result_qc)
 
@@ -2181,7 +2199,20 @@ class DataFrame(BasePandasDataset):
         else:
             self._update_inplace(new_query_compiler=new_query_compiler)
 
-    def _numeric_data(self, axis):
+    def _numeric_data(self, axis: int):
+        """
+        Grabs only numeric columns from frame.
+
+        Parameters
+        ----------
+            axis: int,
+            Axis to inspect on having numeric types only.
+            If axis is not 0, returns the frame itself.
+
+        Returns
+        -------
+        DataFrame with numeric data.
+        """
         # Pandas ignores `numeric_only` if `axis` is 1, but we do have to drop
         # non-numeric columns if `axis` is 0.
         if axis != 0:

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -33,7 +33,7 @@ from pandas.core.dtypes.common import (
 from pandas._libs.lib import no_default
 from pandas._typing import IndexKeyFunc
 import sys
-from typing import Union, Optional
+from typing import Union, Optional, Type
 import warnings
 
 from modin.utils import _inherit_docstrings, to_pandas
@@ -817,30 +817,6 @@ class Series(BasePandasDataset):
             )
         )
 
-    def median(self, axis=None, skipna=None, level=None, numeric_only=None, **kwargs):
-        axis = self._get_axis_number(axis)
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
-        if level is not None:
-            return self.__constructor__(
-                query_compiler=self._query_compiler.median(
-                    axis=axis,
-                    skipna=skipna,
-                    level=level,
-                    numeric_only=numeric_only,
-                    **kwargs,
-                )
-            )
-        return self._reduce_dimension(
-            self._query_compiler.median(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                numeric_only=numeric_only,
-                **kwargs,
-            )
-        )
-
     def memory_usage(self, index=True, deep=False):
         if index:
             result = self._reduce_dimension(
@@ -877,34 +853,6 @@ class Series(BasePandasDataset):
     def nsmallest(self, n=5, keep="first"):
         return Series(query_compiler=self._query_compiler.nsmallest(n=n, keep=keep))
 
-    def sem(
-        self, axis=None, skipna=None, level=None, ddof=1, numeric_only=None, **kwargs
-    ):
-        axis = self._get_axis_number(axis)
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
-        if level is not None:
-            return self.__constructor__(
-                query_compiler=self._query_compiler.sem(
-                    axis=axis,
-                    skipna=skipna,
-                    level=level,
-                    ddof=ddof,
-                    numeric_only=numeric_only,
-                    **kwargs,
-                )
-            )
-        return self._reduce_dimension(
-            self._query_compiler.sem(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                ddof=ddof,
-                numeric_only=numeric_only,
-                **kwargs,
-            )
-        )
-
     def slice_shift(self, periods=1, axis=0):
         if periods == 0:
             return self.copy()
@@ -937,58 +885,6 @@ class Series(BasePandasDataset):
         )
 
         return result.droplevel(0, axis=1) if result.columns.nlevels > 1 else result
-
-    def skew(self, axis=None, skipna=None, level=None, numeric_only=None, **kwargs):
-        axis = self._get_axis_number(axis)
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
-        if level is not None:
-            return self.__constructor__(
-                query_compiler=self._query_compiler.skew(
-                    axis=axis,
-                    skipna=skipna,
-                    level=level,
-                    numeric_only=numeric_only,
-                    **kwargs,
-                )
-            )
-        return self._reduce_dimension(
-            self._query_compiler.skew(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                numeric_only=numeric_only,
-                **kwargs,
-            )
-        )
-
-    def std(
-        self, axis=None, skipna=None, level=None, ddof=1, numeric_only=None, **kwargs
-    ):
-        axis = self._get_axis_number(axis)
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
-        if level is not None:
-            return self.__constructor__(
-                query_compiler=self._query_compiler.std(
-                    axis=axis,
-                    skipna=skipna,
-                    level=level,
-                    ddof=ddof,
-                    numeric_only=numeric_only,
-                    **kwargs,
-                )
-            )
-        return self._reduce_dimension(
-            self._query_compiler.std(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                ddof=ddof,
-                numeric_only=numeric_only,
-                **kwargs,
-            )
-        )
 
     @property
     def plot(
@@ -1471,34 +1367,6 @@ class Series(BasePandasDataset):
             )
         )
 
-    def var(
-        self, axis=None, skipna=None, level=None, ddof=1, numeric_only=None, **kwargs
-    ):
-        axis = self._get_axis_number(axis)
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
-        if level is not None:
-            return self.__constructor__(
-                query_compiler=self._query_compiler.var(
-                    axis=axis,
-                    skipna=skipna,
-                    level=level,
-                    ddof=ddof,
-                    numeric_only=numeric_only,
-                    **kwargs,
-                )
-            )
-        return self._reduce_dimension(
-            self._query_compiler.var(
-                axis=axis,
-                skipna=skipna,
-                level=level,
-                ddof=ddof,
-                numeric_only=numeric_only,
-                **kwargs,
-            )
-        )
-
     def view(self, dtype=None):
         return self.__constructor__(
             query_compiler=self._query_compiler.series_view(dtype=dtype)
@@ -1689,7 +1557,9 @@ class Series(BasePandasDataset):
     def _validate_dtypes(self, numeric_only=False):
         pass
 
-    def _numeric_data(self, axis):
+    def _get_numeric_data(self, axis: int):
+        # `numeric_only` parameter does not supported by Series, so this method
+        # doesn't do anything
         return self
 
     def _update_inplace(self, new_query_compiler):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -33,7 +33,7 @@ from pandas.core.dtypes.common import (
 from pandas._libs.lib import no_default
 from pandas._typing import IndexKeyFunc
 import sys
-from typing import Union, Optional, Type
+from typing import Union, Optional
 import warnings
 
 from modin.utils import _inherit_docstrings, to_pandas

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1689,6 +1689,9 @@ class Series(BasePandasDataset):
     def _validate_dtypes(self, numeric_only=False):
         pass
 
+    def _numeric_data(self, axis):
+        return self
+
     def _update_inplace(self, new_query_compiler):
         """
         Implement [METHOD_NAME].

--- a/modin/pandas/test/dataframe/test_reduction.py
+++ b/modin/pandas/test/dataframe/test_reduction.py
@@ -356,7 +356,7 @@ def test_sum_single_column(data):
 
 
 @pytest.mark.parametrize(
-    "fn", ["max", "min", "median", "skew", "kurt", "sem", "std", "var"]
+    "fn", ["max", "min", "median", "mean", "skew", "kurt", "sem", "std", "var"]
 )
 @pytest.mark.parametrize(
     "numeric_only", bool_arg_values, ids=arg_keys("numeric_only", bool_arg_keys)

--- a/modin/pandas/test/dataframe/test_reduction.py
+++ b/modin/pandas/test/dataframe/test_reduction.py
@@ -305,26 +305,6 @@ def test_prod(
     df_equals(modin_result, pandas_result)
 
 
-@pytest.mark.parametrize(
-    "numeric_only",
-    [
-        pytest.param(None, marks=pytest.mark.xfail(reason="See #1976 for details")),
-        False,
-        True,
-    ],
-)
-@pytest.mark.parametrize(
-    "min_count", int_arg_values, ids=arg_keys("min_count", int_arg_keys)
-)
-def test_prod_specific(min_count, numeric_only):
-    if min_count == 5 and numeric_only:
-        pytest.xfail("see #1953 for details")
-    eval_general(
-        *create_test_dfs(test_data_diff_dtype),
-        lambda df: df.prod(min_count=min_count, numeric_only=numeric_only),
-    )
-
-
 @pytest.mark.parametrize("is_transposed", [False, True])
 @pytest.mark.parametrize(
     "skipna", bool_arg_values, ids=arg_keys("skipna", bool_arg_keys)
@@ -353,19 +333,17 @@ def test_sum(data, axis, skipna, is_transposed):
     df_equals(modin_result, pandas_result)
 
 
+@pytest.mark.parametrize("fn", ["prod, sum"])
 @pytest.mark.parametrize(
-    "numeric_only",
-    [
-        pytest.param(None, marks=pytest.mark.xfail(reason="See #1976 for details")),
-        False,
-        True,
-    ],
+    "numeric_only", bool_arg_values, ids=arg_keys("numeric_only", bool_arg_keys)
 )
-@pytest.mark.parametrize("min_count", int_arg_values)
-def test_sum_specific(min_count, numeric_only):
+@pytest.mark.parametrize(
+    "min_count", int_arg_values, ids=arg_keys("min_count", int_arg_keys)
+)
+def test_sum_prod_specific(fn, min_count, numeric_only):
     eval_general(
         *create_test_dfs(test_data_diff_dtype),
-        lambda df: df.sum(min_count=min_count, numeric_only=numeric_only),
+        lambda df: getattr(df, fn)(min_count=min_count, numeric_only=numeric_only),
     )
 
 
@@ -375,3 +353,16 @@ def test_sum_single_column(data):
     pandas_df = pandas.DataFrame(data).iloc[:, [0]]
     df_equals(modin_df.sum(), pandas_df.sum())
     df_equals(modin_df.sum(axis=1), pandas_df.sum(axis=1))
+
+
+@pytest.mark.parametrize(
+    "fn", ["max", "min", "median", "skew", "kurt", "sem", "std", "var"]
+)
+@pytest.mark.parametrize(
+    "numeric_only", bool_arg_values, ids=arg_keys("numeric_only", bool_arg_keys)
+)
+def test_reduction_specific(fn, numeric_only):
+    eval_general(
+        *create_test_dfs(test_data_diff_dtype),
+        lambda df: getattr(df, fn)(numeric_only=numeric_only),
+    )

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -174,7 +174,6 @@ test_data_diff_dtype = {
     "float_col": [np.NaN, -9.4, 10.1, np.NaN],
     "str_col": ["a", np.NaN, "c", "d"],
     "bool_col": [False, True, True, False],
-    "nan_col": [np.NaN] * 4,
 }
 
 test_data_small_values = list(test_data_small.values())

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -174,6 +174,7 @@ test_data_diff_dtype = {
     "float_col": [np.NaN, -9.4, 10.1, np.NaN],
     "str_col": ["a", np.NaN, "c", "d"],
     "bool_col": [False, True, True, False],
+    "nan_col": [np.NaN] * 4,
 }
 
 test_data_small_values = list(test_data_small.values())


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1976 <!-- issue must be created for each patch -->
- [x] tests added and passing

## Brief description of a bug
You can find reproducer and short explanation at #1976. We're getting error, because of mismatching between internal and external indices. Currently, we're trying to precompute new labels for indices and columns of the resulted frame in reduction operations, but sometimes we're failing to do so.

It happens when `numeric_only` parameter in reduction operations considered to be `None`, going from [pandas documentation](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.sem.html?highlight=numeric_only) in that case pandas determines whether to drop or not to drop non-numeric column only after applying numeric function and so we also can't predict that columns, so we need to compute new labels explicitly, after applying our function.

Functions that affected by this bug is those, that can obtain `numeric_only=None`. [List of affected operations](https://pandas.pydata.org/pandas-docs/stable/search.html?q=numeric_only+If+None%2C+will+attempt+to+use+everything): `kurt max mean median min prod sem skew std sum var`

There is also a bug, that we're not dropping non-numeric columns when `numeric_only=True`, this PR also fixing this.

## What was done in this PR

- Added `preserve_index` parameter to `_fold_reduce` with which we can control: whether to try to precompute new indices or explicitly compute it after applying our function. All reduction operations from the list above passes `preserve_index=False` if `numeric_only=None` (that logic was added at `pandas query_compiler -> _numeric_only_reduce_fn`)
- Added `preserve_index` parameter to `_compute_map_reduce_metadata` at `BasePandasFrame`
- Moved logic of computing new labels at `engines/base/data.py` to `_compute_axis_labels` to get rid of code duplication.
- Added common function `_stat_operation` to apply reduction operations to get rid of code duplication
- Added dropping non-numeric columns when `numeric_only=True` for functions from the list above (at `_stat_operation` function)