### PR TITLE
FIX-#2285: Default to pandas warning message improved

### DIFF
--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -23,6 +23,7 @@ from modin.data_management.functions.default_methods import (
     CatDefault,
     GroupByDefault,
 )
+from modin.error_message import ErrorMessage
 
 from pandas.core.dtypes.common import is_scalar
 import pandas.core.resample
@@ -32,6 +33,7 @@ import numpy as np
 
 def _get_axis(axis):
     def axis_getter(self):
+        ErrorMessage.default_to_pandas(f"DataFrame.get_axis({axis})")
         return self.to_pandas().axes[axis]
 
     return axis_getter

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -209,7 +209,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         ----
         This operation takes a distributed object and converts it directly to pandas.
         """
-        ErrorMessage.default_to_pandas(str(pandas_op))
+        op_name = getattr(pandas_op, "__name__", str(pandas_op))
+        ErrorMessage.default_to_pandas(op_name)
         args = (a.to_pandas() if isinstance(a, type(self)) else a for a in args)
         kwargs = {
             k: v.to_pandas if isinstance(v, type(self)) else v

--- a/modin/data_management/functions/default_methods/binary_default.py
+++ b/modin/data_management/functions/default_methods/binary_default.py
@@ -19,7 +19,7 @@ from pandas.core.dtypes.common import is_list_like
 
 class BinaryDefault(AnyDefault):
     @classmethod
-    def build_default_to_pandas(cls, fn):
+    def build_default_to_pandas(cls, fn, fn_name):
         def bin_ops_wrapper(df, other, *args, **kwargs):
             squeeze_other = kwargs.pop("broadcast", False) or kwargs.pop(
                 "squeeze_other", False
@@ -41,7 +41,4 @@ class BinaryDefault(AnyDefault):
                 result = pandas.DataFrame(result)
             return result
 
-        def wrapper(self, *args, **kwargs):
-            return self.default_to_pandas(bin_ops_wrapper, *args, **kwargs)
-
-        return wrapper
+        return super().build_default_to_pandas(bin_ops_wrapper, fn_name)

--- a/modin/data_management/functions/default_methods/groupby_default.py
+++ b/modin/data_management/functions/default_methods/groupby_default.py
@@ -145,6 +145,8 @@ class GroupBy:
 
 
 class GroupByDefault(DefaultMethod):
+    OBJECT_TYPE = "GroupBy"
+
     @classmethod
     def register(cls, func, **kwargs):
-        return cls.call(GroupBy.build_groupby(func), **kwargs)
+        return cls.call(GroupBy.build_groupby(func), fn_name=func.__name__, **kwargs)

--- a/modin/data_management/functions/default_methods/resample_default.py
+++ b/modin/data_management/functions/default_methods/resample_default.py
@@ -31,6 +31,12 @@ class Resampler:
 
 
 class ResampleDefault(DefaultMethod):
+    OBJECT_TYPE = "Resampler"
+
     @classmethod
     def register(cls, func, squeeze_self=False, **kwargs):
-        return cls.call(Resampler.build_resample(func, squeeze_self), **kwargs)
+        return cls.call(
+            Resampler.build_resample(func, squeeze_self),
+            fn_name=func.__name__,
+            **kwargs
+        )

--- a/modin/data_management/functions/default_methods/rolling_default.py
+++ b/modin/data_management/functions/default_methods/rolling_default.py
@@ -29,6 +29,8 @@ class Rolling:
 
 
 class RollingDefault(DefaultMethod):
+    OBJECT_TYPE = "Rolling"
+
     @classmethod
     def register(cls, func, **kwargs):
-        return cls.call(Rolling.build_rolling(func), **kwargs)
+        return cls.call(Rolling.build_rolling(func), fn_name=func.__name__, **kwargs)

--- a/modin/data_management/functions/default_methods/series_default.py
+++ b/modin/data_management/functions/default_methods/series_default.py
@@ -15,6 +15,8 @@ from .any_default import AnyDefault
 
 
 class SeriesDefault(AnyDefault):
+    OBJECT_TYPE = "Series"
+
     @classmethod
     def frame_wrapper(cls, df):
         return df.squeeze(axis=1)

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -447,15 +447,15 @@ def test_to_pandas_indices():
 @pytest.mark.parametrize(
     "func, regex",
     [
-        (lambda df: df.mean(level=0), r"[^D]*DataFrame\.mean"),
-        (lambda df: df + df, r"[^D]*DataFrame\.add"),
-        (lambda df: df.index, r"[^D]*DataFrame.get_axis\(0\)"),
+        (lambda df: df.mean(level=0), r"DataFrame\.mean"),
+        (lambda df: df + df, r"DataFrame\.add"),
+        (lambda df: df.index, r"DataFrame\.get_axis\(0\)"),
         (
             lambda df: df.drop(columns="col1").squeeze().repeat(2),
-            r"[^S]*Series\.repeat",
+            r"Series\.repeat",
         ),
-        (lambda df: df.groupby("col1").prod(), r"[^G]*GroupBy\.prod"),
-        (lambda df: df.rolling(1).count(), r"[^R]*Rolling\.count"),
+        (lambda df: df.groupby("col1").prod(), r"GroupBy\.prod"),
+        (lambda df: df.rolling(1).count(), r"Rolling\.count"),
     ],
 )
 def test_default_to_pandas_warning_message(func, regex):

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -16,6 +16,7 @@ import pytest
 import modin.pandas as pd
 import numpy as np
 from numpy.testing import assert_array_equal
+from modin.utils import get_current_backend
 
 from .utils import test_data_values, test_data_keys, df_equals
 
@@ -437,3 +438,29 @@ def test_to_pandas_indices():
         assert md_df.axes[axis].equal_levels(
             pd_df.axes[axis]
         ), f"Levels of indices at axis {axis} are different!"
+
+
+@pytest.mark.skipif(
+    get_current_backend() != "BaseOnPython",
+    reason="This test make sense only on BaseOnPython backend.",
+)
+@pytest.mark.parametrize(
+    "func, regex",
+    [
+        (lambda df: df.mean(level=0), r"[^D]*DataFrame\.mean"),
+        (lambda df: df + df, r"[^D]*DataFrame\.add"),
+        (lambda df: df.index, r"[^D]*DataFrame.get_axis\(0\)"),
+        (
+            lambda df: df.drop(columns="col1").squeeze().repeat(2),
+            r"[^S]*Series\.repeat",
+        ),
+        (lambda df: df.groupby("col1").prod(), r"[^G]*GroupBy\.prod"),
+        (lambda df: df.rolling(1).count(), r"[^R]*Rolling\.count"),
+    ],
+)
+def test_default_to_pandas_warning_message(func, regex):
+    data = {"col1": [1, 2, 3], "col2": [4, 5, 6]}
+    df = pd.DataFrame(data)
+
+    with pytest.warns(UserWarning, match=regex):
+        func(df)


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2285 <!-- issue must be created for each patch -->
- [x] tests added and passing

Example of improved warning:
```
# How it started:
UserWarning: <function DefaultMethod.call.<locals>.applyier at 0x7f8a004300d0> defaulting to pandas implementation.

# How it's going:
UserWarning: <function GroupBy.prod> defaulting to pandas implementation.

```