### PR TITLE
FIX-#2522: Added optional default parameter to pop method

### DIFF
--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -155,13 +155,13 @@ def enforce_config():
             self.__check_var(name)
             del orig_env[name]
 
-        def pop(self, name):
+        def pop(self, name, default=object()):
             self.__check_var(name)
-            return orig_env.pop(name)
+            return orig_env.pop(name, default)
 
-        def get(self, name, defvalue=None):
+        def get(self, name, default=None):
             self.__check_var(name)
-            return orig_env.get(name, defvalue)
+            return orig_env.get(name, default)
 
         def __contains__(self, name):
             self.__check_var(name)


### PR DESCRIPTION
Signed-off-by: Marat Idrisov <idrisov.mt@yandex.ru>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2522 
- [ ] tests added and passing _Do we need tests?_
___
A question may arise: Why is the default value not `None` but `object()`?
`os.environ` returns an object of the class `os._Environ`. `_Environ` is inherited from `_collections_abc.MutableMapping`. The [MutableMapping.pop](https://github.com/python/cpython/blob/3.8/Lib/_collections_abc.py#L790) method has `object()` as default value.
