### PR TITLE
FIX-#2258: return 'Commit Message formatting' topic

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ if you have questions about contributing.
 
 <!-- Please give a short brief about these changes. -->
 
-- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
+- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html)
 - [ ] passes `flake8 modin`
 - [ ] passes `black --check modin`
 - [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->

--- a/docs/developer/contributing.rst
+++ b/docs/developer/contributing.rst
@@ -82,6 +82,28 @@ commits and push them to GitHub.
 If you've pushed your changes to GitHub already you'll need to force push your branch
 after this with ``git push -f``.
 
+Commit Message formatting
+-------------------------
+To ensure that all commit messages in the master branch follow a specific format, we
+enforce that all commit messages must follow the following format:
+
+.. code-block:: bash
+  FEAT-#9999: Add `DataFrame.rolling` functionality, to enable rolling window operations
+The ``FEAT`` component represents the type of commit. This component of the commit
+message can be one of the following:
+
+* FEAT: A new feature that is added
+* DOCS: Documentation improvements or updates
+* FIX: A bugfix contribution
+* REFACTOR: Moving or removing code without change in functionality
+* TEST: Test updates or improvements
+
+The ``#9999`` component of the commit message should be the issue number in the Modin
+GitHub issue tracker: https://github.com/modin-project/modin/issues. This is important
+because it links commits to their issues.
+
+The commit message should follow a colon (:) and be descriptive and succinct.
+
 Development Dependencies
 ------------------------
 


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2258 <!-- issue must be created for each patch -->
- [ ] tests added and passing
