### PR TITLE
FIX-#2680: fix omnisci engine work with numpy>=1.20.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: modin_on_omnisci
-          python-version: 3.7.8
+          python-version: 3.7
           environment-file: requirements/env_omnisci.yml
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,7 +274,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: modin_on_omnisci
-          python-version: 3.7
+          python-version: 3.7.8
           environment-file: requirements/env_omnisci.yml
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
@@ -285,17 +285,8 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
-      - name: Print Env
-        shell: bash -l {0}
-        run: env
       - shell: bash -l {0}
         run: pytest modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
-      - name: Publish test-omnisci artefacts
-        uses: actions/upload-artifact@master
-        with:
-          name: Calcite used by omnisci
-          path: /usr/share/miniconda/envs/modin_on_omnisci/bin/calcite-1.0-SNAPSHOT-jar-with-dependencies.jar
-        if: failure()
       - shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash)
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -285,6 +285,9 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
+      - name: Print Env
+        shell: bash -l {0}
+        run: env
       - shell: bash -l {0}
         run: pytest modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
       - name: Publish test-omnisci artefacts

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -287,6 +287,12 @@ jobs:
         run: sudo apt update && sudo apt install -y libhdf5-dev
       - shell: bash -l {0}
         run: pytest modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+      - name: Publish test-omnisci artefacts
+        uses: actions/upload-artifact@master
+        with:
+          name: Calcite used by omnisci
+          path: /usr/share/miniconda/envs/modin_on_omnisci/bin/calcite-1.0-SNAPSHOT-jar-with-dependencies.jar
+        if: failure()
       - shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash)
 

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -1,6 +1,6 @@
 name: modin_on_omnisci
 channels:
-  - intel/label/modintest
+  - intel/label/modin
   - conda-forge
 dependencies:
   - pandas==1.2.3

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -1,6 +1,6 @@
 name: modin_on_omnisci
 channels:
-  - intel/label/modin
+  - intel/label/modintest
   - conda-forge
 dependencies:
   - pandas==1.2.3

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - pandas==1.2.3
   - pyarrow==2.0.0
-  - numpy>=1.16.5,<1.20  # pandas gh-39513
+  - numpy>=1.16.5
   - pip
   - pytest>=6.0.1
   - pytest-cov>=2.10.1

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -1,10 +1,10 @@
 name: modin_on_omnisci
 channels:
-  - intel/label/modin
+  - intel/label/modintest
   - conda-forge
 dependencies:
   - pandas==1.2.3
-  - pyarrow==1.0.0
+  - pyarrow==2.0.0
   - numpy>=1.16.5,<1.20  # pandas gh-39513
   - pip
   - pytest>=6.0.1


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2680 <!-- issue must be created for each patch -->
- [x] tests added and passing

It seems that `pyarrow==1.0.0` doesn't work with `numpy>=1.20.0`, so we have to use a newer version of `pyarrow` (cc @Garra1980 )
The PR also change conda channel to simplify development, since the package can be updated more often without affecting users.

UPD: tested with `numpy==1.20.0, 1.20.1`