### PR TITLE
FEAT-#2375: implementation of multi-column groupby aggregation

### DIFF
--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -1394,6 +1394,7 @@ class BaseQueryCompiler(abc.ABC):
             reduce_args=reduce_args,
             numeric_only=numeric_only,
             drop=drop,
+            method="size",
         )
 
     def groupby_agg(

--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -1408,13 +1408,10 @@ class BaseQueryCompiler(abc.ABC):
         groupby_kwargs,
         drop=False,
     ):
-        if is_multi_by:
-            if isinstance(by, type(self)) and len(by.columns) == 1:
-                by = by.columns[0] if drop else by.to_pandas().squeeze()
-            elif isinstance(by, type(self)):
-                by = list(by.columns)
-        else:
-            by = by.to_pandas().squeeze() if isinstance(by, type(self)) else by
+        if isinstance(by, type(self)) and len(by.columns) == 1:
+            by = by.columns[0] if drop else by.to_pandas().squeeze()
+        elif isinstance(by, type(self)):
+            by = list(by.columns)
 
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.aggregate)(
             self,

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2610,7 +2610,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 except (DataError, TypeError):
                     result = pandas.DataFrame(index=grouped_df.size().index)
                 if isinstance(result, pandas.Series):
-                    result = result.to_frame("__reduced__")
+                    result = result.to_frame(
+                        result.name if result.name is not None else "__reduced__"
+                    )
 
                 result_cols = result.columns
                 result.drop(columns=missmatched_cols, inplace=True, errors="ignore")

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2565,20 +2565,17 @@ class PandasQueryCompiler(BaseQueryCompiler):
             missmatched_cols = pandas.Index([])
             if by is not None:
                 internal_by_df = by[internal_by]
+
                 if isinstance(internal_by_df, pandas.Series):
                     internal_by_df = internal_by_df.to_frame()
 
-                if isinstance(internal_by_df, pandas.DataFrame):
-                    missmatched_cols = internal_by_df.columns.difference(df.columns)
-                    df = pandas.concat(
-                        [df, internal_by_df[missmatched_cols]],
-                        axis=1,
-                    )
-                    internal_by_cols = internal_by_df.columns
-                elif is_multi_by:
-                    internal_by_cols = pandas.Index([internal_by_df.name])
-                else:
-                    internal_by_cols = pandas.Index([internal_by_df])
+                missmatched_cols = internal_by_df.columns.difference(df.columns)
+                df = pandas.concat(
+                    [df, internal_by_df[missmatched_cols]],
+                    axis=1,
+                    copy=False,
+                )
+                internal_by_cols = internal_by_df.columns
 
                 external_by = by.columns.difference(internal_by)
                 external_by_df = by[external_by].squeeze(axis=1)

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2521,7 +2521,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
         agg_kwargs,
         groupby_kwargs,
         drop=False,
-        preserve_labels=True,
     ):
         if callable(agg_func):
             agg_func = wrap_udf_function(agg_func)

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2525,19 +2525,19 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if callable(agg_func):
             agg_func = wrap_udf_function(agg_func)
 
-        if is_multi_by:
-            return super().groupby_agg(
-                by=by,
-                is_multi_by=is_multi_by,
-                axis=axis,
-                agg_func=agg_func,
-                agg_args=agg_args,
-                agg_kwargs=agg_kwargs,
-                groupby_kwargs=groupby_kwargs,
-                drop=drop,
-            )
+        # if is_multi_by:
+        #     return super().groupby_agg(
+        #         by=by,
+        #         is_multi_by=is_multi_by,
+        #         axis=axis,
+        #         agg_func=agg_func,
+        #         agg_args=agg_args,
+        #         agg_kwargs=agg_kwargs,
+        #         groupby_kwargs=groupby_kwargs,
+        #         drop=drop,
+        #     )
 
-        by = by.to_pandas().squeeze() if isinstance(by, type(self)) else by
+        # by = by.to_pandas().squeeze() if isinstance(by, type(self)) else by
 
         # since we're going to modify `groupby_kwargs` dict in a `groupby_agg_builder`,
         # we want to copy it to not propagate these changes into source dict, in case
@@ -2545,14 +2545,43 @@ class PandasQueryCompiler(BaseQueryCompiler):
         groupby_kwargs = groupby_kwargs.copy()
 
         as_index = groupby_kwargs.get("as_index", True)
+        # breakpoint()
 
-        def groupby_agg_builder(df):
+        if not isinstance(by, list):
+            by = [by]
+
+        broadcastable_by = [o._modin_frame for o in by if isinstance(o, type(self))]
+        not_broadcastable_by = [o for o in by if not isinstance(o, type(self))]
+
+        def groupby_agg_builder(df, by=None):
             # Set `as_index` to True to track the metadata of the grouping object
             # It is used to make sure that between phases we are constructing the
             # right index and placing columns in the correct order.
             groupby_kwargs["as_index"] = True
+            #breakpoint()
+            if by is not None:
+                by = by.squeeze(axis=1)
+                if isinstance(by, pandas.DataFrame):
+                    by.columns = [
+                        col if col != "__reduced__" else f"__reduced__{i}"
+                        for i, col in enumerate(by.columns)
+                    ]
+                    df = pandas.concat(
+                        [df] + [by[[o for o in by if o not in df]]],
+                        axis=1,
+                    )
+                    by = list(by.columns)
+
+                if not isinstance(by, list):
+                    by = [by]
+            else:
+                by = []
+
+            by += not_broadcastable_by
+            _drop = drop
 
             def compute_groupby(df):
