### PR TITLE
Change the PyDbEngine initialization to match the new interface #2568

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py
@@ -34,10 +34,10 @@ class OmnisciServer:
     def start_server(cls):
         if cls._server is None:
             cls._server = PyDbEngine(
-                enable_union=1,
-                enable_columnar_output=1,
-                enable_lazy_fetch=0,
-                null_div_by_zero=1,
+                "enable-union",
+                "enable-columnar-output",
+                "null-div-by-zero",
+                **{"enable-lazy-fetch": 0},
             )
 
     @classmethod


### PR DESCRIPTION
Signed-off-by: Galina Petrova <gpetrova@intel.com>

## What do these changes do?
Changed parameters of the omnisci_worker.OmnisciServer.start_server according to the latest Omnisci DBE interface.
This PR depends on https://github.com/intel-ai/omniscidb/pull/119.

<!-- Please give a short brief about these changes. -->

- [X] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [X] passes `flake8 modin`
- [X] passes `black --check modin`
- [X] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [X] Resolves #2568 
- [X] tests added and passing
