### PR TITLE
Ensure excel reader closes file if it is passed as path

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -12,6 +12,7 @@
 # governing permissions and limitations under the License.
 
 import os
+import sys
 from textwrap import dedent
 import warnings
 from packaging import version
@@ -206,6 +207,18 @@ class TestDatasetSize(EnvironmentVariable, type=str):
 
     varname = "MODIN_TEST_DATASET_SIZE"
     choices = ("Small", "Normal", "Big")
+
+
+class TrackFileLeaks(EnvironmentVariable, type=bool):
+    """
+    Whether to track for open file handles leakage during testing
+    """
+
+    varname = "MODIN_TEST_TRACK_FILE_LEAKS"
+    # Turn off tracking on Windows by default because
+    # psutil's open_files() can be extremely slow on Windows (up to adding a few hours).
+    # see https://github.com/giampaolo/psutil/pull/597
+    default = sys.platform != "win32"
 
 
 def _check_vars():

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -26,9 +26,9 @@ import os
 import shutil
 import sqlalchemy as sa
 import csv
-from pandas.util._test_decorators import check_file_leaks
 
 from .utils import (
+    check_file_leaks,
     df_equals,
     json_short_string,
     json_short_bytes,

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -26,6 +26,7 @@ import os
 import shutil
 import sqlalchemy as sa
 import csv
+from pandas.util._test_decorators import check_file_leaks
 
 from .utils import (
     df_equals,
@@ -1184,6 +1185,7 @@ def test_from_clipboard():
 
 
 @pytest.mark.xfail(reason="read_excel is broken for now, see #1733 for details")
+@check_file_leaks
 def test_from_excel():
     setup_excel_file(NROWS)
 
@@ -1195,6 +1197,7 @@ def test_from_excel():
     teardown_excel_file()
 
 
+@check_file_leaks
 def test_from_excel_engine():
     setup_excel_file(NROWS)
 
@@ -1207,6 +1210,7 @@ def test_from_excel_engine():
     teardown_excel_file()
 
 
+@check_file_leaks
 def test_from_excel_index_col():
     setup_excel_file(NROWS)
 
@@ -1219,6 +1223,7 @@ def test_from_excel_index_col():
     teardown_excel_file()
 
 
+@check_file_leaks
 def test_from_excel_all_sheets():
     setup_excel_file(NROWS)
 
@@ -1236,6 +1241,7 @@ def test_from_excel_all_sheets():
     teardown_excel_file()
 
 
+@check_file_leaks
 def test_from_excel_sheetname_title():
     path = "modin/pandas/test/data/excel_sheetname_title.xlsx"
     modin_df = pd.read_excel(path)
@@ -1247,6 +1253,7 @@ def test_from_excel_sheetname_title():
     "sheet_name",
     ["Sheet1", "AnotherSpecialName", "SpecialName", "SecondSpecialName", 0, 1, 2, 3],
 )
+@check_file_leaks
 def test_from_excel_sheet_name(sheet_name):
     fname = "modin/pandas/test/data/modin_error_book.xlsx"
     modin_df = pd.read_excel(fname, sheet_name=sheet_name)

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -23,7 +23,7 @@ from pandas.testing import (
 )
 import modin.pandas as pd
 from modin.utils import to_pandas
-from modin.config import TestDatasetSize
+from modin.config import TestDatasetSize, TrackFileLeaks
 from io import BytesIO
 import os
 from string import ascii_letters
@@ -1018,6 +1018,8 @@ def check_file_leaks(func):
     A decorator that ensures that no *newly* opened file handles are left
     after decorated function is finished.
     """
+    if not TrackFileLeaks.get():
+        return func
 
     @functools.wraps(func)
     def check(*a, **kw):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

`openpyxl` has either a long-standing bug or a design decision that, when opening a file in read-only mode, it does not close the file handle (maybe it does so for caching purposes, no idea).
They have introduced a new `.close()` method, but people say it does not fully close all the handles.

So what I instead did was open the file if passed in a string and close it explicitly.
Also I've optimized the code a little bit by effectively inlining `load_workbook()` function which allowed to eliminate creation of _two_ `ExcelReader()` objects for a single read.

I've also decorated all the excel-reading tests with the checker ~~from Pandas test utils which they introduced in https://github.com/pandas-dev/pandas/pull/30096 when they were fixing this exact issue :)~~ inspired by Pandas but with a little more resilience (it only pays attention to file names and descriptors and ignores the order of open files).
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2465  <!-- issue must be created for each patch -->
- [x] tests added and passing