+                # breakpoint()
                 grouped_df = df.groupby(by=by, axis=axis, **groupby_kwargs)
                 try:
                     if isinstance(agg_func, dict):
@@ -2569,6 +2598,59 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 # issues with extracting the index.
                 except (DataError, TypeError):
                     result = pandas.DataFrame(index=grouped_df.size().index)
+
+                drop = _drop
+
+                if not as_index:
+                    if not isinstance(result.index, pandas.MultiIndex) and (
+                        result.index.name is None or result.index.name in result.columns
+                    ):
+                        drop = False
+                    if drop and isinstance(result.index, pandas.MultiIndex):
+                        has_categorical_by = any(
+                            isinstance(df[o].dtype, pandas.CategoricalDtype)
+                            for o in by
+                            if isinstance(o, str)
+                        )
+
+                        if not has_categorical_by:
+                            duplicated_cols = [
+                                i
+                                for i, name in enumerate(result.index.names)
+                                if name in result.columns
+                            ]
+                            if len(duplicated_cols) == result.index.nlevels:
+                                drop = False
+                            else:
+                                result.index = result.index.droplevel(duplicated_cols)
+                        else:
+                            duplicated_cols = [
+                                name
+                                for name in result.index.names
+                                if name in result.columns
+                            ]
+                            result.drop(columns=duplicated_cols, inplace=True)
+                    result.reset_index(drop=not drop, inplace=True)
+                # breakpoint()
+                new_index_names = [
+                    None
+                    if isinstance(name, str) and name.startswith("__reduced__")
+                    else name
+                    for name in result.index.names
+                ]
+                # breakpoint()
+                cols_to_drop = (
+                    result.columns[result.columns.str.match(r"__reduced__.*")]
+                    if hasattr(result.columns, "str")
+                    else []
+                )
+
+                result.index.names = new_index_names
+
+                # Not dropping columns if result is Series
+                if len(result.columns) > 1:
+                    result.drop(columns=cols_to_drop, inplace=True)
+
                 return result
 
             try:
@@ -2578,8 +2660,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
             except (ValueError, KeyError):
                 return compute_groupby(df.copy())
 
-        new_modin_frame = self._modin_frame._apply_full_axis(
-            axis, lambda df: groupby_agg_builder(df)
+        # breakpoint()
+        new_modin_frame = self._modin_frame.broadcast_apply_full_axis(
+            axis=axis,
+            func=groupby_agg_builder,
+            other=broadcastable_by,
         )
         result = self.__constructor__(new_modin_frame)
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2606,7 +2606,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 # issues with extracting the index.
                 except (DataError, TypeError):
                     result = pandas.DataFrame(index=grouped_df.size().index)
-
+                if isinstance(result, pandas.Series):
+                    result = result.to_frame("__reduced__")
                 if not as_index:
                     if not isinstance(result.index, pandas.MultiIndex) and (
                         result.index.name is None or result.index.name in result.columns

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2561,7 +2561,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 if isinstance(internal_by_df, pandas.DataFrame):
                     df = pandas.concat(
                         [df]
-                        + [internal_by_df[[o for o in internal_by_df if o not in df]]],
+                        + [
+                            internal_by_df.iloc[
+                                :, ~internal_by_df.columns.isin(df.columns)
+                            ]
+                        ],
                         axis=1,
                     )
                     internal_by_cols = list(internal_by_df.columns)

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2673,10 +2673,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
             except (ValueError, KeyError):
                 return compute_groupby(df.copy(), drop)
 
+        apply_indices = list(agg_func.keys()) if isinstance(agg_func, dict) else None
+
         new_modin_frame = self._modin_frame.broadcast_apply_full_axis(
             axis=axis,
             func=lambda df, by=None: groupby_agg_builder(df, by, drop),
             other=broadcastable_by,
+            apply_indices=apply_indices,
         )
         result = self.__constructor__(new_modin_frame)
 

--- a/modin/data_management/functions/default_methods/groupby_default.py
+++ b/modin/data_management/functions/default_methods/groupby_default.py
@@ -75,11 +75,6 @@ class GroupBy:
         ):
             by = cls.validate_by(by)
 
-            if not is_multi_by:
-                groupby_args = groupby_args.copy()
-                as_index = groupby_args.pop("as_index", True)
-                groupby_args["as_index"] = True
-
             grp = df.groupby(by, axis=axis, **groupby_args)
             agg_func = cls.get_func(grp, key, **kwargs)
             result = (
@@ -88,15 +83,7 @@ class GroupBy:
                 else agg_func(grp, **agg_args)
             )
 
-            if not is_multi_by:
-                if as_index:
-                    return result
-                else:
-                    if result.index.name is None or result.index.name in result.columns:
-                        drop = False
-                    return result.reset_index(drop=not drop)
-            else:
-                return result
+            return result
 
         return fn
 

--- a/modin/data_management/functions/default_methods/groupby_default.py
+++ b/modin/data_management/functions/default_methods/groupby_default.py
@@ -140,11 +140,16 @@ class GroupBy:
             grp = df.groupby(by, axis=axis, **groupby_args)
             result = agg_func(grp, **map_args)
 
+            if isinstance(result, pandas.Series):
+                result = result.to_frame()
+
             if not as_index:
                 if (
                     len(result.index.names) == 1 and result.index.names[0] is None
                 ) or all([name in result.columns for name in result.index.names]):
                     drop = False
+                elif kwargs.get("method") == "size":
+                    drop = True
                 result = result.reset_index(drop=not drop)
 
             if result.index.name == "__reduced__":

--- a/modin/data_management/functions/default_methods/groupby_default.py
+++ b/modin/data_management/functions/default_methods/groupby_default.py
@@ -27,6 +27,8 @@ class GroupBy:
     @classmethod
     def validate_by(cls, by):
         def try_cast_series(df):
+            if isinstance(df, pandas.DataFrame):
+                df = df.squeeze(axis=1)
             if not isinstance(df, pandas.Series):
                 return df
             if df.name == "__reduced__":
@@ -111,6 +113,7 @@ class GroupBy:
             **kwargs
         ):
             if not isinstance(by, (pandas.Series, pandas.DataFrame)):
