### PR TITLE
FIX-#2408: Fix read_csv and read_table args when used inside a decora…

### DIFF
--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -103,10 +103,18 @@ def _make_parser_func(sep):
         memory_map=False,
         float_precision=None,
     ):
+        # ISSUE #2408: parse parameter shared with pandas read_csv and read_table and update with provided args
+        _pd_read_csv_signature = dict(inspect.signature(pandas.read_csv).parameters)
         _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
         if kwargs.get("sep", sep) is False:
             kwargs["sep"] = "\t"
-        return _read(**kwargs)
+
+        shared_keys = set(_pd_read_csv_signature.keys()).intersection(kwargs.keys())
+
+        for key in shared_keys:
+            _pd_read_csv_signature[key] = kwargs[key]
+
+        return _read(**_pd_read_csv_signature)
 
     return parser_func
 

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -104,17 +104,15 @@ def _make_parser_func(sep):
         float_precision=None,
     ):
         # ISSUE #2408: parse parameter shared with pandas read_csv and read_table and update with provided args
-        _pd_read_csv_signature = dict(inspect.signature(pandas.read_csv).parameters)
-        _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
-        if kwargs.get("sep", sep) is False:
-            kwargs["sep"] = "\t"
+        _pd_read_csv_signature = {
+            val.name for val in inspect.signature(pandas.read_csv).parameters.values()
+        }
+        _, _, _, f_locals = inspect.getargvalues(inspect.currentframe())
+        if f_locals.get("sep", sep) is False:
+            f_locals["sep"] = "\t"
 
-        shared_keys = set(_pd_read_csv_signature.keys()).intersection(kwargs.keys())
-
-        for key in shared_keys:
-            _pd_read_csv_signature[key] = kwargs[key]
-
-        return _read(**_pd_read_csv_signature)
+        kwargs = {k: v for k, v in f_locals.items() if k in _pd_read_csv_signature}
+        return _read(**kwargs)
 
     return parser_func
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -43,6 +43,7 @@ from .utils import (
     IO_OPS_DATA_DIR,
     io_ops_bad_exc,
     eval_io_from_str,
+    dummy_decorator,
 )
 
 from modin.config import Engine, Backend, IsExperimental
@@ -1475,36 +1476,24 @@ def test_from_csv(make_csv_file, nrows):
     df_equals(modin_df, pandas_df)
 
 
-def dummy_decorator():
-    """A problematic decorator that does not use `functools.wraps`. this introduce unwanted local variables for
-    inspect.currentframe.
-    """
-
-    def wrapper(method):
-        def wrapped_function(self, *args, **kwargs):
-            result = method(self, *args, **kwargs)
-            return result
-
-        return wrapped_function
-
-    return wrapper
-
-
-@pytest.mark.parametrize("nrows", [123, None])
-def test_from_csv_within_decorator_parse_args_correctly(make_csv_file, nrows):
+def test_from_csv_within_decorator(make_csv_file):
     make_csv_file()
 
     @dummy_decorator()
-    def wrapped_read_csv(file, nrows):
-        return pd.read_csv(file, nrows=nrows)
+    def wrapped_read_csv(file, method):
+        if method == "pandas":
+            return pandas.read_csv(file)
 
-    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, nrows=nrows)
-    modin_df = wrapped_read_csv(TEST_CSV_FILENAME, nrows=nrows)
+        if method == "modin":
+            return pd.read_csv(file)
+
+    pandas_df = wrapped_read_csv(TEST_CSV_FILENAME, method="pandas")
+    modin_df = wrapped_read_csv(TEST_CSV_FILENAME, method="modin")
 
     df_equals(modin_df, pandas_df)
 
-    pandas_df = pandas.read_csv(Path(TEST_CSV_FILENAME), nrows=nrows)
-    modin_df = wrapped_read_csv(Path(TEST_CSV_FILENAME), nrows=nrows)
+    pandas_df = wrapped_read_csv(Path(TEST_CSV_FILENAME), method="pandas")
+    modin_df = wrapped_read_csv(Path(TEST_CSV_FILENAME), method="modin")
 
     df_equals(modin_df, pandas_df)
 
@@ -1691,20 +1680,24 @@ def test_from_table(make_csv_file):
     df_equals(modin_df, pandas_df)
 
 
-def test_from_table_within_decorator_parse_args_correctly(make_csv_file):
+def test_from_table_within_decorator(make_csv_file):
     make_csv_file(delimiter="\t")
 
     @dummy_decorator()
-    def wrapped_read_table(file):
-        return pd.read_table(file)
+    def wrapped_read_table(file, method):
+        if method == "pandas":
+            return pandas.read_table(file)
 
-    pandas_df = pandas.read_table(TEST_CSV_FILENAME)
-    modin_df = wrapped_read_table(TEST_CSV_FILENAME)
+        if method == "modin":
+            return pd.read_table(file)
+
+    pandas_df = wrapped_read_table(TEST_CSV_FILENAME, method="pandas")
+    modin_df = wrapped_read_table(TEST_CSV_FILENAME, method="modin")
 
     df_equals(modin_df, pandas_df)
 
-    pandas_df = pandas.read_table(Path(TEST_CSV_FILENAME))
-    modin_df = wrapped_read_table(Path(TEST_CSV_FILENAME))
+    pandas_df = wrapped_read_table(Path(TEST_CSV_FILENAME), method="pandas")
+    modin_df = wrapped_read_table(Path(TEST_CSV_FILENAME), method="modin")
 
     df_equals(modin_df, pandas_df)
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1461,21 +1461,6 @@ def test_from_sas():
     df_equals(modin_df, pandas_df)
 
 
-@pytest.mark.parametrize("nrows", [123, None])
-def test_from_csv(make_csv_file, nrows):
-    make_csv_file()
-
-    pandas_df = pandas.read_csv(TEST_CSV_FILENAME, nrows=nrows)
-    modin_df = pd.read_csv(TEST_CSV_FILENAME, nrows=nrows)
-
-    df_equals(modin_df, pandas_df)
-
-    pandas_df = pandas.read_csv(Path(TEST_CSV_FILENAME), nrows=nrows)
-    modin_df = pd.read_csv(Path(TEST_CSV_FILENAME), nrows=nrows)
-
-    df_equals(modin_df, pandas_df)
-
-
 def test_from_csv_within_decorator(make_csv_file):
     make_csv_file()
 

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -1045,3 +1045,18 @@ def check_file_leaks(func):
             ), f"Unexpected open handles left for: {', '.join(item[0] for item in leaks)}"
 
     return check
+
+
+def dummy_decorator():
+    """A problematic decorator that does not use `functools.wraps`. This introduces unwanted local variables for
+    inspect.currentframe. This decorator is used in test_io to test `read_csv` and `read_table`
+    """
+
+    def wrapper(method):
+        def wrapped_function(self, *args, **kwargs):
+            result = method(self, *args, **kwargs)
+            return result
+
+        return wrapped_function
+
+    return wrapper


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Fix an issue when `read_csv` or `read_table` are used in a decorator which does not use `functools.wraps`, additional local variables may be introducted that causes `parser_func` in `_make_parser_func` incorrectly adding unknown kwargs to `read_csv` and `read_table`.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2408
- [x] tests added and passing
