### PR TITLE
Fix defaulting to Pandas for empty Modin objects

### DIFF
--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -141,6 +141,14 @@ def make_wrapped_class(local_cls: type, rpyc_wrapper_name: str):
         """
         Define a __new__() with a __class__ that is closure-bound, needed for super() to work
         """
+        # update '__class__' magic closure value - used by super()
+        for attr in __class__.__dict__.values():
+            if not callable(attr):
+                continue
+            cells = getattr(attr, "__closure__", None) or ()
+            for cell in cells:
+                if cell.cell_contents is local_cls:
+                    cell.cell_contents = __class__
 
         def __new__(cls, *a, **kw):
             if cls is result and cls.__real_cls__ is not result:

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -71,6 +71,7 @@ _DEFAULT_BEHAVIOUR = {
     "_get_index",
     "_set_index",
     "_pandas_class",
+    "_get_axis_number",
     "empty",
     "index",
     "columns",
@@ -458,29 +459,10 @@ class BasePandasDataset(object):
             except TypeError:
                 return result
 
-    def _get_axis_number(self, axis):
-        """
-        Implement [METHOD_NAME].
-
-        TODO: Add more details for this docstring template.
-
-        Parameters
-        ----------
-        What arguments does this function have.
-        [
-        PARAMETER_NAME: PARAMETERS TYPES
-            Description.
-        ]
-
-        Returns
-        -------
-        What this returns (if anything)
-        """
-        return (
-            getattr(self._pandas_class)()._get_axis_number(axis)
-            if axis is not None
-            else 0
-        )
+    @classmethod
+    def _get_axis_number(cls, axis):
+        """Convert axis name or number to axis number."""
+        return cls._pandas_class._get_axis_number(axis) if axis is not None else 0
 
     def __constructor__(self, *args, **kwargs):
         """Construct DataFrame or Series object depending on self type."""

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -461,7 +461,18 @@ class BasePandasDataset(object):
 
     @classmethod
     def _get_axis_number(cls, axis):
-        """Convert axis name or number to axis number."""
+        """
+        Convert axis name or number to axis index.
+
+        Parameters
+        ----------
+        axis: int, str
+            Axis name ('index' or 'columns') or number to be converted to axis index.
+
+        Returns
+        -------
+        Axis index in the array of axes stored in the dataframe.
+        """
         return cls._pandas_class._get_axis_number(axis) if axis is not None else 0
 
     def __constructor__(self, *args, **kwargs):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -37,6 +37,7 @@ from pandas.core.dtypes.common import (
 )
 import pandas.core.window.rolling
 import pandas.core.resample
+import pandas.core.generic
 from pandas.core.indexing import convert_to_index_sliceable
 from pandas.util._validators import validate_bool_kwarg, validate_percentile
 from pandas._libs.lib import no_default
@@ -69,6 +70,7 @@ _DEFAULT_BEHAVIOUR = {
     "__class__",
     "_get_index",
     "_set_index",
+    "_pandas_class",
     "empty",
     "index",
     "columns",
@@ -102,6 +104,10 @@ class BasePandasDataset(object):
     are the same, we use this object to define the general behavior of those objects
     and then use those objects to define the output type.
     """
+
+    # Pandas class that we pretend to be; usually it has the same name as our class
+    # but lives in "pandas" namespace.
+    _pandas_class = pandas.core.generic.NDFrame
 
     # Siblings are other objects that share the same query compiler. We use this list
     # to update inplace when there is a shallow copy.
@@ -348,7 +354,7 @@ class BasePandasDataset(object):
             # Broadcast is an internally used argument
             kwargs.pop("broadcast", None)
             return self._default_to_pandas(
-                getattr(getattr(pandas, type(self).__name__), op), other, **kwargs
+                getattr(self._pandas_class, op), other, **kwargs
             )
         other = self._validate_other(other, axis, numeric_or_object_only=True)
         exclude_list = [
@@ -403,9 +409,7 @@ class BasePandasDataset(object):
             # it is a DataFrame, Series, etc.) as a pandas object. The outer `getattr`
             # will get the operation (`op`) from the pandas version of the class and run
             # it on the object after we have converted it to pandas.
-            result = getattr(getattr(pandas, type(self).__name__), op)(
-                pandas_obj, *args, **kwargs
-            )
+            result = getattr(self._pandas_class, op)(pandas_obj, *args, **kwargs)
         else:
             ErrorMessage.catch_bugs_and_request_email(
                 failure_condition=True,
@@ -473,7 +477,7 @@ class BasePandasDataset(object):
         What this returns (if anything)
         """
         return (
-            getattr(pandas, type(self).__name__)()._get_axis_number(axis)
+            getattr(self._pandas_class)()._get_axis_number(axis)
             if axis is not None
             else 0
         )
@@ -2730,7 +2734,7 @@ class BasePandasDataset(object):
             and (not hasattr(self, "columns") or key not in self.columns)
         ):
             indexer = convert_to_index_sliceable(
-                getattr(pandas, "DataFrame")(index=self.index), key
+                pandas.DataFrame(index=self.index), key
             )
         if indexer is not None:
             return self._getitem_slice(indexer)
@@ -2824,19 +2828,18 @@ class BasePandasDataset(object):
         return self.to_numpy()
 
     def __getattribute__(self, item):
+        attr = super().__getattribute__(item)
         if item not in _DEFAULT_BEHAVIOUR and not self._query_compiler.lazy_execution:
-            method = object.__getattribute__(self, item)
-            is_callable = callable(method)
             # We default to pandas on empty DataFrames. This avoids a large amount of
             # pain in underlying implementation and returns a result immediately rather
             # than dealing with the edge cases that empty DataFrames have.
-            if is_callable and self.empty:
+            if callable(attr) and self.empty and hasattr(self._pandas_class, item):
 
                 def default_handler(*args, **kwargs):
                     return self._default_to_pandas(item, *args, **kwargs)
 
                 return default_handler
-        return object.__getattribute__(self, item)
+        return attr
 
 
 if IsExperimental.get():

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -59,6 +59,8 @@ from .accessor import CachedAccessor, SparseFrameAccessor
 
 @_inherit_docstrings(pandas.DataFrame, excluded=[pandas.DataFrame.__init__])
 class DataFrame(BasePandasDataset):
+    _pandas_class = pandas.DataFrame
+
     def __init__(
         self,
         data=None,

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -47,6 +47,8 @@ from . import _update_engine
 
 @_inherit_docstrings(pandas.Series, excluded=[pandas.Series.__init__])
 class Series(BasePandasDataset):
+    _pandas_class = pandas.Series
+
     def __init__(
         self,
         data=None,

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -711,3 +711,13 @@ def test_default_to_pandas_warning_message(func, regex):
 
     with pytest.warns(UserWarning, match=regex):
         func(df)
+
+
+def test_empty_dataframe():
+    df = pd.DataFrame(columns=["a", "b"])
+    df[(df.a == 1) & (df.b == 2)]
+
+
+def test_empty_series():
+    s = pd.Series([])
+    pd.to_numeric(s)


### PR DESCRIPTION
## What do these changes do?
* Fix defaulting to Pandas for empty Modin objects - only default if Pandas class we mimick has the attribute being called
* Allow potential renaming (or inheritance) of mimicking classes by introducing `._pandas_class` class attribute
* Slightly improve `_get_axis_number()` (plus add proper docstring to it)

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2839
- [x] Resolves #2833
- [x] tests added and passing
