### PR TITLE
FIX-#2811: fix 'groupby.size' for Series

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2474,6 +2474,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             groupby_kwargs=groupby_args,
             drop=drop,
             method="size",
+            default_to_pandas_func=lambda grp: grp.size(),
         )
         if groupby_args.get("as_index", True):
             result.columns = ["__reduced__"]

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -181,11 +181,6 @@ class GroupbyReduceFunction(MapReduceFunction):
             **kwargs,
         )
 
-        if kwargs.get("method", None) == "size":
-            # In case of 'size' it's enough to apply 'groupby' only
-            # to a single one partition.
-            qc = qc.getitem_column_array(key=[0], numeric=True)
-
         broadcastable_by = getattr(by, "_modin_frame", None)
         apply_indices = list(map_func.keys()) if isinstance(map_func, dict) else None
         new_modin_frame = qc._modin_frame.groupby_reduce(

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -181,6 +181,11 @@ class GroupbyReduceFunction(MapReduceFunction):
             **kwargs,
         )
 
+        if kwargs.get("method", None) == "size":
+            # In case of 'size' it's enough to apply 'groupby' only
+            # to a single one partition.
+            qc = qc.getitem_column_array(key=[0], numeric=True)
+
         broadcastable_by = getattr(by, "_modin_frame", None)
         apply_indices = list(map_func.keys()) if isinstance(map_func, dict) else None
         new_modin_frame = qc._modin_frame.groupby_reduce(

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -153,7 +153,12 @@ class GroupbyReduceFunction(MapReduceFunction):
             or isinstance(by, pandas.Grouper)
         ):
             by = try_cast_to_pandas(by, squeeze=True)
