### PR TITLE
FEAT-#2530: Implementation for `reset_index` on MultiIndex

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -572,7 +572,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 new_modin_frame = self._modin_frame.from_labels()
             if isinstance(new_modin_frame.columns, pandas.MultiIndex):
                 # Fix col_level and col_fill in generated column names because from_labels works with assumption
-                # that col_level and col_fill are not specified and doesn't expand tuples in index names.
+                # that col_level and col_fill are not specified but it expands tuples in level names.
                 col_level = kwargs.get("col_level", 0)
                 col_fill = kwargs.get("col_fill", "")
                 if col_level != 0 or col_fill != "":

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -571,48 +571,50 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 # that col_level and col_fill are not specified and doesn't expand tuples in index names.
                 col_level = kwargs.get("col_level", 0)
                 col_fill = kwargs.get("col_fill", "")
-                levels_names_list = [
-                    f"level_{level_index}" if level_name is None else level_name
-                    for level_index, level_name in enumerate(self.index.names)
-                ]
-                if col_fill is None:
-                    # Initialize col_fill if it is None.
-                    # This is some weird undocumented Pandas behavior to take first
-                    # element of the last column name.
-                    last_col_name = levels_names_list[uniq_sorted_level[-1]]
-                    last_col_name = (
-                        list(last_col_name)
-                        if isinstance(last_col_name, tuple)
-                        else [last_col_name]
-                    )
-                    if len(last_col_name) not in (1, self.columns.nlevels):
-                        raise ValueError(
-                            "col_fill=None is incompatible "
-                            f"with incomplete column name {last_col_name}"
+                if col_level != 0 or col_fill != "":
+                    # Modify generated column names if col_level and col_fil have values different from default.
+                    levels_names_list = [
+                        f"level_{level_index}" if level_name is None else level_name
+                        for level_index, level_name in enumerate(self.index.names)
+                    ]
+                    if col_fill is None:
+                        # Initialize col_fill if it is None.
+                        # This is some weird undocumented Pandas behavior to take first
+                        # element of the last column name.
+                        last_col_name = levels_names_list[uniq_sorted_level[-1]]
+                        last_col_name = (
+                            list(last_col_name)
+                            if isinstance(last_col_name, tuple)
+                            else [last_col_name]
                         )
-                    col_fill = last_col_name[0]
-                columns_list = new_modin_frame.columns.tolist()
-                for level_index, level_value in enumerate(uniq_sorted_level):
-                    level_name = levels_names_list[level_value]
-                    # Expand tuples into separate items and fill the rest with col_fill
-                    top_level = [col_fill] * col_level
-                    middle_level = (
-                        list(level_name)
-                        if isinstance(level_name, tuple)
-                        else [level_name]
-                    )
-                    bottom_level = [col_fill] * (
-                        self.columns.nlevels - (col_level + len(middle_level))
-                    )
-                    item = tuple(top_level + middle_level + bottom_level)
-                    if len(item) > self.columns.nlevels:
-                        raise ValueError(
-                            "Item must have length equal to number of levels."
+                        if len(last_col_name) not in (1, self.columns.nlevels):
+                            raise ValueError(
+                                "col_fill=None is incompatible "
+                                f"with incomplete column name {last_col_name}"
+                            )
+                        col_fill = last_col_name[0]
+                    columns_list = new_modin_frame.columns.tolist()
+                    for level_index, level_value in enumerate(uniq_sorted_level):
+                        level_name = levels_names_list[level_value]
+                        # Expand tuples into separate items and fill the rest with col_fill
+                        top_level = [col_fill] * col_level
+                        middle_level = (
+                            list(level_name)
+                            if isinstance(level_name, tuple)
+                            else [level_name]
                         )
-                    columns_list[level_index] = item
-                new_modin_frame.columns = pandas.MultiIndex.from_tuples(
-                    columns_list, names=self.columns.names
-                )
+                        bottom_level = [col_fill] * (
+                            self.columns.nlevels - (col_level + len(middle_level))
+                        )
+                        item = tuple(top_level + middle_level + bottom_level)
+                        if len(item) > self.columns.nlevels:
+                            raise ValueError(
+                                "Item must have length equal to number of levels."
+                            )
+                        columns_list[level_index] = item
+                    new_modin_frame.columns = pandas.MultiIndex.from_tuples(
+                        columns_list, names=self.columns.names
+                    )
             new_self = self.__constructor__(new_modin_frame)
         else:
             new_self = self.copy()

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -542,14 +542,19 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     # expensive.
                     new_index = self.index.droplevel(level)
                     # These are the index levels that will remain after the reset_index
-                    keep_levels = [i for i in range(len(self.index.names)) if i not in level]
+                    keep_levels = [
+                        i for i in range(len(self.index.names)) if i not in level
+                    ]
                     new_copy = self.copy()
                     # Change the index to have only the levels that will be inserted
                     # into the data. We will replace the old levels later.
                     new_copy.index = self.index.droplevel(keep_levels)
                     new_copy.index.names = [
-                        "level_{}".format(i) if new_copy.index.names[i] is None else new_copy.index.names[i]
-                        for i in range(len(new_copy.index.names))]
+                        "level_{}".format(i)
+                        if new_copy.index.names[i] is None
+                        else new_copy.index.names[i]
+                        for i in range(len(new_copy.index.names))
+                    ]
                     new_modin_frame = new_copy._modin_frame.from_labels()
                     # Replace the levels that will remain as a part of the index.
                     new_modin_frame.index = new_index

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -531,41 +531,46 @@ class PandasQueryCompiler(BaseQueryCompiler):
         """
         drop = kwargs.get("drop", False)
         level = kwargs.get("level", None)
+        new_index = None
+        if level is not None:
+            if not isinstance(level, (tuple, list)):
+                level = [level]
+            level = [self.index._get_level_number(lev) for lev in level]
+            uniq_sorted_level = sorted(set(level))
+            if len(uniq_sorted_level) < self.index.nlevels:
+                # We handle this by separately computing the index. We could just
+                # put the labels into the data and pull them back out, but that is
+                # expensive.
+                new_index = self.index.droplevel(uniq_sorted_level)
+
         if not drop:
-            if level is not None:
-                if not isinstance(level, (tuple, list)):
-                    level = [level]
-                level = [self.index._get_level_number(lev) for lev in level]
-                if len(level) < self.index.nlevels:
-                    # We handle this by separately computing the index. We could just
-                    # put the labels into the data and pull them back out, but that is
-                    # expensive.
-                    new_index = self.index.droplevel(level)
-                    # These are the index levels that will remain after the reset_index
-                    keep_levels = [
-                        i for i in range(len(self.index.names)) if i not in level
-                    ]
-                    new_copy = self.copy()
-                    # Change the index to have only the levels that will be inserted
-                    # into the data. We will replace the old levels later.
-                    new_copy.index = self.index.droplevel(keep_levels)
-                    new_copy.index.names = [
-                        "level_{}".format(i)
-                        if new_copy.index.names[i] is None
-                        else new_copy.index.names[i]
-                        for i in range(len(new_copy.index.names))
-                    ]
-                    new_modin_frame = new_copy._modin_frame.from_labels()
-                    # Replace the levels that will remain as a part of the index.
-                    new_modin_frame.index = new_index
-                else:
-                    new_modin_frame = self._modin_frame.from_labels()
+            if level is not None and len(uniq_sorted_level) < self.index.nlevels:
+                # These are the index levels that will remain after the reset_index
+                keep_levels = [i for i in range(self.index.nlevels) if i not in uniq_sorted_level]
+                new_copy = self.copy()
+                # Change the index to have only the levels that will be inserted
+                # into the data. We will replace the old levels later.
+                new_copy.index = self.index.droplevel(keep_levels)
+                new_copy.index.names = [
+                    "level_{}".format(level_value)
+                    if new_copy.index.names[level_index] is None
+                    else new_copy.index.names[level_index]
+                    for level_index, level_value in enumerate(uniq_sorted_level)
+                ]
+                new_modin_frame = new_copy._modin_frame.from_labels()
+                # Replace the levels that will remain as a part of the index.
+                new_modin_frame.index = new_index
             else:
                 new_modin_frame = self._modin_frame.from_labels()
+            if isinstance(self.columns, pandas.MultiIndex):
+                # Fix col_level and col_fill in generated column names because from_labels works with assumption
+                # that col_level and col_fill are not specified.
+                col_level = kwargs.get("col_level", 0)
+                col_fill = kwargs.get("col_fill", "")
             new_self = self.__constructor__(new_modin_frame)
         else:
             new_self = self.copy()
-            new_self.index = pandas.RangeIndex(len(new_self.index))
+            new_self.index = pandas.RangeIndex(len(new_self.index)) if new_index is None else new_index
         return new_self
 
     def set_index_from_columns(

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -541,7 +541,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 # We handle this by separately computing the index. We could just
                 # put the labels into the data and pull them back out, but that is
                 # expensive.
-                new_index = self.index.droplevel(uniq_sorted_level)
+                new_index = (
+                    self.index.droplevel(uniq_sorted_level)
+                    if len(level) < self.index.nlevels
+                    else pandas.RangeIndex(len(self.index))
+                )
         else:
             uniq_sorted_level = list(range(self.index.nlevels))
 

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -54,6 +54,11 @@ def pytest_addoption(parser):
         default=None,
         help="specifies backend to run tests on",
     )
+    parser.addoption(
+        "--extra-test-parameters",
+        action="store_true",
+        help="activate extra test parameter combinations",
+    )
 
 
 class Patcher:
@@ -216,6 +221,11 @@ def set_base_backend(name=BASE_BACKEND_NAME):
 
 
 def pytest_configure(config):
+    if config.option.extra_test_parameters is not None:
+        import modin.pandas.test.utils as utils
+
+        utils.extra_test_parameters = config.option.extra_test_parameters
+
     backend = config.option.backend
 
     if backend is None:

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -566,7 +566,7 @@ class BasePandasFrame(object):
                     names=self.columns.names,
                 )
                 if self.columns.nlevels > 1
-                else pandas.Index(level_names)
+                else pandas.Index(level_names, tupleize_cols=False)
             )
 
         # Column labels are different for multilevel index.

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -549,13 +549,20 @@ class BasePandasFrame(object):
 
         def generate_new_index(level_names):
             return (
-                pandas.MultiIndex.from_arrays(
+                pandas.MultiIndex.from_tuples(
                     # Set level names on the 1st columns level. This is how reset_index works
                     # when col_level is not specified.
-                    [level_names]
                     # Fill up empty level names with empty string. This is how reset_index works
                     # when col_fill is not specified.
-                    + [[""] * len(level_names)] * (self.columns.nlevels - 1),
+                    # Expand tuples in level names.
+                    [
+                        tuple(
+                            list(level) + [""] * (self.columns.nlevels - len(level))
+                            if isinstance(level, tuple)
+                            else [level] + [""] * (self.columns.nlevels - 1)
+                        )
+                        for level in level_names
+                    ],
                     names=self.columns.names,
                 )
                 if self.columns.nlevels > 1

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1847,7 +1847,10 @@ class BasePandasDataset(object):
             raise ValueError("cannot insert level_0, already exists")
         else:
             new_query_compiler = self._query_compiler.reset_index(
-                drop=drop, level=level
+                drop=drop,
+                level=level,
+                col_level=col_level,
+                col_fill=col_fill,
             )
         return self._create_or_update_from_compiler(new_query_compiler, inplace)
 

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -35,6 +35,8 @@ from modin.pandas.test.utils import (
     int_arg_values,
     create_test_dfs,
     eval_general,
+    generate_multiindex,
+    extra_test_parameters,
 )
 from modin.config import NPartitions
 
@@ -921,6 +923,236 @@ def test_reset_index(data):
     modin_df_cp.reset_index(inplace=True)
     pd_df_cp.reset_index(inplace=True)
     df_equals(modin_df_cp, pd_df_cp)
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(
+            test_data["int_data"],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        test_data["float_nan_data"],
+    ],
+    ids=["int_data", "float_nan_data"],
+)
+@pytest.mark.parametrize("nlevels", [3])
+@pytest.mark.parametrize("columns_multiindex", [True, False])
+@pytest.mark.parametrize(
+    "level",
+    [
+        "no_level",
+        None,
+        0,
+        1,
+        2,
+        [2, 0],
+        [2, 1],
+        [1, 0],
+        pytest.param(
+            [2, 1, 2],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        pytest.param(
+            [0, 0, 0, 0],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+    ],
+)
+@pytest.mark.parametrize("col_level", ["no_col_level", 0, 1, 2])
+@pytest.mark.parametrize("col_fill", ["no_col_fill", None, 0, "new"])
+@pytest.mark.parametrize("drop", [False])
+@pytest.mark.parametrize(
+    "multiindex_levels_names_max_levels",
+    [
+        0,
+        1,
+        2,
+        pytest.param(
+            3, marks=pytest.mark.skipif(not extra_test_parameters, reason="extra")
+        ),
+        pytest.param(
+            4, marks=pytest.mark.skipif(not extra_test_parameters, reason="extra")
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "none_in_index_names",
+    [
+        pytest.param(
+            False,
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        True,
+        "mixed_1st_None",
+        pytest.param(
+            "mixed_2nd_None",
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+    ],
+)
+def test_reset_index_with_multi_index_no_drop(
+    data,
+    nlevels,
+    columns_multiindex,
+    level,
+    col_level,
+    col_fill,
+    drop,
+    multiindex_levels_names_max_levels,
+    none_in_index_names,
+):
+    data_rows = len(data[list(data.keys())[0]])
+    index = generate_multiindex(data_rows, nlevels=nlevels)
+    data_columns = len(data.keys())
+    columns = (
+        generate_multiindex(data_columns, nlevels=nlevels)
+        if columns_multiindex
+        else pandas.RangeIndex(0, data_columns)
+    )
+    # Replace original data columns with generated
+    data = {columns[ind]: data[key] for ind, key in enumerate(data)}
+    index.names = (
+        [f"level_{i}" for i in range(index.nlevels)]
+        if multiindex_levels_names_max_levels == 0
+        else [
+            tuple(
+                [
+                    f"level_{i}_name_{j}"
+                    for j in range(
+                        0,
+                        max(multiindex_levels_names_max_levels + 1 - index.nlevels, 0)
+                        + i,
+                    )
+                ]
+            )
+            if max(multiindex_levels_names_max_levels + 1 - index.nlevels, 0) + i > 0
+            else f"level_{i}"
+            for i in range(index.nlevels)
+        ]
+    )
+
+    if none_in_index_names is True:
+        index.names = [None] * len(index.names)
+    elif none_in_index_names:
+        names_list = list(index.names)
+        start_index = 0 if none_in_index_names == "mixed_1st_None" else 1
+        names_list[start_index::2] = [None] * len(names_list[start_index::2])
+        index.names = names_list
+
+    modin_df = pd.DataFrame(data, index=index, columns=columns)
+    pandas_df = pandas.DataFrame(data, index=index, columns=columns)
+
+    kwargs = {"drop": drop}
+    if level != "no_level":
+        kwargs["level"] = level
+    if col_level != "no_col_level":
+        kwargs["col_level"] = col_level
+    if col_fill != "no_col_fill":
+        kwargs["col_fill"] = col_fill
+    eval_general(modin_df, pandas_df, lambda df: df.reset_index(**kwargs))
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        pytest.param(
+            test_data["int_data"],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        test_data["float_nan_data"],
+    ],
+    ids=["int_data", "float_nan_data"],
+)
+@pytest.mark.parametrize("nlevels", [3])
+@pytest.mark.parametrize(
+    "level",
+    [
+        "no_level",
+        None,
+        0,
+        1,
+        2,
+        [2, 0],
+        [2, 1],
+        [1, 0],
+        pytest.param(
+            [2, 1, 2],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        pytest.param(
+            [0, 0, 0, 0],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "multiindex_levels_names_max_levels",
+    [
+        0,
+        1,
+        2,
+        pytest.param(
+            3, marks=pytest.mark.skipif(not extra_test_parameters, reason="extra")
+        ),
+        pytest.param(
+            4, marks=pytest.mark.skipif(not extra_test_parameters, reason="extra")
+        ),
+    ],
+)
+@pytest.mark.parametrize(
+    "none_in_index_names",
+    [
+        pytest.param(
+            False,
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        True,
+        "mixed_1st_None",
+        pytest.param(
+            "mixed_2nd_None",
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+    ],
+)
+def test_reset_index_with_multi_index_drop(
+    data, nlevels, level, multiindex_levels_names_max_levels, none_in_index_names
+):
+    test_reset_index_with_multi_index_no_drop(
+        data,
+        nlevels,
+        True,
+        level,
+        "no_col_level",
+        "no_col_fill",
+        True,
+        multiindex_levels_names_max_levels,
+        none_in_index_names,
+    )
+
+
+@pytest.mark.parametrize("index_levels_names_max_levels", [0, 1, 2])
+def test_reset_index_with_named_index(index_levels_names_max_levels):
+    modin_df = pd.DataFrame(test_data_values[0])
+    pandas_df = pandas.DataFrame(test_data_values[0])
+
+    index_name = (
+        tuple([f"name_{j}" for j in range(0, index_levels_names_max_levels)])
+        if index_levels_names_max_levels > 0
+        else "NAME_OF_INDEX"
+    )
+    modin_df.index.name = pandas_df.index.name = index_name
+    df_equals(modin_df, pandas_df)
+    df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
+
+    modin_df.reset_index(drop=True, inplace=True)
+    pandas_df.reset_index(drop=True, inplace=True)
+    df_equals(modin_df, pandas_df)
+
+    modin_df = pd.DataFrame(test_data_values[0])
+    pandas_df = pandas.DataFrame(test_data_values[0])
+    modin_df.index.name = pandas_df.index.name = index_name
+    df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -957,6 +957,18 @@ def test_reset_index(data):
             [0, 0, 0, 0],
             marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
         ),
+        pytest.param(
+            ["level_name_1"],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        pytest.param(
+            ["level_name_2", "level_name_1"],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        pytest.param(
+            [2, "level_name_0"],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
     ],
 )
 @pytest.mark.parametrize("col_level", ["no_col_level", 0, 1, 2])
@@ -1043,6 +1055,14 @@ def test_reset_index_with_multi_index_no_drop(
     modin_df = pd.DataFrame(data, index=index, columns=columns)
     pandas_df = pandas.DataFrame(data, index=index, columns=columns)
 
+    if isinstance(level, list):
+        level = [
+            index.names[int(x[len("level_name_") :])]
+            if isinstance(x, str) and x.startswith("level_name_")
+            else x
+            for x in level
+        ]
+
     kwargs = {"drop": drop}
     if level != "no_level":
         kwargs["level"] = level
@@ -1082,6 +1102,18 @@ def test_reset_index_with_multi_index_no_drop(
         ),
         pytest.param(
             [0, 0, 0, 0],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        pytest.param(
+            ["level_name_1"],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        pytest.param(
+            ["level_name_2", "level_name_1"],
+            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+        ),
+        pytest.param(
+            [2, "level_name_0"],
             marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
         ),
     ],

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -230,38 +230,6 @@ def test___repr__():
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_reset_index_with_multi_index(data):
-    modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)
-
-    if len(modin_df.columns) > len(pandas_df.columns):
-        col0 = modin_df.columns[0]
-        col1 = modin_df.columns[1]
-        modin_cols = modin_df.groupby([col0, col1]).count().reset_index().columns
-        pandas_cols = pandas_df.groupby([col0, col1]).count().reset_index().columns
-
-        assert modin_cols.equals(pandas_cols)
-
-
-def test_reset_index_with_named_index():
-    modin_df = pd.DataFrame(test_data_values[0])
-    pandas_df = pandas.DataFrame(test_data_values[0])
-
-    modin_df.index.name = pandas_df.index.name = "NAME_OF_INDEX"
-    df_equals(modin_df, pandas_df)
-    df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
-
-    modin_df.reset_index(drop=True, inplace=True)
-    pandas_df.reset_index(drop=True, inplace=True)
-    df_equals(modin_df, pandas_df)
-
-    modin_df = pd.DataFrame(test_data_values[0])
-    pandas_df = pandas.DataFrame(test_data_values[0])
-    modin_df.index.name = pandas_df.index.name = "NEW_NAME"
-    df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
-
-
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_inplace_series_ops(data):
     pandas_df = pandas.DataFrame(data)
     modin_df = pd.DataFrame(data)

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -31,6 +31,10 @@ import csv
 import psutil
 import functools
 
+# Flag activated on command line with "--extra-test-parameters" option.
+# Used in some tests to perform additional parameter combinations.
+extra_test_parameters = False
+
 random_state = np.random.RandomState(seed=42)
 
 DATASET_SIZE_DICT = {


### PR DESCRIPTION
* Resolves #2530

This adds the algebraic operator `from_labels` to the Modin dataframe
algebra layer in Modin and implements it for the default case.

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2530 <!-- issue must be created for each patch -->
- [ ] tests added and passing
