### PR TITLE
FIX-#2362: fix key handling in 'Series.__setitem__'

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -285,11 +285,16 @@ class Series(BasePandasDataset):
         )
 
     def __setitem__(self, key, value):
-        if key not in self.keys():
-            raise KeyError(key)
-        self._create_or_update_from_compiler(
-            self._query_compiler.setitem(1, key, value), inplace=True
-        )
+        if isinstance(key, slice) and (
+            isinstance(key.start, int) or isinstance(key.stop, int)
+        ):
+            # There could be two type of slices:
+            #   - Location based slice (1:5)
+            #   - Labels based slice ("a":"e")
+            # For location based slice we're going to `iloc`, since `loc` can't manage it.
+            self.iloc[key] = value
+        else:
+            self.loc[key] = value
 
     def __sub__(self, right):
         return self.sub(right)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -180,13 +180,13 @@ def inter_df_math_helper_one_side(modin_series, pandas_series, op):
         pass
 
 
-def create_test_series(vals, sort=False):
+def create_test_series(vals, sort=False, **kwargs):
     if isinstance(vals, dict):
-        modin_series = pd.Series(vals[next(iter(vals.keys()))])
-        pandas_series = pandas.Series(vals[next(iter(vals.keys()))])
+        modin_series = pd.Series(vals[next(iter(vals.keys()))], **kwargs)
+        pandas_series = pandas.Series(vals[next(iter(vals.keys()))], **kwargs)
     else:
-        modin_series = pd.Series(vals)
-        pandas_series = pandas.Series(vals)
+        modin_series = pd.Series(vals, **kwargs)
+        pandas_series = pandas.Series(vals, **kwargs)
     if sort:
         modin_series = modin_series.sort_values().reset_index(drop=True)
         pandas_series = pandas_series.sort_values().reset_index(drop=True)
@@ -524,6 +524,22 @@ def test___setitem__(data):
         modin_series[key] = 0
         pandas_series[key] = 0
         df_equals(modin_series, pandas_series)
+
+
+@pytest.mark.parametrize(
+    "key",
+    [
+        pytest.param(slice(1, 3), id="numeric_slice"),
+        pytest.param(slice("a", "c"), id="index_based_slice"),
+        pytest.param(["a", "c", "e"], id="list_of_labels"),
+        pytest.param([True, False, True, False, True], id="boolean_mask"),
+    ],
+)
+def test___setitem___non_hashable(key):
+    md_sr, pd_sr = create_test_series([1, 2, 3, 4, 5], index=["a", "b", "c", "d", "e"])
+    md_sr[key] = 10
+    pd_sr[key] = 10
+    df_equals(md_sr, pd_sr)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2362 <!-- issue must be created for each patch -->
- [x] tests added and passing

See #2362 for the problem explanation. Old `Series.__setitem__` logic assumed, that the `key` could only be a scalar. However, it also could be a slice, list of labels, boolean mask, etc. There are `loc/iloc` accessors to handle all of this variety of `key` types. So now all `Series.__setitem__` calls are dispatched to `.loc[key]` since `setitem` is a label-based value-accessor, and to `.iloc[key]` if `key` is a int-slice (must to use `iloc` here because `loc` can't manage location-based slices).
