### PR TITLE
FIX-#2253: loc assignment fixed in case of (1, 1) shape frame

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -415,7 +415,9 @@ class _LocationIndexerBase(object):
 
     def _determine_setitem_axis(self, row_lookup, col_lookup, row_scaler, col_scaler):
         """
-        Determine an axis along which we should do an assignment:
+        Determine an axis along which we should do an assignment.
+
+        Note:
             axis = 0: column assignment df[col] = item
             axis = 1: row assignment df.loc[row] = item
             axis = None: assignment along both axes

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -437,11 +437,6 @@ class _LocationIndexerBase(object):
         """
         Determine an axis along which we should do an assignment.
 
-        Note:
-            axis = 0: column assignment df[col] = item
-            axis = 1: row assignment df.loc[row] = item
-            axis = None: assignment along both axes
-
         Parameters
         ----------
         row_lookup: slice or list
@@ -457,6 +452,12 @@ class _LocationIndexerBase(object):
         -------
         int or None
             None if this will be a both axis assignment, number of axis to assign in other cases.
+
+        Notes
+        -----
+            axis = 0: column assignment df[col] = item
+            axis = 1: row assignment df.loc[row] = item
+            axis = None: assignment along both axes
         """
         if self.df.shape == (1, 1):
             return None if not (row_scaler ^ col_scaler) else 1 if row_scaler else 0
@@ -464,7 +465,7 @@ class _LocationIndexerBase(object):
         def get_axis(axis):
             return self.qc.index if axis == 0 else self.qc.columns
 
-        row_look_len, col_look_len = [
+        row_lookup_len, col_lookup_len = [
             len(lookup)
             if not isinstance(lookup, slice)
             else compute_sliced_len(lookup, len(get_axis(i)))
@@ -472,12 +473,12 @@ class _LocationIndexerBase(object):
         ]
 
         if (
-            row_look_len == len(self.qc.index)
-            and col_look_len == 1
+            row_lookup_len == len(self.qc.index)
+            and col_lookup_len == 1
             and isinstance(self.df, DataFrame)
         ):
             axis = 0
-        elif col_look_len == len(self.qc.columns) and row_look_len == 1:
+        elif col_lookup_len == len(self.qc.columns) and row_lookup_len == 1:
             axis = 1
         else:
             axis = None

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -293,7 +293,7 @@ class _LocationIndexerBase(object):
             )
         return self.df.__constructor__(query_compiler=qc_view).squeeze(axis=axis)
 
-    def __setitem__(self, row_lookup, col_lookup, item):
+    def __setitem__(self, row_lookup, col_lookup, item, axis=None):
         """
         Implement [METHOD_NAME].
 
@@ -317,15 +317,11 @@ class _LocationIndexerBase(object):
             col_lookup = range(len(self.qc.columns))[col_lookup]
         # This is True when we dealing with assignment of a full column. This case
         # should be handled in a fastpath with `df[col] = item`.
-        if (
-            len(row_lookup) == len(self.qc.index)
-            and len(col_lookup) == 1
-            and hasattr(self.df, "columns")
-        ):
+        if axis == 0:
             self.df[self.df.columns[col_lookup][0]] = item
         # This is True when we are assigning to a full row. We want to reuse the setitem
         # mechanism to operate along only one axis for performance reasons.
-        elif len(col_lookup) == len(self.qc.columns) and len(row_lookup) == 1:
+        elif axis == 1:
             if hasattr(item, "_query_compiler"):
                 item = item._query_compiler
             new_qc = self.qc.setitem(1, self.qc.index[row_lookup[0]], item)
@@ -417,6 +413,44 @@ class _LocationIndexerBase(object):
         new_qc = self.qc.write_items(row_lookup, col_lookup, item)
         self.df._create_or_update_from_compiler(new_qc, inplace=True)
 
