### PR TITLE
FIX-#2936: Improve performance of Modin XGBoost 

### DIFF
--- a/modin/experimental/xgboost/test/test_default.py
+++ b/modin/experimental/xgboost/test/test_default.py
@@ -23,6 +23,10 @@ import modin.pandas as pd
     Engine.get() == "Ray",
     reason="This test doesn't make sense on Ray backend.",
 )
+@pytest.mark.skipif(
+    Engine.get() == "Python",
+    reason="This test doesn't make sense on not distributed backend (see issue #2938).",
+)
 def test_backend():
     try:
         xgb.train({}, xgb.DMatrix(pd.DataFrame([0]), pd.DataFrame([0])))

--- a/modin/experimental/xgboost/utils.py
+++ b/modin/experimental/xgboost/utils.py
@@ -38,9 +38,9 @@ class RabitContextManager:
 class RabitContext:
     """Context to connect a worker to a rabit tracker"""
 
-    def __init__(self, actor_ip, args):
+    def __init__(self, actor_rank, args):
         self.args = args
-        self.args.append(("DMLC_TASK_ID=[modin.xgboost]:" + actor_ip).encode())
+        self.args.append(("DMLC_TASK_ID=[modin.xgboost]:" + str(actor_rank)).encode())
 
     def __enter__(self):
         xgb.rabit.init(self.args)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
This changes add performance improvements to xgboost using several ways:

1. Variable number of actors, instead of `actor per node` approach
2. Evenly distribution with minimal difference of number parts per node(max difference is 1) for nodes in cluster.
3. Additional manipulation with cluster resources using ray placement groups.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2935 <!-- issue must be created for each patch -->
- [x] tests added and passing
