### PR TITLE
FIX-#2885: Allow level=-1 for non-multiindex in any/all

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -616,7 +616,7 @@ class BasePandasDataset(object):
                     )
                 if (
                     not self._query_compiler.has_multiindex(axis=axis)
-                    and level != 0
+                    and (level > 0 or level < -1)
                     and level != self.index.name
                 ):
                     raise ValueError(
@@ -671,7 +671,7 @@ class BasePandasDataset(object):
                     )
                 if (
                     not self._query_compiler.has_multiindex(axis=axis)
-                    and level != 0
+                    and (level > 0 or level < -1)
                     and level != self.index.name
                 ):
                     raise ValueError(

--- a/modin/pandas/test/dataframe/test_udf.py
+++ b/modin/pandas/test/dataframe/test_udf.py
@@ -113,36 +113,7 @@ def test_apply_type_error(func):
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("level", [None, -1, 0, 1])
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-@pytest.mark.parametrize(
-    "func",
-    [
-        "kurt",
-        pytest.param(
-            "count",
-            marks=pytest.mark.xfail(
-                reason="count method handle level parameter incorrectly"
-            ),
-        ),
-        pytest.param(
-            "sum",
-            marks=pytest.mark.xfail(
-                reason="sum method handle level parameter incorrectly"
-            ),
-        ),
-        pytest.param(
-            "mean",
-            marks=pytest.mark.xfail(
-                reason="mean method handle level parameter incorrectly"
-            ),
-        ),
-        pytest.param(
-            "all",
-            marks=pytest.mark.xfail(
-                reason="all method handle level parameter incorrectly"
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("func", ["kurt", "count", "sum", "mean", "all", "any"])
 def test_apply_text_func_with_level(level, data, func, axis):
     func_kwargs = {"level": level, "axis": axis}
     rows_number = len(next(iter(data.values())))  # length of the first data column


### PR DESCRIPTION
Resolves #2885

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2885 <!-- issue must be created for each patch -->
- [x] tests enabled ~added~ and passing
