### PR TITLE
FIX-#2482: improved handling non-str 'by'

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -29,7 +29,7 @@ import warnings
 
 from modin.backends.base.query_compiler import BaseQueryCompiler
 from modin.error_message import ErrorMessage
-from modin.utils import try_cast_to_pandas, wrap_udf_function
+from modin.utils import try_cast_to_pandas, wrap_udf_function, hashable
 from modin.data_management.functions import (
     Function,
     FoldFunction,
@@ -2555,7 +2555,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         else:
             if not isinstance(by, list):
                 by = [by]
-            internal_by = [o for o in by if isinstance(o, str) and o in self.columns]
+            internal_by = [o for o in by if hashable(o) and o in self.columns]
             internal_qc = (
                 [self.getitem_column_array(internal_by)] if len(internal_by) else []
             )

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -14,7 +14,7 @@
 import pandas
 
 from .mapreducefunction import MapReduceFunction
-from modin.utils import try_cast_to_pandas
+from modin.utils import try_cast_to_pandas, hashable
 
 
 class GroupbyReduceFunction(MapReduceFunction):
@@ -113,7 +113,9 @@ class GroupbyReduceFunction(MapReduceFunction):
         numeric_only=True,
         **kwargs,
     ):
-        if not isinstance(by, (type(query_compiler), str)):
+        if not (isinstance(by, (type(query_compiler)) or hashable(by))) or isinstance(
+            by, pandas.Grouper
+        ):
             by = try_cast_to_pandas(by, squeeze=True)
             default_func = (
                 (lambda grp: grp.agg(map_func))

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1494,3 +1494,34 @@ def test_multi_column_groupby_different_partitions(
         by, as_index=as_index
     )
     eval_general(md_grp, pd_grp, func_to_apply)
+
+
+@pytest.mark.parametrize(
+    "by",
+    [
+        0,
+        1.5,
+        "str",
+        pandas.Timestamp("2020-02-02"),
+        [None],
+        [0, "str"],
+        [None, 0],
+        [pandas.Timestamp("2020-02-02"), 1.5],
+    ],
+)
+@pytest.mark.parametrize("as_index", [True, False])
+def test_not_str_by(by, as_index):
+    data = {f"col{i}": np.arange(5) for i in range(5)}
+    columns = pandas.Index([0, 1.5, "str", pandas.Timestamp("2020-02-02"), None])
+
+    md_df, pd_df = create_test_dfs(data, columns=columns)
+    md_grp, pd_grp = md_df.groupby(by, as_index=as_index), pd_df.groupby(
+        by, as_index=as_index
+    )
+
+    modin_groupby_equals_pandas(md_grp, pd_grp)
+    df_equals(md_grp.sum(), pd_grp.sum())
+    df_equals(md_grp.size(), pd_grp.size())
+    df_equals(md_grp.agg(lambda df: df.mean()), pd_grp.agg(lambda df: df.mean()))
+    df_equals(md_grp.dtypes, pd_grp.dtypes)
+    df_equals(md_grp.first(), pd_grp.first())


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2482 <!-- issue must be created for each patch -->
- [x] tests added and passing

Previously we used `isinstance(by, str)` to check that 'by' is a column name, however, it doesn't work when columns have non-str type, so this PR changes all 'is instance' check to 'is hashable'
