### PR TITLE
FIX-#2365: Fix `Series.value_counts` when `dropna=False`

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -732,18 +732,21 @@ class PandasQueryCompiler(BaseQueryCompiler):
             dropna = kwargs.get("dropna", True)
 
             try:
-                result = df.squeeze(axis=1).groupby(df.index, sort=False).sum()
+                result = (
+                    df.squeeze(axis=1)
+                    .groupby(df.index, sort=False, dropna=dropna)
+                    .sum()
+                )
             # This will happen with Arrow buffer read-only errors. We don't want to copy
             # all the time, so this will try to fast-path the code first.
             except (ValueError):
-                result = df.copy().squeeze(axis=1).groupby(df.index, sort=False).sum()
-
-            if not dropna and np.nan in df.index:
-                result = result.append(
-                    pandas.Series(
-                        [df.squeeze(axis=1).loc[[np.nan]].sum()], index=[np.nan]
-                    )
+                result = (
+                    df.copy()
+                    .squeeze(axis=1)
+                    .groupby(df.index, sort=False, dropna=dropna)
+                    .sum()
                 )
+
             if normalize:
                 result = result / df.squeeze(axis=1).sum()
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3444,6 +3444,26 @@ def test_value_counts(normalize, bins, dropna):
     )
     df_equals(modin_result, pandas_result)
 
+    # from issue #2365
+    arr = np.random.rand(2 ** 6)
+    arr[::10] = np.nan
+    modin_series, pandas_series = create_test_series(arr)
+    modin_result = modin_series.value_counts(dropna=False, ascending=True)
+    pandas_result = sort_index_for_equal_values(
+        pandas_series.value_counts(dropna=False, ascending=True), True
+    )
+    if get_current_backend() == "BaseOnPython":
+        modin_result = sort_index_for_equal_values(modin_result, ascending=True)
+    df_equals(modin_result, pandas_result)
+
+    modin_result = modin_series.value_counts(dropna=False, ascending=False)
+    pandas_result = sort_index_for_equal_values(
+        pandas_series.value_counts(dropna=False, ascending=False), False
+    )
+    if get_current_backend() == "BaseOnPython":
+        modin_result = sort_index_for_equal_values(modin_result, ascending=False)
+    df_equals(modin_result, pandas_result)
+
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_values(data):


### PR DESCRIPTION
Signed-off-by: Igoshev, Yaroslav <yaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2365  <!-- issue must be created for each patch -->
- [x] tests added and passing
