### PR TITLE
FIX-#1263: Fix 'monotonic' implementation to allign new MapReduce beh…

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -643,6 +643,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             "decreasing": lambda df: df.is_monotonic_decreasing,
         }
         monotonic_fn = funcs.get(func_type, funcs["increasing"])
+        series_name = self.columns[0]
 
         def is_monotonic_map(df):
             df = df.squeeze(axis=1)
@@ -662,7 +663,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             result = (
                 monotonic_fn(df["edges"]) if df["is_part_monotonic"].all() else False
             )
-            return pandas.Series([result], name="__reduced__").to_frame()
+            return pandas.Series([result], name=series_name).to_frame()
 
         return MapReduceFunction.register(is_monotonic_map, is_monotonic_reduce)(self)
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -38,6 +38,8 @@ from .utils import (
     test_string_data_keys,
     test_string_list_data_values,
     test_string_list_data_keys,
+    test_data_monotonic_values,
+    test_data_monotonic_keys,
     string_sep_values,
     string_sep_keys,
     string_na_rep_values,
@@ -1849,19 +1851,25 @@ def test_interpolate(data):
         modin_series.interpolate()
 
 
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize(
+    "data", test_data_monotonic_values, ids=test_data_monotonic_keys
+)
 def test_is_monotonic(data):
     modin_series, pandas_series = create_test_series(data)
     assert modin_series.is_monotonic == pandas_series.is_monotonic
 
 
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize(
+    "data", test_data_monotonic_values, ids=test_data_monotonic_keys
+)
 def test_is_monotonic_decreasing(data):
     modin_series, pandas_series = create_test_series(data)
     assert modin_series.is_monotonic_decreasing == pandas_series.is_monotonic_decreasing
 
 
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize(
+    "data", test_data_monotonic_values, ids=test_data_monotonic_keys
+)
 def test_is_monotonic_increasing(data):
     modin_series, pandas_series = create_test_series(data)
     assert modin_series.is_monotonic_increasing == pandas_series.is_monotonic_increasing

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1858,12 +1858,20 @@ def test_is_monotonic(data):
     modin_series, pandas_series = create_test_series(data)
     assert modin_series.is_monotonic == pandas_series.is_monotonic
 
+    modin_series.name = "some_name"
+    pandas_series.name = "some_name"
+    assert modin_series.is_monotonic == pandas_series.is_monotonic
+
 
 @pytest.mark.parametrize(
     "data", test_data_monotonic_values, ids=test_data_monotonic_keys
 )
 def test_is_monotonic_decreasing(data):
     modin_series, pandas_series = create_test_series(data)
+    assert modin_series.is_monotonic_decreasing == pandas_series.is_monotonic_decreasing
+
+    modin_series.name = "some_name"
+    pandas_series.name = "some_name"
     assert modin_series.is_monotonic_decreasing == pandas_series.is_monotonic_decreasing
 
 
@@ -1873,6 +1881,10 @@ def test_is_monotonic_decreasing(data):
 def test_is_monotonic_increasing(data):
     modin_series, pandas_series = create_test_series(data)
     assert modin_series.is_monotonic_increasing == pandas_series.is_monotonic_increasing
+
+    modin_series.name = "some_name"
+    pandas_series.name = "some_name"
+    assert modin_series.is_monotonic_decreasing == pandas_series.is_monotonic_decreasing
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -185,6 +185,17 @@ test_data_diff_dtype = {
     "bool_col": [False, True, True, False],
 }
 
+test_data_monotonic = {
+    "increasing": np.arange(257),
+    "decreasing": np.arange(257, 0, -1),
+    "not monotonic": np.concatenate(
+        [np.arange(32), np.arange(-32, 0), np.arange(-1, 31), np.arange(32)]
+    ),
+}
+
+test_data_monotonic_values = list(test_data_monotonic.values())
+test_data_monotonic_keys = list(test_data_monotonic.keys())
+
 test_data_small_values = list(test_data_small.values())
 test_data_small_keys = list(test_data_small.keys())
 


### PR DESCRIPTION
…avior

Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1263 <!-- issue must be created for each patch -->
- [x] tests passing

The thing that was changed from the previous implementation is that now instead of a bool scalar we return DataFrame with a single column named the same as the Series.