+                by = cls.validate_by(by)
                 return agg_func(
                     df.groupby(by=by, axis=axis, **groupby_args), **map_args
                 )

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -35,13 +35,7 @@ class GroupbyReduceFunction(MapReduceFunction):
                 by = try_cast_to_pandas(by)
                 if isinstance(by, list):
                     by = [
-                        (
-                            o.squeeze()
-                            if o.columns[0] not in query_compiler.columns
-                            else o.columns[0]
-                        )
-                        if isinstance(o, pandas.DataFrame)
-                        else o
+                        o.squeeze() if isinstance(o, pandas.DataFrame) else o
                         for o in by
                     ]
                 return query_compiler.default_to_pandas(

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -30,8 +30,20 @@ class GroupbyReduceFunction(MapReduceFunction):
             numeric_only=True,
             drop=False,
         ):
+            # breakpoint()
             if not isinstance(by, (type(query_compiler), str)):
                 by = try_cast_to_pandas(by)
+                if isinstance(by, list):
+                    by = [
+                        (
+                            o.squeeze()
+                            if o.columns[0] not in query_compiler.columns
+                            else o.columns[0]
+                        )
+                        if isinstance(o, pandas.DataFrame)
+                        else o
+                        for o in by
+                    ]
                 return query_compiler.default_to_pandas(
                     lambda df: map_func(
                         df.groupby(by=by, axis=axis, **groupby_args), **map_args

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -30,7 +30,6 @@ class GroupbyReduceFunction(MapReduceFunction):
             numeric_only=True,
             drop=False,
         ):
-            # breakpoint()
             if not isinstance(by, (type(query_compiler), str)):
                 by = try_cast_to_pandas(by)
                 if isinstance(by, list):

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -31,12 +31,7 @@ class GroupbyReduceFunction(MapReduceFunction):
             drop=False,
         ):
             if not isinstance(by, (type(query_compiler), str)):
