### PR TITLE
FIX-#2470: Performance regression relative to 0.7.4 release

### DIFF
--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -777,9 +777,7 @@ class BasePandasFrame(object):
         def astype_builder(df):
             return df.astype({k: v for k, v in col_dtypes.items() if k in df})
 
-        new_frame = self._frame_mgr_cls.lazy_map_partitions(
-            self._partitions, astype_builder
-        )
+        new_frame = self._frame_mgr_cls.map_partitions(self._partitions, astype_builder)
         return self.__constructor__(
             new_frame,
             self.index,
@@ -1145,7 +1143,7 @@ class BasePandasFrame(object):
         else:
             reduce_func = self._build_mapreduce_func(axis, reduce_func)
 
-        map_parts = self._frame_mgr_cls.lazy_map_partitions(self._partitions, map_func)
+        map_parts = self._frame_mgr_cls.map_partitions(self._partitions, map_func)
         reduce_parts = self._frame_mgr_cls.map_axis_partitions(
             axis, map_parts, reduce_func
         )
@@ -1171,7 +1169,7 @@ class BasePandasFrame(object):
         -------
             A new dataframe.
         """
-        new_partitions = self._frame_mgr_cls.lazy_map_partitions(self._partitions, func)
+        new_partitions = self._frame_mgr_cls.map_partitions(self._partitions, func)
         if dtypes == "copy":
             dtypes = self._dtypes
         elif dtypes is not None:

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -204,7 +204,7 @@ class BaseFrameManager(object):
         new_partitions = np.array(
             [
                 [
-                    part.add_to_apply_calls(
+                    part.apply(
                         apply_func,
                         **{other_name: right[col_idx] if axis else right[row_idx]},
                     )
@@ -587,9 +587,7 @@ class BaseFrameManager(object):
     ):
         preprocessed_func = cls.preprocess_func(func)
         return [
-            obj.add_to_apply_calls(
-                preprocessed_func, other=[o.get() for o in broadcasted], **kwargs
-            )
+            obj.apply(preprocessed_func, other=[o.get() for o in broadcasted], **kwargs)
             for obj, broadcasted in zip(partitions, other.T)
         ]
 
@@ -608,9 +606,7 @@ class BaseFrameManager(object):
             A list of BaseFramePartition objects.
         """
         preprocessed_func = cls.preprocess_func(func)
-        return [
-            obj.add_to_apply_calls(preprocessed_func, **kwargs) for obj in partitions
-        ]
+        return [obj.apply(preprocessed_func, **kwargs) for obj in partitions]
 
     @classmethod
     def apply_func_to_select_indices(


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Using `git bisect` it was found that commit b867edfba345e5f3c28398274b876d7b31f5a5ba introduced regression. This commit was reverted. Measurement results of commit with revert are next (given relation of queries execution times t_0.7.4/t_master, numbers lower 1 corresponds to degradation from 0.7.4 release to current master)
read_csv 1.12 (reading from local csv)
reductions 1.03
map operations 1.13
apply operation 1.8
add column operation 0.96
groupby.agg operation 1.04

mean value for all queries 1.18

As it can be seen degradation is not present now.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2470  <!-- issue must be created for each patch -->
- [x] tests added and passing
