### PR TITLE
Fix 'psutil' install

### DIFF
--- a/examples/docker/nyc-taxi.dockerfile
+++ b/examples/docker/nyc-taxi.dockerfile
@@ -12,11 +12,16 @@
 # governing permissions and limitations under the License.
 
 FROM ubuntu:18.04
+
+ARG PYTHON_VERSION=3.7
 ENV http_proxy ${http_proxy}
 ENV https_proxy ${https_proxy}
 
-RUN apt-get update --yes \
-    && apt-get install wget --yes && \
+RUN apt-get update --yes && \
+    apt-get install --yes --no-install-recommends --fix-missing \
+        gcc \
+        python${PYTHON_VERSION}-dev \
+        wget && \
     rm -rf /var/lib/apt/lists/*
 
 ENV USER modin
@@ -33,7 +38,7 @@ ENV CONDA_DIR ${HOME}/miniconda
 
 SHELL ["/bin/bash", "--login", "-c"]
 
-RUN wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda3.sh && \
+RUN wget --quiet --no-check-certificate https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh -O /tmp/miniconda3.sh && \
     bash /tmp/miniconda3.sh -b -p "${CONDA_DIR}" -f -u && \
     "${CONDA_DIR}/bin/conda" init bash && \
     rm -f /tmp/miniconda3.sh && \
@@ -45,7 +50,7 @@ RUN conda update -n base -c defaults conda -y && \
     pip install --no-cache-dir modin[ray] && \
     conda clean --all --yes
 
-RUN wget https://modin-datasets.s3.amazonaws.com/trips_data.csv -O "${HOME}/trips_data.csv"
+RUN wget --quiet --no-check-certificate https://modin-datasets.s3.amazonaws.com/trips_data.csv -O "${HOME}/trips_data.csv"
 
 COPY nyc-taxi.py "${HOME}/nyc-taxi.py"
 


### PR DESCRIPTION
While building [nyc-taxi.dockerfile](examples/docker/nyc-taxi.dockerfile) I noticed `psutil` installation failed and the following error was reported:

```
ERROR: Command errored out with exit status 1:
     command: /home/modin/miniconda/envs/modin/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-s_zbgkmi/psutil/setup.py'"'"'; __file__='"'"'/tmp/pip-install-s_zbgkmi/psutil/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-02t4eer9/install-record.txt --single-version-externally-managed --compile --install-headers /home/modin/miniconda/envs/modin/include/python3.7m/psutil
         cwd: /tmp/pip-install-s_zbgkmi/psutil/
    Complete output (44 lines):
    running install
    running build
    running build_py
    creating build
    creating build/lib.linux-x86_64-3.7
    creating build/lib.linux-x86_64-3.7/psutil
    copying psutil/_psosx.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_psbsd.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/__init__.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_pslinux.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_psaix.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_compat.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_psposix.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_pswindows.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_common.py -> build/lib.linux-x86_64-3.7/psutil
    copying psutil/_pssunos.py -> build/lib.linux-x86_64-3.7/psutil
    creating build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_aix.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/__main__.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_connections.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_bsd.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_contracts.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_unicode.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_posix.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_memleaks.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_testutils.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_sunos.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_osx.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/runner.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/__init__.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_system.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_misc.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_windows.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_linux.py -> build/lib.linux-x86_64-3.7/psutil/tests
    copying psutil/tests/test_process.py -> build/lib.linux-x86_64-3.7/psutil/tests
    running build_ext
    building 'psutil._psutil_linux' extension
    creating build/temp.linux-x86_64-3.7
    creating build/temp.linux-x86_64-3.7/psutil
    gcc -pthread -B /home/modin/miniconda/envs/modin/compiler_compat -Wl,--sysroot=/ -Wsign-compare -DNDEBUG -g -fwrapv -O3 -Wall -Wstrict-prototypes -fPIC -DPSUTIL_POSIX=1 -DPSUTIL_SIZEOF_PID_T=4 -DPSUTIL_VERSION=573 -DPSUTIL_LINUX=1 -DPSUTIL_ETHTOOL_MISSING_TYPES=1 -I/home/modin/miniconda/envs/modin/include/python3.7m -c psutil/_psutil_common.c -o build/temp.linux-x86_64-3.7/psutil/_psutil_common.o
    unable to execute 'gcc': No such file or directory
    C compiler or Python headers are not installed on this system. Try to run:
    sudo apt-get install gcc python3-dev
    error: command 'gcc' failed with exit status 1
    ----------------------------------------
ERROR: Command errored out with exit status 1: /home/modin/miniconda/envs/modin/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-s_zbgkmi/psutil/setup.py'"'"'; __file__='"'"'/tmp/pip-install-s_zbgkmi/psutil/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' install --record /tmp/pip-record-02t4eer9/install-record.txt --single-version-externally-managed --compile --install-headers /home/modin/miniconda/envs/modin/include/python3.7m/psutil Check the logs for full command output.
```

So I ended up adding those 2 libraries and of course a few minor enhancements to the Dockerfile which is building correctly now.

Closes #2458 
