### PR TITLE
FEAT-#2479: integrate asv

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -303,7 +303,7 @@ jobs:
     env:
       MODIN_ENGINE: ray
       MODIN_MEMORY: 1000000000
-      TestDatasetSize: small
+      MODIN_TEST_DATASET_SIZE: small
     name: test-asv-benchmarks
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
           git fetch upstream
           if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
               asv machine --yes
-              asv dev | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
+              asv dev -v | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
               if grep "failed" benchmarks.log > /dev/null ; then
                   exit 1
               fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,62 @@ jobs:
       - shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash)
   
+  test-asv-benchmarks:
+    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    runs-on: ubuntu-latest
+    env:
+      MODIN_ENGINE: ray
+      MODIN_MEMORY: 1000000000
+      TestDatasetSize: small
+    name: test-asv-benchmarks
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Cache pip
+        uses: actions/cache@v1
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-python-3.7-pip-${{ github.run_id }}-${{ hashFiles('environment.yml') }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: modin
+          environment-file: environment.yml
+          python-version: 3.7
+          channel-priority: strict
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+      - name: Conda environment
+        shell: bash -l {0}
+        run: |
+          conda info
+          conda list
+
+      - name: Running benchmarks
+        shell: bash -l {0}
+        run: |
+          pip install -e .
+          cd asv_bench
+          asv check -E existing
+          git remote add upstream https://github.com/modin-project/modin.git
+          git fetch upstream
+          if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
+              asv machine --yes
+              asv dev | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
+              if grep "failed" benchmarks.log > /dev/null ; then
+                  exit 1
+              fi
+          else
+              echo "Benchmarks did not run, no changes detected"
+          fi
+        if: always()
+
+      - name: Publish benchmarks artifact
+        uses: actions/upload-artifact@master
+        with:
+          name: Benchmarks log
+          path: asv_bench/benchmarks.log
+        if: failure()
+
   test-all:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,7 +337,7 @@ jobs:
           git fetch upstream
           if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
               asv machine --yes
-              asv dev -v | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
+              asv run --quick --show-stderr --python=same --launch-method=spawn | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
               if grep "failed" benchmarks.log > /dev/null ; then
                   exit 1
               fi

--- a/.gitignore
+++ b/.gitignore
@@ -174,4 +174,5 @@ dask-worker-space/
 node_modules
 
 # Asv stuff
-.asv/
+asv_bench/.asv/
+asv_bench/modin/

--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,6 @@ cscope.out
 # Dask workspace
 dask-worker-space/
 node_modules
+
+# Asv stuff
+.asv/

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -1,0 +1,159 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "modin",
+
+    // The project's homepage
+    "project_url": "https://modin.readthedocs.io/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": "..",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+
+    // Customizable commands for building, installing, and
+    // uninstalling the project. See asv.conf.json documentation.
+    //
+    // "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // "build_command": [
+    //     "python setup.py build",
+    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    // ],
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    // "branches": ["master"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    // "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "conda",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/modin-project/modin/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    // "pythons": ["3.7"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    "conda_channels": ["conda-forge", "defaults"],
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list or empty string indicates to just test against the default
+    // (latest) version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed via
+    // pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    "matrix": {
+        "pandas": ["1.1.4"],
+        "packaging": [""],
+        "pip+ray": ["1.0.1"],
+        "pyarrow": ["1.0"]
+    },
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "numpy": "1.8"},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/asv_bench/benchmarks/__init__.py
+++ b/asv_bench/benchmarks/__init__.py
@@ -1,0 +1,1 @@
+"""Modin benchmarks"""

--- a/asv_bench/benchmarks/__init__.py
+++ b/asv_bench/benchmarks/__init__.py
@@ -1,1 +1,14 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 """Modin benchmarks"""

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -12,10 +12,12 @@
 # governing permissions and limitations under the License.
 
 import modin.pandas as pd
-from modin.config import TestDatasetSize
+from modin.config import CpuCount, TestDatasetSize
 from .utils import generate_dataframe, RAND_LOW, RAND_HIGH
 
