### PR TITLE
Fix Pickle support for DataFrame and Series

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,6 +243,8 @@ jobs:
       - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_window.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
+        run: pytest modin/pandas/test/dataframe/test_pickle.py --backend=${{ matrix.backend }}
+      - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_series.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_rolling.py --backend=${{ matrix.backend }}
@@ -395,6 +397,8 @@ jobs:
       - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_window.py
       - shell: bash -l {0}
+        run: pytest modin/pandas/test/dataframe/test_pickle.py
+      - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_series.py
       - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_rolling.py
@@ -530,6 +534,9 @@ jobs:
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_window.py
+        if: matrix.part == 'DataFrame'
+      - shell: bash -l {0}
+        run: pytest modin/pandas/test/dataframe/test_pickle.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_series.py

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -82,6 +82,8 @@ jobs:
       - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_window.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
+        run: pytest modin/pandas/test/dataframe/test_pickle.py --backend=${{ matrix.backend }}
+      - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_series.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_rolling.py --backend=${{ matrix.backend }}
@@ -177,6 +179,8 @@ jobs:
       - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_window.py
       - shell: bash -l {0}
+        run: pytest modin/pandas/test/dataframe/test_pickle.py
+      - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_series.py
       - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_rolling.py
@@ -249,6 +253,9 @@ jobs:
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
         run: pytest modin/pandas/test/dataframe/test_window.py
+        if: matrix.part == 'DataFrame'
+      - shell: bash -l {0}
+        run: pytest modin/pandas/test/dataframe/test_pickle.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_series.py

--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -159,6 +159,11 @@ class BaseQueryCompiler(abc.ABC):
         # TODO create a way to clean up this object.
         pass
 
+    @abc.abstractmethod
+    def finalize(self):
+        """Finalize constructing the dataframe calling all deferred functions which were used to build it."""
+        pass
+
     # END Data Management Methods
 
     # To/From Pandas

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -201,6 +201,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
         else:
             return result
 
+    def finalize(self):
+        self._modin_frame.finalize()
+
     def to_pandas(self):
         return self._modin_frame.to_pandas()
 

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -282,6 +282,18 @@ class BenchmarkMode(EnvironmentVariable, type=bool):
         super().put(value)
 
 
+class PersistentPickle(EnvironmentVariable, type=bool):
+    """
+    When set to off, it allows faster serialization which is only
+    valid in current run (i.e. useless for saving to disk).
+    When set to on, Modin objects could be saved to disk and loaded
+    but serialization/deserialization could take more time.
+    """
+
+    varname = "MODIN_PERSISTENT_PICKLE"
+    default = False
+
+
 def _check_vars():
     """
     Look out for any environment variables that start with "MODIN_" prefix

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -185,6 +185,9 @@ class TestQC(BaseQueryCompiler):
     def __init__(self, modin_frame):
         self._modin_frame = modin_frame
 
+    def finalize(self):
+        self._modin_frame.finalize()
+
     @classmethod
     def from_pandas(cls, df, data_cls):
         return cls(data_cls.from_pandas(df))

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -2138,7 +2138,7 @@ class BasePandasFrame(object):
     def _materialize(self):
         """
         Perform all deferred calls on partitions.
-        
+
         This makes the dataframe independent of history of queries
         that were used to build it.
         """

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -2135,11 +2135,11 @@ class BasePandasFrame(object):
             dtypes=new_dtypes,
         )
 
-    def _materialize(self):
+    def finalize(self):
         """
         Perform all deferred calls on partitions.
 
-        This makes the dataframe independent of history of queries
+        This makes the Frame independent of history of queries
         that were used to build it.
         """
         [part.drain_call_queue() for row in self._partitions for part in row]

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -2134,3 +2134,10 @@ class BasePandasFrame(object):
             self._row_lengths,
             dtypes=new_dtypes,
         )
+
+    def _materialize(self):
+        """
+        Perform all deferred calls, so that the dataframe
+        is made independent of history of queries that were used to build it.
+        """
+        [part.drain_call_queue() for row in self._partitions for part in row]

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -2137,7 +2137,9 @@ class BasePandasFrame(object):
 
     def _materialize(self):
         """
