### PR TITLE
DOCS-#2717: Fix version of Modin for building latest docs

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -3,15 +3,13 @@ click
 flatbuffers
 funcsigs
 mock
-numpy
 opencv-python
 pyyaml
 recommonmark
 sphinx
 sphinx-click
 sphinx_rtd_theme
-pandas
-modin[all]
+git+https://github.com/modin-project/modin.git@master#egg=modin[all]
 sphinxcontrib_plantuml
 sphinx-issues
 xgboost


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

The latest version of master branch will be used for building the latest documentation pages. 
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2717  <!-- issue must be created for each patch -->
- [x] tests passing
