### PR TITLE
FEAT-#2664: Add `to_labels` algebraic operator

### DIFF
--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -29,6 +29,7 @@ from pandas.core.dtypes.common import is_scalar
 import pandas.core.resample
 import pandas
 import numpy as np
+from typing import List, Hashable
 
 
 def _get_axis(axis):
@@ -483,6 +484,30 @@ class BaseQueryCompiler(abc.ABC):
             New QueryCompiler with updated data and reset index.
         """
         return DataFrameDefault.register(pandas.DataFrame.reset_index)(self, **kwargs)
+
+    def set_index_from_columns(
+        self, keys: List[Hashable], drop: bool = True, append: bool = False
+    ):
+        """Create new row labels from a list of columns.
+
+        Parameters
+        ----------
+        keys : list of hashable
+            The list of column names that will become the new index.
+        drop : boolean
+            Whether or not to drop the columns provided in the `keys` argument.
+        append : boolean
+            Whether or not to add the columns in `keys` as new levels appended to the
+            existing index.
+
+        Returns
+        -------
+        PandasQueryCompiler
+            A new QueryCompiler with updated index.
+        """
+        return DataFrameDefault.register(pandas.DataFrame.set_index)(
+            self, keys=keys, drop=drop, append=append
+        )
 
     # END Abstract reindex/reset_index
 


### PR DESCRIPTION
Resolves #2664

This add the algebraic operator for `to_labels`, which enables Modin to
better optimize the movement of data to metadata. See more in the paper
about the algebraic operator:
http://www.vldb.org/pvldb/vol13/p2033-petersohn.pdf

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2664 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
