### PR TITLE
FEAT-#2491: optimized groupby dictionary aggregation

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -98,6 +98,18 @@ class TimeGroupByDefaultAggregations:
     def time_groupby_mean(self, data_size):
         execute(self.df.groupby(by=self.groupby_column).mean())
 
+    def time_groupby_dictionary_reduction(self, impl, data_type, data_size):
+        cols_to_agg = self.df.columns[1:4]
+        self.df.groupby(by=self.df.columns[0]).agg(
+            {k: v for k, v in zip(cols_to_agg, ["sum", "count", "any"])}
+        )
+
+    def time_groupby_dictionary_aggregation(self, impl, data_type, data_size):
+        cols_to_agg = self.df.columns[1:4]
+        self.df.groupby(by=self.df.columns[0]).agg(
+            {k: v for k, v in zip(cols_to_agg, ["quantile", "std", "median"])}
+        )
+
 
 class TimeJoin:
     param_names = ["data_size", "how", "sort"]

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -58,21 +58,21 @@ def execute(df):
 
 
 class BaseTimeGroupBy:
-    def setup(self, data_size, count_columns=1):
+    def setup(self, data_size, ncols=1):
         self.df = generate_dataframe(
             ASV_USE_IMPL, "int", data_size[1], data_size[0], RAND_LOW, RAND_HIGH
         )
-        self.groupby_columns = self.df.columns[:count_columns].tolist()
+        self.groupby_columns = self.df.columns[:ncols].tolist()
 
 
 class TimeMultiColumnGroupby(BaseTimeGroupBy):
-    param_names = ["data_size", "count_columns"]
+    param_names = ["data_size", "ncols"]
     params = [UNARY_OP_DATA_SIZE, [6]]
 
-    def time_groupby_agg_quan(self, data_size, count_columns):
+    def time_groupby_agg_quan(self, data_size, ncols):
         execute(self.df.groupby(by=self.groupby_columns).agg("quantile"))
 
-    def time_groupby_agg_mean(self, data_size, count_columns):
+    def time_groupby_agg_mean(self, data_size, ncols):
         execute(self.df.groupby(by=self.groupby_columns).apply(lambda df: df.mean()))
 
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2509,6 +2509,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
     ):
         def is_reduce_fn(o, deep_level=0):
             if not isinstance(o, str) and isinstance(o, Container):
+                # `deep_level` parameter specifies the number of nested containers that was met:
+                # - if it's 0, then we're outside of container, `o` could be either function name
+                #   or container of function names/renamers.
+                # - if it's 1, then we're inside container of function names/renamers. `o` must be
+                #   either function name or renamer (renamer is some container which length == 2,
+                #   the first element is the new column name and the second is the function name).
                 assert deep_level == 0 or (
                     deep_level > 0 and len(o) == 2
                 ), f"Got the renamer with incorrect length, expected 2 got {len(o)}."

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -23,7 +23,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas.core.base import DataError
 from typing import Type, Callable
-from collections.abc import Container
+from collections.abc import Iterable
 import warnings
 
 
@@ -2462,7 +2462,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         map_dict = {}
         reduce_dict = {}
         rename_columns = any(
-            not isinstance(fn, str) and isinstance(fn, Container)
+            not isinstance(fn, str) and isinstance(fn, Iterable)
             for fn in agg_func.values()
         )
         for col, col_funcs in agg_func.items():
@@ -2475,11 +2475,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
             map_fns = []
             for i, fn in enumerate(col_funcs):
-                if not isinstance(fn, str) and isinstance(fn, Container):
-                    assert (
-                        len(fn) == 2
-                    ), f"Incorrect number of values to unpack. (got {len(fn)} expected 2)"
-                    future_col_name, func = fn[0], fn[1]
+                if not isinstance(fn, str) and isinstance(fn, Iterable):
+                    future_col_name, func = fn
                 elif isinstance(fn, str):
                     future_col_name, func = fn, fn
                 else:

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2465,16 +2465,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
             not isinstance(fn, str) and isinstance(fn, Container)
             for fn in agg_func.values()
         )
-        # breakpoint()
         for col, col_funcs in agg_func.items():
-            # single function without renaming
             if not rename_columns:
                 map_dict[col], reduce_dict[col] = groupby_reduce_functions[col_funcs]
                 continue
 
             if isinstance(col_funcs, str):
                 col_funcs = [col_funcs]
-            # breakpoint()
+
             map_fns = []
             for i, fn in enumerate(col_funcs):
                 if not isinstance(fn, str) and isinstance(fn, Container):
@@ -2486,11 +2484,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     future_col_name, func = fn, fn
                 else:
                     raise TypeError
-                # breakpoint()
+
                 map_fns.append((future_col_name, groupby_reduce_functions[func][0]))
                 reduce_dict[(col, future_col_name)] = groupby_reduce_functions[func][1]
             map_dict[col] = map_fns
