### PR TITLE
FIX-#2305: fix handling of renaming aggregation

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -517,22 +517,22 @@ class BasePandasDataset(object):
 
     agg = aggregate
 
-    def _aggregate(self, arg, *args, **kwargs):
+    def _aggregate(self, func, *args, **kwargs):
         _axis = kwargs.pop("_axis", 0)
         kwargs.pop("_level", None)
 
-        if isinstance(arg, str):
+        if isinstance(func, str):
             kwargs.pop("is_transform", None)
-            return self._string_function(arg, *args, **kwargs)
+            return self._string_function(func, *args, **kwargs)
 
         # Dictionaries have complex behavior because they can be renamed here.
-        elif isinstance(arg, dict):
-            return self._default_to_pandas("agg", arg, *args, **kwargs)
-        elif is_list_like(arg) or callable(arg):
+        elif func is None or isinstance(func, dict):
+            return self._default_to_pandas("agg", func, *args, **kwargs)
+        elif is_list_like(func) or callable(func):
             kwargs.pop("is_transform", None)
-            return self.apply(arg, axis=_axis, args=args, **kwargs)
+            return self.apply(func, axis=_axis, args=args, **kwargs)
         else:
-            raise TypeError("type {} is not callable".format(type(arg)))
+            raise TypeError("type {} is not callable".format(type(func)))
 
     def _string_function(self, func, *args, **kwargs):
         assert isinstance(func, str)

--- a/modin/pandas/test/dataframe/test_udf.py
+++ b/modin/pandas/test/dataframe/test_udf.py
@@ -42,6 +42,18 @@ NPartitions.put(4)
 matplotlib.use("Agg")
 
 
+def test_agg_dict():
+    md_df, pd_df = create_test_dfs(test_data_values[0])
+    agg_dict = {pd_df.columns[0]: "sum", pd_df.columns[-1]: ("sum", "count")}
+    eval_general(md_df, pd_df, lambda df: df.agg(agg_dict), raising_exceptions=True)
+
+    agg_dict = {
+        "new_col1": (pd_df.columns[0], "sum"),
+        "new_col2": (pd_df.columns[-1], "count"),
+    }
+    eval_general(md_df, pd_df, lambda df: df.agg(**agg_dict), raising_exceptions=True)
+
+
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize(
     "func",


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2305 <!-- issue must be created for each patch -->
- [x] tests added and passing

See #2305 for the problem description. This PR adds `func is None` check to the if-statement which dispatches aggregation execution to the dict branch.
