### PR TITLE
FIX-#2747: forward Modin categories to OmniSci

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py
@@ -16,7 +16,6 @@ import sys
 import os
 
 import pyarrow as pa
-import numpy as np
 
 prev = sys.getdlopenflags()
 sys.setdlopenflags(1 | 256)  # RTLD_LAZY+RTLD_GLOBAL
@@ -75,37 +74,6 @@ class OmnisciServer:
     @classmethod
     def put_arrow_to_omnisci(cls, table, name=None):
         name = cls._genName(name)
-
-        # Currently OmniSci doesn't support Arrow table import with
-        # dictionary columns. Here we cast dictionaries until support
-        # is in place.
-        # https://github.com/modin-project/modin/issues/1738
-        schema = table.schema
-        new_schema = schema
-        need_cast = False
-        new_cols = {}
-        # for i, field in enumerate(schema):
-        #     if pa.types.is_dictionary(field.type):
-        #         # Conversion for dictionary of null type to string is not supported
-        #         # in Arrow. Build new column for this case for now.
-        #         if pa.types.is_null(field.type.value_type):
-        #             mask_vals = np.full(table.num_rows, True, dtype=bool)
-        #             mask = pa.array(mask_vals)
-        #             new_col_data = np.empty(table.num_rows, dtype=str)
-        #             new_col = pa.array(new_col_data, pa.string(), mask)
-        #             new_cols[i] = new_col
-        #         else:
-        #             need_cast = True
-        #         new_field = pa.field(
-        #             field.name, pa.string(), field.nullable, field.metadata
-        #         )
-        #         new_schema = new_schema.set(i, new_field)
-
-        for i, col in new_cols.items():
-            table = table.set_column(i, new_schema[i], col)
-
-        if need_cast:
-            table = table.cast(new_schema)
 
         fragment_size = OmnisciFragmentSize.get()
         if fragment_size is None:

--- a/modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py
@@ -84,22 +84,22 @@ class OmnisciServer:
         new_schema = schema
         need_cast = False
         new_cols = {}
-        for i, field in enumerate(schema):
-            if pa.types.is_dictionary(field.type):
-                # Conversion for dictionary of null type to string is not supported
-                # in Arrow. Build new column for this case for now.
-                if pa.types.is_null(field.type.value_type):
-                    mask_vals = np.full(table.num_rows, True, dtype=bool)
-                    mask = pa.array(mask_vals)
-                    new_col_data = np.empty(table.num_rows, dtype=str)
-                    new_col = pa.array(new_col_data, pa.string(), mask)
-                    new_cols[i] = new_col
-                else:
-                    need_cast = True
-                new_field = pa.field(
-                    field.name, pa.string(), field.nullable, field.metadata
-                )
-                new_schema = new_schema.set(i, new_field)
+        # for i, field in enumerate(schema):
+        #     if pa.types.is_dictionary(field.type):
+        #         # Conversion for dictionary of null type to string is not supported
+        #         # in Arrow. Build new column for this case for now.
+        #         if pa.types.is_null(field.type.value_type):
+        #             mask_vals = np.full(table.num_rows, True, dtype=bool)
+        #             mask = pa.array(mask_vals)
+        #             new_col_data = np.empty(table.num_rows, dtype=str)
+        #             new_col = pa.array(new_col_data, pa.string(), mask)
+        #             new_cols[i] = new_col
+        #         else:
+        #             need_cast = True
+        #         new_field = pa.field(
+        #             field.name, pa.string(), field.nullable, field.metadata
+        #         )
+        #         new_schema = new_schema.set(i, new_field)
 
         for i, col in new_cols.items():
             table = table.set_column(i, new_schema[i], col)

--- a/modin/experimental/engines/omnisci_on_ray/frame/partition_manager.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/partition_manager.py
@@ -115,7 +115,20 @@ class OmnisciOnRayFrameManager(RayFrameManager):
             if len(unsupported_cols) > 0:
                 return None, unsupported_cols
 
+            def cast_categories_to_str(obj):
+                cols = [
+                    name
+                    for name, col in obj.dtypes.items()
+                    if isinstance(col, pandas.CategoricalDtype)
+                ]
+                if len(cols):
+                    # Extremely inefficient
+                    obj = obj.astype({col: "str" for col in cols})
+                    obj = obj.astype({col: "category" for col in cols})
+                return obj
+
             try:
+                obj = cast_categories_to_str(obj)
                 at = pyarrow.Table.from_pandas(obj)
             except pyarrow.lib.ArrowTypeError as e:
                 regex = r"Conversion failed for column ([^\W]*)"

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -358,6 +358,14 @@ class TestCSV:
             usecols=usecols,
         )
 
+    def test_read_csv_category(self):
+        eval_io(
+            fn_name="read_csv",
+            # read_csv kwargs
+            filepath_or_buffer=pytest.csvs_names["test_read_csv_regular"],
+            dtype={"col1": "category"},
+        )
+
 
 class TestMasks:
     data = {


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #2747 <!-- issue must be created for each patch -->
- [ ] tests added and passing

OmniSci branch with Arrow 2.0 and enabled support for dictionary encoding: https://github.com/dchigarev/omniscidb/tree/modin_cats