### PR TITLE
FIX-#2374: remove extra code; add pandas way to handle duplicate values in reindex func for binary operations

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -41,6 +41,8 @@ else:
 JOIN_DATA_SIZE = MERGE_DATA_SIZE
 ARITHMETIC_DATA_SIZE = GROUPBY_DATA_SIZE
 
+CONCAT_DATA_SIZE = [(10_128, 100, 10_000, 128)]
+
 
 class TimeGroupBy:
     param_names = ["impl", "data_type", "data_size"]
@@ -109,6 +111,51 @@ class TimeMerge:
 
     def time_merge(self, impl, data_type, data_size, how, sort):
         self.df1.merge(self.df2, on=self.df1.columns[0], how=how, sort=sort)
+
+
+class TimeConcat:
+    param_names = ["data_type", "data_size", "how", "axis"]
+    params = [
+        ["int"],
+        CONCAT_DATA_SIZE,
+        ["inner"],
+        [0, 1],
+    ]
+
+    def setup(self, data_type, data_size, how, axis):
+        # shape for generate_dataframe: first - ncols, second - nrows
+        self.df1 = generate_dataframe(
+            "modin", data_type, data_size[1], data_size[0], RAND_LOW, RAND_HIGH
+        )
+        self.df2 = generate_dataframe(
+            "modin", data_type, data_size[3], data_size[2], RAND_LOW, RAND_HIGH
+        )
+
+    def time_concat(self, data_type, data_size, how, axis):
+        pd.concat([self.df1, self.df2], axis=axis, join=how)
+
+
+class TimeBinaryOp:
+    param_names = ["data_type", "data_size", "binary_op", "axis"]
+    params = [
+        ["int"],
+        CONCAT_DATA_SIZE,
+        ["mul"],
+        [0, 1],
+    ]
+
+    def setup(self, data_type, data_size, binary_op, axis):
+        # shape for generate_dataframe: first - ncols, second - nrows
+        self.df1 = generate_dataframe(
+            "modin", data_type, data_size[1], data_size[0], RAND_LOW, RAND_HIGH
+        )
+        self.df2 = generate_dataframe(
+            "modin", data_type, data_size[3], data_size[2], RAND_LOW, RAND_HIGH
+        )
+        self.op = getattr(self.df1, binary_op)
+
+    def time_concat(self, data_type, data_size, binary_op, axis):
+        self.op(self.df2, axis=axis)
 
 
 class TimeArithmetic:

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1689,7 +1689,9 @@ class BasePandasFrame(object):
             validate_axes="all" if new_partitions.size != 0 else False,
         )
 
-    def _copartition(self, axis, other, how, sort, force_repartition=False):
+    def _copartition(
+        self, axis, other, how, sort, force_repartition=False, reindex=True
+    ):
         """
         Copartition two dataframes.
 
@@ -1726,6 +1728,7 @@ class BasePandasFrame(object):
                 self.axes[axis].copy(),
             )
 
+        # import pdb;pdb.set_trace()
         index_other_obj = [o.axes[axis] for o in other]
         joined_index = self._join_index_objects(axis, index_other_obj, how, sort)
         # sorting is performed in some cases when sort=`False`
@@ -1746,7 +1749,7 @@ class BasePandasFrame(object):
             #
             # if not joined_index.is_unique and axis == 0:
             #    return lambda df: df
-            if index.equals(joined_index):
+            if not reindex or index.equals(joined_index):
                 return lambda df: df
             return lambda df: df.reindex(joined_index, axis=axis)
 
@@ -1835,9 +1838,14 @@ class BasePandasFrame(object):
             A new dataframe.
         """
         left_parts, right_parts, joined_index = self._copartition(
-            0, right_frame, join_type, sort=True
+            0,
+            right_frame,
+            join_type,
+            sort=True,
+            reindex=False,
         )
         # unwrap list returned by `copartition`.
+        # import pdb;pdb.set_trace()
         right_parts = right_parts[0]
         new_frame = self._frame_mgr_cls.binary_operation(
             1, left_parts, lambda l, r: op(l, r), right_parts

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1729,7 +1729,10 @@ class BasePandasFrame(object):
             )
 
         index_other_obj = [o.axes[axis] for o in other]
-        joined_index = self._join_index_objects(axis, index_other_obj, how, sort)
+        if how == "reindex_to_self":
+            joined_index = self.axes[axis]
+        else:
+            joined_index = self._join_index_objects(axis, index_other_obj, how, sort)
 
         # We have to set these because otherwise when we perform the functions it may
         # end up serializing this entire object.

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1723,7 +1723,7 @@ class BasePandasFrame(object):
         Returns
         -------
         Tuple
