### PR TITLE
FIX-#2543: fixed handling 'as_index' at GroupBy dictionary renaming aggregation

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2483,7 +2483,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     raise TypeError
 
                 map_fns.append((new_col_name, groupby_reduce_functions[func][0]))
-                reduce_dict[(col, new_col_name)] = groupby_reduce_functions[func][1]
+                reduced_col_name = (
+                    (*col, new_col_name)
+                    if isinstance(col, tuple)
+                    else (col, new_col_name)
+                )
+                reduce_dict[reduced_col_name] = groupby_reduce_functions[func][1]
             map_dict[col] = map_fns
         return GroupbyReduceFunction.register(map_dict, reduce_dict)(
             query_compiler=self,

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -425,6 +425,20 @@ class DataFrameGroupBy(object):
         )
 
         if relabeling_required:
+            if not self._as_index:
+                nby_cols = len(result.columns) - len(new_columns)
+                order = np.concatenate([np.arange(nby_cols), order + nby_cols])
+                by_cols = result.columns[:nby_cols]
+                new_columns = pandas.Index(new_columns)
+                if by_cols.nlevels != new_columns.nlevels:
+                    by_cols = by_cols.remove_unused_levels()
+                    empty_levels = [
+                        i
+                        for i, level in enumerate(by_cols.levels)
+                        if len(level) == 1 and level[0] == ""
+                    ]
+                    by_cols = by_cols.droplevel(empty_levels)
+                new_columns = by_cols.append(new_columns)
             result = result.iloc[:, order]
             result.columns = new_columns
         return result


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2543 <!-- issue must be created for each patch -->
- [x] tests added and passing