-            default_func = cls.restore_default_function(map_func, **kwargs)
+            default_func = kwargs.get(
+                "default_to_pandas_func",
+                (lambda grp: grp.agg(map_func))
+                if isinstance(map_func, dict)
+                else map_func,
+            )
             return query_compiler.default_to_pandas(
                 lambda df: default_func(
                     df.groupby(by=by, axis=axis, **groupby_args), **map_args
@@ -194,14 +199,6 @@ class GroupbyReduceFunction(MapReduceFunction):
             return agg_func
         partition_dict = {k: v for k, v in agg_func.items() if k in df.columns}
         return lambda grp: grp.agg(partition_dict)
-
-    @staticmethod
-    def restore_default_function(agg_func, method=None, **kwargs):
-        if method == "size":
-            return lambda grp: grp.size()
-        return (
-            (lambda grp: grp.agg(agg_func)) if isinstance(agg_func, dict) else agg_func
-        )
 
     @classmethod
     def build_map_reduce_functions(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -480,9 +480,65 @@ class DataFrameGroupBy(object):
         )
 
     def size(self):
-        if self._axis == 1:
+        if self._axis == 0:
+            # Series objects in 'by' mean we couldn't handle the case
+            # and transform 'by' to a query compiler.
+            # In this case we are just defaulting to pandas.
+            if is_list_like(self._by) and any(
+                isinstance(o, type(self._df._query_compiler)) for o in self._by
+            ):
+                work_object = DataFrameGroupBy(
+                    self._df,
+                    self._by,
+                    self._axis,
+                    drop=False,
+                    idx_name=None,
+                    squeeze=self._squeeze,
+                    **self._kwargs,
+                )
+                result = work_object._wrap_aggregation(
+                    type(work_object._query_compiler).groupby_size,
+                    lambda df: df.size(),
+                    numeric_only=False,
+                )
+                result = result.__constructor__(
+                    query_compiler=result._query_compiler
+                ).squeeze(axis=1)
+                if isinstance(result, Series):
+                    # Pandas does not name size() output for Series
+                    result.name = None
+                return result
+            work_object = SeriesGroupBy(
+                self._df[self._df.columns[0]]
+                if self._kwargs.get("as_index")
+                else self._df[self._df.columns[0]].to_frame(),
+                self._by,
+                self._axis,
+                drop=False,
+                idx_name=None,
+                squeeze=self._squeeze,
+                **self._kwargs,
+            )
+            result = work_object._wrap_aggregation(
+                type(work_object._query_compiler).groupby_size,
+                lambda df: df.size(),
+                numeric_only=False,
+            ).squeeze(axis=1)
+            result = result.__constructor__(query_compiler=result._query_compiler)
+            if not self._kwargs.get("as_index") and not isinstance(result, Series):
+                result = result.rename(columns={0: "size"})
+                result = (
+                    result.rename(columns={"__reduced__": "index"})
+                    if "__reduced__" in result.columns
+                    else result
+                )
+            else:
+                # Pandas does not name size() output for Series
+                result.name = None
+            return result.fillna(0)
+        else:
             return DataFrameGroupBy(
-                self._df.T.iloc[:, [0]],
+                self._df.T,
                 self._by,
                 0,
                 drop=self._drop,
@@ -490,34 +546,6 @@ class DataFrameGroupBy(object):
                 squeeze=self._squeeze,
                 **self._kwargs,
             ).size()
-        work_object = DataFrameGroupBy(
-            self._df,
-            self._by,
-            self._axis,
-            drop=False,
-            idx_name=None,
-            squeeze=self._squeeze,
-            **self._kwargs,
-        )
-        result = work_object._wrap_aggregation(
-            type(work_object._query_compiler).groupby_size,
-            lambda df: df.size(),
-            numeric_only=False,
-        )
-        if not isinstance(result, Series):
-            result = result.squeeze(axis=1)
-        if not self._kwargs.get("as_index") and not isinstance(result, Series):
-            result = result.rename(columns={0: "size"})
-            result = (
-                result.rename(columns={"__reduced__": "index"})
-                if "__reduced__" in result.columns
-                else result
-            )
-        elif isinstance(self._df, Series):
-            result.name = self._df.name
-        else:
-            result.name = None
-        return result.fillna(0)
 
     def sum(self, **kwargs):
         return self._wrap_aggregation(
@@ -985,6 +1013,40 @@ class DataFrameGroupBy(object):
     ],
 )
 class SeriesGroupBy(DataFrameGroupBy):
+    def __init__(self, df, *args, **kwargs):
+        if not isinstance(df, Series):
+            df = df.squeeze(axis=1)
+        ErrorMessage.catch_bugs_and_request_email(
+            not isinstance(df, Series),
+            f"SeriesGroupBy is supposed to obtain only Series objects, got: {type(df)}",
+        )
+        super(SeriesGroupBy, self).__init__(df.to_frame(), *args, **kwargs)
+        self._name = df.name or "__reduced__"
+
+    _NO_RENAME_METHODS = ["ngroup"]
+
+    def _build_series_wrapper(self, func):
+        def name_setter(*args, **kwargs):
+            if kwargs.get("axis", 0) == 1:
+                raise ValueError("No axis named 1 for object type Series")
+            result = func(*args, **kwargs)
+            if hasattr(result, "_query_compiler"):
+                if not isinstance(result, Series):
+                    result = result.squeeze(axis=1)
+                result.name = (
+                    self._name if func.__name__ not in self._NO_RENAME_METHODS else None
+                )
+            return result
+
+        name_setter.__name__ = func.__name__
+        return name_setter
+
+    def __getattribute__(self, key):
+        attr = object.__getattribute__(self, key)
+        if not key.startswith("_") and callable(attr):
+            return self._build_series_wrapper(attr)
+        return attr
+
     @property
     def ndim(self):
         return 1  # ndim is always 1 for Series
@@ -1016,7 +1078,8 @@ class SeriesGroupBy(DataFrameGroupBy):
                     Series(
                         query_compiler=self._query_compiler.getitem_row_array(
                             self._index.get_indexer_for(self._index_grouped[k].unique())
-                        )
+                        ),
+                        name=self._name,
                     ),
                 )
                 for k in (sorted(group_ids) if self._sort else group_ids)
@@ -1028,7 +1091,8 @@ class SeriesGroupBy(DataFrameGroupBy):
                     Series(
                         query_compiler=self._query_compiler.getitem_column_array(
                             self._index_grouped[k].unique()
-                        )
+                        ),
+                        name=self._name,
                     ),
                 )
                 for k in (sorted(group_ids) if self._sort else group_ids)

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -1020,8 +1020,8 @@ class SeriesGroupBy(DataFrameGroupBy):
             not isinstance(df, Series),
             f"SeriesGroupBy is supposed to obtain only Series objects, got: {type(df)}",
         )
-        super(SeriesGroupBy, self).__init__(df.to_frame(), *args, **kwargs)
-        self._name = df.name or "__reduced__"
+        self._name = df.name if df.name is not None else "__reduced__"
+        super(SeriesGroupBy, self).__init__(df.to_frame(self._name), *args, **kwargs)
 
     _NO_RENAME_METHODS = ["ngroup"]
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -480,65 +480,9 @@ class DataFrameGroupBy(object):
         )
 
     def size(self):