+    def _determine_setitem_axis(self, row_lookup, col_lookup, row_scaler, col_scaler):
+        """
+        Determine an axis along which we should do an assignment:
+            axis = 0: column assignment df[col] = item
+            axis = 1: row assignment df.loc[row] = item
+            axis = None: assignment along both axes
+
+        Parameters
+        ----------
+        row_lookup: slice or list
+            Indexer for rows
+        col_lookup: slice or list
+            Indexer for columns
+        row_scaler: bool
+            Whether indexer for rows was slacar or not
+        col_scaler: bool
+            Whether indexer for columns was slacer or not
+
+        Returns
+        -------
+        int or None
+            None if this will be a both axis assignment, number of axis to assign in other cases.
+        """
+        if self.df.shape == (1, 1):
+            return None if not (row_scaler ^ col_scaler) else 1 if row_scaler else 0
+
+        if (
+            len(row_lookup) == len(self.qc.index)
+            and len(col_lookup) == 1
+            and hasattr(self.df, "columns")
+        ):
+            axis = 0
+        elif len(col_lookup) == len(self.qc.columns) and len(row_lookup) == 1:
+            axis = 1
+        else:
+            axis = None
+        return axis
+
 
 class _LocIndexer(_LocationIndexerBase):
     """An indexer for modin_df.loc[] functionality."""
@@ -507,7 +541,7 @@ class _LocIndexer(_LocationIndexerBase):
         -------
         What this returns (if anything)
         """
-        row_loc, col_loc, _, __, ___ = _parse_tuple(key)
+        row_loc, col_loc, _, row_scaler, col_scaler = _parse_tuple(key)
         if isinstance(row_loc, list) and len(row_loc) == 1:
             if row_loc[0] not in self.qc.index:
                 index = self.qc.index.insert(len(self.qc.index), row_loc[0])
@@ -525,7 +559,14 @@ class _LocIndexer(_LocationIndexerBase):
             self.qc = self.df._query_compiler
         else:
             row_lookup, col_lookup = self._compute_lookup(row_loc, col_loc)
-            super(_LocIndexer, self).__setitem__(row_lookup, col_lookup, item)
+            super(_LocIndexer, self).__setitem__(
+                row_lookup,
+                col_lookup,
+                item,
+                axis=self._determine_setitem_axis(
+                    row_lookup, col_lookup, row_scaler, col_scaler
+                ),
+            )
 
     def _compute_enlarge_labels(self, locator, base_index):
         """
@@ -663,12 +704,19 @@ class _iLocIndexer(_LocationIndexerBase):
         -------
         What this returns (if anything)
         """
-        row_loc, col_loc, _, __, ___ = _parse_tuple(key)
+        row_loc, col_loc, _, row_scaler, col_scaler = _parse_tuple(key)
         self._check_dtypes(row_loc)
         self._check_dtypes(col_loc)
 
         row_lookup, col_lookup = self._compute_lookup(row_loc, col_loc)
-        super(_iLocIndexer, self).__setitem__(row_lookup, col_lookup, item)
+        super(_iLocIndexer, self).__setitem__(
+            row_lookup,
+            col_lookup,
+            item,
+            axis=self._determine_setitem_axis(
+                row_lookup, col_lookup, row_scaler, col_scaler
+            ),
+        )
 
     def _compute_lookup(self, row_loc, col_loc):
         """

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -390,9 +390,6 @@ def test_loc_multi_index():
 @pytest.mark.parametrize("index", [["row1", "row2", "row3"], ["row1"]])
 @pytest.mark.parametrize("columns", [["col1", "col2"], ["col1"]])
 def test_loc_assignment(index, columns):
-    if len(index) == 1 and len(columns) == 1:
-        pytest.skip("See Modin issue #2253 for details")
-
     md_df, pd_df = create_test_dfs(index=index, columns=columns)
     for i, ind in enumerate(index):
         for j, col in enumerate(columns):


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2253 <!-- issue must be created for each patch -->
- [x] tests passing

You can find a brief bug explanation and reproducer at #2253

## What was done:
- Moved logic about determining assignment axis from `__setitem__` to a separate method, `__setitem__` now obtains assignment axis as a parameter
- Since for frames with shape `(1, 1)` we can't compute assignment axis by row and column lookups, now for `(1, 1)` shape frames we're doing it by row and column scaler parameters. The idea is that if row identifier was scalar, and column don't, then it's definitely a row assignment and vie-versa
```
Example:
df.loc["a", any_non_scalar_indexer] -> row_scaler = True   | This is going to be row assignment
                                    -> col_scaler = False  |

df.loc[any_indexer, "a"] -> row_scaler = False | This is goint to be a column assignment
                         -> col_scaler = True  |

df.loc["a", "b"] -> row_scaler = True                                        | This is going to be a both axis assignment
                 -> col_scaler = True                                        |
df.loc[any_non_scalar_indexer, any_non_scalar_indexer] -> row_scaler = False |
						       -> col_scaler = False |
```