### PR TITLE
FIX-#2531: fix handling level parameter in groupby

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -369,12 +369,14 @@ class DataFrame(BasePandasDataset):
         elif hashable(by) and not isinstance(by, pandas.Grouper):
             drop = by in self.columns
             idx_name = by
-            if self._query_compiler.has_multiindex(
-                axis=axis
-            ) and by in self._query_compiler.get_index_names(axis):
+            if (
+                self._query_compiler.has_multiindex(axis=axis)
+                and by in self._query_compiler.get_index_names(axis)
+                and by is not None
+            ):
                 # In this case we pass the string value of the name through to the
                 # partitions. This is more efficient than broadcasting the values.
-                pass
+                level, by = by, None
             elif level is None:
                 by = self.__getitem__(by)._query_compiler
         elif isinstance(by, Series):

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -144,6 +144,7 @@ def from_modin_frame_to_mi(df, sortorder=None, names=None):
 def is_label(obj, label, axis=0):
     """
     Check whether or not 'obj' contain column or index level with name 'label'.
+
     Parameters
     ----------
     obj: DataFrame, Series or QueryCompiler
@@ -152,6 +153,7 @@ def is_label(obj, label, axis=0):
         Label name to check.
     axis: int,
         Axis to search name along.
+
     Returns
     -------
     Boolean

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -14,6 +14,7 @@
 """Implement utils for pandas component."""
 
 from pandas import MultiIndex
+from modin.utils import hashable
 
 
 def from_non_pandas(df, index, columns, dtype):
@@ -138,6 +139,27 @@ def from_modin_frame_to_mi(df, sortorder=None, names=None):
         ErrorMessage.default_to_pandas("`MultiIndex.from_frame`")
         df = df._to_pandas()
     return _original_pandas_MultiIndex_from_frame(df, sortorder, names)
+
+
+def is_label(obj, label, axis=0):
+    """
+    Check whether or not 'obj' contain column or index level with name 'label'.
+    Parameters
+    ----------
+    obj: DataFrame, Series or QueryCompiler
+        Object to check.
+    label: object,
+        Label name to check.
+    axis: int,
+        Axis to search name along.
+    Returns
+    -------
+    Boolean
+    """
+    qc = getattr(obj, "_query_compiler", obj)
+    return hashable(label) and (
+        label in qc.get_axis(axis ^ 1) or label in qc.get_index_names(axis)
+    )
 
 
 _original_pandas_MultiIndex_from_frame = MultiIndex.from_frame

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -133,10 +133,12 @@ def wrap_into_list(*args, skipna=True):
     """
     Creates a list of passed values, if some value is a list it appends its values
     to the result one by one instead inserting the whole list object.
+
     Parameters
     ----------
     skipna: boolean,
         Whether or not to skip nan or None values.
+
     Returns
     -------
     List of passed values.

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -12,6 +12,8 @@
 # governing permissions and limitations under the License.
 
 import pandas
+import numpy as np
+
 from modin.config import Engine, Backend, IsExperimental
 
 
@@ -125,6 +127,33 @@ def try_cast_to_pandas(obj, squeeze=False):
                 else getattr(pandas.Series, fn_name, obj)
             )
     return obj
+
+
+def wrap_into_list(*args, skipna=True):
+    """
+    Creates a list of passed values, if some value is a list it appends its values
+    to the result one by one instead inserting the whole list object.
+    Parameters
+    ----------
+    skipna: boolean,
+        Whether or not to skip nan or None values.
+    Returns
+    -------
+    List of passed values.
+    """
+
+    def isnan(o):
+        return o is None or (isinstance(o, float) and np.isnan(o))
+
+    res = []
+    for o in args:
+        if skipna and isnan(o):
+            continue
+        if isinstance(o, list):
+            res.extend(o)
+        else:
+            res.append(o)
+    return res
 
 
 def wrap_udf_function(func):


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2531 <!-- issue must be created for each patch -->
- [x] tests added and passing

<details><summary>How pandas processes grouping on index level</summary>

- We can specify level name in `by` parameter, mixing with column names is allowed: `df.groupby(by=["level_name", "col_name"])`
- We can specify index of the level via `level` parameter: `df.groupby(level=[0, 1])`
- We can't specify both `by` and `level` parameter (undocumented behaviour): `df.groupby(by="col_name", level=0) # Error`

</details>

This PR changes the way of handling grouping on the index level. Now it's splitting axis-by and level-by into two different variables (`by` and `level`) and then it's backend responsibility to make proper groups. Keeping columns and level names in different variables seems more convenient to me, rather than having a `by` variable which mixes them both and which forces us to distinguish level and column names every time we need it. I see a few use-cases for this:

1. While solving the actual bug (#2531) it was found out, that 
```python
df.groupby("level_name").groups != df.index.groupby("level_name") # previous logic
df.groupby("level_name").groups == df.index.groupby(df.index.levels["level_name"]) # current logic
``` 
so that forces us to do a different logic for column-name-by and level-name-by.
2. Some backends may have different ways of representing indices (for example OmniSci, which represents indices by hidden columns in the frame), so it would be a good hint for level-groupby implementation that column and level names are separated.