### PR TITLE
FIX-#2882: Set timeout for IO tests on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,6 +557,7 @@ jobs:
         run: python -m pytest modin/pandas/test/test_general.py
         if: matrix.part == 3
       - shell: bash -l {0}
+        timeout-minutes: 20
         run: python -m pytest modin/pandas/test/test_io.py
         if: matrix.part == 3
       - shell: bash -l {0}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -276,6 +276,7 @@ jobs:
         run: python -m pytest modin/pandas/test/test_general.py
         if: matrix.part == 3
       - shell: bash -l {0}
+        timeout-minutes: 20
         run: python -m pytest modin/pandas/test/test_io.py
         if: matrix.part == 3
       - shell: bash -l {0}


### PR DESCRIPTION
Signed-off-by: Igoshev, Yaroslav <yaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2882  <!-- issue must be created for each patch -->
- [x] tests passing
