### PR TITLE
Workaround for libthrift issues in CI

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,6 +5,7 @@ dependencies:
   - pandas==1.2.3
   - numpy>=1.16.5,<1.20  # pandas gh-39513
   - pyarrow>=1.0.0
+  - libthrift<0.14.1  # ref: modin gh-2840
   - dask[complete]>=2.12.0,<=2.19.0
   - distributed>=2.12.0,<=2.19.0
   - xarray

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -5,6 +5,7 @@ channels:
 dependencies:
   - pandas==1.2.3
   - pyarrow==2.0.0
+  - libthrift<0.14.1  # ref: modin gh-2840
   - numpy>=1.16.5
   - pip
   - pytest>=6.0.1


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Manually pin `libthrift` to `0.14.0` as required by current `arrow` builds in conda-forge.
Should not be needed in a day or two when updated `arrow` and `thrift` packages are ready, so we may want to revert it after they fix the dependencies.

The main reasoning behind this (temporary) PR is to unblock the "red CI".

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2840
- [ ] tests added and passing
