### PR TITLE
FIX-#2307: Fix usage of callable usecols in read_csv

### DIFF
--- a/modin/engines/base/io/text/csv_dispatcher.py
+++ b/modin/engines/base/io/text/csv_dispatcher.py
@@ -13,7 +13,6 @@
 
 from modin.engines.base.io.text.text_file_dispatcher import TextFileDispatcher
 from modin.data_management.utils import compute_chunksize
-from pandas.io.parsers import _validate_usecols_arg
 import pandas
 import csv
 import sys
@@ -90,14 +89,6 @@ class CSVDispatcher(TextFileDispatcher):
         column_names = empty_pd_df.columns
         skipfooter = kwargs.get("skipfooter", None)
         skiprows = kwargs.pop("skiprows", None)
-        usecols_md = _validate_usecols_arg(usecols)
-        if usecols is not None and usecols_md[1] != "integer":
-            del kwargs["usecols"]
-            all_cols = pandas.read_csv(
-                cls.file_open(filepath_or_buffer, "rb"),
-                **dict(kwargs, nrows=0, skipfooter=0),
-            ).columns
-            usecols = all_cols.get_indexer_for(list(usecols_md[0]))
         parse_dates = kwargs.pop("parse_dates", False)
         partition_kwargs = dict(
             kwargs,
@@ -106,7 +97,6 @@ class CSVDispatcher(TextFileDispatcher):
             skipfooter=0,
             skiprows=None,
             parse_dates=parse_dates,
-            usecols=usecols,
         )
         encoding = kwargs.get("encoding", None)
         quotechar = kwargs.get("quotechar", '"').encode(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -292,6 +292,13 @@ class TestCsv:
             skip_blank_lines=skip_blank_lines,
         )
 
+    @pytest.mark.parametrize("usecols", [lambda col_name: col_name in ["a", "b", "e"]])
+    def test_from_csv_with_callable_usecols(self, usecols):
+        fname = "modin/pandas/test/data/test_usecols.csv"
+        pandas_df = pandas.read_csv(fname, usecols=usecols)
+        modin_df = pd.read_csv(fname, usecols=usecols)
+        df_equals(modin_df, pandas_df)
+
     # General Parsing Configuration
     @pytest.mark.parametrize("dtype", [None, True])
     @pytest.mark.parametrize("engine", [None, "python", "c"])


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2307 <!-- issue must be created for each patch -->
- [ ] tests added and passing
