### PR TITLE
Fix loc/iloc assignments when columns are selected

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -391,12 +391,16 @@ class _LocationIndexerBase(object):
                     "an iterable"
                 )
             if hasattr(item, "columns"):
-                if not all(idx in item.columns for idx in col_lookup):
+                own_cols = self.qc.columns
+                # convert indices in column lookup to column names, as Pandas reindex expects them so
+                lookup = [own_cols[idx] for idx in col_lookup]
+                if not all(col in item.columns for col in lookup):
+                    # TODO: think if it is needed to handle cases when columns have duplicate names
                     raise ValueError(
                         "Must have equal len keys and value when setting "
                         "with an iterable"
                     )
-                item = item.reindex(index=row_lookup, columns=col_lookup)
+                item = item.reindex(index=row_lookup, columns=lookup)
             else:
                 item = item.reindex(index=row_lookup)
         try:

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -385,24 +385,24 @@ class _LocationIndexerBase(object):
         # It is valid to pass a DataFrame or Series to __setitem__ that is larger than
         # the target the user is trying to overwrite. This
         if isinstance(item, (pandas.Series, pandas.DataFrame, Series, DataFrame)):
-            if not all(idx in item.index for idx in row_lookup):
+            # convert indices in lookups to names, as Pandas reindex expects them to be so
+            index_values = self.qc.index[row_lookup]
+            if not all(idx in item.index for idx in index_values):
                 raise ValueError(
                     "Must have equal len keys and value when setting with "
                     "an iterable"
                 )
             if hasattr(item, "columns"):
-                own_cols = self.qc.columns
-                # convert indices in column lookup to column names, as Pandas reindex expects them so
-                lookup = [own_cols[idx] for idx in col_lookup]
-                if not all(col in item.columns for col in lookup):
+                column_values = self.qc.columns[col_lookup]
+                if not all(col in item.columns for col in column_values):
                     # TODO: think if it is needed to handle cases when columns have duplicate names
                     raise ValueError(
                         "Must have equal len keys and value when setting "
                         "with an iterable"
                     )
-                item = item.reindex(index=row_lookup, columns=lookup)
+                item = item.reindex(index=index_values, columns=column_values)
             else:
-                item = item.reindex(index=row_lookup)
+                item = item.reindex(index=index_values)
         try:
             item = np.array(item)
             if np.prod(to_shape) == np.prod(item.shape):

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -425,6 +425,11 @@ def loc_iter_dfs():
 @pytest.mark.parametrize("reverse_order", [False, True])
 @pytest.mark.parametrize("axis", [0, 1])
 def test_loc_iter_assignment(loc_iter_dfs, reverse_order, axis):
+    if reverse_order and axis:
+        pytest.xfail(
+            "Due to internal sorting of lookup values assignment order is lost, see GH-#2552"
+        )
+
     md_df, pd_df = loc_iter_dfs
 
     select = [slice(None), slice(None)]
@@ -446,6 +451,7 @@ def test_loc_order(loc_iter_dfs, reverse_order, axis):
     select = tuple(select)
 
     df_equals(pd_df.loc[select], md_df.loc[select])
+
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_loc_nested_assignment(data):

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -436,6 +436,17 @@ def test_loc_iter_assignment(loc_iter_dfs, reverse_order, axis):
     df_equals(md_df, pd_df)
 
 
+@pytest.mark.parametrize("reverse_order", [False, True])
+@pytest.mark.parametrize("axis", [0, 1])
+def test_loc_order(loc_iter_dfs, reverse_order, axis):
+    md_df, pd_df = loc_iter_dfs
+
+    select = [slice(None), slice(None)]
+    select[axis] = sorted(pd_df.axes[axis][:-1], reverse=reverse_order)
+    select = tuple(select)
+
+    df_equals(pd_df.loc[select], md_df.loc[select])
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_loc_nested_assignment(data):
     modin_df = pd.DataFrame(data)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -411,13 +411,28 @@ def test_loc_assignment(index, columns):
     df_equals(md_df, pd_df)
 
 
-@pytest.mark.parametrize("columns", [["col1", "col2", "col3"]])
-def test_loc_iter_assignment(columns):
-    md_df, pd_df = create_test_dfs(
-        {col: [idx] for idx, col in enumerate(columns)}, columns=columns
+@pytest.fixture
+def loc_iter_dfs():
+    columns = ["col1", "col2", "col3"]
+    index = ["row1", "row2", "row3"]
+    return create_test_dfs(
+        {col: ([idx] * len(index)) for idx, col in enumerate(columns)},
+        columns=columns,
+        index=index,
     )
-    md_df.loc[:, columns[:-1]] = md_df.loc[:, columns[:-1]].astype("float")
-    pd_df.loc[:, columns[:-1]] = pd_df.loc[:, columns[:-1]].astype("float")
+
+
+@pytest.mark.parametrize("reverse_order", [False, True])
+@pytest.mark.parametrize("axis", [0, 1])
+def test_loc_iter_assignment(loc_iter_dfs, reverse_order, axis):
+    md_df, pd_df = loc_iter_dfs
+
+    select = [slice(None), slice(None)]
+    select[axis] = sorted(pd_df.axes[axis][:-1], reverse=reverse_order)
+    select = tuple(select)
+
+    pd_df.loc[select] = pd_df.loc[select].copy()
+    md_df.loc[select] = md_df.loc[select].copy()
     df_equals(md_df, pd_df)
 
 

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -436,8 +436,8 @@ def test_loc_iter_assignment(loc_iter_dfs, reverse_order, axis):
     select[axis] = sorted(pd_df.axes[axis][:-1], reverse=reverse_order)
     select = tuple(select)
 
-    pd_df.loc[select] = pd_df.loc[select].copy()
-    md_df.loc[select] = md_df.loc[select].copy()
+    pd_df.loc[select] = pd_df.loc[select] + pd_df.loc[select]
+    md_df.loc[select] = md_df.loc[select] + md_df.loc[select]
     df_equals(md_df, pd_df)
 
 

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -411,6 +411,16 @@ def test_loc_assignment(index, columns):
     df_equals(md_df, pd_df)
 
 
+@pytest.mark.parametrize("columns", [["col1", "col2", "col3"]])
+def test_loc_iter_assignment(columns):
+    md_df, pd_df = create_test_dfs(
+        {col: [idx] for idx, col in enumerate(columns)}, columns=columns
+    )
+    md_df.loc[:, columns[:-1]] = md_df.loc[:, columns[:-1]].astype("float")
+    pd_df.loc[:, columns[:-1]] = pd_df.loc[:, columns[:-1]].astype("float")
+    df_equals(md_df, pd_df)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_loc_nested_assignment(data):
     modin_df = pd.DataFrame(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
The problem in current code is that it treats index and columns uniformely, while Pandas seems to be treating them differently.
Current code provides an indexing in the columns, but then checks for column names in the object being assigned (also `pandas.reindex()` expects column names, not column positions).

So I'm converting positions to names before trying to assign.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1620
- [x] tests added and passing
