### PR TITLE
FIX-#2871: fix 'value_counts' benchmarks

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -394,30 +394,17 @@ class TimeFillna:
 
 
 class BaseTimeValueCounts:
-    subset_params = {
-        "all": lambda shape: shape[1],
-        "half": lambda shape: shape[1] // 2,
-    }
-
-    def setup(self, shape, ngroups=5, subset="all"):
-        try:
-            subset = self.subset_params[subset]
-        except KeyError:
-            raise KeyError(
-                f"Invalid value for 'subset={subset}'. Allowed: {list(self.subset_params.keys())}"
-            )
-        ncols = subset(shape)
+    def setup(self, shape, ngroups=5, subset=1):
         ngroups = translator_groupby_ngroups(ngroups, shape)
-        self.df, _ = generate_dataframe(
+        self.df, self.subset = generate_dataframe(
             ASV_USE_IMPL,
             "int",
             *shape,
             RAND_LOW,
             RAND_HIGH,
-            groupby_ncols=ncols,
+            groupby_ncols=subset,
             count_groups=ngroups,
         )
-        self.subset = self.df.columns[:ncols].tolist()
 
 
 class TimeValueCountsFrame(BaseTimeValueCounts):
@@ -425,7 +412,7 @@ class TimeValueCountsFrame(BaseTimeValueCounts):
     params = [
         UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
         GROUPBY_NGROUPS[ASV_DATASET_SIZE],
-        ["all", "half"],
+        [2, 10],
     ]
 
     def time_value_counts(self, *args, **kwargs):
@@ -442,7 +429,7 @@ class TimeValueCountsSeries(BaseTimeValueCounts):
 
     def setup(self, shape, ngroups, bins):
         super().setup(ngroups=ngroups, shape=shape)
-        self.df = self.df.iloc[:, 0]
+        self.df = self.df[self.subset[0]]
 
     def time_value_counts(self, shape, ngroups, bins):
         execute(self.df.value_counts(bins=bins))


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2871 <!-- issue must be created for each patch -->
- [ ] tests passing

Motivation for these changes described in #2871.
