### PR TITLE
Re-enable TestExcel::test_read_excel

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1279,7 +1279,6 @@ class TestJson:
 
 
 class TestExcel:
-    @pytest.mark.xfail(reason="read_excel is broken for now, see #1733 for details")
     @check_file_leaks
     def test_read_excel(self):
         unique_filename = get_unique_filename(extension="xlsx")


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
I suspect the original issue had the same root cause as #2404 which I had earlier fixed by #2526, so #1733 should be fixed as well.
I'm now just enabling the test, as it passes fine on my local machine anyway.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1733
- [x] tests added and passing