-        Perform all deferred calls, so that the dataframe
-        is made independent of history of queries that were used to build it.
+        Perform all deferred calls on partitions.
+        
+        This makes the dataframe independent of history of queries
+        that were used to build it.
         """
         [part.drain_call_queue() for row in self._partitions for part in row]

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -88,6 +88,10 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         self._modin_frame = frame
         self._shape_hint = shape_hint
 
+    def finalize():
+        # TODO: implement this for OmniSci backend
+        raise NotImplementedError()
+
     def to_pandas(self):
         return self._modin_frame.to_pandas()
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -64,6 +64,33 @@ sentinel = object()
 # special purposes, like serving remote context
 _ATTRS_NO_LOOKUP = {"____id_pack__", "__name__"}
 
+_DEFAULT_BEHAVIOUR = {
+    "__init__",
+    "__class__",
+    "_get_index",
+    "_set_index",
+    "empty",
+    "index",
+    "columns",
+    "name",
+    "dtypes",
+    "dtype",
+    "_get_name",
+    "_set_name",
+    "_default_to_pandas",
+    "_query_compiler",
+    "_to_pandas",
+    "_build_repr_df",
+    "_reduce_dimension",
+    "__repr__",
+    "__len__",
+    "_create_or_update_from_compiler",
+    "_update_inplace",
+    # for persistance
+    "_inflate",
+    "__reduce__",
+} | _ATTRS_NO_LOOKUP
+
 
 class BasePandasDataset(object):
     """
@@ -2795,30 +2822,7 @@ class BasePandasDataset(object):
         return self.to_numpy()
 
     def __getattribute__(self, item):
-        default_behaviors = {
-            "__init__",
-            "__class__",
-            "_get_index",
-            "_set_index",
-            "empty",
-            "index",
-            "columns",
-            "name",
-            "dtypes",
-            "dtype",
-            "_get_name",
-            "_set_name",
-            "_default_to_pandas",
-            "_query_compiler",
-            "_to_pandas",
-            "_build_repr_df",
-            "_reduce_dimension",
-            "__repr__",
-            "__len__",
-            "_create_or_update_from_compiler",
-            "_update_inplace",
-        } | _ATTRS_NO_LOOKUP
-        if item not in default_behaviors and not self._query_compiler.lazy_execution:
+        if item not in _DEFAULT_BEHAVIOUR and not self._query_compiler.lazy_execution:
             method = object.__getattribute__(self, item)
             is_callable = callable(method)
             # We default to pandas on empty DataFrames. This avoids a large amount of

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -89,7 +89,7 @@ _DEFAULT_BEHAVIOUR = {
     # for persistance support;
     # see DataFrame methods docstrings for more
     "_inflate_light",
-    "_inflate_full"
+    "_inflate_full",
     "__reduce__",
 } | _ATTRS_NO_LOOKUP
 
@@ -2752,9 +2752,6 @@ class BasePandasDataset(object):
         if key.start is None and key.stop is None:
             return self.copy()
         return self.iloc[key]
-
-    def __getstate__(self):
-        return self._default_to_pandas("__getstate__")
 
     def __gt__(self, right):
         return self.gt(right)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -86,8 +86,10 @@ _DEFAULT_BEHAVIOUR = {
     "__len__",
     "_create_or_update_from_compiler",
     "_update_inplace",
-    # for persistance
-    "_inflate",
+    # for persistance support;
+    # see DataFrame methods docstrings for more
+    "_inflate_light",
+    "_inflate_full"
     "__reduce__",
 } | _ATTRS_NO_LOOKUP
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2425,6 +2425,7 @@ class DataFrame(BasePandasDataset):
         return cls(query_compiler=query_compiler)
 
     def __reduce__(self):
+        self._query_compiler._modin_frame._materialize()
         return self._inflate, (self._query_compiler,)
 
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2094,9 +2094,6 @@ class DataFrame(BasePandasDataset):
     def __round__(self, decimals=0):
         return self._default_to_pandas(pandas.DataFrame.__round__, decimals=decimals)
 
