### PR TITLE
FIX-#2658: Move backend check in xgb to train/predict

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -221,6 +221,8 @@ jobs:
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
       - shell: bash -l {0}
+        run: pytest modin/experimental/xgboost/test/test_default.py --backend=${{ matrix.backend }}
+      - shell: bash -l {0}
         run: python -m pytest modin/test/backends/base/test_internals.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_binary.py --backend=${{ matrix.backend }}
@@ -368,6 +370,8 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
+      - shell: bash -l {0}
+        run: pytest modin/experimental/xgboost/test/test_default.py
       - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_binary.py
       - shell: bash -l {0}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -62,6 +62,8 @@ jobs:
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
       - shell: bash -l {0}
+        run: pytest modin/experimental/xgboost/test/test_default.py --backend=${{ matrix.backend }}
+      - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_binary.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_default.py --backend=${{ matrix.backend }}
@@ -154,6 +156,8 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
+      - shell: bash -l {0}
+        run: pytest modin/experimental/xgboost/test/test_default.py
       - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_binary.py
       - shell: bash -l {0}

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -34,3 +34,4 @@ dependencies:
   - boto3
   - asv
   - ray-core >=1.0.0
+  - py-xgboost >=1.3

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -34,4 +34,5 @@ dependencies:
   - boto3
   - asv
   - ray-core >=1.0.0
-  - py-xgboost >=1.3
+  - pip:
+      - xgboost >=1.3

--- a/modin/experimental/xgboost/test/__init__.py
+++ b/modin/experimental/xgboost/test/__init__.py
@@ -1,0 +1,12 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.

--- a/modin/experimental/xgboost/test/test_default.py
+++ b/modin/experimental/xgboost/test/test_default.py
@@ -1,0 +1,30 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+import pytest
+from modin.config import Engine
+
+import modin.experimental.xgboost as xgb
+
+
+@pytest.mark.skipif(
+    Engine.get() == "Ray",
+    reason="This test doesn't make sense on Ray backend.",
+)
+@pytest.mark.parametrize("func", ["train", "predict"])
+def test_backend(func):
+    try:
+        getattr(xgb, func)({}, xgb.ModinDMatrix(None, None))
+    except ValueError:
+        pass

--- a/modin/experimental/xgboost/xgboost.py
+++ b/modin/experimental/xgboost/xgboost.py
@@ -98,7 +98,7 @@ def train(
     if Engine.get() == "Ray":
         from .xgboost_ray import _train
     else:
-        raise ValueError("Current version supports only Ray engine as MODIN_ENGINE.")
+        raise ValueError("Current version supports only Ray engine.")
 
     result = _train(
         dtrain, nthread, evenly_data_distribution, params, *args, evals=evals, **kwargs
@@ -141,7 +141,7 @@ def predict(
     if Engine.get() == "Ray":
         from .xgboost_ray import _predict
     else:
-        raise ValueError("Current version supports only Ray engine as MODIN_ENGINE.")
+        raise ValueError("Current version supports only Ray engine.")
 
     if isinstance(model, xgb.Booster):
         booster = model

--- a/modin/experimental/xgboost/xgboost.py
+++ b/modin/experimental/xgboost/xgboost.py
@@ -20,11 +20,6 @@ import xgboost as xgb
 
 from modin.config import Engine
 
-if Engine.get() == "Ray":
-    from .xgboost_ray import _train, _predict
-else:
-    raise ValueError("Current version supports only Ray engine as MODIN_ENGINE.")
-
 LOGGER = logging.getLogger("[modin.xgboost]")
 
 
@@ -99,6 +94,12 @@ def train(
                          'eval': {'logloss': ['0.480385', '0.357756']}}}
     """
     LOGGER.info("Training started")
+
+    if Engine.get() == "Ray":
+        from .xgboost_ray import _train
+    else:
+        raise ValueError("Current version supports only Ray engine as MODIN_ENGINE.")
+
     result = _train(
         dtrain, nthread, evenly_data_distribution, params, *args, evals=evals, **kwargs
     )
@@ -136,6 +137,11 @@ def predict(
         Array with prediction results.
     """
     LOGGER.info("Prediction started")
+
+    if Engine.get() == "Ray":
+        from .xgboost_ray import _predict
+    else:
+        raise ValueError("Current version supports only Ray engine as MODIN_ENGINE.")
 
     if isinstance(model, xgb.Booster):
         booster = model

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,3 +27,4 @@ pandas_gbq
 cloudpickle
 rpyc==4.1.5
 asv
+xgboost>=1.3


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
This changes move checking of backend to separate function to make importing module possible.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2658  <!-- issue must be created for each patch -->

