### PR TITLE
TEST-#2488: Increase commitlint message length limit to 88 characters from 70

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -2,7 +2,7 @@ module.exports = {
 	plugins: ['commitlint-plugin-jira-rules'],
 	extends: ['jira'],
 	rules: {
-		"header-max-length": [2, "always", 70],
+		"header-max-length": [2, "always", 88],
 		"signed-off-by": [2, "always", "Signed-off-by"],
 		"jira-task-id-max-length": [0, "always", 10],
 		"jira-task-id-project-key": [2, "always", ["FEAT", "DOCS", "FIX", "REFACTOR", "TEST"]],


### PR DESCRIPTION

* Resolves #2488

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2488 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
