### PR TITLE
FIX-#2277: applied Title Case to the names of DATASET_SIZE_DICT keys

### DIFF
--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -28,13 +28,13 @@ from io import BytesIO
 random_state = np.random.RandomState(seed=42)
 
 DATASET_SIZE_DICT = {
-    "small": (2 ** 2, 2 ** 3),
-    "normal": (2 ** 6, 2 ** 8),
-    "big": (2 ** 7, 2 ** 12),
+    "Small": (2 ** 2, 2 ** 3),
+    "Normal": (2 ** 6, 2 ** 8),
+    "Big": (2 ** 7, 2 ** 12),
 }
 
 # Size of test dataframes
-NCOLS, NROWS = DATASET_SIZE_DICT.get(TestDatasetSize.get(), DATASET_SIZE_DICT["normal"])
+NCOLS, NROWS = DATASET_SIZE_DICT.get(TestDatasetSize.get(), DATASET_SIZE_DICT["Normal"])
 
 # Range for values for test data
 RAND_LOW = 0


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2277 <!-- issue must be created for each patch -->
- [ ] tests passing
