### PR TITLE
Fix Python 3.9 warnings

### DIFF
--- a/modin/backends/pandas/parsers.py
+++ b/modin/backends/pandas/parsers.py
@@ -248,14 +248,14 @@ class PandasExcelParser(PandasParser):
             """
             b = match.group(0)
             return re.sub(
-                b"\d+",  # noqa: W605
+                br"\d+",
                 lambda c: str(int(c.group(0).decode("utf-8")) - _skiprows).encode(
                     "utf-8"
                 ),
                 b,
             )
 
-        bytes_data = re.sub(b'r="[A-Z]*\d+"', update_row_nums, bytes_data)  # noqa: W605
+        bytes_data = re.sub(br'r="[A-Z]*\d+"', update_row_nums, bytes_data)
         bytesio = BytesIO(excel_header + bytes_data + footer)
         # Use openpyxl to read/parse sheet data
         reader = WorksheetReader(ws, bytesio, ex.shared_strings, False)

--- a/modin/pandas/iterator.py
+++ b/modin/pandas/iterator.py
@@ -13,7 +13,7 @@
 
 """Place to define the Modin iterator."""
 
-from collections import Iterator
+from collections.abc import Iterator
 
 
 class PartitionIterator(Iterator):

--- a/stress_tests/kaggle/kaggle14.py
+++ b/stress_tests/kaggle/kaggle14.py
@@ -50,7 +50,7 @@ plt.show()
 data["Initial"] = 0
 for i in data:
     data["Initial"] = data.Name.str.extract(
-        "([A-Za-z]+)\."  # noqa: W605
+        r"([A-Za-z]+)\."  # noqa: W605
     )  # lets extract the Salutations
 pd.crosstab(data.Initial, data.Sex).T.style.background_gradient(
     cmap="summer_r"

--- a/stress_tests/kaggle/kaggle4.py
+++ b/stress_tests/kaggle/kaggle4.py
@@ -51,7 +51,7 @@ sns.distplot(train["SalePrice"], fit=norm)
 (mu, sigma) = norm.fit(train["SalePrice"])
 print("\n mu = {:.2f} and sigma = {:.2f}\n".format(mu, sigma))
 plt.legend(
-    ["Normal dist. ($\mu=$ {:.2f} and $\sigma=$ {:.2f} )".format(mu, sigma)],
+    [r"Normal dist. ($\mu=$ {:.2f} and $\sigma=$ {:.2f} )".format(mu, sigma)],
     loc="best",  # noqa: W605
 )
 plt.ylabel("Frequency")
@@ -64,7 +64,7 @@ sns.distplot(train["SalePrice"], fit=norm)
 (mu, sigma) = norm.fit(train["SalePrice"])
 print("\n mu = {:.2f} and sigma = {:.2f}\n".format(mu, sigma))
 plt.legend(
-    ["Normal dist. ($\mu=$ {:.2f} and $\sigma=$ {:.2f} )".format(mu, sigma)],
+    [r"Normal dist. ($\mu=$ {:.2f} and $\sigma=$ {:.2f} )".format(mu, sigma)],
     loc="best",  # noqa: W605
 )
 plt.ylabel("Frequency")

--- a/stress_tests/kaggle/kaggle5.py
+++ b/stress_tests/kaggle/kaggle5.py
@@ -53,7 +53,7 @@ combine = [train_df, test_df]
 "After", train_df.shape, test_df.shape, combine[0].shape, combine[1].shape
 for dataset in combine:
     dataset["Title"] = dataset.Name.str.extract(
-        " ([A-Za-z]+)\.", expand=False
+        r" ([A-Za-z]+)\.", expand=False
     )  # noqa: W605
 pd.crosstab(train_df["Title"], train_df["Sex"])
 for dataset in combine:


### PR DESCRIPTION
## What do these changes do?

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/CONTRIBUTING.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2637 
- [ ] tests added and passing

This also fixes below warnings : 

```
find . -iname '*.py' | xargs -P4 -I{} python3.9 -Wall -m py_compile {}  
./modin/backends/pandas/parsers.py:251: DeprecationWarning: invalid escape sequence \d
  b"\d+",  # noqa: W605
./modin/backends/pandas/parsers.py:258: DeprecationWarning: invalid escape sequence \d
  bytes_data = re.sub(b'r="[A-Z]*\d+"', update_row_nums, bytes_data)  # noqa: W605
./versioneer.py:421: DeprecationWarning: invalid escape sequence \s
  LONG_VERSION_PY['git'] = '''
./stress_tests/kaggle/kaggle14.py:53: DeprecationWarning: invalid escape sequence \.
  "([A-Za-z]+)\."  # noqa: W605
./stress_tests/kaggle/kaggle4.py:54: DeprecationWarning: invalid escape sequence \m
  ["Normal dist. ($\mu=$ {:.2f} and $\sigma=$ {:.2f} )".format(mu, sigma)],
./stress_tests/kaggle/kaggle4.py:67: DeprecationWarning: invalid escape sequence \m
  ["Normal dist. ($\mu=$ {:.2f} and $\sigma=$ {:.2f} )".format(mu, sigma)],
./stress_tests/kaggle/kaggle5.py:56: DeprecationWarning: invalid escape sequence \.
  " ([A-Za-z]+)\.", expand=False
```