-        if self._axis == 0:
-            # Series objects in 'by' mean we couldn't handle the case
-            # and transform 'by' to a query compiler.
-            # In this case we are just defaulting to pandas.
-            if is_list_like(self._by) and any(
-                isinstance(o, type(self._df._query_compiler)) for o in self._by
-            ):
-                work_object = DataFrameGroupBy(
-                    self._df,
-                    self._by,
-                    self._axis,
-                    drop=False,
-                    idx_name=None,
-                    squeeze=self._squeeze,
-                    **self._kwargs,
-                )
-                result = work_object._wrap_aggregation(
-                    type(work_object._query_compiler).groupby_size,
-                    lambda df: df.size(),
-                    numeric_only=False,
-                )
-                result = result.__constructor__(
-                    query_compiler=result._query_compiler
-                ).squeeze(axis=1)
-                if isinstance(result, Series):
-                    # Pandas does not name size() output for Series
-                    result.name = None
-                return result
-            work_object = SeriesGroupBy(
-                self._df[self._df.columns[0]]
-                if self._kwargs.get("as_index")
-                else self._df[self._df.columns[0]].to_frame(),
-                self._by,
-                self._axis,
-                drop=False,
-                idx_name=None,
-                squeeze=self._squeeze,
-                **self._kwargs,
-            )
-            result = work_object._wrap_aggregation(
-                type(work_object._query_compiler).groupby_size,
-                lambda df: df.size(),
-                numeric_only=False,
-            )
-            result = result.__constructor__(query_compiler=result._query_compiler)
-            if not self._kwargs.get("as_index") and not isinstance(result, Series):
-                result = result.rename(columns={0: "size"})
-                result = (
-                    result.rename(columns={"__reduced__": "index"})
-                    if "__reduced__" in result.columns
-                    else result
-                )
-            else:
-                # Pandas does not name size() output for Series
-                result.name = None
-            return result.fillna(0)
-        else:
+        if self._axis == 1:
             return DataFrameGroupBy(
-                self._df.T,
+                self._df.T.iloc[:, [0]],
                 self._by,
                 0,
                 drop=self._drop,
@@ -546,6 +490,34 @@ class DataFrameGroupBy(object):
                 squeeze=self._squeeze,
                 **self._kwargs,
             ).size()
+        work_object = DataFrameGroupBy(
+            self._df,
+            self._by,
+            self._axis,
+            drop=False,
+            idx_name=None,
+            squeeze=self._squeeze,
+            **self._kwargs,
+        )
+        result = work_object._wrap_aggregation(
+            type(work_object._query_compiler).groupby_size,
+            lambda df: df.size(),
+            numeric_only=False,
+        )
+        if not isinstance(result, Series):
+            result = result.squeeze(axis=1)
+        if not self._kwargs.get("as_index") and not isinstance(result, Series):
+            result = result.rename(columns={0: "size"})
+            result = (
+                result.rename(columns={"__reduced__": "index"})
+                if "__reduced__" in result.columns
+                else result
+            )
+        elif isinstance(self._df, Series):
+            result.name = self._df.name
+        else:
+            result.name = None
+        return result.fillna(0)
 
     def sum(self, **kwargs):
         return self._wrap_aggregation(

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1314,10 +1314,9 @@ class Series(BasePandasDataset):
     def to_frame(self, name=None):
         from .dataframe import DataFrame
 
-        self_cp = self.copy()
         if name is not None:
-            self_cp.name = name
-        return DataFrame(self_cp)
+            name = [name]
+        return DataFrame(self, columns=name)
 
     def to_list(self):
         return self._default_to_pandas(pandas.Series.to_list)

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1314,9 +1314,10 @@ class Series(BasePandasDataset):
     def to_frame(self, name=None):
         from .dataframe import DataFrame
 
+        self_cp = self.copy()
         if name is not None:
-            name = [name]
-        return DataFrame(self, columns=name)
+            self_cp.name = name
+        return DataFrame(self_cp)
 
     def to_list(self):
         return self._default_to_pandas(pandas.Series.to_list)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -914,6 +914,7 @@ def test_series_groupby(by, as_index_series_or_dataframe):
         eval_max(modin_groupby, pandas_groupby)
         eval_len(modin_groupby, pandas_groupby)
         eval_sum(modin_groupby, pandas_groupby)
+        eval_size(modin_groupby, pandas_groupby)
         eval_ngroup(modin_groupby, pandas_groupby)
         eval_nunique(modin_groupby, pandas_groupby)
         eval_median(modin_groupby, pandas_groupby)


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2811 <!-- issue must be created for each patch -->
- [x] tests added and passing

The original problem was that we were accessing `.columns` field from a grouping object, which is a Series sometimes. ~~Got rid of it by refactoring `groupby.size()`.~~ Now we're converting Series to DataFrame while constructing SeriesGroupBy object to be able to write common logic for DataFrame and Series (which sometimes involves accessing of DataFrame-specific attributes like `.columns`) at the base groupby class