### PR TITLE
FIX-#2073: Fix column names when `parse_dates` is enabled

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -459,21 +459,7 @@ class TestCsv:
 
     # Datetime Handling tests
     @pytest.mark.parametrize(
-        "parse_dates",
-        [
-            True,
-            False,
-            ["col2"],
-            ["col2", "col4"],
-            [1, 3],
-            pytest.param(
-                {"foo": ["col2", "col4"]},
-                marks=pytest.mark.xfail(
-                    Engine.get() != "Python",
-                    reason="Exception: Internal Error - issue #2073",
-                ),
-            ),
-        ],
+        "parse_dates", [True, False, ["col2"], ["col2", "col4"], [1, 3]]
     )
     @pytest.mark.parametrize("infer_datetime_format", [True, False])
     @pytest.mark.parametrize("keep_date_col", [True, False])


### PR DESCRIPTION
Resolves #2073

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2073 <!-- issue must be created for each patch -->
- [x] tests enabled ~added~ and passing
