### PR TITLE
REFACTOR-#2853: Add support of drop-in replacement of xgboost

### DIFF
--- a/docs/modin_xgboost.rst
+++ b/docs/modin_xgboost.rst
@@ -22,32 +22,25 @@ XGBoost Train and Predict
 -------------------------
 
 Distributed XGBoost functionality is placed in ``modin.experimental.xgboost`` module.
-``modin.experimental.xgboost`` provides a xgboost-like API for ``train`` and ``predict`` functions.
+``modin.experimental.xgboost`` provides a drop-in replacement API for ``train`` and ``Booster.predict`` xgboost functions.
 
 .. automodule:: modin.experimental.xgboost
   :members: train
 
-``train`` has all arguments of the ``xgboost.train`` function except for ``evals_result``
-parameter which is returned as part of function return value instead of argument.
-
-.. automodule:: modin.experimental.xgboost
-  :noindex:
+.. autoclass:: modin.experimental.xgboost.Booster
   :members: predict
-
-``predict`` is similar to ``xgboost.Booster.predict`` with an additional argument,
-``model``.
 
 
 ModinDMatrix
 ------------
 
-Data is passed to ``modin.experimental.xgboost`` functions via a ``ModinDMatrix`` object.
+Data is passed to ``modin.experimental.xgboost`` functions via a Modin ``DMatrix`` object.
 
 .. automodule:: modin.experimental.xgboost
   :noindex:
-  :members: ModinDMatrix
+  :members: DMatrix
 
-Currently, the ``ModinDMatrix`` supports ``modin.pandas.DataFrame`` only as an input.
+Currently, the Modin ``DMatrix`` supports ``modin.pandas.DataFrame`` only as an input.
 
 
 A Single Node / Cluster setup
@@ -95,9 +88,9 @@ All processing will be in a `single node` mode.
   X = pd.DataFrame(iris.data)
   y = pd.DataFrame(iris.target)
   
-  # Create ModinDMatrix
-  dtrain = xgb.ModinDMatrix(X, y)
-  dtest = xgb.ModinDMatrix(X, y)
+  # Create DMatrix
+  dtrain = xgb.DMatrix(X, y)
+  dtest = xgb.DMatrix(X, y)
   
   # Set training parameters
   xgb_params = {
@@ -109,20 +102,27 @@ All processing will be in a `single node` mode.
   }
   steps = 20
   
+  # Create dict for evaluation results
+  evals_result = dict()
+  
   # Run training
   model = xgb.train(
       xgb_params,
       dtrain,
       steps,
-      evals=[(dtrain, "train")]
+      evals=[(dtrain, "train")],
+      evals_result=evals_result
   )
   
-  # Save for some usage
-  evals_result = model["history"]
-  booster = model["booster"]
+  # Print evaluation results
+  print(f'Evals results:\n{evals_result}')
   
   # Predict results
-  prediction = xgb.predict(model, dtest)
+  prediction = model.predict(dtest)
+  
+  # Print prediction results
+  print(f'Prediction results:\n{prediction}')
+
 
 
 .. _Dataframe: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.html

--- a/modin/experimental/xgboost/__init__.py
+++ b/modin/experimental/xgboost/__init__.py
@@ -11,6 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from .xgboost import ModinDMatrix, train, predict
+from .xgboost import DMatrix, Booster, train
 
-__all__ = ["ModinDMatrix", "train", "predict"]
+__all__ = ["DMatrix", "Booster", "train"]

--- a/modin/experimental/xgboost/test/test_default.py
+++ b/modin/experimental/xgboost/test/test_default.py
@@ -16,15 +16,15 @@ import pytest
 from modin.config import Engine
 
 import modin.experimental.xgboost as xgb
+import modin.pandas as pd
 
 
 @pytest.mark.skipif(
     Engine.get() == "Ray",
     reason="This test doesn't make sense on Ray backend.",
 )
-@pytest.mark.parametrize("func", ["train", "predict"])
-def test_backend(func):
+def test_backend():
     try:
-        getattr(xgb, func)({}, xgb.ModinDMatrix(None, None))
+        xgb.train({}, xgb.DMatrix(pd.DataFrame([0]), pd.DataFrame([0])))
     except ValueError:
         pass


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

This refactoring makes possible of using Modin XGBoost instead of classic xgboost by one-line code changes.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2853  <!-- issue must be created for each patch -->
- [x] tests added and passing
