### PR TITLE
TEST-#2292: Cover by tests Datetime Handling parameters of read_csv

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -177,13 +177,12 @@ def _make_csv_file(filenames):
         add_nan_lines=False,
         thousands_separator=None,
         decimal_separator=None,
-        lineterminator=None,
         comment_col_char=None,
         quoting=csv.QUOTE_MINIMAL,
         quotechar='"',
         doublequote=True,
         escapechar=None,
-        line_terminator=os.linesep,
+        line_terminator=None,
     ):
         if os.path.exists(filename) and not force:
             pass
@@ -588,10 +587,15 @@ class TestReadCSV:
         cache_dates,
     ):
         if request.config.getoption("--simulate-cloud").lower() != "off":
-            pytest.xfail("The reason of tests fail in `cloud` mode is unknown for now")
-        case_with_TypeError = isinstance(parse_dates, dict) and callable(date_parser)
-        case_with_TypeError_exc = list(io_ops_bad_exc)
-        case_with_TypeError_exc.remove(TypeError)
+            pytest.xfail(
+                "The reason of tests fail in `cloud` mode is unknown for now - issue #2340"
+            )
+
+        raising_exceptions = io_ops_bad_exc  # default value
+        if isinstance(parse_dates, dict) and callable(date_parser):
+            # In this case raised TypeError: <lambda>() takes 1 positional argument but 2 were given
+            raising_exceptions = list(io_ops_bad_exc)
+            raising_exceptions.remove(TypeError)
 
         kwargs = {
             "parse_dates": parse_dates,
@@ -606,9 +610,7 @@ class TestReadCSV:
             filepath_or_buffer=pytest.csvs_names["test_read_csv_regular"],
             fn_name="read_csv",
             check_kwargs_callable=not callable(date_parser),
-            raising_exceptions=case_with_TypeError_exc
-            if case_with_TypeError
-            else io_ops_bad_exc,
+            raising_exceptions=raising_exceptions,
             **kwargs,
         )
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -579,6 +579,7 @@ class TestReadCSV:
     @pytest.mark.parametrize("cache_dates", [True, False])
     def test_read_csv_datetime(
         self,
+        request,
         parse_dates,
         infer_datetime_format,
         keep_date_col,
@@ -586,6 +587,8 @@ class TestReadCSV:
         dayfirst,
         cache_dates,
     ):
+        if request.config.getoption("--simulate-cloud").lower() != "off":
+            pytest.xfail("The reason of tests fail in `cloud` mode is unknown for now")
         case_with_TypeError = isinstance(parse_dates, dict) and callable(date_parser)
         case_with_TypeError_exc = list(io_ops_bad_exc)
         case_with_TypeError_exc.remove(TypeError)

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -642,6 +642,7 @@ def eval_general(
     __inplace__=False,
     check_exception_type=True,
     raising_exceptions=None,
+    check_kwargs_callable=True,
     **kwargs,
 ):
     if raising_exceptions:
@@ -670,7 +671,7 @@ def eval_general(
             return (md_result, pd_result) if not __inplace__ else (modin_df, pandas_df)
 
     for key, value in kwargs.items():
-        if callable(value):
+        if check_kwargs_callable and callable(value):
             values = execute_callable(value)
             # that means, that callable raised an exception
             if values is None:
@@ -696,6 +697,7 @@ def eval_io(
     cast_to_str=False,
     check_exception_type=True,
     raising_exceptions=io_ops_bad_exc,
+    check_kwargs_callable=True,
     *args,
     **kwargs,
 ):
@@ -732,6 +734,7 @@ def eval_io(
         applyier,
         check_exception_type=check_exception_type,
         raising_exceptions=raising_exceptions,
+        check_kwargs_callable=check_kwargs_callable,
         *args,
         **kwargs,
     )


### PR DESCRIPTION
This PR adds unit tests for Datetime handling parameters of `read_csv`.

Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution! 
Please review the contributing docs: https://modin.readthedocs.io/en/latest/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2292  <!-- issue must be created for each patch -->
- [ ] tests added and passing
