### PR TITLE
FIX-#2709: fixed typo in '_copartition'

### DIFF
--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -1810,7 +1810,7 @@ class BasePandasFrame(object):
                 or others_lengths[i] != base_lengths
             )
 
-        # perform repartitioning and reindexing for `other` frames if needed
+        # perform repartitioning and reindexing for `other_frames` if needed
         reindexed_other_list = [None] * len(other_frames)
         for i in range(len(other_frames)):
             if do_repartition_others[i]:
@@ -1819,7 +1819,7 @@ class BasePandasFrame(object):
                     i
                 ]._frame_mgr_cls.map_axis_partitions(
                     axis,
-                    other[i]._partitions,
+                    other_frames[i]._partitions,
                     make_reindexer(do_repartition_others[i], base_frame_idx + 1 + i),
                     lengths=base_lengths,
                 )

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1243,6 +1243,8 @@ def test___setitem__(data):
 
     df_equals(modin_df, pandas_df)
 
+
+def test___setitem__partitions_aligning():
     # from issue #2390
     modin_df = pd.DataFrame({"a": [1, 2, 3]})
     pandas_df = pandas.DataFrame({"a": [1, 2, 3]})
@@ -1259,12 +1261,15 @@ def test___setitem__(data):
     # Setting new column
     pd_df["b"] = pandas.Series(np.arange(4))
     md_df["b"] = pd.Series(np.arange(4))
-
     df_equals(md_df, pd_df)
+
     # Setting existing column
     pd_df["b"] = pandas.Series(np.arange(4))
     md_df["b"] = pd.Series(np.arange(4))
+    df_equals(md_df, pd_df)
 
+    pd_df["a"] = pandas.Series(np.arange(4))
+    md_df["a"] = pd.Series(np.arange(4))
     df_equals(md_df, pd_df)
 
 


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2709 <!-- issue must be created for each patch -->
- [x] tests added and passing

There are two related arrays that we operate on at `_copartition`: `other` and `other_frames`. 
`other` - function parameter, it contains frames to concatenate with `self`. After joining indices we're [picking the first non-empty frame](https://github.com/modin-project/modin/blob/e74e01279b8c1b6d01652e2e24a060e3ee47b919/modin/engines/base/frame/data.py#L1778-L1780) in a `[self] + [other]` list to be our `base_frame` with which we're aligning partitioning with, all other frames are moved into the `other_frames`. So if `self` is not empty then `other == other_frames` and we couldn't see any errors. However when `self` is empty (for example when we're replacing the first column) then `other[base_index: base_index + 1] == other_frames`, so we can see an error.