### PR TITLE
TEST-#2809: move sort function from 'value_counts' tests to utils

### DIFF
--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -18,7 +18,12 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from modin.utils import get_current_backend, to_pandas
 
-from .utils import test_data_values, test_data_keys, df_equals
+from .utils import (
+    test_data_values,
+    test_data_keys,
+    df_equals,
+    sort_index_for_equal_values,
+)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
@@ -590,34 +595,6 @@ def test_unique():
 
 @pytest.mark.parametrize("normalize, bins, dropna", [(True, 3, False)])
 def test_value_counts(normalize, bins, dropna):
-    def sort_index_for_equal_values(result, ascending):
-        is_range = False
-        is_end = False
-        i = 0
-        new_index = np.empty(len(result), dtype=type(result.index))
-        while i < len(result):
-            j = i
-            if i < len(result) - 1:
-                while result[result.index[i]] == result[result.index[i + 1]]:
-                    i += 1
-                    if is_range is False:
-                        is_range = True
-                    if i == len(result) - 1:
-                        is_end = True
-                        break
-            if is_range:
-                k = j
-                for val in sorted(result.index[j : i + 1], reverse=not ascending):
-                    new_index[k] = val
-                    k += 1
-                if is_end:
-                    break
-                is_range = False
-            else:
-                new_index[j] = result.index[j]
-            i += 1
-        return type(result)(result, index=new_index)
-
     # We sort indices for Modin and pandas result because of issue #1650
     values = np.array([3, 1, 2, 3, 4, np.nan])
     modin_result = sort_index_for_equal_values(

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -66,6 +66,7 @@ from .utils import (
     test_data_categorical_keys,
     generate_multiindex,
     test_data_diff_dtype,
+    sort_index_for_equal_values,
 )
 from modin.config import NPartitions
 
@@ -3381,34 +3382,6 @@ def test_update(data, other_data):
 
 @pytest.mark.parametrize("normalize, bins, dropna", [(True, 3, False)])
 def test_value_counts(normalize, bins, dropna):
-    def sort_index_for_equal_values(result, ascending):
-        is_range = False
-        is_end = False
-        i = 0
-        new_index = np.empty(len(result), dtype=type(result.index))
-        while i < len(result):
-            j = i
-            if i < len(result) - 1:
-                while result[result.index[i]] == result[result.index[i + 1]]:
-                    i += 1
-                    if is_range is False:
-                        is_range = True
-                    if i == len(result) - 1:
-                        is_end = True
-                        break
-            if is_range:
-                k = j
-                for val in sorted(result.index[j : i + 1], reverse=not ascending):
-                    new_index[k] = val
-                    k += 1
-                if is_end:
-                    break
-                is_range = False
-            else:
-                new_index[j] = result.index[j]
-            i += 1
-        return type(result)(result, index=new_index)
-
     # We sort indices for Modin and pandas result because of issue #1650
     modin_series, pandas_series = create_test_series(test_data_values[0])
 

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -1218,3 +1218,20 @@ def teardown_test_file(test_path):
 def teardown_test_files(test_paths: list):
     for path in test_paths:
         teardown_test_file(path)
+
+
+def sort_index_for_equal_values(series, ascending=False):
+    if series.index.dtype == np.float64:
+        # HACK: workaround for pandas bug:
+        # https://github.com/pandas-dev/pandas/issues/34455
+        series.index = series.index.astype("str")
+    res = series.groupby(series, sort=False).apply(
+        lambda df: df.sort_index(ascending=ascending)
+    )
+    if res.index.nlevels > series.index.nlevels:
+        # Sometimes GroupBy adds an extra level with 'by' to the result index.
+        # GroupBy is very inconsistent about when it's doing this, so that's
+        # why this clumsy if-statement is used.
+        res.index = res.index.droplevel(0)
+    res.name = series.name
+    return res


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2809 <!-- issue must be created for each patch -->
- [x] tests passing
