### PR TITLE
FIX-#2311: fixed performance regression at reduction operations

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -171,8 +171,9 @@ def _numeric_only_reduce_fn(applier: Type[Function], *funcs) -> Callable:
     """
 
     def caller(self, *args, **kwargs):
-        # If `numeric_only` is None then we don't know what columns/indices will
-        # be dropped at the result of reduction function, and so can't preserve labels
+        # If `numeric_only` is None and the frame contains non-numeric columns,
+        # then we don't know what columns/indices will be dropped at the result
+        # of reduction function, and so can't preserve labels
         preserve_index = kwargs.get("numeric_only", None) is not None
         return applier.register(*funcs, preserve_index=preserve_index)(
             self, *args, **kwargs

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1449,8 +1449,18 @@ class BasePandasDataset(object):
 
         """
         axis = self._get_axis_number(axis)
-        if numeric_only is not None and not numeric_only:
-            self._validate_dtypes(numeric_only=True)
+        # If `numeric_only` is None, then we can do this precheck to whether or not
+        # frame contains non-numeric columns, if it doesn't, then we can pass to a backend
+        # `numeric_only=False` parameter and make its work easier in that case, rather than
+        # performing under complicate `numeric_only=None` parameter
+        if not numeric_only:
+            try:
+                self._validate_dtypes(numeric_only=True)
+            except TypeError:
+                if numeric_only is not None:
+                    raise
+            else:
+                numeric_only = False
 
         data = self._get_numeric_data(axis) if numeric_only else self
 

--- a/modin/pandas/test/dataframe/test_reduction.py
+++ b/modin/pandas/test/dataframe/test_reduction.py
@@ -358,11 +358,14 @@ def test_sum_single_column(data):
 @pytest.mark.parametrize(
     "fn", ["max", "min", "median", "mean", "skew", "kurt", "sem", "std", "var"]
 )
+@pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize(
     "numeric_only", bool_arg_values, ids=arg_keys("numeric_only", bool_arg_keys)
 )
-def test_reduction_specific(fn, numeric_only):
+def test_reduction_specific(fn, numeric_only, axis):
+    if fn == "mean" and axis == 1:
+        pytest.skip("See issue #2313 for details")
     eval_general(
         *create_test_dfs(test_data_diff_dtype),
-        lambda df: getattr(df, fn)(numeric_only=numeric_only),
+        lambda df: getattr(df, fn)(numeric_only=numeric_only, axis=axis),
     )


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2311 <!-- issue must be created for each patch -->
- [x] tests added and passing

## What was done
- Removed logic by computing new axis in case of `numeric_only=None` from `_compute_map_reduce_metadata`, to have all logic about validating axis in `_validate_internal_axis`
- Added new mode at `_validate_internal_axis`, where we're also validating not reduced axis with `force=True` on it
- Now `_compute_map_reduce_metadata` uses new added mode to validate axes in case of `preserve_index=False`
- Removed unnecessary `dtypes` recomputing at `_compute_map_reduce_metadata` in case of `axis=0`
- Now, in case of `numeric_only=None` at reduction operations, we're checking is all columns of the frame are numeric, and if it is, then setting `numeric_only=False` to preserve labels

Regression in cases not affected by bug described in #1976 (`numeric_only=None` and frame contains only numeric data):
**Axis = 0:**
| Method name |Before [`55e3459`](https://github.com/modin-project/modin/commit/55e345951818761ad26711cde91bb0d2b296aa5f) | After #2314 | After [`55e3459`](https://github.com/modin-project/modin/commit/55e345951818761ad26711cde91bb0d2b296aa5f) | Degradation xTIMES after [`55e3459`](https://github.com/modin-project/modin/commit/55e345951818761ad26711cde91bb0d2b296aa5f)| Current degradation xTIMES after #2314 |
|-|-|-|-|-|-|
| mean | 0.55s | 0.57s | 1.12s | 2.03x | 1.03x |
| std | 0.23s | 0.23s | 0.77s | 3.3x | 1x |
| kurt | 0.23s | 0.25s | 0.76s | 3.3x | 1.08x |
| max | 0.51s | 0.55s | 1.07s |  2.09x | 1.07x |
| median | 0.23s | 0.23s | 0.76s | 3.3x | 1x |
| min | 0.52s | 0.54s | 1.06s | 2.03x | 1.03x |
| prod | 0.51s | 0.55s | 0.97s | 1.9x | 1.07x |
| sem | 0.23s | 0.22s | 0.76s | 3.3x | 0.95x |
| skew | 0.23s | 0.23s | 0.76s | 3.3x | 1x |
| sum | 0.50s | 0.54s | 1.06s | 2.12x | 1.08x |
| var | 0.22s | 0.23s | 0.77s | 3.3x | 1.04x |
| sum min_count | 0.27s | 0.3s | - | - | 1.1x |
| prod min_count | 0.25s | 0.29s | - | - | 1.16x |


**Axis = 1:**
| Method name |Before [`55e3459`](https://github.com/modin-project/modin/commit/55e345951818761ad26711cde91bb0d2b296aa5f) | After #2314 | Current degradation xTIMES after #2314 |
|-|-|-|-|
| mean | 0.60s | 0.60s | 1x |
| std | 0.25s | 0.26s | 1.04x | 
| kurt | 0.25s | 0.31s | 1.24x |
| max | 0.55s | 0.61s | 1.1x |
| median | 0.26s | 0.27s | 1.03x |
| min | 0.53s | 0.61s | 1.15x |
| prod | 0.53s | 0.61s | 1.15x |
| sem | 0.26s | 0.26s | 1x |
| skew | 0.27s | 0.27s | 1x |
| sum | 0.52s | 0.58s | 1.11x |
| var | 0.27s | 0.27s | 1x |
| sum min_count | 0.27s | 0.32s | 1.18x |
| prod min_count | 0.27s | 0.31s | 1.14x |


<details><summary> script </summary>

```python
import pandas
import modin.pandas as pd

from timeit import default_timer as timer
import numpy as np

NCOLS = 2 ** 10
NROWS = 2 ** 10
RAND_LOW = 0
RAND_HIGH = 100
random_state = np.random.RandomState(seed=42)


def measure(df, op):
    if isinstance(op, str):
        func = lambda df, *args, **kwargs: getattr(df, op)(*args, **kwargs)
    else:
        func = op
    start = timer()
    # repr to trigger materialization
    repr(func(df, axis=1))
    end = timer()
    return end - start


float_nan_data = {
    f"col{int((i - NCOLS /2)% NCOLS + 1)}": [
        x if (j % 4 == 0 and i > NCOLS // 2) or (j != i and i <= NCOLS // 2) else np.NaN
        for j, x in enumerate(random_state.uniform(RAND_LOW, RAND_HIGH, size=(NROWS)))
    ]
    for i in range(NCOLS)
}


def build_min_count(op_name):
    method = lambda df, *args, **kwargs: getattr(df, op_name)(min_count=2, *args, **kwargs)
    method.__name__ = f"{op_name} min_count"
    return method


def to_str(x):
    return x if isinstance(x, str) else x.__name__


operations = [
    "mean",
    "std",
    "kurt",
    "max",
    "median",
    "min",
    "prod",
    "sem",
    "skew",
    "sum",
    "var",
    build_min_count("sum"),
    build_min_count("prod"),
]
NTRIES = 20
df = pd.DataFrame(float_nan_data)
for op in operations:
    result = np.min([measure(df, op) for _ in range(NTRIES)])
    print(f"Min time of {NTRIES} tries for {to_str(op)}: {result}")
```


</details>

