### PR TITLE
FIX-#2380: don't ignore lengths parameter for dask engine

### DIFF
--- a/modin/data_management/utils.py
+++ b/modin/data_management/utils.py
@@ -85,7 +85,7 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
     if length_list is not None:
         length_list.insert(0, 0)
         sums = np.cumsum(length_list)
-        if axis == 0:
+        if axis == 0 or isinstance(result, pandas.Series):
             return [result.iloc[sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
         else:
             return [result.iloc[:, sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
@@ -94,7 +94,7 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
         return [result]
     # We do this to restore block partitioning
     chunksize = compute_chunksize(result, num_splits, axis=axis)
-    if axis == 0:
+    if axis == 0 or isinstance(result, pandas.Series):
         return [
             result.iloc[chunksize * i : chunksize * (i + 1)] for i in range(num_splits)
         ]

--- a/modin/data_management/utils.py
+++ b/modin/data_management/utils.py
@@ -82,8 +82,6 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
     list
         A list of Pandas DataFrames.
     """
-    if num_splits == 1:
-        return result
     if length_list is not None:
         length_list.insert(0, 0)
         sums = np.cumsum(length_list)
@@ -91,6 +89,9 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
             return [result.iloc[sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
         else:
             return [result.iloc[:, sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
+
+    if num_splits == 1:
+        return [result]
     # We do this to restore block partitioning
     chunksize = compute_chunksize(result, num_splits, axis=axis)
     if axis == 0:

--- a/modin/engines/base/frame/axis_partition.py
+++ b/modin/engines/base/frame/axis_partition.py
@@ -216,10 +216,6 @@ class PandasFrameAxisPartition(BaseFrameAxisPartition):
 
         dataframe = pandas.concat(list(partitions), axis=axis, copy=False)
         result = func(dataframe, **kwargs)
-        if isinstance(result, pandas.Series):
-            if num_splits == 1:
-                return result
-            return [result] + [pandas.Series([]) for _ in range(num_splits - 1)]
 
         if manual_partition:
             # The split function is expecting a list

--- a/modin/engines/base/frame/axis_partition.py
+++ b/modin/engines/base/frame/axis_partition.py
@@ -91,10 +91,7 @@ class BaseFrameAxisPartition(object):  # pragma: no cover
     partition_type = None
 
     def _wrap_partitions(self, partitions):
-        if isinstance(partitions, self.instance_type):
-            return [self.partition_type(partitions)]
-        else:
-            return [self.partition_type(obj) for obj in partitions]
+        return [self.partition_type(obj) for obj in partitions]
 
 
 class PandasFrameAxisPartition(BaseFrameAxisPartition):

--- a/modin/engines/dask/pandas_on_dask/frame/axis_partition.py
+++ b/modin/engines/dask/pandas_on_dask/frame/axis_partition.py
@@ -43,13 +43,15 @@ class PandasOnDaskFrameAxisPartition(PandasFrameAxisPartition):
             *partitions,
             pure=False,
         )
-        if num_splits == 1:
-            return axis_result
+
+        lengths = kwargs.get("_lengths", None)
+        result_num_splits = len(lengths) if lengths else num_splits
+
         # We have to do this to split it back up. It is already split, but we need to
         # get futures for each.
         return [
             client.submit(lambda l: l[i], axis_result, pure=False)
-            for i in range(num_splits)
+            for i in range(result_num_splits)
         ]
 
     @classmethod
@@ -68,8 +70,6 @@ class PandasOnDaskFrameAxisPartition(PandasFrameAxisPartition):
             *partitions,
             pure=False,
         )
-        if num_splits == 1:
-            return axis_result
         # We have to do this to split it back up. It is already split, but we need to
         # get futures for each.
         return [


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

* Add `lengths` parameter handling for dask engine.
* Make `split_result_of_axis_func_pandas` always return a list value and removes a bug in which the wrong number of partitions is returned (in the case when `num_splits==1` and `lengths != 1`)

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2380 <!-- issue must be created for each patch -->
- [ ] tests added and passing
