### PR TITLE
FIX-#1765: Fix support of s3 in `read_parquet`

### DIFF
--- a/modin/backends/pandas/parsers.py
+++ b/modin/backends/pandas/parsers.py
@@ -355,6 +355,17 @@ class PandasParquetParser(PandasParser):
     def parse(fname, **kwargs):
         num_splits = kwargs.pop("num_splits", None)
         columns = kwargs.get("columns", None)
+        if fname.startswith("s3://"):
+            from botocore.exceptions import NoCredentialsError
+            import s3fs
+
+            try:
+                fs = s3fs.S3FileSystem()
+                fname = fs.open(fname)
+            except NoCredentialsError:
+                fs = s3fs.S3FileSystem(anon=True)
+                fname = fs.open(fname)
+
         if num_splits is None:
             return pandas.read_parquet(fname, **kwargs)
         kwargs["use_pandas_metadata"] = True

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -285,14 +285,14 @@ class BasePandasFrame(object):
                 [
                     self._partitions[i][j]
                     for j in range(len(self._partitions[i]))
-                    if j < len(self._column_widths) and self._column_widths[j] > 0
+                    if j < len(self._column_widths) and self._column_widths[j] != 0
                 ]
                 for i in range(len(self._partitions))
-                if i < len(self._row_lengths) and self._row_lengths[i] > 0
+                if i < len(self._row_lengths) and self._row_lengths[i] != 0
             ]
         )
-        self._column_widths_cache = [w for w in self._column_widths if w > 0]
-        self._row_lengths_cache = [r for r in self._row_lengths if r > 0]
+        self._column_widths_cache = [w for w in self._column_widths if w != 0]
+        self._row_lengths_cache = [r for r in self._row_lengths if r != 0]
 
     def _validate_axis_equality(self, axis: int, force: bool = False):
         """

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -12,5 +12,6 @@ dependencies:
   - coverage<5.0
   - pygithub==1.53
   - omniscidbe4py
+  - s3fs>=0.4.2
   - pip:
     - ray>=1.0.0


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1765  <!-- issue must be created for each patch -->
- [x] tests added and passing