-            A tuple (left data, right data list, joined index).
+            A tuple (left data, right data list).
         """
         if isinstance(other, type(self)):
             other = [other]
@@ -1742,8 +1742,6 @@ class BasePandasFrame(object):
         if make_map_reindexer is None:
 
             def make_map_func(index, *args, **kwargs):
-                # left - specific argument for case of binary operation;
-                # it choose indexer for left or right index
                 if index.equals(joined_index):
                     return lambda df: df
                 return lambda df: df.reindex(joined_index, axis=axis)
@@ -1834,7 +1832,7 @@ class BasePandasFrame(object):
         BasePandasFrame
             A new dataframe.
         """
-        joined_index, ilidx, iridx = self.axes[0].join(
+        joined_index, lidx, ridx = self.axes[0].join(
             right_frame.axes[0], how=join_type, sort=True, return_indexers=True
         )
 
@@ -1846,7 +1844,7 @@ class BasePandasFrame(object):
 
             # case with duplicate values; way from pandas
             return lambda df: df._reindex_with_indexers(
-                {0: [joined_index, ilidx if left else iridx]},
+                {0: [joined_index, lidx if left else ridx]},
                 copy=True,
                 allow_dups=True,
             )

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1728,28 +1728,16 @@ class BasePandasFrame(object):
                 self.axes[axis].copy(),
             )
 
-        # import pdb;pdb.set_trace()
         index_other_obj = [o.axes[axis] for o in other]
         joined_index = self._join_index_objects(axis, index_other_obj, how, sort)
-        # sorting is performed in some cases when sort=`False`
-        # workaround
-        if not sort and all(
-            joined_index.unique().sort_values()
-            == self.axes[axis].unique().sort_values()
-        ):
-            joined_index = self.axes[axis]
+
         # We have to set these because otherwise when we perform the functions it may
         # end up serializing this entire object.
         left_old_idx = self.axes[axis]
         right_old_idxes = index_other_obj
 
         def make_map_func(index):
-            # below works
-            # pandas.DataFrame([0,1,2,3,4,5]).reindex([0,0,1,1,2,2])
-            #
-            # if not joined_index.is_unique and axis == 0:
-            #    return lambda df: df
-            if not reindex or index.equals(joined_index):
+            if index.equals(joined_index):
                 return lambda df: df
             return lambda df: df.reindex(joined_index, axis=axis)
 

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1709,7 +1709,8 @@ class BasePandasFrame(object):
             The axis to copartition along (0 - rows, 1 - columns).
         other : BasePandasFrame
             The other dataframes(s) to copartition against.
-        joined_index : Index, default None
+        joined_index : Index
+            The index used for reindexing partitions.
         force_repartition : bool, default False
             Whether or not to force the repartitioning. By default,
             this method will skip repartitioning if it is possible. This is because
@@ -1740,7 +1741,7 @@ class BasePandasFrame(object):
 
         if make_map_reindexer is None:
 
-            def make_map_func(index, left=True):
+            def make_map_func(index, *args, **kwargs):
                 # left - specific argument for case of binary operation;
                 # it choose indexer for left or right index
                 if index.equals(joined_index):

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1728,13 +1728,25 @@ class BasePandasFrame(object):
 
         index_other_obj = [o.axes[axis] for o in other]
         joined_index = self._join_index_objects(axis, index_other_obj, how, sort)
+        # sorting is performed in some cases when sort=`False`
+        # workaround
+        if not sort and all(
+            joined_index.unique().sort_values()
+            == self.axes[axis].unique().sort_values()
+        ):
+            joined_index = self.axes[axis]
         # We have to set these because otherwise when we perform the functions it may
         # end up serializing this entire object.
         left_old_idx = self.axes[axis]
         right_old_idxes = index_other_obj
 
-        def make_map_func():
-            if not joined_index.is_unique and axis == 0:
+        def make_map_func(index):
+            # below works
+            # pandas.DataFrame([0,1,2,3,4,5]).reindex([0,0,1,1,2,2])
+            #
+            # if not joined_index.is_unique and axis == 0:
+            #    return lambda df: df
+            if index.equals(joined_index):
                 return lambda df: df
             return lambda df: df.reindex(joined_index, axis=axis)
 
@@ -1745,7 +1757,7 @@ class BasePandasFrame(object):
             reindexed_self = self._frame_mgr_cls.map_axis_partitions(
                 axis,
                 self._partitions,
-                make_map_func(),
+                make_map_func(left_old_idx),
             )
 
         def get_column_widths(partitions):
