### PR TITLE
TEST-#2722: add ASV read_csv skiprows benchmark

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -17,10 +17,8 @@
 # define `MODIN_ASV_USE_IMPL` env var to choose library for using in performance
 # measurements
 
-import os
 import modin.pandas as pd
 import numpy as np
-import pandas
 
 from .utils import (
     generate_dataframe,
@@ -29,70 +27,14 @@ from .utils import (
     random_string,
     random_columns,
     random_booleans,
+    ASV_USE_IMPL,
+    ASV_DATASET_SIZE,
+    BINARY_OP_DATA_SIZE,
+    UNARY_OP_DATA_SIZE,
+    GROUPBY_NGROUPS,
+    IMPL,
+    execute,
 )
-
-try:
-    from modin.config import NPartitions
-
-    NPARTITIONS = NPartitions.get()
-except ImportError:
-    NPARTITIONS = pd.DEFAULT_NPARTITIONS
-
-try:
-    from modin.config import TestDatasetSize, AsvImplementation
-
-    ASV_USE_IMPL = AsvImplementation.get()
-    ASV_DATASET_SIZE = TestDatasetSize.get() or "Small"
-except ImportError:
-    # The same benchmarking code can be run for different versions of Modin, so in
-    # case of an error importing important variables, we'll just use predefined values
-    ASV_USE_IMPL = os.environ.get("MODIN_ASV_USE_IMPL", "modin")
-    ASV_DATASET_SIZE = os.environ.get("MODIN_TEST_DATASET_SIZE", "Small")
-
-assert ASV_USE_IMPL in ("modin", "pandas")
-
-BINARY_OP_DATA_SIZE = {
-    "Big": [
-        ((5000, 5000), (5000, 5000)),
-        # the case extremely inefficient
-        # ((20, 500_000), (10, 1_000_000)),
-        ((500_000, 20), (1_000_000, 10)),
-    ],
-    "Small": [
-        ((250, 250), (250, 250)),
-        ((20, 10_000), (10, 25_000)),
-        ((10_000, 20), (25_000, 10)),
-    ],
-}
-
-UNARY_OP_DATA_SIZE = {
-    "Big": [
-        (5000, 5000),
-        # the case extremely inefficient
-        # (10, 1_000_000),
-        (1_000_000, 10),
-    ],
-    "Small": [
-        (250, 250),
-        (10, 10_000),
-        (10_000, 10),
-    ],
-}
-
-GROUPBY_NGROUPS = {
-    "Big": 100,
-    "Small": 5,
-}
-
-IMPL = {
-    "modin": pd,
-    "pandas": pandas,
-}
-
-
-def execute(df):
-    "Make sure the calculations are done."
-    return df.shape, df.dtypes
 
 
 class BaseTimeGroupBy:

--- a/asv_bench/benchmarks/io/__init__.py
+++ b/asv_bench/benchmarks/io/__init__.py
@@ -1,0 +1,12 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -1,0 +1,60 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import modin.pandas as pd
+import numpy as np
+
+from ..utils import (
+    generate_dataframe,
+    RAND_LOW,
+    RAND_HIGH,
+    ASV_USE_IMPL,
+    ASV_DATASET_SIZE,
+    UNARY_OP_DATA_SIZE,
+    IMPL,
+    execute,
+)
+
+# ray init
+if ASV_USE_IMPL == "modin":
+    pd.DataFrame([])
+
+
+class BaseReadCsv:
+    # test data file can de created only once
+    def setup_cache(self, test_filename="io_test_file"):
+        test_filenames = {}
+        for shape in UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE]:
+            data_id = "_".join([str(size) for size in shape])
+            test_filenames[data_id] = f"{test_filename}_{data_id}.csv"
+            df = generate_dataframe("pandas", "str_int", *shape, RAND_LOW, RAND_HIGH)
+            df.to_csv(test_filenames[data_id], index=False)
+
+        return test_filenames
+
+
+class TimeReadCsvSkiprows(BaseReadCsv):
+    param_names = ["shape", "skiprows"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [
+            None,
+            lambda x: x % 2,
+            np.arange(1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0] // 10),
+            np.arange(1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0], 2),
+        ],
+    ]
+
+    def time_skiprows(self, test_filenames, shape, skiprows):
+        data_id = "_".join([str(size) for size in shape])
+        execute(IMPL[ASV_USE_IMPL].read_csv(test_filenames[data_id], skiprows=skiprows))

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -23,6 +23,7 @@ from ..utils import (
     UNARY_OP_DATA_SIZE,
     IMPL,
     execute,
+    get_array_id,
 )
 
 # ray init
@@ -35,7 +36,7 @@ class BaseReadCsv:
     def setup_cache(self, test_filename="io_test_file"):
         test_filenames = {}
         for shape in UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE]:
-            data_id = "_".join([str(size) for size in shape])
+            data_id = get_array_id(shape)
             test_filenames[data_id] = f"{test_filename}_{data_id}.csv"
             df = generate_dataframe("pandas", "str_int", *shape, RAND_LOW, RAND_HIGH)
             df.to_csv(test_filenames[data_id], index=False)
@@ -56,5 +57,8 @@ class TimeReadCsvSkiprows(BaseReadCsv):
     ]
 
     def time_skiprows(self, test_filenames, shape, skiprows):
-        data_id = "_".join([str(size) for size in shape])
-        execute(IMPL[ASV_USE_IMPL].read_csv(test_filenames[data_id], skiprows=skiprows))
+        execute(
+            IMPL[ASV_USE_IMPL].read_csv(
+                test_filenames[get_array_id(shape)], skiprows=skiprows
+            )
+        )

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -23,7 +23,7 @@ from ..utils import (
     UNARY_OP_DATA_SIZE,
     IMPL,
     execute,
-    get_array_id,
+    get_shape_id,
 )
 
 # ray init