-    def __setstate__(self, state):
-        return self._default_to_pandas(pandas.DataFrame.__setstate__, state)
-
     def __delitem__(self, key):
         if key not in self:
             raise KeyError(key)
@@ -2421,16 +2418,14 @@ class DataFrame(BasePandasDataset):
     def _inflate_light(cls, query_compiler):
         """
         Re-creates the object from previously-serialized lightweight representation.
+
         The method is used for faster but not disk-storable persistence.
         """
         return cls(query_compiler=query_compiler)
 
     @classmethod
     def _inflate_full(cls, pandas_df):
-        """
-        Re-creates the object from previously-serialized disk-storable
-        representation.
-        """
+        """Re-creates the object from previously-serialized disk-storable representation."""
         return cls(data=from_pandas(pandas_df))
 
     def __reduce__(self):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2429,7 +2429,7 @@ class DataFrame(BasePandasDataset):
         return cls(data=from_pandas(pandas_df))
 
     def __reduce__(self):
-        self._query_compiler._modin_frame._materialize()
+        self._query_compiler.finalize()
         if PersistentPickle.get():
             return self._inflate_full, (self._to_pandas(),)
         return self._inflate_light, (self._query_compiler,)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2416,6 +2416,17 @@ class DataFrame(BasePandasDataset):
         else:
             return self._getitem_column(key)
 
+    # persistance support
+    @classmethod
+    def _inflate(cls, query_compiler):
+        """
+        Creates the object from previously-serialized representation
+        """
+        return cls(query_compiler=query_compiler)
+
+    def __reduce__(self):
+        return self._inflate, (self._query_compiler,)
+
 
 if IsExperimental.get():
     from modin.experimental.cloud.meta_magic import make_wrapped_class

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2413,7 +2413,7 @@ class DataFrame(BasePandasDataset):
         else:
             return self._getitem_column(key)
 
