### PR TITLE
FIX-#2572: pinned arrow version in OmniSci CI dependencies

### DIFF
--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -4,7 +4,7 @@ channels:
   - conda-forge
 dependencies:
   - pandas==1.1.5
-  - pyarrow>=1.0.0
+  - pyarrow==1.0.0
   - numpy
   - pip
   - pytest>=6.0.1


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2572 <!-- issue must be created for each patch -->
- [ ] tests added and passing