@@ -1764,7 +1776,7 @@ class BasePandasFrame(object):
                 reindexed_other = other[i]._frame_mgr_cls.map_axis_partitions(
                     axis,
                     other[i]._partitions,
-                    make_map_func(),
+                    make_map_func(right_old_idxes[i]),
                     lengths=get_row_lengths(reindexed_self)
                     if axis == 0
                     else get_column_widths(reindexed_self),

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -238,7 +238,7 @@ class BaseFrameManager(ABC):
         right : The right partitions.
         keep_partitioning : boolean. Default is False
             The flag to keep partitions for Modin Frame.
-        lengths : list(int)
+        lengths : list(int), default None
             The list of lengths to shuffle the object.
 
         Returns
@@ -250,6 +250,8 @@ class BaseFrameManager(ABC):
         # partitions as best we can right now.
         if keep_partitioning:
             num_splits = len(left) if axis == 0 else len(left.T)
+        elif lengths:
+            num_splits = len(lengths)
         else:
             num_splits = cls._compute_num_partitions()
         preprocessed_map_func = cls.preprocess_func(apply_func)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1975,7 +1975,7 @@ class DataFrame(BasePandasDataset):
                         self._query_compiler.concat(
                             1,
                             value._query_compiler,
-                            join="reindex_to_self",
+                            join="left",
                         ),
                         inplace=True,
                     )

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1975,7 +1975,7 @@ class DataFrame(BasePandasDataset):
                         self._query_compiler.concat(
                             1,
                             value._query_compiler,
-                            join="left",
+                            join="reindex_to_self",
                         ),
                         inplace=True,
                     )

--- a/modin/test/backends/pandas/test_internals.py
+++ b/modin/test/backends/pandas/test_internals.py
@@ -36,7 +36,7 @@ def test_aligning_blocks_with_duplicated_index():
 
     data21 = [0]
     data22 = [1, 2, 3]
-    # import pandas as pd
+
     df1 = pd.DataFrame(data11).append(pd.DataFrame(data12))
     df2 = pd.DataFrame(data21).append(pd.DataFrame(data22))
 

--- a/modin/test/backends/pandas/test_internals.py
+++ b/modin/test/backends/pandas/test_internals.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-import pytest
 import modin.pandas as pd
 from modin.pandas.test.utils import create_test_dfs
 
@@ -44,7 +43,6 @@ def test_aligning_blocks_with_duplicated_index():
     repr(df1 - df2)
 
 
-@pytest.mark.xfail(reason="xfail until #2443 is merged")
 def test_aligning_partitions():
     data = [0, 1, 2, 3, 4, 5]
     modin_df1, _ = create_test_dfs({"a": data, "b": data})

--- a/modin/test/backends/pandas/test_internals.py
+++ b/modin/test/backends/pandas/test_internals.py
@@ -36,7 +36,7 @@ def test_aligning_blocks_with_duplicated_index():
 
     data21 = [0]
     data22 = [1, 2, 3]
-
+    # import pandas as pd
     df1 = pd.DataFrame(data11).append(pd.DataFrame(data12))
     df2 = pd.DataFrame(data21).append(pd.DataFrame(data22))
 

--- a/modin/test/backends/pandas/test_internals.py
+++ b/modin/test/backends/pandas/test_internals.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import pytest
 import modin.pandas as pd
 from modin.pandas.test.utils import create_test_dfs
 
@@ -43,6 +44,7 @@ def test_aligning_blocks_with_duplicated_index():
     repr(df1 - df2)
 
 
+@pytest.mark.xfail(reason="xfail until #2443 is merged")
 def test_aligning_partitions():
     data = [0, 1, 2, 3, 4, 5]
     modin_df1, _ = create_test_dfs({"a": data, "b": data})

--- a/modin/test/backends/pandas/test_internals.py
+++ b/modin/test/backends/pandas/test_internals.py
@@ -12,6 +12,9 @@
 # governing permissions and limitations under the License.
 
 import modin.pandas as pd
+from modin.pandas.test.utils import create_test_dfs
+
+pd.DEFAULT_NPARTITIONS = 4
 
 
 def test_aligning_blocks():
@@ -38,3 +41,14 @@ def test_aligning_blocks_with_duplicated_index():
     df2 = pd.DataFrame(data21).append(pd.DataFrame(data22))
 
     repr(df1 - df2)
+
+
+def test_aligning_partitions():
+    data = [0, 1, 2, 3, 4, 5]
+    modin_df1, _ = create_test_dfs({"a": data, "b": data})
+    modin_df = modin_df1.loc[:2]
+
+    modin_df2 = modin_df.append(modin_df)
+
+    modin_df2["c"] = modin_df1["b"]
+    repr(modin_df2)


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

* for concat operation, repartition occurs only when it is necessary to re-index or align the partitions(`force_repartition=False`)
* new behavior for `broadcast_axis_partitions` function - we save the partitioning also in the case when `keep_partitioning=False` and lengths are passed
* new behaviors for `_join_index_objects`:
  * self.axes[axis] should be passed via others_index[0]
  * in the case when all indexes are equal, we do not perform join operation, but simply return `self.axes[axis]` as `joined_index`
  * the reindex operation does not work when the object (Series or DataFrame) for which the operation is being performed contains an index with duplicate values - but we can do this using indexers and the private pandas function `_reindex_with_indexers`
* repartitioning of `self` frame occurs only when it is necessary to re-index (for all operations)
* repartitioning of `other` frames occurs only for those in the list that need to be reindexed or the partirioning does not match `self` partitioning (for all operations)
 

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2374, #2490 <!-- issue must be created for each patch -->
- [x] tests added and passing