-pd.DEFAULT_NPARTITIONS = 4
+# define `MODIN_CPUS` env var to control the number of partitions
+# it should be defined before modin.pandas import
+pd.DEFAULT_NPARTITIONS = CpuCount.get()
 
 if TestDatasetSize.get() == "Big":
     MERGE_DATA_SIZE = [

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1,0 +1,126 @@
+# Write the benchmarking functions here.
+# See "Writing benchmarks" in the asv docs for more information.
+import modin.pandas as pd
+import numpy as np
+
+pd.DEFAULT_NPARTITIONS = 4
+
+
+class TimeGroupBy:
+    param_names = ["rows_cols"]
+    params = [
+        [
+            (100, 1000),
+            (10000, 1000),
+        ]
+    ]
+
+    def setup(self, rows_cols):
+        rows, cols = rows_cols
+        # workaround for #2482
+        columns = [str(x) for x in range(cols)]
+        self.df = pd.DataFrame(
+            np.random.randint(0, 100, size=(rows, cols)), columns=columns
+        )
+
+    # add case for multiple by
+    def time_groupby_sum(self, rows_cols):
+        self.df.groupby(by="1").sum()
+
+    def time_groupby_mean(self, rows_cols):
+        self.df.groupby(by="1").mean()
+
+    def time_groupby_count(self, rows_cols):
+        self.df.groupby(by="1").count()
+
+
+class TimeJoin:
+    param_names = ["rows_cols", "how"]
+    params = [
+        [
+            (100, 1000),
+            (10000, 1000),
+        ],
+        ["outer", "inner", "left", "right"],
+    ]
+
+    def setup(self, rows_cols, how):
+        rows, cols = rows_cols
+        # workaround for #2482
+        columns = [str(x) for x in range(cols)]
+        numpy_data = np.random.randint(0, 100, size=(rows, cols)), columns=columns
+        self.df_left = pd.DataFrame(numpy_data)
+        self.df_right = pd.DataFrame(numpy_data)
+
+    def time_join(self, rows_cols, how):
+        self.df_left.join(self.df_right, how=how, lsuffix="left_")
+
+
+class TimeMerge:
+    param_names = ["rows_cols", "how"]
+    params = [
+        [
+            (100, 1000),
+            (10000, 1000),
+        ],
+        ["outer", "inner", "left", "right"],
+    ]
+
+    def setup(self, rows_cols, how):
+        rows, cols = rows_cols
+        # workaround for #2482
+        columns = [str(x) for x in range(cols)]
+        numpy_data = np.random.randint(0, 100, size=(rows, cols)), columns=columns
+        self.df_left = pd.DataFrame(numpy_data)
+        self.df_right = pd.DataFrame(numpy_data)
+
+    def time_merge(self, rows_cols, how):
+        self.df_left.merge(self.df_right, how=how, left_index=True, right_index=True)
+
+
+class TimeArithmetic:
+    param_names = ["rows_cols"]
+    params = [
+        [
+            (100, 1000),
+            (10000, 1000),
+        ]
+    ]
+
+    def setup(self, rows_cols):
+        rows, cols = rows_cols
+        # workaround for #2482
+        columns = [str(x) for x in range(cols)]
+        self.df = pd.DataFrame(
+            np.random.randint(0, 100, size=(rows, cols)), columns=columns
+        )
+
+    def time_transpose_lazy(self, rows_cols):
+        self.df.T
+
+    def time_transpose(self, rows_cols):
+        repr(self.df.T)
+
+    def time_sum(self, rows_cols):
+        self.df.sum()
+
+    def time_sum_axis_1(self, rows_cols):
+        self.df.sum(axis=1)
+
+    def time_median(self, rows_cols):
+        self.df.median()
+
+    def time_median_axis_1(self, rows_cols):
+        self.df.median(axis=1)
+
+    def time_nunique(self, rows_cols):
+        self.df.nunique()
+
+    def time_nunique_axis_1(self, rows_cols):
+        self.df.nunique(axis=1)
+
+    def time_apply(self, rows_cols):
+        self.df.apply(lambda df: df.sum())
+
+    def time_apply(self, rows_cols):
+        self.df.apply(lambda df: df.sum(), axis=1)

--- a/asv_bench/benchmarks/utils.py
+++ b/asv_bench/benchmarks/utils.py
@@ -1,0 +1,95 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import logging
+import modin.pandas as pd
+import pandas
+import numpy as np
+
+RAND_LOW = 0
+RAND_HIGH = 100
+random_state = np.random.RandomState(seed=42)
+
+
+class weakdict(dict):
+    __slots__ = ("__weakref__",)
+
+
+data_cache = dict()
+dataframes_cache = dict()
+
+
+def gen_int_data(ncols, nrows, rand_low, rand_high):
+    cache_key = ("int", ncols, nrows, rand_low, rand_high)
+    if cache_key in data_cache:
+        return data_cache[cache_key]
+
+    logging.info(
+        "Generating int data {} rows and {} columns [{}-{}]".format(
+            nrows, ncols, rand_low, rand_high
+        )
+    )
+    data = {
+        "col{}".format(i): random_state.randint(rand_low, rand_high, size=(nrows))
+        for i in range(ncols)
+    }
+    data_cache[cache_key] = weakdict(data)
+    return data
+
+
+def gen_str_int_data(ncols, nrows, rand_low, rand_high):
+    cache_key = ("str_int", ncols, nrows, rand_low, rand_high)
+    if cache_key in data_cache:
+        return data_cache[cache_key]
+
+    logging.info(
+        "Generating str_int data {} rows and {} columns [{}-{}]".format(
+            nrows, ncols, rand_low, rand_high
+        )
+    )
+    data = gen_int_data(ncols, nrows, rand_low, rand_high).copy()
+    data["gb_col"] = [
+        "str_{}".format(random_state.randint(rand_low, rand_high)) for i in range(nrows)
+    ]
+    data_cache[cache_key] = weakdict(data)
+    return data
+
+
+def gen_data(data_type, ncols, nrows, rand_low, rand_high):
+    if data_type == "int":
+        return gen_int_data(ncols, nrows, rand_low, rand_high)
+    elif data_type == "str_int":
+        return gen_str_int_data(ncols, nrows, rand_low, rand_high)
+    else:
+        assert False
+
+
+def generate_dataframe(impl, data_type, ncols, nrows, rand_low, rand_high):
+    cache_key = (impl, data_type, ncols, nrows, rand_low, rand_high)
+    if cache_key in dataframes_cache:
+        return dataframes_cache[cache_key]
+
+    logging.info(
+        "Allocating {} DataFrame {}: {} rows and {} columns [{}-{}]".format(
+            impl, data_type, nrows, ncols, rand_low, rand_high
+        )
+    )
+    data = gen_data(data_type, ncols, nrows, rand_low, rand_high)
+    if impl == "modin":
+        df = pd.DataFrame(data)
+    elif impl == "pandas":
+        df = pandas.DataFrame(data)
+    else:
+        assert False
+    dataframes_cache[cache_key] = df
+    return df

--- a/environment.yml
+++ b/environment.yml
@@ -32,5 +32,6 @@ dependencies:
   - rpyc==4.1.5
   - cloudpickle==1.4.1
   - boto3
+  - asv
   - pip:
     - ray>=1.0.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ msgpack
 pandas_gbq
 cloudpickle
 rpyc==4.1.5
+asv


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

* `TimeArithmetic` benchmark - an alternative for `ci/benchmarks/pandas/arithmetic_benchmark.py` (except `df.T` op)
* `TimeMerge` benchmark - an alternative for `ci/benchmarks/test_benchmarks.py::test_merge`
* `TimeJoin` benchmark made by analogy with `TimeMerge`
* Data generation functionality is just copied from `test_benchmarks.py` (I suppose we can remove duplicated functionality later)
* **Note** we should run asv with `--launch-method=spawn` (forkserver is not work)

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2479 <!-- issue must be created for each patch -->
- [x] tests added and passing

What needs to be completed:
* look at `modin/ci/benchmarks` for benchmarks that can be used with asv (This is an experimental feature, out of scope for now)
* define new microbenchmarks based on workloads (This is an experimental feature, out of scope for now)
* update documentation: how to use the tool locally and when is it needed?
  - If benchmarks are added or changed inside `asv_bench` folder, CI will do a test run to check the functionality.
  - Run full performance suite on the target machine at least once a day. Then publish the results. (Asv offers functionality to publish results to github pages - `asv gh_pages`)
  - When changing important parts of the code, ask contributors to run the appropriate set of benchmarks locally - before and after the changes to see performance impact (`asv continuous -f 1.1 upstream/master HEAD -b TimeMerge`).
