### PR TITLE
FEAT-#2629: implement usecols for read_csv with OmniSci backend

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/io.py
+++ b/modin/experimental/engines/omnisci_on_ray/io.py
@@ -175,7 +175,7 @@ class OmnisciOnRayIO(RayIO):
                     "Specified a delimiter and delim_whitespace=True; you can only specify one."
                 )
 
-            usecols_md = cls._define_usecols(mykwargs)
+            usecols_md = cls._prepare_pyarrow_usecols(mykwargs)
 
             po = ParseOptions(
                 delimiter="\\s+" if delim_whitespace else delimiter,
@@ -236,7 +236,7 @@ class OmnisciOnRayIO(RayIO):
             return pa.from_numpy_dtype(tname)
 
     @classmethod
-    def _define_usecols(cls, read_csv_kwargs):
+    def _prepare_pyarrow_usecols(cls, read_csv_kwargs):
         """
         Define `usecols` parameter in the way pyarrow can process it.
         ----------
@@ -245,7 +245,7 @@ class OmnisciOnRayIO(RayIO):
 
         Returns
         -------
-        usecols_md:
+        usecols_md: list
                 Redefined `usecols` parameter.
         """
         usecols = read_csv_kwargs.get("usecols", None)
@@ -275,7 +275,7 @@ class OmnisciOnRayIO(RayIO):
             elif usecols_names_dtypes == "integer":
                 # columns should be sorted because pandas doesn't preserve columns order
                 usecols_md = sorted(usecols_md)
-                if len(column_names) < max(usecols_md):
+                if len(column_names) < usecols_md[-1]:
                     raise NotImplementedError(
                         "max usecols value is higher than the number of columns"
                     )
@@ -284,5 +284,7 @@ class OmnisciOnRayIO(RayIO):
                 usecols_md = [
                     col_name for col_name in column_names if usecols_md(col_name)
                 ]
+            else:
+                raise NotImplementedError("unsupported `usecols` parameter")
 
         return usecols_md

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -328,6 +328,36 @@ class TestCSV:
             parse_dates=parse_dates,
         )
 
+    @pytest.mark.parametrize("engine", [None, "arrow"])
+    @pytest.mark.parametrize(
+        "usecols",
+        [
+            None,
+            ["col1"],
+            ["col1", "col1"],
+            ["col1", "col2", "col6"],
+            ["col6", "col2", "col1"],
+            [0],
+            [0, 0],
+            [0, 1, 5],
+            [5, 1, 0],
+            lambda x: x in ["col1", "col2"],
+        ],
+    )
+    def test_read_csv_col_handling(
+        self,
+        engine,
+        usecols,
+    ):
+        eval_io(
+            fn_name="read_csv",
+            check_kwargs_callable=not callable(usecols),
+            md_extra_kwargs={"engine": engine},
+            # read_csv kwargs
+            filepath_or_buffer=pytest.csvs_names["test_read_csv_regular"],
+            usecols=usecols,
+        )
+
 
 class TestMasks:
     data = {


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2629  <!-- issue must be created for each patch -->
- [x] tests added and passing
