### PR TITLE
FIX-#2742: fix performance degradation for dictionary GroupBy aggregation

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2363,16 +2363,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # nature. They require certain data to exist on the same partition, and
     # after the shuffle, there should be only a local map required.
 
-    groupby_count = GroupbyReduceFunction.register(*groupby_reduce_functions["count"])
-    groupby_any = GroupbyReduceFunction.register(*groupby_reduce_functions["any"])
-    groupby_min = GroupbyReduceFunction.register(*groupby_reduce_functions["min"])
-    groupby_prod = GroupbyReduceFunction.register(*groupby_reduce_functions["prod"])
-    groupby_max = GroupbyReduceFunction.register(*groupby_reduce_functions["max"])
-    groupby_all = GroupbyReduceFunction.register(*groupby_reduce_functions["all"])
-    groupby_sum = GroupbyReduceFunction.register(*groupby_reduce_functions["sum"])
-    groupby_size = GroupbyReduceFunction.register(
-        *groupby_reduce_functions["size"], method="size"
-    )
+    groupby_all = GroupbyReduceFunction.register("all")
+    groupby_any = GroupbyReduceFunction.register("any")
+    groupby_count = GroupbyReduceFunction.register("count")
+    groupby_max = GroupbyReduceFunction.register("max")
+    groupby_min = GroupbyReduceFunction.register("min")
+    groupby_prod = GroupbyReduceFunction.register("prod")
+    groupby_size = GroupbyReduceFunction.register("size", method="size")
+    groupby_sum = GroupbyReduceFunction.register("sum")
 
     def _groupby_dict_reduce(
         self, by, axis, agg_func, agg_args, agg_kwargs, groupby_kwargs, drop=False


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2742 <!-- issue must be created for each patch -->
- [x] tests pass

You can see the problem explanation in #2742. This PR replaces all the callables in [`groupby_reduce_functions`](https://github.com/modin-project/modin/blob/8ebbad9bca36aba0ddfc58dac89b9a66b0bfe41a/modin/data_management/functions/groupby_function.py#L234) to its string names, so now dictionary aggregation applies string functions to the columns and therefore performs much faster with a-lot-of-groups groupby. This PR also brings an ability to pass only a function name to the `GroupByReduce.register` for simplicity.

```
MODIN_CPUS=4 MODIN_TEST_DATASET_SIZE=Big asv continuous src/master HEAD --launch-method=spawn -b TimeGroupByDictionaryAggregation --split

       before           after         ratio
       [aa818f5a]       [c177b8aa]
         <master>         <issue-2742>
-        705±20ms         126±20ms     0.18  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((5000, 5000), <function <lambda> at 0x7f37d61c8d40>, 'reduction')
-	 197±10ms         104±10ms     0.53  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((1000000, 10), 100, 'reduction')
-	 944±20ms         113±10ms     0.12  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((1000000, 10), <function <lambda> at 0x7f37d61c8d40>, 'reduction')
SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```