### PR TITLE
Fix bug 2406: filter dictionary aggregation keys to limit them to keys only present in current partition

### DIFF
--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1194,8 +1194,14 @@ def test_shift_freq(groupby_axis, shift_axis):
     "by_and_agg_dict",
     [
         {
-            "by": ["col1", "col2"],
-            "agg_dict": {"max": ("col3", np.max), "min": ("col3", np.min)},
+            "by": [
+                list(test_data["int_data"].keys())[0],
+                list(test_data["int_data"].keys())[1],
+            ],
+            "agg_dict": {
+                "max": (list(test_data["int_data"].keys())[2], np.max),
+                "min": (list(test_data["int_data"].keys())[2], np.min),
+            },
         },
         {
             "by": ["col1"],

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1201,7 +1201,7 @@ def test_shift_freq(groupby_axis, shift_axis):
             "by": ["col1"],
             "agg_dict": {
                 "max": (list(test_data["int_data"].keys())[0], np.max),
-                "min": (list(test_data["int_data"].keys())[-2], np.min),
+                "min": (list(test_data["int_data"].keys())[-1], np.min),
             },
         },
     ],


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2406  <!-- issue must be created for each patch -->
- [x] tests added and passing