-    # persistance support
+    # Persistance support methods - BEGIN
     @classmethod
     def _inflate_light(cls, query_compiler):
         """
@@ -2433,6 +2433,8 @@ class DataFrame(BasePandasDataset):
         if PersistentPickle.get():
             return self._inflate_full, (self._to_pandas(),)
         return self._inflate_light, (self._query_compiler,)
+
+    # Persistance support methods - END
 
 
 if IsExperimental.get():

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1743,7 +1743,7 @@ class Series(BasePandasDataset):
         return cls(data=pandas_series)
 
     def __reduce__(self):
-        self._query_compiler._modin_frame._materialize()
+        self._query_compiler.finalize()
         if PersistentPickle.get():
             return self._inflate_full, (self._to_pandas(),)
         return self._inflate_light, (self._query_compiler, self.name)

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1734,6 +1734,14 @@ class Series(BasePandasDataset):
             return self._reduce_dimension(result)
         return self.__constructor__(query_compiler=result)
 
+    @classmethod
+    def _inflate(cls, query_compiler, name):
+        return cls(query_compiler=query_compiler, name=name)
+
+    def __reduce__(self):
+        self._query_compiler._modin_frame._materialize()
+        return self._inflate, (self._query_compiler, self.name)
+
 
 if IsExperimental.get():
     from modin.experimental.cloud.meta_magic import make_wrapped_class

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1734,6 +1734,7 @@ class Series(BasePandasDataset):
             return self._reduce_dimension(result)
         return self.__constructor__(query_compiler=result)
 
+    # Persistance support methods - BEGIN
     @classmethod
     def _inflate_light(cls, query_compiler, name):
         return cls(query_compiler=query_compiler, name=name)
@@ -1747,6 +1748,8 @@ class Series(BasePandasDataset):
         if PersistentPickle.get():
             return self._inflate_full, (self._to_pandas(),)
         return self._inflate_light, (self._query_compiler, self.name)
+
+    # Persistance support methods - END
 
 
 if IsExperimental.get():

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -62,7 +62,6 @@ matplotlib.use("Agg")
         ("lookup", lambda df: {"row_labels": [0], "col_labels": ["int_col"]}),
         ("mask", lambda df: {"cond": df != 0}),
         ("pct_change", None),
-        ("__getstate__", None),
         ("to_xarray", None),
         ("flags", None),
         ("set_flags", lambda df: {"allows_duplicate_labels": False}),
@@ -86,15 +85,6 @@ def test_style():
     data = test_data_values[0]
     with pytest.warns(UserWarning):
         pd.DataFrame(data).style
-
-
-def test___setstate__():
-    data = test_data_values[0]
-    with pytest.warns(UserWarning):
-        try:
-            pd.DataFrame(data).__setstate__(None)
-        except TypeError:
-            pass
 
 
 def test_to_timestamp():

--- a/modin/pandas/test/dataframe/test_pickle.py
+++ b/modin/pandas/test/dataframe/test_pickle.py
@@ -13,6 +13,7 @@
 
 import pytest
 import pickle
+import numpy as np
 
 import modin.pandas as pd
 from modin.config import PersistentPickle
@@ -22,7 +23,7 @@ from modin.pandas.test.utils import df_equals
 
 @pytest.fixture
 def modin_df():
-    return pd.DataFrame({"col1": [1, 2, 3], "col2": [3, 4, 5]})
+    return pd.DataFrame({"col1": np.arange(1000), "col2": np.arange(2000, 3000)})
 
 
 @pytest.fixture
@@ -48,4 +49,6 @@ def test_column_pickle(modin_column, modin_df, persistent):
     other = pickle.loads(dmp)
     df_equals(modin_column.to_frame(), other.to_frame())
 
-    assert len(dmp) < len(pickle.dumps(modin_df))
+    # make sure we don't pickle the whole frame if doing persistent storage
+    if persistent:
+        assert len(dmp) < len(pickle.dumps(modin_df))

--- a/modin/pandas/test/dataframe/test_pickle.py
+++ b/modin/pandas/test/dataframe/test_pickle.py
@@ -1,0 +1,51 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pytest
+import pickle
+
+import modin.pandas as pd
+from modin.config import PersistentPickle
+
+from modin.pandas.test.utils import df_equals
+
+
+@pytest.fixture
+def modin_df():
+    return pd.DataFrame({"col1": [1, 2, 3], "col2": [3, 4, 5]})
+
+
+@pytest.fixture
+def modin_column(modin_df):
+    return modin_df["col1"]
+
+
+@pytest.fixture(params=[True, False])
+def persistent(request):
+    old = PersistentPickle.get()
+    PersistentPickle.put(request.param)
+    yield request.param
+    PersistentPickle.put(old)
+
+
+def test_dataframe_pickle(modin_df, persistent):
+    other = pickle.loads(pickle.dumps(modin_df))
+    df_equals(modin_df, other)
+
+
+def test_column_pickle(modin_column, modin_df, persistent):
+    dmp = pickle.dumps(modin_column)
+    other = pickle.loads(dmp)
+    df_equals(modin_column.to_frame(), other.to_frame())
+
+    assert len(dmp) < len(pickle.dumps(modin_df))

--- a/modin/test/test_backends_api.py
+++ b/modin/test/test_backends_api.py
@@ -23,6 +23,7 @@ def test_base_abstract_methods():
     allowed_abstract_methods = [
         "__init__",
         "free",
+        "finalize",
         "to_pandas",
         "from_pandas",
         "from_arrow",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
* Fix Pickle support for Modin `DataFrame` and `Series` by implementing `__reduce__` protocol (ref: [Python docs](https://docs.python.org/3/library/pickle.html#object.__reduce__))
* Add new protected method `_materialize` to Modin Frame which makes sure all deferred functions for each partition are executed
* Add configuration variable `PersistentPickle` that controls how objects are pickled (backed by `MODIN_PERSISTENT_PICKLE` environment variable): in light mode we store all internals (like partitions), which should be faster for e.g. huge distributed DataFrames (we'll store just arrays of `Ray.ObjectIDs` instead of full data), in full mode it is possible to save pickled objects to disk and restore them in other Modin session but it is slower because we pull in all the data to the driver process
* Extract the construction of the set of default attributes to a global variable - slightly speeds up `__getattribute__` _(unrelated to the PR but small enough so I hope to make it through)_

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #672 (and potentially some more)
- [x] tests added and passing
