### PR TITLE
FIX-#2887: Match pandas error message on `Series.sum`

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1249,6 +1249,8 @@ class Series(BasePandasDataset):
         **kwargs,
     ):
         axis = self._get_axis_number(axis)
+        if numeric_only is True:
+            raise NotImplementedError("Series.sum does not implement numeric_only")
         if level is not None:
             if (
                 not self._query_compiler.has_multiindex(axis=axis)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3059,19 +3059,7 @@ def test_subtract(data):
 @pytest.mark.parametrize(
     "skipna", bool_arg_values, ids=arg_keys("skipna", bool_arg_keys)
 )
-@pytest.mark.parametrize(
-    "numeric_only",
-    [
-        None,
-        False,
-        pytest.param(
-            True,
-            marks=pytest.mark.xfail(
-                reason="numeric_only not implemented for pandas.Series"
-            ),
-        ),
-    ],
-)
+@pytest.mark.parametrize("numeric_only", [None, False, True])
 @pytest.mark.parametrize(
     "min_count", int_arg_values, ids=arg_keys("min_count", int_arg_keys)
 )


### PR DESCRIPTION
Resolves #2887

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2887 <!-- issue must be created for each patch -->
- [x] tests enabled~added~ and passing
