### PR TITLE
FIX-#2453: Remove sorting indices for equal values in `Series.value_counts`

### DIFF
--- a/docs/supported_apis/series_supported.rst
+++ b/docs/supported_apis/series_supported.rst
@@ -474,10 +474,8 @@ the related section on `Defaulting to pandas`_.
 +-----------------------------+---------------------------------+----------------------------------------------------+
 | ``valid``                   | D                               |                                                    |
 +-----------------------------+---------------------------------+----------------------------------------------------+
-| ``value_counts``            | Y                               | The indices of resulting object will be in         |
-|                             |                                 | descending (ascending, if ascending=True) order for|
-|                             |                                 | equal values.                                      |
-|                             |                                 | In pandas indices are located in random order.     |
+| ``value_counts``            | Y                               | The indices order of resulting object may differ   |
+|                             |                                 | from pandas.                                       |
 +-----------------------------+---------------------------------+----------------------------------------------------+
 | ``values``                  | Y                               |                                                    |
 +-----------------------------+---------------------------------+----------------------------------------------------+

--- a/docs/supported_apis/utilities_supported.rst
+++ b/docs/supported_apis/utilities_supported.rst
@@ -21,10 +21,8 @@ default to pandas.
 +---------------------------+---------------------------------+----------------------------------------------------+
 | `pd.unique`_              | Y                               |                                                    |
 +---------------------------+---------------------------------+----------------------------------------------------+
-| ``pd.value_counts``       | Y                               | The indices of resulting object will be in         |
-|                           |                                 | descending (ascending, if ascending=True) order for|
-|                           |                                 | equal values.                                      |
-|                           |                                 | In pandas indices are located in random order.     |
+| ``pd.value_counts``       | Y                               | The indices order of resulting object may differ   |
+|                           |                                 | from pandas.                                       |
 +---------------------------+---------------------------------+----------------------------------------------------+
 | `pd.cut`_                 | D                               |                                                    |
 +---------------------------+---------------------------------+----------------------------------------------------+

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -750,58 +750,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             if normalize:
                 result = result / df.squeeze(axis=1).sum()
 