@@ -36,15 +36,15 @@ class BaseReadCsv:
     def setup_cache(self, test_filename="io_test_file"):
         test_filenames = {}
         for shape in UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE]:
-            data_id = get_array_id(shape)
-            test_filenames[data_id] = f"{test_filename}_{data_id}.csv"
+            shape_id = get_shape_id(shape)
+            test_filenames[shape_id] = f"{test_filename}_{shape_id}.csv"
             df = generate_dataframe("pandas", "str_int", *shape, RAND_LOW, RAND_HIGH)
-            df.to_csv(test_filenames[data_id], index=False)
+            df.to_csv(test_filenames[shape_id], index=False)
 
         return test_filenames
 
     def setup(self, test_filenames, shape, *args, **kwargs):
-        self.data_id = get_array_id(shape)
+        self.shape_id = get_shape_id(shape)
 
 
 class TimeReadCsvSkiprows(BaseReadCsv):
@@ -61,5 +61,7 @@ class TimeReadCsvSkiprows(BaseReadCsv):
 
     def time_skiprows(self, test_filenames, shape, skiprows):
         execute(
-            IMPL[ASV_USE_IMPL].read_csv(test_filenames[self.data_id], skiprows=skiprows)
+            IMPL[ASV_USE_IMPL].read_csv(
+                test_filenames[self.shape_id], skiprows=skiprows
+            )
         )

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -43,6 +43,9 @@ class BaseReadCsv:
 
         return test_filenames
 
+    def setup(self, test_filenames, shape, *args, **kwargs):
+        self.data_id = get_array_id(shape)
+
 
 class TimeReadCsvSkiprows(BaseReadCsv):
     param_names = ["shape", "skiprows"]
@@ -58,7 +61,5 @@ class TimeReadCsvSkiprows(BaseReadCsv):
 
     def time_skiprows(self, test_filenames, shape, skiprows):
         execute(
-            IMPL[ASV_USE_IMPL].read_csv(
-                test_filenames[get_array_id(shape)], skiprows=skiprows
-            )
+            IMPL[ASV_USE_IMPL].read_csv(test_filenames[self.data_id], skiprows=skiprows)
         )

--- a/asv_bench/benchmarks/utils.py
+++ b/asv_bench/benchmarks/utils.py
@@ -209,3 +209,7 @@ def random_booleans(number):
 def execute(df):
     "Make sure the calculations are done."
     return df.shape, df.dtypes
+
+
+def get_array_id(array):
+    return "_".join([str(element) for element in array])

--- a/asv_bench/benchmarks/utils.py
+++ b/asv_bench/benchmarks/utils.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import os
 import logging
 import modin.pandas as pd
 import pandas
@@ -20,6 +21,65 @@ import uuid
 RAND_LOW = 0
 RAND_HIGH = 100
 random_state = np.random.RandomState(seed=42)
+
+
+try:
+    from modin.config import NPartitions
+
+    NPARTITIONS = NPartitions.get()
+except ImportError:
+    NPARTITIONS = pd.DEFAULT_NPARTITIONS
+
+try:
+    from modin.config import TestDatasetSize, AsvImplementation
+
+    ASV_USE_IMPL = AsvImplementation.get()
+    ASV_DATASET_SIZE = TestDatasetSize.get() or "Small"
+except ImportError:
+    # The same benchmarking code can be run for different versions of Modin, so in
+    # case of an error importing important variables, we'll just use predefined values
+    ASV_USE_IMPL = os.environ.get("MODIN_ASV_USE_IMPL", "modin")
+    ASV_DATASET_SIZE = os.environ.get("MODIN_TEST_DATASET_SIZE", "Small")
+
+assert ASV_USE_IMPL in ("modin", "pandas")
+
+BINARY_OP_DATA_SIZE = {
+    "Big": [
+        ((5000, 5000), (5000, 5000)),
+        # the case extremely inefficient
+        # ((20, 500_000), (10, 1_000_000)),
+        ((500_000, 20), (1_000_000, 10)),
+    ],
+    "Small": [
+        ((250, 250), (250, 250)),
+        ((20, 10_000), (10, 25_000)),
+        ((10_000, 20), (25_000, 10)),
+    ],
+}
+
+UNARY_OP_DATA_SIZE = {
+    "Big": [
+        (5000, 5000),
+        # the case extremely inefficient
+        # (10, 1_000_000),
+        (1_000_000, 10),
+    ],
+    "Small": [
+        (250, 250),
+        (10, 10_000),
+        (10_000, 10),
+    ],
+}
+
+GROUPBY_NGROUPS = {
+    "Big": 100,
+    "Small": 5,
+}
+
+IMPL = {
+    "modin": pd,
+    "pandas": pandas,
+}
 
 
 class weakdict(dict):
@@ -144,3 +204,8 @@ def random_columns(df_columns, columns_number):
 
 def random_booleans(number):
     return list(random_state.choice([True, False], size=number))
+
+
+def execute(df):
+    "Make sure the calculations are done."
+    return df.shape, df.dtypes

--- a/asv_bench/benchmarks/utils.py
+++ b/asv_bench/benchmarks/utils.py
@@ -211,5 +211,5 @@ def execute(df):
     return df.shape, df.dtypes
 
 
-def get_array_id(array):
+def get_shape_id(array):
     return "_".join([str(element) for element in array])


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
This PR added ASV benchmark for `read_csv` function with `skiprows` parameter. Also some common for IO and others benchmarks functions and configuration parameters were moved into `utils` module.

Note: subpart of https://github.com/modin-project/modin/pull/2607

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2722  <!-- issue must be created for each patch -->
- [x] tests passing
