### PR TITLE
TEST-#2766: use string keyword instead of lambdas in ASV benchmarks

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -34,13 +34,13 @@ from .utils import (
     GROUPBY_NGROUPS,
     IMPL,
     execute,
+    translator_groupby_ngroups,
 )
 
 
 class BaseTimeGroupBy:
     def setup(self, shape, ngroups=5, groupby_ncols=1):
-        if isinstance(ngroups, str) and ngroups == "huge_amount_groups":
-            ngroups = min(shape[0] // 2, 5000)
+        ngroups = translator_groupby_ngroups(ngroups, shape)
         self.df, self.groupby_columns = generate_dataframe(
             ASV_USE_IMPL,
             "int",
@@ -407,6 +407,7 @@ class BaseTimeValueCounts:
                 f"Invalid value for 'subset={subset}'. Allowed: {list(self.subset_params.keys())}"
             )
         ncols = subset(shape)
+        ngroups = translator_groupby_ngroups(ngroups, shape)
         self.df, _ = generate_dataframe(
             ASV_USE_IMPL,
             "int",

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -39,8 +39,8 @@ from .utils import (
 
 class BaseTimeGroupBy:
     def setup(self, shape, ngroups=5, groupby_ncols=1):
-        if callable(ngroups):
-            ngroups = ngroups(shape[0])
+        if isinstance(ngroups, str) and ngroups == "huge_amount_groups":
+            ngroups = min(shape[0] // 2, 5000)
         self.df, self.groupby_columns = generate_dataframe(
             ASV_USE_IMPL,
             "int",

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -53,15 +53,32 @@ class TimeReadCsvSkiprows(BaseReadCsv):
         UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
         [
             None,
-            lambda x: x % 2,
-            np.arange(1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0] // 10),
-            np.arange(1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0], 2),
+            "half_rows",
+            "sequence",
+            "sequence_step2",
         ],
     ]
+
+    def setup(self, test_filenames, shape, skiprows):
+        super().setup(test_filenames, shape, skiprows)
+
+        if skiprows:
+            skiprows_dict = {
+                "half_rows": lambda x: x % 2,
+                "sequence": np.arange(
+                    1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0] // 10
+                ),
+                "sequence_step2": np.arange(
+                    1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0], 2
+                ),
+            }
+            self.skiprows = skiprows_dict[skiprows]
+        else:
+            self.skiprows = None
 
     def time_skiprows(self, test_filenames, shape, skiprows):
         execute(
             IMPL[ASV_USE_IMPL].read_csv(
-                test_filenames[self.shape_id], skiprows=skiprows
+                test_filenames[self.shape_id], skiprows=self.skiprows
             )
         )

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -53,9 +53,9 @@ class TimeReadCsvSkiprows(BaseReadCsv):
         UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
         [
             None,
-            "half_rows",
-            "sequence",
-            "sequence_step2",
+            "lambda_even_rows",
+            "range_uniform",
+            "range_step2",
         ],
     ]
 
@@ -64,11 +64,11 @@ class TimeReadCsvSkiprows(BaseReadCsv):
 
         if skiprows:
             skiprows_dict = {
-                "half_rows": lambda x: x % 2,
-                "sequence": np.arange(
+                "lambda_even_rows": lambda x: x % 2,
+                "range_uniform": np.arange(
                     1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0] // 10
                 ),
-                "sequence_step2": np.arange(
+                "range_step2": np.arange(
                     1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0], 2
                 ),
             }

--- a/asv_bench/benchmarks/io/csv.py
+++ b/asv_bench/benchmarks/io/csv.py
@@ -48,6 +48,12 @@ class BaseReadCsv:
 
 
 class TimeReadCsvSkiprows(BaseReadCsv):
+    skiprows_mapping = {
+        "lambda_even_rows": lambda x: x % 2,
+        "range_uniform": np.arange(1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0] // 10),
+        "range_step2": np.arange(1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0], 2),
+    }
+
     param_names = ["shape", "skiprows"]
     params = [
         UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
@@ -61,20 +67,7 @@ class TimeReadCsvSkiprows(BaseReadCsv):
 
     def setup(self, test_filenames, shape, skiprows):
         super().setup(test_filenames, shape, skiprows)
-
-        if skiprows:
-            skiprows_dict = {
-                "lambda_even_rows": lambda x: x % 2,
-                "range_uniform": np.arange(
-                    1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0] // 10
-                ),
-                "range_step2": np.arange(
-                    1, UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE][0][0], 2
-                ),
-            }
-            self.skiprows = skiprows_dict[skiprows]
-        else:
-            self.skiprows = None
+        self.skiprows = self.skiprows_mapping[skiprows] if skiprows else None
 
     def time_skiprows(self, test_filenames, shape, skiprows):
         execute(

--- a/asv_bench/benchmarks/utils.py
+++ b/asv_bench/benchmarks/utils.py
@@ -72,7 +72,7 @@ UNARY_OP_DATA_SIZE = {
 }
 
 GROUPBY_NGROUPS = {
-    "Big": [100, lambda nrows: min(nrows // 2, 5000)],
+    "Big": [100, "huge_amount_groups"],
     "Small": [5],
 }
 

--- a/asv_bench/benchmarks/utils.py
+++ b/asv_bench/benchmarks/utils.py
@@ -82,6 +82,15 @@ IMPL = {
 }
 
 
+def translator_groupby_ngroups(groupby_ngroups, shape):
+    if ASV_DATASET_SIZE == "Big":
+        if groupby_ngroups == "huge_amount_groups":
+            return min(shape[0] // 2, 5000)
+        return groupby_ngroups
+    else:
+        return groupby_ngroups
+
+
 class weakdict(dict):
     __slots__ = ("__weakref__",)
 


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2766  <!-- issue must be created for each patch -->
- [ ] tests added and passing
