### PR TITLE
FEAT-#2624: Allow read_csv,json,fwf to use file handles without falling back to Pandas 

### DIFF
--- a/modin/engines/base/io/text/csv_dispatcher.py
+++ b/modin/engines/base/io/text/csv_dispatcher.py
@@ -22,6 +22,7 @@ import sys
 class CSVDispatcher(TextFileDispatcher):
     @classmethod
     def _read(cls, filepath_or_buffer, **kwargs):
+        filepath_or_buffer = cls.get_path_or_buffer(filepath_or_buffer)
         if isinstance(filepath_or_buffer, str):
             if not cls.file_exists(filepath_or_buffer):
                 return cls.single_worker_read(filepath_or_buffer, **kwargs)

--- a/modin/engines/base/io/text/fwf_dispatcher.py
+++ b/modin/engines/base/io/text/fwf_dispatcher.py
@@ -22,6 +22,7 @@ import sys
 class FWFDispatcher(TextFileDispatcher):
     @classmethod
     def read(cls, filepath_or_buffer, **kwargs):
+        filepath_or_buffer = cls.get_path_or_buffer(filepath_or_buffer)
         if isinstance(filepath_or_buffer, str):
             if not cls.file_exists(filepath_or_buffer):
                 return cls.single_worker_read(filepath_or_buffer, **kwargs)

--- a/modin/engines/base/io/text/json_dispatcher.py
+++ b/modin/engines/base/io/text/json_dispatcher.py
@@ -22,6 +22,7 @@ from csv import QUOTE_NONE
 class JSONDispatcher(TextFileDispatcher):
     @classmethod
     def _read(cls, path_or_buf, **kwargs):
+        path_or_buf = cls.get_path_or_buffer(path_or_buf)
         if isinstance(path_or_buf, str):
             if not cls.file_exists(path_or_buf):
                 return cls.single_worker_read(path_or_buf, **kwargs)


### PR DESCRIPTION
Resolves #2624 

## What do these changes do?

See some of the context in #2624 -- what this PR does is adds in some code so that when a file handle is passed into `modin.pandas.read_*` - we extract the filepath from it using the `.name` attribute of the buffer, check if it exists, convert it to an absolute path and then let the rest of the `read_*` code move ahead as though that string was passed in initially.

The reason that a file handle has to fall back to Pandas in a single worker is because file handles can't be pickled and sent across processes, since they aren't serialisable. This PR should hopefully do nothing but make the `read_*` method more performant where possible, and continue to fallback to single worker Pandas where not. So hopefully a win-win.

Certainly on my laptop (Macbook Pro 13" 2019 with 16G Ram, quad-core CPU) it turned `modin.pandas.read_csv` for a `2.9G` csv file with `12m` rows from 60s to 17s and got rid of the Dask warnings saying worker memory limit was nearing its limit when using file handles (which are unavoidable with the data framework I'm using). 

This is my first contribution to the repo, so please feel free to let me know if I've done anything wrong!

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