-        # breakpoint()
+
         return GroupbyReduceFunction.register(map_dict, reduce_dict)(
             query_compiler=self,
             by=by,

--- a/modin/data_management/functions/__init__.py
+++ b/modin/data_management/functions/__init__.py
@@ -17,7 +17,7 @@ from .mapreducefunction import MapReduceFunction
 from .reductionfunction import ReductionFunction
 from .foldfunction import FoldFunction
 from .binary_function import BinaryFunction
-from .groupby_function import GroupbyReduceFunction
+from .groupby_function import GroupbyReduceFunction, groupby_reduce_functions
 
 __all__ = [
     "Function",
@@ -27,4 +27,5 @@ __all__ = [
     "FoldFunction",
     "BinaryFunction",
     "GroupbyReduceFunction",
+    "groupby_reduce_functions",
 ]

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -99,15 +99,6 @@ class GroupbyReduceFunction(MapReduceFunction):
             insert_levels = partition_idx == 0 and (drop or method == "size")
             result.reset_index(drop=not insert_levels, inplace=True)
 
-        cols_to_drop = list(
-            result.columns[result.columns.str.match(r"__reduced__.*", na=False)]
-            if hasattr(result.columns, "str")
-            else []
-        )
-
-        if method != "size" and len(cols_to_drop) > 0 and len(df.columns) > 1:
-            result.drop(columns=cols_to_drop, inplace=True, errors="ignore")
-
         return result
 
     @classmethod

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -45,7 +45,6 @@ class GroupbyReduceFunction(MapReduceFunction):
         # Set `as_index` to True to track the metadata of the grouping object
         # It is used to make sure that between phases we are constructing the
         # right index and placing columns in the correct order.
-        as_index = groupby_args.get("as_index", True)
         groupby_args["as_index"] = True
         groupby_args["observed"] = True
         if other is not None:

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -20,174 +20,253 @@ from modin.utils import try_cast_to_pandas
 class GroupbyReduceFunction(MapReduceFunction):
     @classmethod
     def call(cls, map_func, reduce_func, *call_args, **call_kwds):
-        def caller(
-            query_compiler,
-            by,
-            axis,
-            groupby_args,
-            map_args,
-            reduce_args=None,
-            numeric_only=True,
-            drop=False,
-        ):
-            if not isinstance(by, (type(query_compiler), str)):
-                by = try_cast_to_pandas(by, squeeze=True)
-                return query_compiler.default_to_pandas(
-                    lambda df: map_func(
-                        df.groupby(by=by, axis=axis, **groupby_args), **map_args
-                    )
+        assert not (
+            isinstance(map_func, dict) ^ isinstance(reduce_func, dict)
+        ) and not (
+            callable(map_func) ^ callable(reduce_func)
+        ), "Map and reduce functions must be either both dict or both callable."
+
+        return lambda *args, **kwargs: cls.caller(
+            *args, map_func=map_func, reduce_func=reduce_func, **kwargs, **call_kwds
+        )
+
+    @classmethod
+    def map(
+        cls,
+        df,
+        other=None,
+        axis=0,
+        by=None,
+        groupby_args=None,
+        map_func=None,
+        map_args=None,
+        drop=False,
+    ):
+        # Set `as_index` to True to track the metadata of the grouping object
+        # It is used to make sure that between phases we are constructing the
+        # right index and placing columns in the correct order.
+        as_index = groupby_args.get("as_index", True)
+        groupby_args["as_index"] = True
+        groupby_args["observed"] = True
+        if other is not None:
+            other = other.squeeze(axis=axis ^ 1)
+            if isinstance(other, pandas.DataFrame):
+                df = pandas.concat(
+                    [df] + [other[[o for o in other if o not in df]]],
+                    axis=1,
                 )
-            assert axis == 0, "Can only groupby reduce with axis=0"
+                other = list(other.columns)
+            by_part = other
+        else:
+            by_part = by
 
-            if numeric_only:
-                qc = query_compiler.getitem_column_array(
-                    query_compiler._modin_frame._numeric_columns(True)
+        apply_func = cls.try_filter_dict(map_func, df)
+        result = apply_func(
+            df.groupby(by=by_part, axis=axis, **groupby_args), **map_args
+        )
+        return result
+
+    @classmethod
+    def reduce(
+        cls,
+        df,
+        partition_idx=0,
+        axis=0,
+        groupby_args=None,
+        reduce_func=None,
+        reduce_args=None,
+        drop=False,
+        **kwargs,
+    ):
+        by_part = list(df.index.names)
+        if drop and len(df.columns.intersection(by_part)) > 0:
+            df.drop(columns=by_part, errors="ignore", inplace=True)
+
+        groupby_args = groupby_args.copy()
+        method = kwargs.get("method", None)
+        as_index = groupby_args["as_index"]
+
+        # Set `as_index` to True to track the metadata of the grouping object
+        groupby_args["as_index"] = True
+
+        # since now index levels contain out 'by', in the reduce phace
+        # we want to group on these levels
+        groupby_args["level"] = list(range(len(df.index.names)))
+
+        apply_func = cls.try_filter_dict(reduce_func, df)
+        result = apply_func(df.groupby(axis=axis, **groupby_args), **reduce_args)
+
+        if not as_index:
+            insert_levels = partition_idx == 0 and (drop or method == "size")
+            result.reset_index(drop=not insert_levels, inplace=True)
+
+        cols_to_drop = list(
+            result.columns[result.columns.str.match(r"__reduced__.*", na=False)]
+            if hasattr(result.columns, "str")
+            else []
+        )
+
+        if method != "size" and len(cols_to_drop) > 0 and len(df.columns) > 1:
+            result.drop(columns=cols_to_drop, inplace=True, errors="ignore")
+
+        return result
+
+    @classmethod
+    def caller(
+        cls,
+        query_compiler,
+        by,
+        axis,
+        groupby_args,
+        map_args,
+        map_func,
+        numeric_only=True,
+        **kwargs,
+    ):
+        if not isinstance(by, (type(query_compiler), str)):
+            by = try_cast_to_pandas(by, squeeze=True)
+            default_func = (
+                (lambda grp: grp.agg(map_func))
+                if isinstance(map_func, dict)
+                else map_func
+            )
+            return query_compiler.default_to_pandas(
+                lambda df: default_func(
+                    df.groupby(by=by, axis=axis, **groupby_args), **map_args
                 )
-            else:
-                qc = query_compiler
-            # since we're going to modify `groupby_args` dict in a `compute_map`,
-            # we want to copy it to not propagate these changes into source dict, in case
-            # of unsuccessful end of function
-            groupby_args = groupby_args.copy()
+            )
+        assert axis == 0, "Can only groupby reduce with axis=0"
 
-            as_index = groupby_args.get("as_index", True)
-            observed = groupby_args.get("observed", False)
+        if numeric_only:
+            qc = query_compiler.getitem_column_array(
+                query_compiler._modin_frame._numeric_columns(True)
+            )
+        else:
+            qc = query_compiler
 
-            if isinstance(by, str):
+        map_fn, reduce_fn = cls.build_map_reduce_functions(
+            by=by,
+            axis=axis,
+            groupby_args=groupby_args,
+            map_func=map_func,
+            map_args=map_args,
+            **kwargs,
+        )
 
-                def _map(df):
-                    # Set `as_index` to True to track the metadata of the grouping
-                    # object It is used to make sure that between phases we are
-                    # constructing the right index and placing columns in the correct
-                    # order.
-                    groupby_args["as_index"] = True
-                    groupby_args["observed"] = True
+        broadcastable_by = getattr(by, "_modin_frame", None)
+        apply_indices = list(map_func.keys()) if isinstance(map_func, dict) else None
+        new_modin_frame = qc._modin_frame.groupby_reduce(
+            axis, broadcastable_by, map_fn, reduce_fn, apply_indices=apply_indices
+        )
 
-                    result = map_func(
-                        df.groupby(by=by, axis=axis, **groupby_args), **map_args
-                    )
-                    # The _modin_groupby_ prefix indicates that this is the first
-                    # partition, and since we may need to insert the grouping data in
-                    # the reduce phase
-                    if (
-                        not isinstance(result.index, pandas.MultiIndex)
-                        and result.index.name is not None
-                        and result.index.name in result.columns
-                    ):
-                        result.index.name = "{}{}".format(
-                            "_modin_groupby_", result.index.name
-                        )
-                    return result
+        result = query_compiler.__constructor__(new_modin_frame)
+        if result.index.name == "__reduced__":
+            result.index.name = None
+        return result
 
-            else:
+    @staticmethod
+    def try_filter_dict(agg_func, df):
+        if not isinstance(agg_func, dict):
+            return agg_func
+        partition_dict = {k: v for k, v in agg_func.items() if k in df.columns}
+        return lambda grp: grp.agg(partition_dict)
 
-                def _map(df, other):
-                    def compute_map(df, other):
-                        # Set `as_index` to True to track the metadata of the grouping object
-                        # It is used to make sure that between phases we are constructing the
-                        # right index and placing columns in the correct order.
-                        groupby_args["as_index"] = True
-                        groupby_args["observed"] = True
+    @classmethod
+    def build_map_reduce_functions(
+        cls,
+        by,
+        axis,
+        groupby_args,
+        map_func,
+        map_args,
+        reduce_func,
+        reduce_args,
+        drop,
+        **kwargs,
+    ):
+        # if by is a query compiler, then it will be broadcasted explicit via
+        # groupby_reduce method of the modin frame and so we don't want secondary
+        # implicit broadcastion via passing it as an function argument.
+        if hasattr(by, "_modin_frame"):
+            by = None
 
-                        other = other.squeeze(axis=axis ^ 1)
-                        if isinstance(other, pandas.DataFrame):
-                            df = pandas.concat(
-                                [df] + [other[[o for o in other if o not in df]]],
-                                axis=1,
-                            )
-                            other = list(other.columns)
-                        result = map_func(
-                            df.groupby(by=other, axis=axis, **groupby_args), **map_args
-                        )
-                        # if `other` has category dtype, then pandas will drop that
-                        # column after groupby, inserting it back to correctly process
-                        # reduce phase
-                        if (
-                            drop
-                            and not as_index
-                            and isinstance(other, pandas.Series)
-                            and isinstance(other.dtype, pandas.CategoricalDtype)
-                            and result.index.name is not None
-                            and result.index.name not in result.columns
-                        ):
-                            result.insert(
-                                loc=0, column=result.index.name, value=result.index
-                            )
-                        # The _modin_groupby_ prefix indicates that this is the first partition,
-                        # and since we may need to insert the grouping data in the reduce phase
-                        if (
-                            not isinstance(result.index, pandas.MultiIndex)
-                            and result.index.name is not None
-                            and result.index.name in result.columns
-                        ):
-                            result.index.name = "{}{}".format(
-                                "_modin_groupby_", result.index.name
-                            )
-                        return result
-
-                    try:
-                        return compute_map(df, other)
-                    # This will happen with Arrow buffer read-only errors. We don't want to copy
-                    # all the time, so this will try to fast-path the code first.
-                    except ValueError:
-                        return compute_map(df.copy(), other.copy())
-
-            def _reduce(df):
-                def compute_reduce(df):
-                    other_len = len(df.index.names)
-                    df = df.reset_index(drop=False)
-                    # See note above about setting `as_index`
-                    groupby_args["as_index"] = as_index
-                    groupby_args["observed"] = observed
-                    if other_len > 1:
-                        by_part = list(df.columns[0:other_len])
-                    else:
-                        by_part = df.columns[0]
-                    result = reduce_func(
-                        df.groupby(by=by_part, axis=axis, **groupby_args), **reduce_args
-                    )
-                    if (
-                        not isinstance(result.index, pandas.MultiIndex)
-                        and result.index.name is not None
-                        and "_modin_groupby_" in result.index.name
-                    ):
-                        result.index.name = result.index.name[len("_modin_groupby_") :]
-                    if isinstance(by_part, str) and by_part in result.columns:
-                        if "_modin_groupby_" in by_part and drop:
-                            col_name = by_part[len("_modin_groupby_") :]
-                            new_result = result.drop(columns=col_name, errors="ignore")
-                            new_result.columns = [
-                                col_name if "_modin_groupby_" in c else c
-                                for c in new_result.columns
-                            ]
-                            return new_result
-                        else:
-                            return (
-                                result.drop(columns=by_part)
-                                if call_kwds.get("method", None) != "size"
-                                else result
-                            )
-                    return result
-
-                try:
-                    return compute_reduce(df)
-                # This will happen with Arrow buffer read-only errors. We don't want to copy
-                # all the time, so this will try to fast-path the code first.
-                except ValueError:
-                    return compute_reduce(df.copy())
-
-            # TODO: try to precompute `new_index` and `new_columns`
-            if isinstance(by, str):
-                new_modin_frame = qc._modin_frame._map_reduce(
-                    axis, _map, reduce_func=_reduce, preserve_index=False
+        def _map(df, other=None, **kwargs):
+            def wrapper(df, other=None):
+                return cls.map(
+                    df,
+                    other,
+                    axis=axis,
+                    by=by,
+                    groupby_args=groupby_args.copy(),
+                    map_func=map_func,
+                    map_args=map_args,
+                    drop=drop,
+                    **kwargs,
                 )
-            else:
-                new_modin_frame = qc._modin_frame.groupby_reduce(
-                    axis, by._modin_frame, _map, _reduce
-                )
-            result = query_compiler.__constructor__(new_modin_frame)
-            if result.index.name == "__reduced__":
-                result.index.name = None
+
+            try:
+                result = wrapper(df, other)
+            # This will happen with Arrow buffer read-only errors. We don't want to copy
+            # all the time, so this will try to fast-path the code first.
+            except ValueError:
+                result = wrapper(df.copy(), other if other is None else other.copy())
             return result
 
-        return caller
+        def _reduce(df, **call_kwargs):
+            def wrapper(df):
+                return cls.reduce(
+                    df,
+                    axis=axis,
+                    groupby_args=groupby_args,
+                    reduce_func=reduce_func,
+                    reduce_args=reduce_args,
+                    drop=drop,
+                    **kwargs,
+                    **call_kwargs,
+                )
+
+            try:
+                result = wrapper(df)
+            # This will happen with Arrow buffer read-only errors. We don't want to copy
+            # all the time, so this will try to fast-path the code first.
+            except ValueError:
+                result = wrapper(df.copy())
+            return result
+
+        return _map, _reduce
+
+
+groupby_reduce_functions = {
+    "all": (
+        lambda df, *args, **kwargs: df.all(*args, **kwargs),
+        lambda df, *args, **kwargs: df.all(*args, **kwargs),
+    ),
+    "any": (
+        lambda df, *args, **kwargs: df.any(*args, **kwargs),
+        lambda df, *args, **kwargs: df.any(*args, **kwargs),
+    ),
+    "count": (
+        lambda df, *args, **kwargs: df.count(*args, **kwargs),
+        lambda df, *args, **kwargs: df.sum(*args, **kwargs),
+    ),
+    "max": (
+        lambda df, *args, **kwargs: df.max(*args, **kwargs),
+        lambda df, *args, **kwargs: df.max(*args, **kwargs),
+    ),
+    "min": (
+        lambda df, *args, **kwargs: df.min(*args, **kwargs),
+        lambda df, *args, **kwargs: df.min(*args, **kwargs),
+    ),
+    "prod": (
+        lambda df, *args, **kwargs: df.prod(*args, **kwargs),
+        lambda df, *args, **kwargs: df.prod(*args, **kwargs),
+    ),
+    "size": (
+        lambda df, *args, **kwargs: pandas.DataFrame(df.size(*args, **kwargs)),
+        lambda df, *args, **kwargs: df.sum(*args, **kwargs),
+    ),
+    "sum": (
+        lambda df, *args, **kwargs: df.sum(*args, **kwargs),
+        lambda df, *args, **kwargs: df.sum(*args, **kwargs),
+    ),
+}

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -2023,6 +2023,8 @@ class BasePandasFrame(object):
             new_columns: Index (optional),
                 The columns of the result. We may know this in advance,
                 and if not provided it must be computed.
+            apply_indices : list-like (optional),
+                Indices of `axis ^ 1` to apply groupby over.
 
         Returns
         -------

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1996,26 +1996,48 @@ class BasePandasFrame(object):
         )
 
     def groupby_reduce(
-        self, axis, by, map_func, reduce_func, new_index=None, new_columns=None
+        self,
+        axis,
+        by,
+        map_func,
+        reduce_func,
+        new_index=None,
+        new_columns=None,
+        apply_indices=None,
     ):
         """Groupby another dataframe and aggregate the result.
 
-        Args:
-            axis: The axis to groupby and aggregate over.
-            by: The dataframe to group by.
-            map_func: The map component of the aggregation.
-            reduce_func: The reduce component of the aggregation.
-            new_index: (optional) The index of the result. We may know this in advance,
+        Parameters
+        ----------
+            axis: int,
+                The axis to groupby and aggregate over.
+            by: ModinFrame (optional),
+                The dataframe to group by.
+            map_func: callable,
+                The map component of the aggregation.
+            reduce_func: callable,
+                The reduce component of the aggregation.
+            new_index: Index (optional),
+                The index of the result. We may know this in advance,
                 and if not provided it must be computed.
-            new_columns: (optional) The columns of the result. We may know this in
-                advance, and if not provided it must be computed.
+            new_columns: Index (optional),
+                The columns of the result. We may know this in advance,
+                and if not provided it must be computed.
 
         Returns
         -------
              A new dataframe.
         """
+        by_parts = by if by is None else by._partitions
+
+        if apply_indices is not None:
+            numeric_indices = self.axes[axis ^ 1].get_indexer_for(apply_indices)
+            apply_indices = list(
+                self._get_dict_of_block_index(axis ^ 1, numeric_indices).keys()
+            )
+
         new_partitions = self._frame_mgr_cls.groupby_reduce(
-            axis, self._partitions, by._partitions, map_func, reduce_func
+            axis, self._partitions, by_parts, map_func, reduce_func, apply_indices
         )
         new_axes = [
             self._compute_axis_labels(i, new_partitions)

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -401,6 +401,9 @@ class BaseFrameManager(ABC):
             The flag to keep partitions for Modin Frame.
         lengths : list(int)
             The list of lengths to shuffle the object.
+        enumerate_partitions : bool (optional, default False),
+            Whether or not to pass partition index into `map_func`.
+            Note that `map_func` must be able to obtain `partition_idx` kwarg.
 
         Returns
         -------

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -99,12 +99,25 @@ class BaseFrameManager(ABC):
         )
 
     @classmethod
-    def groupby_reduce(cls, axis, partitions, by, map_func, reduce_func):
+    def groupby_reduce(
+        cls, axis, partitions, by, map_func, reduce_func, apply_indices=None
+    ):
         """Groupby data using the map_func provided along the axis over the partitions then reduce using reduce_func."""
-        mapped_partitions = cls.broadcast_apply(
-            axis, map_func, left=partitions, right=by, other_name="other"
+        if apply_indices is not None:
+            # breakpoint()
+            partitions = (
+                partitions[apply_indices] if axis else partitions[:, apply_indices]
+            )
+
+        if by is not None:
+            mapped_partitions = cls.broadcast_apply(
+                axis, map_func, left=partitions, right=by, other_name="other"
+            )
+        else:
+            mapped_partitions = cls.map_partitions(partitions, map_func)
+        return cls.map_axis_partitions(
+            axis, mapped_partitions, reduce_func, enumerate_partitions=True
         )
-        return cls.map_axis_partitions(axis, mapped_partitions, reduce_func)
 
     @classmethod
     def broadcast_apply_select_indices(
@@ -351,6 +364,7 @@ class BaseFrameManager(ABC):
         map_func,
         keep_partitioning=False,
         lengths=None,
+        enumerate_partitions=False,
     ):
         """
         Apply `map_func` to every partition.
@@ -385,6 +399,7 @@ class BaseFrameManager(ABC):
             keep_partitioning=keep_partitioning,
             right=None,
             lengths=lengths,
+            enumerate_partitions=enumerate_partitions,
         )
 
     @classmethod

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -102,7 +102,28 @@ class BaseFrameManager(ABC):
     def groupby_reduce(
         cls, axis, partitions, by, map_func, reduce_func, apply_indices=None
     ):
-        """Groupby data using the map_func provided along the axis over the partitions then reduce using reduce_func."""
+        """
+        Groupby data using the map_func provided along the axis over the partitions then reduce using reduce_func.
+
+        Parameters
+        ----------
+            axis: int,
+                Axis to groupby over.
+            partitions: numpy 2D array,
+                Partitions of the ModinFrame to groupby.
+            by: numpy 2D array (optional),
+                Partitions of 'by' to broadcast.
+            map_func: callable,
+                Map function.
+            reduce_func: callable,
+                Reduce function.
+            apply_indices : list of ints (optional),
+                Indices of `axis ^ 1` to apply function over.
+
+        Returns
+        -------
+            Partitions with applied groupby.
+        """
         if apply_indices is not None:
             partitions = (
                 partitions[apply_indices] if axis else partitions[:, apply_indices]

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -104,7 +104,6 @@ class BaseFrameManager(ABC):
     ):
         """Groupby data using the map_func provided along the axis over the partitions then reduce using reduce_func."""
         if apply_indices is not None:
-            # breakpoint()
             partitions = (
                 partitions[apply_indices] if axis else partitions[:, apply_indices]
             )

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -355,7 +355,7 @@ class DataFrame(BasePandasDataset):
         # strings is passed in, the data used for the groupby is dropped before the
         # groupby takes place.
         drop = False
-
+        # breakpoint()
         if (
             not isinstance(by, (pandas.Series, Series))
             and is_list_like(by)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -355,7 +355,7 @@ class DataFrame(BasePandasDataset):
         # strings is passed in, the data used for the groupby is dropped before the
         # groupby takes place.
         drop = False
-        # breakpoint()
+
         if (
             not isinstance(by, (pandas.Series, Series))
             and is_list_like(by)

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -377,15 +377,15 @@ class DataFrameGroupBy(object):
         relabeling_required = False
         if isinstance(func, dict) or func is None:
 
-            def try_get_str_func(o):
-                if not isinstance(o, str) and isinstance(o, Iterable):
-                    return [try_get_str_func(v) for v in o]
-                return o.__name__ if callable(o) and o.__name__ in dir(self) else o
+            def try_get_str_func(fn):
+                if not isinstance(fn, str) and isinstance(fn, Iterable):
+                    return [try_get_str_func(f) for f in fn]
+                return fn.__name__ if callable(fn) and fn.__name__ in dir(self) else fn
 
             relabeling_required, func_dict, new_columns, order = reconstruct_func(
                 func, **kwargs
             )
-            func_dict = {k: try_get_str_func(v) for k, v in func_dict.items()}
+            func_dict = {col: try_get_str_func(fn) for col, fn in func_dict.items()}
 
             if any(i not in self._df.columns for i in func_dict.keys()):
                 from pandas.core.base import SpecificationError

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -29,6 +29,7 @@ from pandas.core.dtypes.common import is_list_like
 from pandas.core.aggregation import reconstruct_func
 import pandas.core.common as com
 from types import BuiltinFunctionType
+from collections.abc import Iterable
 
 from modin.error_message import ErrorMessage
 from modin.utils import _inherit_docstrings, try_cast_to_pandas, wrap_udf_function
@@ -376,22 +377,15 @@ class DataFrameGroupBy(object):
         relabeling_required = False
         if isinstance(func, dict) or func is None:
 
-            def _reconstruct_func(func, **kwargs):
-                relabeling_required, func, new_columns, order = reconstruct_func(
-                    func, **kwargs
-                )
-                # We convert to the string version of the function for simplicity.
-                func = {
-                    k: v
-                    if not callable(v) or v.__name__ not in dir(self)
-                    else v.__name__
-                    for k, v in func.items()
-                }
-                return relabeling_required, func, new_columns, order
+            def try_get_str_func(o):
+                if not isinstance(o, str) and isinstance(o, Iterable):
+                    return [try_get_str_func(v) for v in o]
+                return o.__name__ if callable(o) and o.__name__ in dir(self) else o
 
-            relabeling_required, func_dict, new_columns, order = _reconstruct_func(
+            relabeling_required, func_dict, new_columns, order = reconstruct_func(
                 func, **kwargs
             )
+            func_dict = {k: try_get_str_func(v) for k, v in func_dict.items()}
 
             if any(i not in self._df.columns for i in func_dict.keys()):
                 from pandas.core.base import SpecificationError

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -391,6 +391,8 @@ class DataFrameGroupBy(object):
                 from pandas.core.base import SpecificationError
 
                 raise SpecificationError("nested renamer is not supported")
+            if func is None:
+                kwargs = {}
             func = func_dict
         elif is_list_like(func):
             return self._default_to_pandas(

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -114,7 +114,6 @@ def test_mixed_dtypes_groupby(as_index):
         )
         eval_shift(modin_groupby, pandas_groupby)
         eval_mean(modin_groupby, pandas_groupby)
-        # breakpoint()
         eval_any(modin_groupby, pandas_groupby)
         eval_min(modin_groupby, pandas_groupby)
         eval_general(

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -114,6 +114,7 @@ def test_mixed_dtypes_groupby(as_index):
         )
         eval_shift(modin_groupby, pandas_groupby)
         eval_mean(modin_groupby, pandas_groupby)
+        # breakpoint()
         eval_any(modin_groupby, pandas_groupby)
         eval_min(modin_groupby, pandas_groupby)
         eval_general(
@@ -1426,9 +1427,7 @@ def test_unknown_groupby(columns):
 @pytest.mark.parametrize(
     "func_to_apply",
     [
-        pytest.param(
-            lambda df: df.sum(), marks=pytest.mark.skip("See modin issue #2512")
-        ),
+        lambda df: df.sum(),
         lambda df: df.size(),
         lambda df: df.quantile(),
         lambda df: df.dtypes,

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -641,6 +641,7 @@ def test_large_row_groupby(is_by_category):
         min,
         sum,
         {"A": "sum"},
+        {"A": lambda df: df.sum()},
         {"A": "max", "B": "sum", "C": "min"},
     ]
     for func in agg_functions:
@@ -1437,7 +1438,7 @@ def test_unknown_groupby(columns):
         ),
         lambda grp: grp.agg(
             {
-                df_from_grp(grp).columns[0]: (max, min, sum),
+                df_from_grp(grp).columns[0]: (("new_max", max), min, sum),
                 df_from_grp(grp).columns[-1]: (sum, min, max),
             }
         ),

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1456,7 +1456,7 @@ def test_unknown_groupby(columns):
             {
                 list(test_data_values[0].keys())[1]: [
                     ("new_sum", "sum"),
-                    ("new_prod", "prod"),
+                    ("new_min", "min"),
                 ],
                 list(test_data_values[0].keys())[-2]: np.sum,
             }


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2491 #2512<!-- issue must be created for each patch -->
- [x] tests added and passing

## What was done

- Added [`groupby_reduce_functions` dictionary](https://github.com/dchigarev/modin/blob/021d45e900455eddbbaf1bffa295d50fdfa838ba/modin/data_management/functions/groupby_function.py#L229) of all supported reduction operation in pandas backend, it contains map and reduce functions for every method. That was done to easily translate function name in aggregation dictionary to its proper map and reduce functions.
- Now, when `PandasQueryCompiler.groupby_agg` obtains dictionary as a function, it checks that all function exists in the `groupby_reduce_functions` dictionary, if it is - going to new added [`PandasQueryCompiler._groupby_dict_reduce`](https://github.com/dchigarev/modin/blob/021d45e900455eddbbaf1bffa295d50fdfa838ba/modin/backends/pandas/query_compiler.py#L2459) method, otherwise continues in `groupby_agg`.
- Added [`PandasQueryCompiler._groupby_dict_reduce`](https://github.com/dchigarev/modin/blob/021d45e900455eddbbaf1bffa295d50fdfa838ba/modin/backends/pandas/query_compiler.py#L2459) method to properly dispatch function names to its map+reduce implementations. 
- Refactored [`data_management/functions/groupby_function.py`](https://github.com/dchigarev/modin/blob/dict_agg_op/modin/data_management/functions/groupby_function.py) to reduce the amount of unused code and split map and reduce phase in different methods. Overall logic of `GroupbyReduceFunction` doesn't changed much
- Added partitions enumeration at reduce phase to fix #2512, now we're inserting 'by' columns in case of `as_index=False` only if `partition_idx == 0`
- Added `apply_indices` parameter to [`BaseModinFrame.groupby_reduce`](https://github.com/dchigarev/modin/blob/021d45e900455eddbbaf1bffa295d50fdfa838ba/modin/engines/base/frame/data.py#L1998) method, it allows us to do not touch partitions that do not contains columns to aggregate

## Performance
Number of groups: 100
Times in tables: median of 10 runs
Function: 3 reduction function applied to 3 different columns (`sum, prod, count`)

Since now we're applying 2 functions to partitions instead of 1 (map + reduce), we can see a little regression in dictionary aggregation for small datasets (~200k rows) because we're getting more overhead of partitioning than profit. But when the number of rows becomes bigger (1kk+) we see a significant increase in performance.

<details><summary> 16 cores </summary>


|(200.000, 256)|len(by) == 1|len(by) == 2|len(by) == 6|
|-|-|-|-|
|pandas|0.008s|0.012s|0.023s|
|modin #2534|0.14s|0.17s|0.21s|
|modin master|0.14s|0.15s|0.18s|

|(1.000.000, 256)|len(by) == 1|len(by) == 2|len(by) == 6|
|-|-|-|-|
|pandas|0.029s|0.057s|0.11s|
|modin #2534|0.13s|0.17s|0.24s|
|modin master|0.26s|0.31s|0.41s|


|(10.000.000, 20)|len(by) == 1|len(by) == 2|len(by) == 6|
|-|-|-|-|
|pandas|0.31s|0.6s|1.18s|
|modin #2534|0.37s|0.5s|0.62s|
|modin master|1.29s|1.77s|2.86s|

</details>

<details><summary> 112 cores </summary>


|(200.000, 256)|len(by) == 1|len(by) == 2|len(by) == 6|
|-|-|-|-|
|pandas|0.008s|0.012s|0.023s|
|modin #2534|0.36s|0.5s|0.7s|
|modin master|0.4s|0.47s|0.63s|

|(1.000.000, 256)|len(by) == 1|len(by) == 2|len(by) == 6|
|-|-|-|-|
|pandas|0.029s|0.057s|0.11s|
|modin #2534|0.37s|0.49s|0.69s|
|modin master|0.57s|0.64s|0.81s|


|(10.000.000, 20)|len(by) == 1|len(by) == 2|len(by) == 6|
|-|-|-|-|
|pandas|0.31s|0.6s|1.18s|
|modin #2534|0.41s|0.59s|0.78s|
|modin master|1.73s|2.06s|3.16s|

</details>

<details><summary> Script to measure </summary>


```python
import numpy as np
import os
import pandas
from modin.utils import try_cast_to_pandas
from timeit import default_timer as timer


def generate_data_file(
    nrows=200000,
    ncols=256,
    ngroups=100,
    filename=None,
    force=False,
    rand_low=-100,
    rang_high=100,
):
    if filename is None:
        filename = os.path.abspath(
            f"int_dataset-{nrows},{ncols},{rand_low},{rang_high},{ngroups}.csv"
        )

    print("generating", filename)

    if os.path.exists(filename) and not force:
        return filename

    data = {
        f"col{i}":
        # Generates ngroups for groupby in each column
        list(np.random.randint(rand_low, rang_high, ngroups)) * (nrows // ngroups)
        for i in np.arange(ncols)
    }
    print("dict generated!")
    df = pandas.DataFrame(data)
    print("dataframe created!")
    df.to_csv(filename)
    print("csv ready!")
    return filename


def measure_fn(fn, n):
    times = []
    for _ in range(n):
        t1 = timer()
        fn()
        times.append(timer() - t1)
    return np.min(times), np.median(times), times


def measure_time(df, by, n, **kwargs):
    print(f"\n======= Testing {kwargs['operation'][0]} =======")
    # Printing parameters:
    kwargs.update(
        {"Frame shape": df.shape, "len(by)": len(by), "ncores": pd.DEFAULT_NPARTITIONS}
    )
    op = kwargs.pop("operation")[1]

    print("Parameters:")
    for k, v in kwargs.items():
        print(f"\t{k}: {v}")

    as_index = kwargs["as_index"]

    def measure():
        md_res = op(df.groupby(by, as_index=as_index))
        # shape to trigger materialization
        md_res.shape

    min_t, median_t, times = measure_fn(measure, n)

    print(f"Min time: {min_t}s | Median time: {median_t}s")


if __name__ == "__main__":
    import modin.pandas as pd
    from modin.pandas.test.utils import df_equals

    pd.DEFAULT_NPARTITIONS = 16

    nrows = [200_000, 1_000_000]

    by_cols = [
        ["col0"],
        ["col0", "col1"],
        ["col0", "col1", "col2", "col3", "col4", "col5"],
    ]
    operation = [
        ("agg", lambda grp: grp.agg({"col6": "sum", "col7": "prod", "col8": "count"})),
    ]
    as_index = [True]
    ngroups = 100

    for nrows_ in nrows:
        fname = generate_data_file(nrows_, ngroups=ngroups)
        md_df = pd.read_csv(fname)
        for op in operation:
            for by in by_cols:
                for as_ind in as_index:
                    measure_time(
                        md_df,
                        by,
                        operation=op,
                        ngroups=ngroups,
                        as_index=as_ind,
                        n=10,
                    )
```


</details>

## ASV runs:
As described above we can see some degradation for small frames, but when the frame becomes bigger (1kk+ rows) performance increased:
<details><summary> 16 cores </summary>


```
MODIN_CPUS=16 asv continuous src/master HEAD -b TimeGroupBy --launch-method=spawn -a number=5
       before           after         ratio
     [f98a7b3a]       [830d2ea3]
     <master>        <dict_agg_op>
+      56.1±0.4ms       80.2±0.7ms     1.43  benchmarks.TimeGroupBy.time_groupby_dictionary_reduction('modin', 'int', (2000, 100))

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE DECREASED.


MODIN_CPUS=16 MODIN_TEST_DATASET_SIZE=Big asv continuous src/master HEAD -b TimeGroupBy --launch-method=spawn -a number=5
       before           after         ratio
     [f98a7b3a]       [830d2ea3]
     <master>        <dict_agg_op>
+        99.9±2ms          127±2ms     1.27  benchmarks.TimeGroupBy.time_groupby_dictionary_reduction('modin', 'int', (5000, 5000))
-         167±4ms          127±3ms     0.76  benchmarks.TimeGroupBy.time_groupby_dictionary_reduction('modin', 'int', (10, 1000000))
SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE DECREASED.
```


</details>


<details><summary> 112 cores </summary>



```
MODIN_CPUS=112 asv continuous src/master HEAD -b TimeGroupBy --launch-method=spawn -a number=5
       before           after         ratio
     [f98a7b3a]       [830d2ea3]
     <master>        <dict_agg_op>
+      56.9±0.4ms          150±2ms     2.64  benchmarks.TimeGroupBy.time_groupby_dictionary_reduction('modin', 'int', (2000, 100))

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE DECREASED.


MODIN_CPUS=112 MODIN_TEST_DATASET_SIZE=Big asv continuous src/master HEAD -b TimeGroupBy --launch-method=spawn -a number=5
       before           after         ratio
     [f98a7b3a]       [830d2ea3]
     <master>        <dict_agg_op>
-         482±8ms          368±8ms     0.76  benchmarks.TimeGroupBy.time_groupby_dictionary_reduction('modin', 'int', (10, 1000000))

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```


</details>