-            result = result.sort_values(ascending=ascending) if sort else result
-
-            # We want to sort both values and indices of the result object.
-            # This function will sort indices for equal values.
-            def sort_index_for_equal_values(result, ascending):
-                """
-                Sort indices for equal values of result object.
-
-                Parameters
-                ----------
-                result : pandas.Series or pandas.DataFrame with one column
-                    The object whose indices for equal values is needed to sort.
-                ascending : boolean
-                    Sort in ascending (if it is True) or descending (if it is False) order.
-
-                Returns
-                -------
-                pandas.DataFrame
-                    A new DataFrame with sorted indices.
-                """
-                is_range = False
-                is_end = False
-                i = 0
-                new_index = np.empty(len(result), dtype=type(result.index))
-                while i < len(result):
-                    j = i
-                    if i < len(result) - 1:
-                        while result[result.index[i]] == result[result.index[i + 1]]:
-                            i += 1
-                            if is_range is False:
-                                is_range = True
-                            if i == len(result) - 1:
-                                is_end = True
-                                break
-                    if is_range:
-                        k = j
-                        for val in sorted(
-                            result.index[j : i + 1], reverse=not ascending
-                        ):
-                            new_index[k] = val
-                            k += 1
-                        if is_end:
-                            break
-                        is_range = False
-                    else:
-                        new_index[j] = result.index[j]
-                    i += 1
-                return pandas.DataFrame(
-                    result, index=new_index, columns=["__reduced__"]
-                )
-
-            return sort_index_for_equal_values(result, ascending)
+            return result.sort_values(ascending=ascending) if sort else result
 
         return MapReduceFunction.register(
             map_func, reduce_func, axis=0, preserve_index=False

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -352,23 +352,29 @@ def test_value_counts(normalize, bins, dropna):
             else:
                 new_index[j] = result.index[j]
             i += 1
-        return pandas.Series(result, index=new_index)
+        return type(result)(result, index=new_index)
 
-    # We sort indices for pandas result because of issue #1650
+    # We sort indices for Modin and pandas result because of issue #1650
     values = np.array([3, 1, 2, 3, 4, np.nan])
-    modin_result = pd.value_counts(values, normalize=normalize, ascending=False)
+    modin_result = sort_index_for_equal_values(
+        pd.value_counts(values, normalize=normalize, ascending=False), False
+    )
     pandas_result = sort_index_for_equal_values(
         pandas.value_counts(values, normalize=normalize, ascending=False), False
     )
     df_equals(modin_result, pandas_result)
 
-    modin_result = pd.value_counts(values, bins=bins, ascending=False)
+    modin_result = sort_index_for_equal_values(
+        pd.value_counts(values, bins=bins, ascending=False), False
+    )
     pandas_result = sort_index_for_equal_values(
         pandas.value_counts(values, bins=bins, ascending=False), False
     )
     df_equals(modin_result, pandas_result)
 
-    modin_result = pd.value_counts(values, dropna=dropna, ascending=True)
+    modin_result = sort_index_for_equal_values(
+        pd.value_counts(values, dropna=dropna, ascending=True), True
+    )
     pandas_result = sort_index_for_equal_values(
         pandas.value_counts(values, dropna=dropna, ascending=True), True
     )

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -21,7 +21,7 @@ from numpy.testing import assert_array_equal
 from pandas.core.base import SpecificationError
 import sys
 
-from modin.utils import to_pandas, get_current_backend
+from modin.utils import to_pandas
 from .utils import (
     random_state,
     RAND_LOW,
@@ -3376,33 +3376,28 @@ def test_value_counts(normalize, bins, dropna):
             i += 1
         return type(result)(result, index=new_index)
 
-    # We sort indices for pandas result because of issue #1650
+    # We sort indices for Modin and pandas result because of issue #1650
     modin_series, pandas_series = create_test_series(test_data_values[0])
-    modin_result = modin_series.value_counts(normalize=normalize, ascending=False)
 
-    if get_current_backend() == "BaseOnPython":
-        modin_result = sort_index_for_equal_values(modin_result, ascending=False)
-
+    modin_result = sort_index_for_equal_values(
+        modin_series.value_counts(normalize=normalize, ascending=False), False
+    )
     pandas_result = sort_index_for_equal_values(
         pandas_series.value_counts(normalize=normalize, ascending=False), False
     )
     df_equals(modin_result, pandas_result)
 
-    modin_result = modin_series.value_counts(bins=bins, ascending=False)
-
-    if get_current_backend() == "BaseOnPython":
-        modin_result = sort_index_for_equal_values(modin_result, ascending=False)
-
+    modin_result = sort_index_for_equal_values(
+        modin_series.value_counts(bins=bins, ascending=False), False
+    )
     pandas_result = sort_index_for_equal_values(
         pandas_series.value_counts(bins=bins, ascending=False), False
     )
     df_equals(modin_result, pandas_result)
 
-    modin_result = modin_series.value_counts(dropna=dropna, ascending=True)
-
-    if get_current_backend() == "BaseOnPython":
-        modin_result = sort_index_for_equal_values(modin_result, ascending=True)
-
+    modin_result = sort_index_for_equal_values(
+        modin_series.value_counts(dropna=dropna, ascending=True), True
+    )
     pandas_result = sort_index_for_equal_values(
         pandas_series.value_counts(dropna=dropna, ascending=True), True
     )
@@ -3412,20 +3407,20 @@ def test_value_counts(normalize, bins, dropna):
     arr = np.random.rand(2 ** 6)
     arr[::10] = np.nan
     modin_series, pandas_series = create_test_series(arr)
-    modin_result = modin_series.value_counts(dropna=False, ascending=True)
+    modin_result = sort_index_for_equal_values(
+        modin_series.value_counts(dropna=False, ascending=True), True
+    )
     pandas_result = sort_index_for_equal_values(
         pandas_series.value_counts(dropna=False, ascending=True), True
     )
-    if get_current_backend() == "BaseOnPython":
-        modin_result = sort_index_for_equal_values(modin_result, ascending=True)
     df_equals(modin_result, pandas_result)
 
-    modin_result = modin_series.value_counts(dropna=False, ascending=False)
+    modin_result = sort_index_for_equal_values(
+        modin_series.value_counts(dropna=False, ascending=False), False
+    )
     pandas_result = sort_index_for_equal_values(
         pandas_series.value_counts(dropna=False, ascending=False), False
     )
-    if get_current_backend() == "BaseOnPython":
-        modin_result = sort_index_for_equal_values(modin_result, ascending=False)
     df_equals(modin_result, pandas_result)
 
 


### PR DESCRIPTION
Signed-off-by: Igoshev, Yaroslav <yaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Because there is the issue #1650 we can remove the logic related to sorting indices for equal values. So we can significantly improve execution time `Series.value_counts` itself and also one of our benchmark.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2453  <!-- issue must be created for each patch -->
- [x] tests passing