-                by = try_cast_to_pandas(by)
-                if isinstance(by, list):
-                    by = [
-                        o.squeeze() if isinstance(o, pandas.DataFrame) else o
-                        for o in by
-                    ]
+                by = try_cast_to_pandas(by, squeeze=True)
                 return query_compiler.default_to_pandas(
                     lambda df: map_func(
                         df.groupby(by=by, axis=axis, **groupby_args), **map_args

--- a/modin/engines/base/frame/axis_partition.py
+++ b/modin/engines/base/frame/axis_partition.py
@@ -149,7 +149,7 @@ class PandasFrameAxisPartition(BaseFrameAxisPartition):
                 other_axis_partition = [other_axis_partition]
 
             # (other_shape[i-1], other_shape[i]) will indicate slice
-            # to restore i axis partition
+            # to restore i-1 axis partition
             other_shape = np.cumsum(
                 [0] + [len(o.list_of_blocks) for o in other_axis_partition]
             )

--- a/modin/engines/base/frame/axis_partition.py
+++ b/modin/engines/base/frame/axis_partition.py
@@ -148,11 +148,11 @@ class PandasFrameAxisPartition(BaseFrameAxisPartition):
             if not isinstance(other_axis_partition, list):
                 other_axis_partition = [other_axis_partition]
 
-            other_shape = np.zeros(len(other_axis_partition) + 1, dtype=np.int)
-            for i in range(1, len(other_axis_partition) + 1):
-                other_shape[i] = other_shape[i - 1] + len(
-                    other_axis_partition[i - 1].list_of_blocks
-                )
+            # (other_shape[i-1], other_shape[i]) will indicate slice
+            # to restore i axis partition
+            other_shape = np.cumsum(
+                [0] + [len(o.list_of_blocks) for o in other_axis_partition]
+            )
 
             return self._wrap_partitions(
                 self.deploy_func_between_two_axis_partitions(
@@ -273,7 +273,7 @@ class PandasFrameAxisPartition(BaseFrameAxisPartition):
         # reshaping flattened `rt_parts` array into a frame with shape `other_shape`
         combined_axis = [
             pandas.concat(
-                [rt_parts[j] for j in range(other_shape[i - 1], other_shape[i])],
+                rt_parts[other_shape[i - 1] : other_shape[i]],
                 axis=axis,
                 copy=False,
             )

--- a/modin/engines/base/frame/axis_partition.py
+++ b/modin/engines/base/frame/axis_partition.py
@@ -143,6 +143,7 @@ class PandasFrameAxisPartition(BaseFrameAxisPartition):
         """
         if num_splits is None:
             num_splits = len(self.list_of_blocks)
+
         if other_axis_partition is not None:
             if not isinstance(other_axis_partition, list):
                 other_axis_partition = [other_axis_partition]
@@ -266,7 +267,7 @@ class PandasFrameAxisPartition(BaseFrameAxisPartition):
             A list of Pandas DataFrames.
         """
         lt_frame = pandas.concat(partitions[:len_of_left], axis=axis, copy=False)
-        # breakpoint()
+
         rt_parts = partitions[len_of_left:]
 
         # reshaping flattened `rt_parts` array into a frame with shape `other_shape`

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1704,11 +1704,9 @@ class BasePandasFrame(object):
         -------
              A new Modin DataFrame
         """
-        if other is not None and not isinstance(other, list):
+        if not isinstance(other, list):
             other = [other]
-        other = (
-            [o._partitions for o in other] if other is not None and len(other) else None
-        )
+        other = [o._partitions for o in other if o is not None] if len(other) else None
         new_partitions = self._frame_mgr_cls.broadcast_axis_partitions(
             axis=axis,
             left=self._partitions,

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1736,7 +1736,7 @@ class BasePandasFrame(object):
             None,
             dtypes,
             validate_axes="all"
-            if any(o is None for o in [new_index, new_columns])
+            if any(o is not None for o in [new_index, new_columns])
             else False,
         )
 

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1699,6 +1699,9 @@ class BasePandasFrame(object):
                 advance, and if not provided it must be computed.
             apply_indices : list-like (optional),
                 Indices of `axis ^ 1` to apply function over.
+            enumerate_partitions : bool (optional, default False),
+                Whether or not to pass partition index into applied `func`.
+                Note that `func` must be able to obtain `partition_idx` kwarg.
             dtypes : list-like (optional)
                 The data types of the result. This is an optimization
                 because there are functions that always result in a particular data

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1688,7 +1688,7 @@ class BasePandasFrame(object):
                 The axis to apply over (0 - rows, 1 - columns).
             func : callable
                 The function to apply.
-            other : other Modin frame to broadcast
+            other : others Modin frames to broadcast
             new_index : list-like (optional)
                 The index of the result. We may know this in advance,
                 and if not provided it must be computed.
@@ -1704,10 +1704,15 @@ class BasePandasFrame(object):
         -------
              A new Modin DataFrame
         """
+        if other is not None and not isinstance(other, list):
+            other = [other]
+        other = (
+            [o._partitions for o in other] if other is not None and len(other) else None
+        )
         new_partitions = self._frame_mgr_cls.broadcast_axis_partitions(
             axis=axis,
             left=self._partitions,
-            right=other if other is None else other._partitions,
+            right=other,
             apply_func=self._build_mapreduce_func(axis, func),
             keep_partitioning=True,
         )

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1707,11 +1707,10 @@ class BasePandasFrame(object):
         -------
              A new Modin DataFrame
         """
-        if other is not None and not isinstance(other, list):
-            other = [other]
-        other = (
-            [o._partitions for o in other] if other is not None and len(other) else None
-        )
+        if other is not None:
+            if not isinstance(other, list):
+                other = [other]
+            other = [o._partitions for o in other] if len(other) else None
 
         if apply_indices is not None:
             numeric_indices = self.axes[axis ^ 1].get_indexer_for(apply_indices)

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1679,6 +1679,7 @@ class BasePandasFrame(object):
         new_index=None,
         new_columns=None,
         apply_indices=None,
+        enumerate_partitions=False,
         dtypes=None,
     ):
         """Broadcast partitions of other dataframe partitions and apply a function along full axis.
@@ -1724,6 +1725,7 @@ class BasePandasFrame(object):
             right=other,
             apply_func=self._build_mapreduce_func(axis, func),
             apply_indices=apply_indices,
+            enumerate_partitions=enumerate_partitions,
             keep_partitioning=True,
         )
         # Index objects for new object creation. This is shorter than if..else

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1735,7 +1735,9 @@ class BasePandasFrame(object):
             None,
             None,
             dtypes,
-            validate_axes="all" if new_partitions.size != 0 else False,
+            validate_axes="all"
+            if any(o is None for o in [new_index, new_columns])
+            else False,
         )
 
     def _copartition(self, axis, other, how, sort, force_repartition=False):

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1704,9 +1704,11 @@ class BasePandasFrame(object):
         -------
              A new Modin DataFrame
         """
-        if not isinstance(other, list):
+        if other is not None and not isinstance(other, list):
             other = [other]
-        other = [o._partitions for o in other if o is not None] if len(other) else None
+        other = (
+            [o._partitions for o in other] if other is not None and len(other) else None
+        )
         new_partitions = self._frame_mgr_cls.broadcast_axis_partitions(
             axis=axis,
             left=self._partitions,

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1696,7 +1696,7 @@ class BasePandasFrame(object):
             new_columns : list-like (optional)
                 The columns of the result. We may know this in
                 advance, and if not provided it must be computed.
-            apply_indices : list of ints (optional),
+            apply_indices : list-like (optional),
                 Indices of `axis ^ 1` to apply function over.
             dtypes : list-like (optional)
                 The data types of the result. This is an optimization
@@ -1717,8 +1717,6 @@ class BasePandasFrame(object):
             apply_indices = self._get_dict_of_block_index(
                 axis ^ 1, numeric_indices
             ).keys()
-        else:
-            apply_indices = None
 
         new_partitions = self._frame_mgr_cls.broadcast_axis_partitions(
             axis=axis,

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -248,6 +248,9 @@ class BaseFrameManager(ABC):
             The flag to keep partitions for Modin Frame.
         apply_indices : list of ints (optional),
             Indices of `axis ^ 1` to apply function over.
+        enumerate_partitions : bool (optional, default False),
+            Whether or not to pass partition index into `apply_func`.
+            Note that `apply_func` must be able to obtain `partition_idx` kwarg.
         lengths : list(int), default None
             The list of lengths to shuffle the object.
 

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -68,7 +68,11 @@ class BaseFrameManager(ABC):
         -------
             a list of `BaseFrameAxisPartition` objects.
         """
-        return [cls._column_partitions_class(col) for col in partitions.T]
+        if not isinstance(partitions, list):
+            partitions = [partitions]
+        return [
+            cls._column_partitions_class(col) for frame in partitions for col in frame.T
+        ]
 
     @classmethod
     def row_partitions(cls, partitions):
@@ -81,7 +85,9 @@ class BaseFrameManager(ABC):
         -------
             a list of `BaseFrameAxisPartition` objects.
         """
-        return [cls._row_partition_class(row) for row in partitions]
+        if not isinstance(partitions, list):
+            partitions = [partitions]
+        return [cls._row_partition_class(row) for frame in partitions for row in frame]
 
     @classmethod
     def axis_partition(cls, partitions, axis):
@@ -257,6 +263,7 @@ class BaseFrameManager(ABC):
         preprocessed_map_func = cls.preprocess_func(apply_func)
         left_partitions = cls.axis_partition(left, axis)
         right_partitions = None if right is None else cls.axis_partition(right, axis)
+        # breakpoint()
         # For mapping across the entire axis, we don't maintain partitioning because we
         # may want to line to partitioning up with another BlockPartitions object. Since
         # we don't need to maintain the partitioning, this gives us the opportunity to

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -231,6 +231,7 @@ class BaseFrameManager(ABC):
         left,
         right,
         keep_partitioning=False,
+        apply_indices=None,
         lengths=None,
     ):
         """
@@ -244,6 +245,8 @@ class BaseFrameManager(ABC):
         right : The right partitions.
         keep_partitioning : boolean. Default is False
             The flag to keep partitions for Modin Frame.
+        apply_indices : list of ints (optional),
+            Indices of `axis ^ 1` to apply function over.
         lengths : list(int), default None
             The list of lengths to shuffle the object.
 
@@ -275,13 +278,16 @@ class BaseFrameManager(ABC):
             kw["_lengths"] = lengths
             kw["manual_partition"] = True
 
+        if apply_indices is None:
+            apply_indices = np.arange(len(left_partitions))
+
         result_blocks = np.array(
             [
-                part.apply(
+                left_partitions[i].apply(
                     preprocessed_map_func,
                     **kw,
                 )
-                for part in left_partitions
+                for i in apply_indices
             ]
         )
         # If we are mapping over columns, they are returned to use the same as

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -263,7 +263,6 @@ class BaseFrameManager(ABC):
         preprocessed_map_func = cls.preprocess_func(apply_func)
         left_partitions = cls.axis_partition(left, axis)
         right_partitions = None if right is None else cls.axis_partition(right, axis)
-        # breakpoint()
         # For mapping across the entire axis, we don't maintain partitioning because we
         # may want to line to partitioning up with another BlockPartitions object. Since
         # we don't need to maintain the partitioning, this gives us the opportunity to

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -232,6 +232,7 @@ class BaseFrameManager(ABC):
         right,
         keep_partitioning=False,
         apply_indices=None,
+        enumerate_partitions=False,
         lengths=None,
     ):
         """
@@ -286,8 +287,9 @@ class BaseFrameManager(ABC):
                 left_partitions[i].apply(
                     preprocessed_map_func,
                     **kw,
+                    **({"partition_idx": idx} if enumerate_partitions else {}),
                 )
-                for i in apply_indices
+                for idx, i in enumerate(apply_indices)
             ]
         )
         # If we are mapping over columns, they are returned to use the same as

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -234,8 +234,8 @@ class OmnisciOnRayFrame(BasePandasFrame):
                 for obj in by:
                     if isinstance(obj, str):
                         by_cols.append(obj)
-                    elif hasattr(obj, "_query_compiler"):
-                        by_frames.append(obj._query_compiler._modin_frame)
+                    elif hasattr(obj, "_modin_frame"):
+                        by_frames.append(obj._modin_frame)
                     else:
                         raise NotImplementedError("unsupported groupby args")
                 by_cols = Index.__new__(Index, data=by_cols, dtype=self.columns.dtype)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -436,7 +436,6 @@ class DataFrame(BasePandasDataset):
                 ):
                     names = [o.name if isinstance(o, Series) else o for o in by]
                     raise KeyError(next(x for x in names if x not in self))
-        # breakpoint()
         return DataFrameGroupBy(
             self,
             by,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -380,10 +380,7 @@ class DataFrame(BasePandasDataset):
             else:
                 by = self.__getitem__(by)._query_compiler
         elif isinstance(by, Series):
-            if by._parent is self:
-                drop = True
-            else:
-                drop = False
+            drop = by._parent is self
             idx_name = by.name
             by = by._query_compiler
         elif is_list_like(by):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -414,9 +414,6 @@ class DataFrame(BasePandasDataset):
                 if len(external_by) == 0:
                     by = self[internal_by]._query_compiler
 
-                # if len(by) == 1 and isinstance(by[0], type(self._query_compiler)):
-                #     by = by[0]
-
                 drop = True
             else:
                 mismatch = len(by) != len(self.axes[axis])

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -380,7 +380,10 @@ class DataFrame(BasePandasDataset):
             else:
                 by = self.__getitem__(by)._query_compiler
         elif isinstance(by, Series):
-            drop = by._parent is self
+            if by._parent is self:
+                drop = True
+            else:
+                drop = False
             idx_name = by.name
             by = by._query_compiler
         elif is_list_like(by):
@@ -406,13 +409,13 @@ class DataFrame(BasePandasDataset):
                     else:
                         external_by.append(current_by)
 
-                internal_qc = (
-                    [self[internal_by]._query_compiler] if len(internal_by) else []
-                )
+                by = internal_by + external_by
 
-                by = internal_qc + external_by
-                if len(by) == 1 and isinstance(by[0], type(self._query_compiler)):
-                    by = by[0]
+                if len(external_by) == 0:
+                    by = self[internal_by]._query_compiler
+
+                # if len(by) == 1 and isinstance(by[0], type(self._query_compiler)):
+                #     by = by[0]
 
                 drop = True
             else:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -393,6 +393,8 @@ class DataFrame(BasePandasDataset):
                 )
                 for o in by
             ):
+                # We want to split 'by's into those that belongs to the self (internal_by)
+                # and those that doesn't (external_by)
                 internal_by, external_by = [], []
 
                 for current_by in by:

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -37,12 +37,6 @@ from modin.config import IsExperimental
 from .series import Series
 
 
-class Grouper:
-    def __init__(self, parent, raw_by):
-        self._parent = parent
-        self._raw_by = raw_by
-
-
 @_inherit_docstrings(
     pandas.core.groupby.DataFrameGroupBy,
     excluded=[
@@ -477,7 +471,6 @@ class DataFrameGroupBy(object):
         )
 
     def size(self):
-        # breakpoint()
         if self._axis == 0:
             # Series objects in 'by' mean we couldn't handle the case
             # and transform 'by' to a query compiler.

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -27,6 +27,7 @@ import pandas
 import pandas.core.groupby
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.aggregation import reconstruct_func
+from types import BuiltinFunctionType
 import pandas.core.common as com
 from types import BuiltinFunctionType
 
@@ -261,7 +262,8 @@ class DataFrameGroupBy(object):
         return result
 
     def apply(self, func, *args, **kwargs):
-        func = wrap_udf_function(func)
+        if not isinstance(func, BuiltinFunctionType):
+            func = wrap_udf_function(func)
         return self._apply_agg_function(
             # Grouping column in never dropped in groupby.apply, so drop=False
             lambda df: df.apply(func, *args, **kwargs),

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -31,7 +31,7 @@ import pandas.core.common as com
 from types import BuiltinFunctionType
 
 from modin.error_message import ErrorMessage
-from modin.utils import _inherit_docstrings, try_cast_to_pandas
+from modin.utils import _inherit_docstrings, try_cast_to_pandas, wrap_udf_function
 from modin.backends.base.query_compiler import BaseQueryCompiler
 from modin.config import IsExperimental
 from .series import Series
@@ -261,6 +261,7 @@ class DataFrameGroupBy(object):
         return result
 
     def apply(self, func, *args, **kwargs):
+        func = wrap_udf_function(func)
         return self._apply_agg_function(
             # Grouping column in never dropped in groupby.apply, so drop=False
             lambda df: df.apply(func, *args, **kwargs),

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -811,10 +811,7 @@ class DataFrameGroupBy(object):
                         by
                     ).to_pandas()
                 else:
-                    by = [
-                        o.squeeze() if isinstance(o, pandas.DataFrame) else o
-                        for o in try_cast_to_pandas(by)
-                    ]
+                    by = try_cast_to_pandas(by, squeeze=True)
                     pandas_df = self._df._to_pandas()
                 self._index_grouped_cache = pandas_df.groupby(by=by).groups
             else:
@@ -949,10 +946,7 @@ class DataFrameGroupBy(object):
         else:
             by = self._by
 
-        by = try_cast_to_pandas(by)
-
-        if isinstance(by, list):
-            by = [(o.squeeze()) if isinstance(o, pandas.DataFrame) else o for o in by]
+        by = try_cast_to_pandas(by, squeeze=True)
 
         def groupby_on_multiple_columns(df, *args, **kwargs):
             return f(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -900,15 +900,7 @@ class DataFrameGroupBy(object):
             f, dict
         ), "'{0}' object is not callable and not a dict".format(type(f))
 
-        # For aggregations, pandas behavior does this for the result.
-        # For other operations it does not, so we wait until there is an aggregation to
-        # actually perform this operation.
-        if not self._is_multi_by and self._idx_name is not None and drop and self._drop:
-            groupby_qc = self._query_compiler.drop(columns=[self._idx_name])
-        else:
-            groupby_qc = self._query_compiler
-
-        new_manager = groupby_qc.groupby_agg(
+        new_manager = self._query_compiler.groupby_agg(
             by=self._by,
             is_multi_by=self._is_multi_by,
             axis=self._axis,

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -27,7 +27,6 @@ import pandas
 import pandas.core.groupby
 from pandas.core.dtypes.common import is_list_like
 from pandas.core.aggregation import reconstruct_func
-from types import BuiltinFunctionType
 import pandas.core.common as com
 from types import BuiltinFunctionType
 
@@ -81,6 +80,7 @@ class DataFrameGroupBy(object):
                 and all(
                     (isinstance(obj, str) and obj in self._query_compiler.columns)
                     or isinstance(obj, type(self._query_compiler))
+                    or is_list_like(obj)
                     for obj in self._by
                 )
             )
@@ -274,7 +274,7 @@ class DataFrameGroupBy(object):
     def dtypes(self):
         if self._axis == 1:
             raise ValueError("Cannot call dtypes on groupby with axis=1")
-        if self._is_multi_by and not self._as_index:
+        if not self._as_index:
             return self.apply(lambda df: df.dtypes)
         else:
             return self._apply_agg_function(lambda df: df.dtypes, drop=self._as_index)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1370,12 +1370,13 @@ def test_mixed_columns_not_from_df(columns, as_index):
 
     md_df, pd_df = create_test_dfs(data)
     by_md, by_pd = map(get_columns, [md_df, pd_df])
-    
+
     pd_grp = pd_df.groupby(by_pd, **groupby_kw)
     md_grp = md_df.groupby(by_md, **groupby_kw)
 
+    modin_groupby_equals_pandas(md_grp, pd_grp)
     eval_general(md_grp, pd_grp, lambda grp: grp.size())
-    eval_general(md_grp, pd_grp, lambda grp: grp.agg(lambda df: df.sum()))
+    eval_general(md_grp, pd_grp, lambda grp: grp.apply(lambda df: df.sum()))
     eval_general(md_grp, pd_grp, lambda grp: grp.first())
 
 

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -349,7 +349,11 @@ def test_simple_row_groupby(by, as_index, col1_category):
 
     # Workaround for Pandas bug #34656. Recreate groupby object for Pandas
     pandas_groupby = pandas_df.groupby(by=pandas_by, as_index=as_index)
-    apply_functions = [lambda df: df.sum(), min]
+    apply_functions = [
+        lambda df: df.sum(),
+        lambda df: pandas.Series([1, 2, 3, 4], name="result"),
+        min,
+    ]
     for func in apply_functions:
         eval_apply(modin_groupby, pandas_groupby, func)
 

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1466,5 +1466,4 @@ def test_multi_column_groupby_different_partitions(
     md_grp, pd_grp = md_df.groupby(by, as_index=as_index), pd_df.groupby(
         by, as_index=as_index
     )
-
     eval_general(md_grp, pd_grp, func_to_apply)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1422,10 +1422,11 @@ def test_unknown_groupby(columns):
     "func_to_apply",
     [
         lambda df: df.sum(),
-        lambda df: df.count(),
         lambda df: df.size(),
-        lambda df: df.mean(),
         lambda df: df.quantile(),
+        lambda df: df.dtypes,
+        lambda df: df.apply(lambda df: df.sum()),
+        lambda df: df.apply(lambda df: pandas.Series([1, 2, 3, 4])),
         lambda grp: grp.agg(
             {
                 df_from_grp(grp).columns[0]: (max, min, sum),
@@ -1438,12 +1439,15 @@ def test_unknown_groupby(columns):
         ),
     ],
 )
-def test_multi_column_groupby_different_partitions(func_to_apply):
+@pytest.mark.parametrize("as_index", [True, False])
+def test_multi_column_groupby_different_partitions(func_to_apply, as_index):
     data = test_data_values[0]
     md_df, pd_df = create_test_dfs(data)
 
     # columns that will be located in a different partitions
     by = [pd_df.columns[0], pd_df.columns[-1]]
 
-    md_grp, pd_grp = md_df.groupby(by), pd_df.groupby(by)
+    md_grp, pd_grp = md_df.groupby(by, as_index=as_index), pd_df.groupby(
+        by, as_index=as_index
+    )
     eval_general(md_grp, pd_grp, func_to_apply)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -258,12 +258,12 @@ class GetColumn:
             marks=pytest.mark.xfail(reason="Excluded because of bug #1554"),
         ),
         # but cum* functions produce undefined results with NaNs so we need to test the same combinations without NaN too
-        ["col5"],  # 10
+        ["col5"],
         ["col1", "col5"],
         ["col5", "col4"],
         ["col4", "col5"],
         ["col5", "col4", "col1"],
-        ["col1", pd.Series([1, 5, 7, 8])],  # 15
+        ["col1", pd.Series([1, 5, 7, 8])],
         [pd.Series([1, 5, 7, 8])],
         [
             pd.Series([1, 5, 7, 8]),
@@ -274,7 +274,7 @@ class GetColumn:
         ],
         ["col1", GetColumn("col5")],
         [GetColumn("col1"), GetColumn("col5")],
-        [GetColumn("col1")],  # 20
+        [GetColumn("col1")],
     ],
 )
 @pytest.mark.parametrize("as_index", [True, False])

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -81,7 +81,7 @@ def hashable(obj):
     return True
 
 
-def try_cast_to_pandas(obj):
+def try_cast_to_pandas(obj, squeeze=False):
     """
     Converts obj and all nested objects from modin to pandas if it is possible,
     otherwise returns obj
@@ -96,22 +96,25 @@ def try_cast_to_pandas(obj):
         Converted object
     """
     if hasattr(obj, "_to_pandas"):
-        return obj._to_pandas()
+        result = obj._to_pandas()
+        if squeeze:
+            result = result.squeeze(axis=1)
+        return result
     if hasattr(obj, "to_pandas"):
         result = obj.to_pandas()
+        if squeeze:
+            result = result.squeeze(axis=1)
         # Query compiler case, it doesn't have logic about convertion to Series
         if (
-            hasattr(result, "columns")
-            and len(result.columns) == 1
-            and result.columns[0] == "__reduced__"
+            isinstance(getattr(result, "name", None), str)
+            and result.name == "__reduced__"
         ):
-            result = result.squeeze(axis=1)
             result.name = None
         return result
     if isinstance(obj, (list, tuple)):
-        return type(obj)([try_cast_to_pandas(o) for o in obj])
+        return type(obj)([try_cast_to_pandas(o, squeeze=squeeze) for o in obj])
     if isinstance(obj, dict):
-        return {k: try_cast_to_pandas(v) for k, v in obj.items()}
+        return {k: try_cast_to_pandas(v, squeeze=squeeze) for k, v in obj.items()}
     if callable(obj):
         module_hierarchy = getattr(obj, "__module__", "").split(".")
         fn_name = getattr(obj, "__name__", None)

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -98,7 +98,16 @@ def try_cast_to_pandas(obj):
     if hasattr(obj, "_to_pandas"):
         return obj._to_pandas()
     if hasattr(obj, "to_pandas"):
-        return obj.to_pandas()
+        result = obj.to_pandas()
+        # Query compiler case, it doesn't have logic about convertion to Series
+        if (
+            hasattr(result, "columns")
+            and len(result.columns) == 1
+            and result.columns[0] == "__reduced__"
+        ):
+            result = result.squeeze(axis=1)
+            result.name = None
+        return result
     if isinstance(obj, (list, tuple)):
         return type(obj)([try_cast_to_pandas(o) for o in obj])
     if isinstance(obj, dict):


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2375 <!-- issue must be created for each patch -->
- [x] tests added and passing

## What was done
Check #2375 to see the basic idea of this implementation.

- Added ability to broadcast multiple modin frames with different partitioning.
- Reworked handling internal + external 'by'. Now if every 'by' are internal (columns names or Series whos `parent is self`) then 'by' will be a query compiler that contains all columns. If we have internal + external 'by', then 'by' will be a list of column names and external 'by's (or their query compilers if they have one). If we have only external 'by' then 'by' will be a list of external 'by's (or their query compilers if they have one). 
Previously it was possible that we're passing modin Series to a backend, now it could be only query compiler.
- Removed `squeeze` parameter from `groupby_kwargs`, because we're processing this at API level and this prevents us from getting tons of warnings from pandas that this parameter is deprecated.

Time measurements with `pd.DEFAULT_NPARTITIONS = 16` and 100 number of groups
|`(200.000, 257)`|quantile, `len(by) == 1`|quantile, `len(by) == 2`|quantile, `len(by) == 6`|apply(mean), `len(by) == 1`|apply(mean), `len(by) == 2`|apply(mean), `len(by) == 6`|
|-|-|-|-|-|-|-|
|pandas|5.66s|5.66s|5.58s|0.62s|0.64s|0.66s|
|modin #2461|1.05s|1.09s|1.14s|0.39s|0.42s|0.50s|
|modin master|1.34s|6.4s|6.46s|0.51s|1.42s|1.47s|

|`(1.000.000, 257)`|quantile, `len(by) == 1`|quantile, `len(by) == 2`|quantile, `len(by) == 6`|apply(mean), `len(by) == 1`|apply(mean), `len(by) == 2`|apply(mean), `len(by) == 6`|
|-|-|-|-|-|-|-|
|pandas|34.27s|34.52s|34.61s|2.54s|2.95s|3.04s|
|modin #2461|5.79s|5.73s|5.96s|1.09s|1.27s|1.56s|
|modin master|6.13s|37.71s|36.6s|1.06s|5.5s|5.59s|

<details><summary> Script </summary>


```python
import numpy as np
import os
import pandas
from modin.utils import try_cast_to_pandas
from timeit import default_timer as timer


def generate_data_file(
    nrows=200000,
    ncols=256,
    ngroups=100,
    filename=None,
    force=False,
    rand_low=-100,
    rang_high=100,
):
    if filename is None:
        filename = os.path.abspath(
            f"int_dataset-{nrows},{ncols},{rand_low},{rang_high},{ngroups}.csv"
        )

    print("generating", filename)

    if os.path.exists(filename) and not force:
        return filename

    data = {
        f"col{i}":
        # Generates ngroups for groupby in each column
        list(np.random.randint(rand_low, rang_high, ngroups)) * (nrows // ngroups)
        for i in np.arange(ncols)
    }
    print("dict generated!")
    df = pandas.DataFrame(data)
    print("dataframe created!")
    df.to_csv(filename)
    print("csv ready!")
    return filename


def measure_fn(fn, n):
    times = []
    for _ in range(n):
        t1 = timer()
        fn()
        times.append(timer() - t1)
    return np.min(times), np.median(times), times


def measure_time(df, by, n, **kwargs):
    print(f"\n======= Testing {kwargs['operation'][0]} =======")
    # Printing parameters:
    kwargs.update(
        {"Frame shape": df.shape, "len(by)": len(by), "ncores": pd.DEFAULT_NPARTITIONS}
    )
    op = kwargs.pop("operation")[1]

    print("Parameters:")
    for k, v in kwargs.items():
        print(f"\t{k}: {v}")

    as_index = kwargs["as_index"]

    def measure():
        md_res = op(df.groupby(by, as_index=as_index))
        # repr to trigger materialization
        repr(md_res)

    min_t, median_t, times = measure_fn(measure, n)

    print(f"Min time: {min_t}s | Median time: {median_t}s")


if __name__ == "__main__":
    import modin.pandas as pd
    from modin.pandas.test.utils import df_equals

    pd.DEFAULT_NPARTITIONS = 16

    nrows = [200_000, 1_000_000]
    by_cols = [
        ["col0"],
        ["col0", "col1"],
        ["col0", "col1", "col2", "col3", "col4", "col5"],
    ]
    operation = [
        ("quantile", lambda grp: grp.agg("quantile")),
        ("apply(mean)", lambda grp: grp.apply(lambda df: df.mean())),
    ]
    as_index = [True]
    ngroups = 100

    for nrows_ in nrows:
        fname = generate_data_file(nrows_, ngroups=ngroups)
        md_df = pd.read_csv(fname)
        for op in operation:
            for by in by_cols:
                for as_ind in as_index:
                    measure_time(
                        md_df,
                        by,
                        operation=op,
                        ngroups=ngroups,
                        as_index=as_ind,
                        n=10,
                    )
```


</details>