### PR TITLE
FEAT-2787: implement true/false_values for read_csv with OmniSci backend

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/io.py
+++ b/modin/experimental/engines/omnisci_on_ray/io.py
@@ -189,8 +189,13 @@ class OmnisciOnRayIO(RayIO):
                 check_utf8=None,
                 column_types=column_types,
                 null_values=None,
-                true_values=None,
-                false_values=None,
+                # we need to add default true/false_values like Pandas does
+                true_values=true_values + ["TRUE", "True", "true"]
+                if true_values is not None
+                else true_values,
+                false_values=false_values + ["False", "FALSE", "false"]
+                if false_values is not None
+                else false_values,
                 # timestamp fields should be handled as strings if parse_dates
                 # didn't passed explicitly as an array or a dict
                 timestamp_parsers=[""] if isinstance(parse_dates, bool) else None,

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -358,6 +358,23 @@ class TestCSV:
             usecols=usecols,
         )
 
+    # General Parsing Configuration
+    @pytest.mark.parametrize("true_values", [["Yes"], ["Yes", "true"], None])
+    @pytest.mark.parametrize("false_values", [["No"], ["No", "false"], None])
+    def test_read_csv_parsing(
+        self,
+        true_values,
+        false_values,
+    ):
+        eval_io(
+            fn_name="read_csv",
+            md_extra_kwargs={"engine": "arrow"},
+            # read_csv kwargs
+            filepath_or_buffer=pytest.csvs_names["test_read_csv_yes_no"],
+            true_values=true_values,
+            false_values=false_values,
+        )
+
 
 class TestMasks:
     data = {


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #2787  <!-- issue must be created for each patch -->
- [ ] tests added and passing
