### PR TITLE
FIX-#2566: Ensure `Series.unique` does not return a scalar when there is only one unique value

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1345,7 +1345,8 @@ class Series(BasePandasDataset):
         )
 
     def unique(self):
-        return self._query_compiler.unique().to_numpy().squeeze()
+        # Ensure we don't return a scalar to match shape of Panda's output
+        return np.atleast_1d(self._query_compiler.unique().to_numpy().squeeze())
 
     def update(self, other):
         if not isinstance(other, Series):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1345,8 +1345,9 @@ class Series(BasePandasDataset):
         )
 
     def unique(self):
-        # Ensure we don't return a scalar to match shape of Panda's output
-        return np.atleast_1d(self._query_compiler.unique().to_numpy().squeeze())
+        return self.__constructor__(
+            query_compiler=self._query_compiler.unique()
+        ).to_numpy()
 
     def update(self, other):
         if not isinstance(other, Series):

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -528,10 +528,12 @@ def test_unique():
     modin_result = pd.unique([2, 1, 3, 3])
     pandas_result = pandas.unique([2, 1, 3, 3])
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.unique(pd.Series([2] + [1] * 5))
     pandas_result = pandas.unique(pandas.Series([2] + [1] * 5))
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.unique(
         pd.Series([pd.Timestamp("20160101"), pd.Timestamp("20160101")])
@@ -540,6 +542,7 @@ def test_unique():
         pandas.Series([pandas.Timestamp("20160101"), pandas.Timestamp("20160101")])
     )
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.unique(
         pd.Series(
@@ -558,6 +561,7 @@ def test_unique():
         )
     )
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.unique(
         pd.Index(
@@ -576,10 +580,12 @@ def test_unique():
         )
     )
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.unique(pd.Series(pd.Categorical(list("baabc"))))
     pandas_result = pandas.unique(pandas.Series(pandas.Categorical(list("baabc"))))
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
 
 @pytest.mark.parametrize("normalize, bins, dropna", [(True, 3, False)])

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3287,16 +3287,19 @@ def test_unique(data):
     modin_result = modin_series.unique()
     pandas_result = pandas_series.unique()
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.Series([2, 1, 3, 3], name="A").unique()
     pandas_result = pandas.Series([2, 1, 3, 3], name="A").unique()
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.Series([pd.Timestamp("2016-01-01") for _ in range(3)]).unique()
     pandas_result = pandas.Series(
         [pd.Timestamp("2016-01-01") for _ in range(3)]
     ).unique()
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.Series(
         [pd.Timestamp("2016-01-01", tz="US/Eastern") for _ in range(3)]
@@ -3305,10 +3308,12 @@ def test_unique(data):
         [pd.Timestamp("2016-01-01", tz="US/Eastern") for _ in range(3)]
     ).unique()
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pandas.Series(pd.Categorical(list("baabc"))).unique()
     pandas_result = pd.Series(pd.Categorical(list("baabc"))).unique()
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.Series(
         pd.Categorical(list("baabc"), categories=list("abc"), ordered=True)
@@ -3317,6 +3322,7 @@ def test_unique(data):
         pd.Categorical(list("baabc"), categories=list("abc"), ordered=True)
     ).unique()
     assert_array_equal(modin_result, pandas_result)
+    assert modin_result.shape == pandas_result.shape
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Ensures that `Series.unique` does not return a scalar when there is only one unique value. This solves the problem of the behavior of Modin and Pandas differing when there is only one unique value (https://github.com/modin-project/modin/issues/2566). Modin will return a scalar if there is only one unique value because the `unique` function calls `squeeze`, removing any axes of length 1. Pandas' `unique` function does not return a scalar when there is only one unique value.

Removing `squeeze` from the `unique` definition causes tests to fail because there can be additional axes where Pandas doesn't have any.

## Testing
The current tests do not catch this because they use `np.testing.assert_array_equal`, which treats scalars as an array. I have added an assert to check that the shapes of Modin's and Pandas' outputs are the same. The previous implementation of `unique` does not pass these new checks.  

I only tried running the tests I modified and don't know about others failing. Other functions may also need to be modified to handle this case.
<!-- Please give a short brief about these changes. -->

## Checklist
- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2566 <!-- issue must be created for each patch -->
- [x] tests added and passing 


