### PR TITLE
DOCS-#2578: fix simple typo, parition -> partition

### DIFF
--- a/modin/engines/dask/pandas_on_dask/frame/partition.py
+++ b/modin/engines/dask/pandas_on_dask/frame/partition.py
@@ -125,7 +125,7 @@ class PandasOnDaskFramePartition(BaseFramePartition):
 
     def to_numpy(self, **kwargs):
         """
-        Convert the object stored in this parition to a NumPy array.
+        Convert the object stored in this partition to a NumPy array.
 
         Returns
         -------

--- a/modin/engines/ray/pandas_on_ray/frame/partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition.py
@@ -95,7 +95,7 @@ class PandasOnRayFramePartition(BaseFramePartition):
 
     def to_numpy(self, **kwargs):
         """
-        Convert the object stored in this parition to a NumPy array.
+        Convert the object stored in this partition to a NumPy array.
 
         Returns
         -------


### PR DESCRIPTION
There is a small typo in modin/engines/dask/pandas_on_dask/frame/partition.py, modin/engines/ray/pandas_on_ray/frame/partition.py.

Should read `partition` rather than `parition`.

Fixes #2578

Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md