### PR TITLE
TEST-#2598: Add test for clean install from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
   test-clean-install-windows:
     needs: [ lint-commit, lint-flake8, lint-black, test-api, test-headers ]
     runs-on: windows-latest
-    name: test-clean-install-windowsgit
+    name: test-clean-install-windows
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.7.x"
+          architecture: "x64"
       - name: Clean install and run
         shell: bash -l {0}
         run: |
@@ -141,6 +145,10 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
+      - uses: actions/setup-python@v2
+        with:
+          python-version: "3.7.x"
+          architecture: "x64"
       - name: Clean install and run
         shell: bash -l {0}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,7 +133,7 @@ jobs:
   test-clean-install-windows:
     needs: [ lint-commit, lint-flake8, lint-black, test-api, test-headers ]
     runs-on: windows-latest
-    name: test-clean-install-ubuntu
+    name: test-clean-install-windowsgit
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,8 +130,8 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install -e .[all]
-          MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
-          MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+          MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3]))"
+          MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3]))"
 
   test-clean-install-windows:
     needs: [ lint-commit, lint-flake8, lint-black, test-api, test-headers ]
@@ -145,8 +145,8 @@ jobs:
         shell: bash -l {0}
         run: |
           python -m pip install -e .[all]
-          MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
-          MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+          MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3]))"
+          MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3]))"
 
   test-internals:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,12 +126,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - shell: bash -l {0}
-        run: pip install -e .[all]
-      - shell: bash -l {0}
-        run: MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
-      - shell: bash -l {0}
-        run: MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+      - name: Clean install and run
+        shell: bash -l {0}
+        run: |
+          python -m pip install -e .[all]
+          MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+          MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
 
   test-clean-install-windows:
     needs: [ lint-commit, lint-flake8, lint-black, test-api, test-headers ]
@@ -141,12 +141,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - shell: bash -l {0}
-        run: pip install -e .[all]
-      - shell: bash -l {0}
-        run: MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
-      - shell: bash -l {0}
-        run: MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+      - name: Clean install and run
+        shell: bash -l {0}
+        run: |
+          python -m pip install -e .[all]
+          MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+          MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
 
   test-internals:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,30 @@ jobs:
         shell: bash -l {0}
         run: python -m pytest modin/test/test_headers.py
 
+  test-clean-install-ubuntu:
+    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    runs-on: ubuntu-latest
+    name: test-clean-install-ubuntu
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      run: pip install -e .[all]
+      run: MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+      run: MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+
+  test-clean-install-windows:
+    needs: [ lint-commit, lint-flake8, lint-black, test-api, test-headers ]
+    runs-on: windows-latest
+    name: test-clean-install-ubuntu
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      run: pip install -e .[all]
+      run: MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+      run: MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+
   test-internals:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,9 +126,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      run: pip install -e .[all]
-      run: MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
-      run: MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+      - shell: bash -l {0}
+        run: pip install -e .[all]
+      - shell: bash -l {0}
+        run: MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+      - shell: bash -l {0}
+        run: MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
 
   test-clean-install-windows:
     needs: [ lint-commit, lint-flake8, lint-black, test-api, test-headers ]
@@ -138,9 +141,12 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      run: pip install -e .[all]
-      run: MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
-      run: MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+      - shell: bash -l {0}
+        run: pip install -e .[all]
+      - shell: bash -l {0}
+        run: MODIN_ENGINE=dask python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
+      - shell: bash -l {0}
+        run: MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3])"
 
   test-internals:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]


### PR DESCRIPTION
* Resolves #2598

This change adds a test for installing Modin without all of the testing
dependencies.

It is intended to test how a user who does not have all of the test
dependencies will see a Modin import.

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2598 <!-- issue must be created for each patch -->
- [x] tests added and passing
