### PR TITLE
TEST-#2805: use wait function to get the right performance times

### DIFF
--- a/asv_bench/benchmarks/scalability/scalability_benchmarks.py
+++ b/asv_bench/benchmarks/scalability/scalability_benchmarks.py
@@ -60,4 +60,5 @@ class TimeToPandas:
         self.data = generate_dataframe("modin", "int", *shape, RAND_LOW, RAND_HIGH)
 
     def time_to_pandas(self, shape, cpus):
-        execute(to_pandas(self.data))
+        # to_pandas is already synchronous
+        to_pandas(self.data)


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2805 <!-- issue must be created for each patch -->
- [ ] tests added and passing


**Note**: there is no need to wait https://github.com/modin-project/modin/pull/2801, because we should have another implementation inside `asv_bench` folder which will be used for old commits.
