### PR TITLE
FIX-#2473: Some configuration values should not be transformed

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -16,7 +16,7 @@ from textwrap import dedent
 import warnings
 from packaging import version
 
-from .pubsub import Parameter, _TYPE_PARAMS
+from .pubsub import Parameter, _TYPE_PARAMS, ExactStr
 
 
 class EnvironmentVariable(Parameter, type=str, abstract=True):
@@ -112,7 +112,7 @@ class IsRayCluster(EnvironmentVariable, type=bool):
     varname = "MODIN_RAY_CLUSTER"
 
 
-class RayRedisAddress(EnvironmentVariable, type=str):
+class RayRedisAddress(EnvironmentVariable, type=ExactStr):
     """
     What Redis address to connect to when running in Ray cluster
     """
@@ -142,7 +142,7 @@ class Memory(EnvironmentVariable, type=int):
     varname = "MODIN_MEMORY"
 
 
-class RayPlasmaDir(EnvironmentVariable, type=str):
+class RayPlasmaDir(EnvironmentVariable, type=ExactStr):
     """
     Path to Plasma storage for Ray
     """
@@ -158,7 +158,7 @@ class IsOutOfCore(EnvironmentVariable, type=bool):
     varname = "MODIN_OUT_OF_CORE"
 
 
-class SocksProxy(EnvironmentVariable, type=str):
+class SocksProxy(EnvironmentVariable, type=ExactStr):
     """
     SOCKS proxy address if it is needed for SSH to work
     """

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -22,10 +22,22 @@ class TypeDescriptor(typing.NamedTuple):
     help: str
 
 
+class ExactStr(str):
+    """
+    To be used in type params where no transformations are needed
+    """
+
+
 _TYPE_PARAMS = {
     str: TypeDescriptor(
         decode=lambda value: value.strip().title(),
         normalize=lambda value: value.strip().title(),
+        verify=lambda value: True,
+        help="a case-insensitive string",
+    ),
+    ExactStr: TypeDescriptor(
+        decode=lambda value: value,
+        normalize=lambda value: value,
         verify=lambda value: True,
         help="a string",
     ),

--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -14,7 +14,7 @@
 import os
 import pytest
 
-from modin.config.envvars import EnvironmentVariable, _check_vars
+from modin.config.envvars import EnvironmentVariable, _check_vars, ExactStr
 
 
 @pytest.fixture
@@ -25,9 +25,9 @@ def make_unknown_env():
     del os.environ[varname]
 
 
-@pytest.fixture
-def make_custom_envvar():
-    class CustomVar(EnvironmentVariable, type=str):
+@pytest.fixture(params=[str, ExactStr])
+def make_custom_envvar(request):
+    class CustomVar(EnvironmentVariable, type=request.param):
         """ custom var """
 
         default = 10
@@ -40,7 +40,7 @@ def make_custom_envvar():
 @pytest.fixture
 def set_custom_envvar(make_custom_envvar):
     os.environ[make_custom_envvar.varname] = "  custom  "
-    yield "Custom"
+    yield "Custom" if make_custom_envvar.type is str else "  custom  "
     del os.environ[make_custom_envvar.varname]
 
 


### PR DESCRIPTION
Some configuration variables should not be transformed upon reading them from user input (e.g. Ray plasma directory), fix that.

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2473 <!-- issue must be created for each patch -->
- [x] tests added and passing
