### PR TITLE
Added performance improve to dataframe.py __insert__ to use iloc and …

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -967,10 +967,8 @@ class DataFrame(BasePandasDataset):
             if loc < 0:
                 raise ValueError("unbounded slice")
             if isinstance(value, Series):
-                value = value._query_compiler
-            new_query_compiler = self._query_compiler.insert(loc, column, value)
-
-        self._update_inplace(new_query_compiler=new_query_compiler)
+                new_frame = pandas.concat(self.to_pandas().iloc[:, :loc], pandas.DataFrame({column: value}), self.to_pandas().iloc[:, loc], axis=1)
+        self._update_inplace(new_query_compiler=new_frame.from_pandas()._query_compiler)
 
     def interpolate(
         self,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -942,11 +942,11 @@ class DataFrame(BasePandasDataset):
                     )
             new_index = value.index.copy()
             new_columns = self.columns.insert(loc, column)
-            new_query_compiler = DataFrame(
+            new_frame = DataFrame(
                 value, index=new_index, columns=new_columns
             )._query_compiler
         elif len(self.columns) == 0 and loc == 0:
-            new_query_compiler = DataFrame(
+            new_frame = DataFrame(
                 data=value, columns=[column], index=self.index
             )._query_compiler
         else:
@@ -967,7 +967,12 @@ class DataFrame(BasePandasDataset):
             if loc < 0:
                 raise ValueError("unbounded slice")
             if isinstance(value, Series):
-                new_frame = pandas.concat(self.to_pandas().iloc[:, :loc], pandas.DataFrame({column: value}), self.to_pandas().iloc[:, loc], axis=1)
+                new_frame = pandas.concat(
+                    self.to_pandas().iloc[:, :loc],
+                    pandas.DataFrame({column: value}),
+                    self.to_pandas().iloc[:, loc],
+                    axis=1,
+                )
         self._update_inplace(new_query_compiler=new_frame.from_pandas()._query_compiler)
 
     def interpolate(


### PR DESCRIPTION
Enhancement: Rewriting insert to use apply_func_to_select_indices instead of apply_func_to_select_indices_along_full_axis #670

…pd.concat instead of query compiler

Signed-off-by: DayneSorvisto <daynesorvisto@yahoo.ca>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
