### PR TITLE
TEST-#2951: add ASV config for omnisci backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -359,30 +359,30 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/setup-python@v2
         with:
-          activate-environment: modin
-          environment-file: environment-dev.yml
-          python-version: 3.7
-          channel-priority: strict
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-      - name: Conda environment
-        shell: bash -l {0}
-        run: |
-          conda info
-          conda list
-
+          python-version: "3.7.x"
+          architecture: "x64"
+      - name: ASV installation
+        run: pip install git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
       - name: Running benchmarks
-        shell: bash -l {0}
         run: |
-          pip install -e .
+          # ASV correctly creates environments for testing only from the branch
+          # with `master` name
+          git checkout -b master
           cd asv_bench
-          asv check -E existing
+          asv check -v
           git remote add upstream https://github.com/modin-project/modin.git
           git fetch upstream
           if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
               asv machine --yes
-              asv run --quick --show-stderr --python=same --launch-method=spawn | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
+              asv run --quick --show-stderr --launch-method=spawn \
+                | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
+              # check omnisci backend
+              MODIN_BACKEND=omnisci MODIN_EXPERIMENTAL=true asv run --quick \
+                --show-stderr --launch-method=spawn --config asv.conf.omnisci.json \
+                -b time_head -b time_iloc -b time_loc -b time_columns -b time_index -b time_shape \
+                | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
               if grep "failed" benchmarks.log > /dev/null ; then
                   exit 1
               fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -381,7 +381,7 @@ jobs:
               # check omnisci backend
               MODIN_BACKEND=omnisci MODIN_EXPERIMENTAL=true asv run --quick \
                 -b ^omnisci.benchmarks.TimeHead -b ^omnisci.benchmarks.TimeReadCsvNames \
-                --show-stderr --launch-method=spawn --config asv.conf.omnisci.json -v || echo $?
+                --show-stderr --launch-method=forkserver --config asv.conf.omnisci.json -v || echo $?
 
               conda init bash
               conda activate $(conda env list | grep .asv)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,6 +417,9 @@ jobs:
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000
+      MKL_NUM_THREADS: 1
+      NUMEXPR_NUM_THREADS: 1
+      OMP_NUM_THREADS: 1
     name: test-ubuntu (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
       - uses: actions/checkout@v2
@@ -520,6 +523,9 @@ jobs:
       MODIN_ENGINE: "python"
       MODIN_EXPERIMENTAL: "True"
       MODIN_MEMORY: 1000000000
+      MKL_NUM_THREADS: 1
+      NUMEXPR_NUM_THREADS: 1
+      OMP_NUM_THREADS: 1
     name: test cloud
     steps:
       - uses: actions/checkout@v2
@@ -582,6 +588,9 @@ jobs:
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000
+      MKL_NUM_THREADS: 1
+      NUMEXPR_NUM_THREADS: 1
+      OMP_NUM_THREADS: 1
     name: test-windows
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,12 +376,11 @@ jobs:
           git fetch upstream
           if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
               asv machine --yes
-              asv run --quick --show-stderr --launch-method=spawn \
+              asv run --quick --show-stderr --launch-method=spawn -b ^benchmarks -b ^io -b ^scalability \
                 | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
               # check omnisci backend
-              MODIN_BACKEND=omnisci MODIN_EXPERIMENTAL=true asv run --quick \
+              MODIN_BACKEND=omnisci MODIN_EXPERIMENTAL=true asv run --quick -b ^omnisci \
                 --show-stderr --launch-method=spawn --config asv.conf.omnisci.json \
-                -b time_head -b time_iloc -b time_loc -b time_columns -b time_index -b time_shape \
                 | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
               if grep "failed" benchmarks.log > /dev/null ; then
                   exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           python-version: "3.7.x"
           architecture: "x64"
       - run: pip install flake8 flake8-print
-      - run: flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py
+      - run: flake8 --enable=T modin/ asv_bench/benchmarks scripts/doc_checker.py
 
   test-api:
     runs-on: ubuntu-latest
@@ -350,6 +350,9 @@ jobs:
   test-asv-benchmarks:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     env:
       MODIN_ENGINE: ray
       MODIN_MEMORY: 1000000000
@@ -359,12 +362,16 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - uses: actions/setup-python@v2
+      - uses: conda-incubator/setup-miniconda@v2
         with:
-          python-version: "3.7.x"
-          architecture: "x64"
+          auto-activate-base: true
+          activate-environment: ""
       - name: ASV installation
-        run: pip install git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
+        run: |
+          # FIXME: use the tag or release version of ASV as soon as it appears;
+          # The ability to build a conda environment by specifying yml file has not
+          # yet appeared in the release versions;
+          pip install git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
       - name: Running benchmarks
         run: |
           # ASV correctly creates environments for testing only from the branch
@@ -376,20 +383,11 @@ jobs:
           git fetch upstream
           if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
               asv machine --yes
-              #asv run --quick --show-stderr --launch-method=spawn -b ^benchmarks -b ^io -b ^scalability \
-              #  | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
+              asv run --quick --show-stderr --launch-method=spawn -b ^benchmarks -b ^io -b ^scalability \
+                | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
               # check omnisci backend
-              MODIN_BACKEND=omnisci MODIN_EXPERIMENTAL=true asv run --quick \
-                -b ^omnisci.benchmarks.TimeHead -b ^omnisci.benchmarks.TimeReadCsvNames \
-                --show-stderr --launch-method=forkserver --config asv.conf.omnisci.json -v || echo $?
-
-              conda init bash
-              conda activate $(conda env list | grep .asv)
-              conda list
-              conda deactivate
-
               MODIN_BACKEND=omnisci MODIN_EXPERIMENTAL=true asv run --quick -b ^omnisci \
-                --show-stderr --launch-method=spawn --config asv.conf.omnisci.json \
+                --show-stderr --launch-method=forkserver --config asv.conf.omnisci.json \
                 | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
               if grep "failed" benchmarks.log > /dev/null ; then
                   exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,9 +376,13 @@ jobs:
           git fetch upstream
           if git diff upstream/master --name-only | grep -q "^asv_bench/"; then
               asv machine --yes
-              asv run --quick --show-stderr --launch-method=spawn -b ^benchmarks -b ^io -b ^scalability \
-                | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
+              #asv run --quick --show-stderr --launch-method=spawn -b ^benchmarks -b ^io -b ^scalability \
+              #  | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
               # check omnisci backend
+              asv setup --config asv.conf.omnisci.json -v
+              conda activate $(conda env list | grep .asv)
+              conda list
+              conda deactivate
               MODIN_BACKEND=omnisci MODIN_EXPERIMENTAL=true asv run --quick -b ^omnisci \
                 --show-stderr --launch-method=spawn --config asv.conf.omnisci.json \
                 | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
           python-version: "3.7.x"
           architecture: "x64"
       - run: pip install flake8 flake8-print
-      - run: flake8 --enable=T modin/ asv_bench/benchmarks scripts/doc_checker.py
+      - run: flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py
 
   test-api:
     runs-on: ubuntu-latest
@@ -379,10 +379,15 @@ jobs:
               #asv run --quick --show-stderr --launch-method=spawn -b ^benchmarks -b ^io -b ^scalability \
               #  | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log
               # check omnisci backend
-              asv setup --config asv.conf.omnisci.json -v
+              MODIN_BACKEND=omnisci MODIN_EXPERIMENTAL=true asv run --quick \
+                -b ^omnisci.benchmarks.TimeHead -b ^omnisci.benchmarks.TimeReadCsvNames \
+                --show-stderr --launch-method=spawn --config asv.conf.omnisci.json -v || echo $?
+
+              conda init bash
               conda activate $(conda env list | grep .asv)
               conda list
               conda deactivate
+
               MODIN_BACKEND=omnisci MODIN_EXPERIMENTAL=true asv run --quick -b ^omnisci \
                 --show-stderr --launch-method=spawn --config asv.conf.omnisci.json \
                 | sed "/failed$/ s/^/##[error]/" | tee benchmarks.log

--- a/asv_bench/asv.conf.omnisci.json
+++ b/asv_bench/asv.conf.omnisci.json
@@ -1,0 +1,158 @@
+{
+    // The version of the config file format.  Do not change, unless
+    // you know what you are doing.
+    "version": 1,
+
+    // The name of the project being benchmarked
+    "project": "modin",
+
+    // The project's homepage
+    "project_url": "https://modin.readthedocs.io/",
+
+    // The URL or local path of the source code repository for the
+    // project being benchmarked
+    "repo": "..",
+
+    // The Python project's subdirectory in your repo.  If missing or
+    // the empty string, the project is assumed to be located at the root
+    // of the repository.
+    // "repo_subdir": "",
+
+    // Customizable commands for building, installing, and
+    // uninstalling the project. See asv.conf.json documentation.
+    //
+    "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
+    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
+    // "build_command": [
+    //     "python setup.py build",
+    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
+    // ],
+
+    // List of branches to benchmark. If not provided, defaults to "master"
+    // (for git) or "default" (for mercurial).
+    // "branches": ["master"], // for git
+    // "branches": ["default"],    // for mercurial
+
+    // The DVCS being used.  If not set, it will be automatically
+    // determined from "repo" by looking at the protocol in the URL
+    // (if remote), or by looking for special directories, such as
+    // ".git" (if local).
+    // "dvcs": "git",
+
+    // The tool to use to create environments.  May be "conda",
+    // "virtualenv" or other value depending on the plugins in use.
+    // If missing or the empty string, the tool will be automatically
+    // determined by looking for tools on the PATH environment
+    // variable.
+    "environment_type": "conda",
+
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    //"install_timeout": 600,
+
+    // the base URL to show a commit for the project.
+    "show_commit_url": "https://github.com/modin-project/modin/commit/",
+
+    // The Pythons you'd like to test against.  If not provided, defaults
+    // to the current version of Python used to run `asv`.
+    "pythons": ["3.7"],
+
+    // The list of conda channel names to be searched for benchmark
+    // dependency packages in the specified order
+    "conda_channels": ["conda-forge", "defaults"],
+
+    "conda_environment_file": "../requirements/env_omnisci.yml",
+
+    // The matrix of dependencies to test.  Each key is the name of a
+    // package (in PyPI) and the values are version numbers.  An empty
+    // list or empty string indicates to just test against the default
+    // (latest) version. null indicates that the package is to not be
+    // installed. If the package to be tested is only available from
+    // PyPi, and the 'environment_type' is conda, then you can preface
+    // the package name by 'pip+', and the package will be installed via
+    // pip (with all the conda available packages installed first,
+    // followed by the pip installed packages).
+    "matrix": {
+        "omniscidbe4py": "",
+    },
+    // Combinations of libraries/python versions can be excluded/included
+    // from the set to test. Each entry is a dictionary containing additional
+    // key-value pairs to include/exclude.
+    //
+    // An exclude entry excludes entries where all values match. The
+    // values are regexps that should match the whole string.
+    //
+    // An include entry adds an environment. Only the packages listed
+    // are installed. The 'python' key is required. The exclude rules
+    // do not apply to includes.
+    //
+    // In addition to package names, the following keys are available:
+    //
+    // - python
+    //     Python version, as in the *pythons* variable above.
+    // - environment_type
+    //     Environment type, as above.
+    // - sys_platform
+    //     Platform, as in sys.platform. Possible values for the common
+    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
+    //
+    // "exclude": [
+    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
+    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
+    // ],
+    //
+    // "include": [
+    //     // additional env for python2.7
+    //     {"python": "2.7", "numpy": "1.8"},
+    //     // additional env if run on windows+conda
+    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
+    // ],
+
+    // The directory (relative to the current directory) that benchmarks are
+    // stored in.  If not provided, defaults to "benchmarks"
+    // "benchmark_dir": "benchmarks",
+
+    // The directory (relative to the current directory) to cache the Python
+    // environments in.  If not provided, defaults to "env"
+    "env_dir": ".asv/env",
+
+    // The directory (relative to the current directory) that raw benchmark
+    // results are stored in.  If not provided, defaults to "results".
+    "results_dir": ".asv/results",
+
+    // The directory (relative to the current directory) that the html tree
+    // should be written to.  If not provided, defaults to "html".
+    "html_dir": ".asv/html",
+
+    // The number of characters to retain in the commit hashes.
+    // "hash_length": 8,
+
+    // `asv` will cache results of the recent builds in each
+    // environment, making them faster to install next time.  This is
+    // the number of builds to keep, per environment.
+    // "build_cache_size": 2,
+
+    // The commits after which the regression search in `asv publish`
+    // should start looking for regressions. Dictionary whose keys are
+    // regexps matching to benchmark names, and values corresponding to
+    // the commit (exclusive) after which to start looking for
+    // regressions.  The default is to start from the first commit
+    // with results. If the commit is `null`, regression detection is
+    // skipped for the matching benchmark.
+    //
+    // "regressions_first_commits": {
+    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
+    //    "another_benchmark": null,   // Skip regression detection altogether
+    // },
+
+    // The thresholds for relative change in results, after which `asv
+    // publish` starts reporting regressions. Dictionary of the same
+    // form as in ``regressions_first_commits``, with values
+    // indicating the thresholds.  If multiple entries match, the
+    // maximum is taken. If no entry matches, the default is 5%.
+    //
+    // "regressions_thresholds": {
+    //    "some_benchmark": 0.01,     // Threshold of 1%
+    //    "another_benchmark": 0.5,   // Threshold of 50%
+    // },
+}

--- a/asv_bench/asv.conf.omnisci.json
+++ b/asv_bench/asv.conf.omnisci.json
@@ -13,31 +13,10 @@
     // project being benchmarked
     "repo": "..",
 
-    // The Python project's subdirectory in your repo.  If missing or
-    // the empty string, the project is assumed to be located at the root
-    // of the repository.
-    // "repo_subdir": "",
-
     // Customizable commands for building, installing, and
     // uninstalling the project. See asv.conf.json documentation.
     //
     "install_command": ["in-dir={env_dir} python -mpip install {wheel_file}"],
-    // "uninstall_command": ["return-code=any python -mpip uninstall -y {project}"],
-    // "build_command": [
-    //     "python setup.py build",
-    //     "PIP_NO_BUILD_ISOLATION=false python -mpip wheel --no-deps --no-index -w {build_cache_dir} {build_dir}"
-    // ],
-
-    // List of branches to benchmark. If not provided, defaults to "master"
-    // (for git) or "default" (for mercurial).
-    // "branches": ["master"], // for git
-    // "branches": ["default"],    // for mercurial
-
-    // The DVCS being used.  If not set, it will be automatically
-    // determined from "repo" by looking at the protocol in the URL
-    // (if remote), or by looking for special directories, such as
-    // ".git" (if local).
-    // "dvcs": "git",
 
     // The tool to use to create environments.  May be "conda",
     // "virtualenv" or other value depending on the plugins in use.
@@ -45,10 +24,6 @@
     // determined by looking for tools on the PATH environment
     // variable.
     "environment_type": "conda",
-
-    // timeout in seconds for installing any dependencies in environment
-    // defaults to 10 min
-    //"install_timeout": 600,
 
     // the base URL to show a commit for the project.
     "show_commit_url": "https://github.com/modin-project/modin/commit/",
@@ -63,55 +38,6 @@
 
     "conda_environment_file": "../requirements/env_omnisci.yml",
 
-    // The matrix of dependencies to test.  Each key is the name of a
-    // package (in PyPI) and the values are version numbers.  An empty
-    // list or empty string indicates to just test against the default
-    // (latest) version. null indicates that the package is to not be
-    // installed. If the package to be tested is only available from
-    // PyPi, and the 'environment_type' is conda, then you can preface
-    // the package name by 'pip+', and the package will be installed via
-    // pip (with all the conda available packages installed first,
-    // followed by the pip installed packages).
-    //"matrix": {
-    //    "omniscidbe4py": "",
-    //},
-    // Combinations of libraries/python versions can be excluded/included
-    // from the set to test. Each entry is a dictionary containing additional
-    // key-value pairs to include/exclude.
-    //
-    // An exclude entry excludes entries where all values match. The
-    // values are regexps that should match the whole string.
-    //
-    // An include entry adds an environment. Only the packages listed
-    // are installed. The 'python' key is required. The exclude rules
-    // do not apply to includes.
-    //
-    // In addition to package names, the following keys are available:
-    //
-    // - python
-    //     Python version, as in the *pythons* variable above.
-    // - environment_type
-    //     Environment type, as above.
-    // - sys_platform
-    //     Platform, as in sys.platform. Possible values for the common
-    //     cases: 'linux2', 'win32', 'cygwin', 'darwin'.
-    //
-    // "exclude": [
-    //     {"python": "3.2", "sys_platform": "win32"}, // skip py3.2 on windows
-    //     {"environment_type": "conda", "six": null}, // don't run without six on conda
-    // ],
-    //
-    // "include": [
-    //     // additional env for python2.7
-    //     {"python": "2.7", "numpy": "1.8"},
-    //     // additional env if run on windows+conda
-    //     {"platform": "win32", "environment_type": "conda", "python": "2.7", "libpython": ""},
-    // ],
-
-    // The directory (relative to the current directory) that benchmarks are
-    // stored in.  If not provided, defaults to "benchmarks"
-    // "benchmark_dir": "benchmarks",
-
     // The directory (relative to the current directory) to cache the Python
     // environments in.  If not provided, defaults to "env"
     "env_dir": ".asv/env",
@@ -123,36 +49,4 @@
     // The directory (relative to the current directory) that the html tree
     // should be written to.  If not provided, defaults to "html".
     "html_dir": ".asv/html",
-
-    // The number of characters to retain in the commit hashes.
-    // "hash_length": 8,
-
-    // `asv` will cache results of the recent builds in each
-    // environment, making them faster to install next time.  This is
-    // the number of builds to keep, per environment.
-    // "build_cache_size": 2,
-
-    // The commits after which the regression search in `asv publish`
-    // should start looking for regressions. Dictionary whose keys are
-    // regexps matching to benchmark names, and values corresponding to
-    // the commit (exclusive) after which to start looking for
-    // regressions.  The default is to start from the first commit
-    // with results. If the commit is `null`, regression detection is
-    // skipped for the matching benchmark.
-    //
-    // "regressions_first_commits": {
-    //    "some_benchmark": "352cdf",  // Consider regressions only after this commit
-    //    "another_benchmark": null,   // Skip regression detection altogether
-    // },
-
-    // The thresholds for relative change in results, after which `asv
-    // publish` starts reporting regressions. Dictionary of the same
-    // form as in ``regressions_first_commits``, with values
-    // indicating the thresholds.  If multiple entries match, the
-    // maximum is taken. If no entry matches, the default is 5%.
-    //
-    // "regressions_thresholds": {
-    //    "some_benchmark": 0.01,     // Threshold of 1%
-    //    "another_benchmark": 0.5,   // Threshold of 50%
-    // },
 }

--- a/asv_bench/asv.conf.omnisci.json
+++ b/asv_bench/asv.conf.omnisci.json
@@ -72,9 +72,9 @@
     // the package name by 'pip+', and the package will be installed via
     // pip (with all the conda available packages installed first,
     // followed by the pip installed packages).
-    "matrix": {
-        "omniscidbe4py": "",
-    },
+    //"matrix": {
+    //    "omniscidbe4py": "",
+    //},
     // Combinations of libraries/python versions can be excluded/included
     // from the set to test. Each entry is a dictionary containing additional
     // key-value pairs to include/exclude.

--- a/asv_bench/benchmarks/omnisci/__init__.py
+++ b/asv_bench/benchmarks/omnisci/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Modin on OmniSci backend benchmarks."""

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -13,8 +13,6 @@
 
 """General Modin on OmniSci backend benchmarks."""
 
-from time import time
-
 import modin.pandas as pd
 import numpy as np
 
@@ -28,44 +26,32 @@ from ..utils import (
     IMPL,
     execute,
     translator_groupby_ngroups,
-    get_shape_id,
     random_columns,
     random_booleans,
 )
 
-BINARY_OP_DATA_SIZE = {
-    "big": [
-        ((500_000, 20), (1_000_000, 10)),
-    ],
-    "small": [
-        ((10_000, 20), (25_000, 10)),
-    ],
-}
-
-UNARY_OP_DATA_SIZE = {
-    "big": [
-        (1_000_000, 10),
-    ],
-    "small": [
-        (10_000, 10),
-    ],
-}
+from .utils import (
+    BINARY_OP_DATA_SIZE,
+    UNARY_OP_DATA_SIZE,
+    trigger_import,
+)
 
 
-def trigger_import(*dfs):
-    print("triger_import start")
-    from modin.experimental.engines.omnisci_on_ray.frame.omnisci_worker import (
-        OmnisciServer,
-    )
+class TimeJoin:
+    param_names = ["shape", "how"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        ["left", "inner"],
+    ]
 
-    for df in dfs:
-        df.shape  # to trigger real execution
-        df._query_compiler._modin_frame._partitions[0][
-            0
-        ].frame_id = OmnisciServer().put_arrow_to_omnisci(
-            df._query_compiler._modin_frame._partitions[0][0].get()
-        )  # to trigger real execution
-    print("triger_import end")
+    def setup(self, shape, how):
+        self.df1 = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        self.df2 = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df1, self.df2)
+
+    def time_join(self, shape, how):
+        # join dataframes on index to get the predictable shape
+        execute(self.df1.join(self.df2, how=how, lsuffix="left_"))
 
 
 class TimeMerge:
@@ -91,6 +77,192 @@ class TimeMerge:
         execute(
             self.df1.merge(self.df2, on="col1", how=how, suffixes=("left_", "right_"))
         )
+
+
+class TimeAppend:
+    param_names = ["shapes"]
+    params = [
+        BINARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+    ]
+
+    def setup(self, shapes):
+        self.df1 = generate_dataframe(
+            ASV_USE_IMPL, "int", *shapes[0], RAND_LOW, RAND_HIGH
+        )
+        self.df2 = generate_dataframe(
+            ASV_USE_IMPL, "int", *shapes[1], RAND_LOW, RAND_HIGH
+        )
+        trigger_import(self.df1, self.df2)
+
+    def time_append(self, shapes):
+        execute(self.df1.append(self.df2))
+
+
+class TimeBinaryOp:
+    param_names = ["shape", "binary_op"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        ["mul"],
+    ]
+
+    def setup(self, shape, binary_op):
+        self.df1 = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df1)
+
+    def time_mul_scalar(self, shape, binary_op):
+        execute(self.df1 * 2)
+
+    def time_mul_series(self, shape, binary_op):
+        execute(self.df1["col1"] * self.df1["col2"])
+
+    def time_mul_dataframes(self, shape, binary_op):
+        execute(self.df1 * self.df1)
+
+
+class TimeArithmetic:
+    param_names = ["shape"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+    ]
+
+    def setup(self, shape):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df)
+
+    def time_sum(self, shape):
+        execute(self.df.sum())
+
+    def time_median(self, shape):
+        execute(self.df.median())
+
+    def time_nunique(self, shape):
+        execute(self.df.nunique())
+
+    def time_apply(self, shape):
+        execute(self.df.apply(lambda df: df.sum()))
+
+    def time_mean(self, shape):
+        execute(self.df.mean())
+
+
+class TimeSortValues:
+    param_names = ["shape", "columns_number", "ascending_list"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [1, 5],
+        [False, True],
+    ]
+
+    def setup(self, shape, columns_number, ascending_list):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df)
+        self.columns = random_columns(self.df.columns, columns_number)
+        self.ascending = (
+            random_booleans(columns_number)
+            if ascending_list
+            else bool(random_booleans(1)[0])
+        )
+
+    def time_sort_values(self, shape, columns_number, ascending_list):
+        execute(self.df.sort_values(self.columns, ascending=self.ascending))
+
+
+class TimeDrop:
+    param_names = ["shape", "drop_ncols"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [1, 0.8],
+    ]
+
+    def setup(self, shape, drop_ncols):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df)
+        drop_count = (
+            int(len(self.df.axes[1]) * drop_ncols)
+            if isinstance(drop_ncols, float)
+            else drop_ncols
+        )
+        self.labels = self.df.axes[1][:drop_count]
+
+    def time_drop(self, shape, drop_ncols):
+        execute(self.df.drop(self.labels, axis=1))
+
+
+class TimeHead:
+    param_names = ["shape", "head_count"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [5, 0.8],
+    ]
+
+    def setup(self, shape, head_count):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df)
+        self.head_count = (
+            int(head_count * len(self.df.index))
+            if isinstance(head_count, float)
+            else head_count
+        )
+
+    def time_head(self, shape, head_count):
+        execute(self.df.head(self.head_count))
+
+
+class TimeFillna:
+    param_names = ["value_type", "shape", "limit"]
+    params = [
+        ["scalar", "dict"],
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [None],
+    ]
+
+    def setup(self, value_type, shape, limit):
+        pd = IMPL[ASV_USE_IMPL]
+        columns = [f"col{x}" for x in range(shape[1])]
+        self.df = pd.DataFrame(np.nan, index=pd.RangeIndex(shape[0]), columns=columns)
+        trigger_import(self.df)
+
+        value = self.create_fillna_value(value_type, shape)
+        limit = int(limit * shape[0]) if limit else None
+        self.kw = {"value": value, "limit": limit}
+
+    def time_fillna(self, value_type, shape, limit):
+        execute(self.df.fillna(**self.kw))
+
+    @staticmethod
+    def create_fillna_value(value_type: str, shape: tuple):
+        if value_type == "scalar":
+            value = 18.19
+        elif value_type == "dict":
+            value = {k: k * 1.23 for k in range(shape[0])}
+        else:
+            assert False
+        return value
+
+
+class TimeValueCountsSeries:
+    param_names = ["shape", "ngroups"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        GROUPBY_NGROUPS[ASV_DATASET_SIZE],
+    ]
+
+    def setup(self, shape, ngroups):
+        ngroups = translator_groupby_ngroups(ngroups, shape)
+        self.df, self.column_names = generate_dataframe(
+            ASV_USE_IMPL,
+            "int",
+            *shape,
+            RAND_LOW,
+            RAND_HIGH,
+            groupby_ncols=1,
+            count_groups=ngroups,
+        )
+        self.series = self.df[self.column_names[0]]
+        trigger_import(self.series)
+
+    def time_value_counts(self, shape, ngroups):
+        execute(self.series.value_counts())
 
 
 class TimeIndexing:
@@ -124,182 +296,6 @@ class TimeIndexing:
         execute(self.df.loc[self.indexer])
 
 
-class TimeHead:
-    param_names = ["shape", "head_count"]
-    params = [
-        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-        [5, 0.8],
-    ]
-
-    def setup(self, shape, head_count):
-        start = time()
-        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
-        trigger_import(self.df)
-        self.head_count = (
-            int(head_count * len(self.df.index))
-            if isinstance(head_count, float)
-            else head_count
-        )
-        print(f"setup time: {time()-start}")
-
-    def time_head(self, shape, head_count):
-        start = time()
-        execute(self.df.head(self.head_count))
-        print(f"time_head time: {time()-start}")
-
-
-class TimeProperties:
-    param_names = ["shape"]
-    params = [
-        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-    ]
-
-    def setup(self, shape):
-        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
-        trigger_import(self.df)
-
-    def time_shape(self, shape):
-        return self.df.shape
-
-    def time_columns(self, shape):
-        return self.df.columns
-
-    def time_index(self, shape):
-        return self.df.index
-
-
-def create_fillna_value(value_type: str, shape: tuple):
-    if value_type == "scalar":
-        value = 18.19
-    elif value_type == "dict":
-        value = {k: k * 1.23 for k in range(shape[0])}
-    else:
-        assert False
-    return value
-
-
-class TimeFillna:
-    param_names = ["value_type", "shape", "limit"]
-    params = [
-        ["scalar", "dict"],
-        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-        [None],
-    ]
-
-    def setup(self, value_type, shape, limit):
-        pd = IMPL[ASV_USE_IMPL]
-        columns = [f"col{x}" for x in range(shape[1])]
-        self.df = pd.DataFrame(np.nan, index=pd.RangeIndex(shape[0]), columns=columns)
-        trigger_import(self.df)
-
-        value = create_fillna_value(value_type, shape)
-        limit = int(limit * shape[0]) if limit else None
-        self.kw = {"value": value, "limit": limit}
-
-    def time_fillna(self, value_type, shape, limit):
-        execute(self.df.fillna(**self.kw))
-
-
-class TimeAstype:
-    param_names = ["shape", "dtype", "astype_ncolumns"]
-    params = [
-        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-        ["float64"],
-        ["one", "all"],
-    ]
-
-    def setup(self, shape, dtype, astype_ncolumns):
-        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
-        trigger_import(self.df)
-
-        if astype_ncolumns == "all":
-            self.astype_arg = dtype
-        elif astype_ncolumns == "one":
-            self.astype_arg = {"col1": dtype}
-        else:
-            assert False
-
-    def time_astype(self, shape, dtype, astype_ncolumns):
-        execute(self.df.astype(self.astype_arg))
-
-
-class TimeArithmetic:
-    param_names = ["shape", "axis"]
-    params = [
-        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-        [0],
-    ]
-
-    def setup(self, shape, axis):
-        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
-        trigger_import(self.df)
-
-    def time_mean(self, shape, axis):
-        execute(self.df.agg("sum"))
-
-
-class TimeReadCsvNames:
-    param_names = ["shape"]
-    params = [
-        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-    ]
-
-    def setup_cache(self, test_filename="io_test_file_csv_names"):
-        # filenames with a metadata of saved dataframes
-        cache = {}
-        for shape in UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE]:
-            df = generate_dataframe("pandas", "int", *shape, RAND_LOW, RAND_HIGH)
-            file_id = get_shape_id(shape)
-            cache[file_id] = (
-                f"{test_filename}_{file_id}.csv",
-                df.columns.to_list(),
-                df.dtypes.to_dict(),
-            )
-            df.to_csv(cache[file_id][0], index=False)
-        return cache
-
-    def setup(self, cache, shape):
-        # ray init
-        if ASV_USE_IMPL == "modin":
-            pd.DataFrame([])
-        file_id = get_shape_id(shape)
-        self.filename, self.names, self.dtype = cache[file_id]
-
-    def time_read_csv_names(self, cache, shape):
-        df = IMPL[ASV_USE_IMPL].read_csv(
-            self.filename,
-            names=self.names,
-            header=0,
-            dtype=self.dtype,
-        )
-        trigger_import(df)
-
-
-class TimeValueCountsSeries:
-    param_names = ["shape", "ngroups"]
-    params = [
-        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-        GROUPBY_NGROUPS[ASV_DATASET_SIZE],
-    ]
-
-    def setup(self, shape, ngroups):
-        ngroups = translator_groupby_ngroups(ngroups, shape)
-        self.df, self.column_names = generate_dataframe(
-            ASV_USE_IMPL,
-            "int",
-            *shape,
-            RAND_LOW,
-            RAND_HIGH,
-            groupby_ncols=1,
-            count_groups=ngroups,
-        )
-        self.series = self.df[self.column_names[0]]
-        trigger_import(self.series)
-
-    def time_value_counts(self, shape, ngroups):
-        execute(self.series.value_counts())
-
-
 class TimeResetIndex:
     param_names = ["shape", "drop", "level"]
     params = [UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE], [False, True], [None, "level_1"]]
@@ -321,26 +317,31 @@ class TimeResetIndex:
         execute(self.df.reset_index(drop=drop, level=level))
 
 
-class TimeSortValues:
-    param_names = ["shape", "columns_number", "ascending_list"]
+class TimeAstype:
+    param_names = ["shape", "dtype", "astype_ncolumns"]
     params = [
         UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-        [1, 5],
-        [False, True],
+        ["float64"],
+        ["one", "all"],
     ]
 
-    def setup(self, shape, columns_number, ascending_list):
+    def setup(self, shape, dtype, astype_ncolumns):
         self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
         trigger_import(self.df)
-        self.columns = random_columns(self.df.columns, columns_number)
-        self.ascending = (
-            random_booleans(columns_number)
-            if ascending_list
-            else bool(random_booleans(1)[0])
-        )
+        self.astype_arg = self.create_astype_arg(dtype, astype_ncolumns)
 
-    def time_sort_values(self, shape, columns_number, ascending_list):
-        execute(self.df.sort_values(self.columns, ascending=self.ascending))
+    def time_astype(self, shape, dtype, astype_ncolumns):
+        execute(self.df.astype(self.astype_arg))
+
+    @staticmethod
+    def create_astype_arg(dtype, astype_ncolumns):
+        if astype_ncolumns == "all":
+            astype_arg = dtype
+        elif astype_ncolumns == "one":
+            astype_arg = {"col1": dtype}
+        else:
+            assert False
+        return astype_arg
 
 
 class TimeDescribe:
@@ -357,78 +358,21 @@ class TimeDescribe:
         execute(self.df.describe())
 
 
-class TimeBinaryOp:
-    param_names = ["shape", "binary_op"]
+class TimeProperties:
+    param_names = ["shape"]
     params = [
         UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-        ["mul"],
     ]
 
-    def setup(self, shape, binary_op):
-        self.df1 = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
-        trigger_import(self.df1)
-
-    def time_mul_scalar(self, shape, binary_op):
-        execute(self.df1 * 2)
-
-    def time_mul_series(self, shape, binary_op):
-        execute(self.df1["col1"] * self.df1["col2"])
-
-    def time_mul_dataframes(self, shape, binary_op):
-        execute(self.df1 * self.df1)
-
-
-class TimeDrop:
-    param_names = ["shape", "drop_ncols"]
-    params = [
-        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-        [1, 0.8],
-    ]
-
-    def setup(self, shape, drop_ncols):
+    def setup(self, shape):
         self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
         trigger_import(self.df)
-        drop_count = (
-            int(len(self.df.axes[1]) * drop_ncols)
-            if isinstance(drop_ncols, float)
-            else drop_ncols
-        )
-        self.labels = self.df.axes[1][:drop_count]
 
-    def time_drop(self, shape, drop_ncols):
-        execute(self.df.drop(self.labels, axis=1))
+    def time_shape(self, shape):
+        return self.df.shape
 
+    def time_columns(self, shape):
+        return self.df.columns
 
-class TimeJoin:
-    param_names = ["shape", "how"]
-    params = [
-        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-        ["left", "inner"],
-    ]
-
-    def setup(self, shape, how):
-        self.df1 = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
-        self.df2 = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
-        trigger_import(self.df1, self.df2)
-
-    def time_join(self, shape, how):
-        # join dataframes on index to get the predictable shape
-        execute(self.df1.join(self.df2, how=how, lsuffix="left_"))
-
-
-class TimeAppend:
-    param_names = ["shapes"]
-    params = [
-        BINARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
-    ]
-
-    def setup(self, shapes):
-        self.df1 = generate_dataframe(
-            ASV_USE_IMPL, "int", *shapes[0], RAND_LOW, RAND_HIGH
-        )
-        self.df2 = generate_dataframe(
-            ASV_USE_IMPL, "int", *shapes[1], RAND_LOW, RAND_HIGH
-        )
-
-    def time_append(self, shapes):
-        execute(self.df1.append(self.df2))
+    def time_index(self, shape):
+        return self.df.index

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -13,7 +13,6 @@
 
 """General Modin on OmniSci backend benchmarks."""
 
-import modin.pandas as pd
 import numpy as np
 
 from ..utils import (
@@ -301,6 +300,7 @@ class TimeResetIndex:
     params = [UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE], [False, True], [None, "level_1"]]
 
     def setup(self, shape, drop, level):
+        pd = IMPL[ASV_USE_IMPL]
         if not drop or level == "level_1":
             raise NotImplementedError
 

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -1,0 +1,152 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""General Modin on OmniSci backend benchmarks."""
+
+
+from ..utils import (
+    generate_dataframe,
+    RAND_LOW,
+    RAND_HIGH,
+    ASV_USE_IMPL,
+    ASV_DATASET_SIZE,
+    execute,
+)
+
+BINARY_OP_DATA_SIZE = {
+    "big": [
+        ((500_000, 20), (1_000_000, 10)),
+    ],
+    "small": [
+        ((10_000, 20), (25_000, 10)),
+    ],
+}
+
+UNARY_OP_DATA_SIZE = {
+    "big": [
+        (1_000_000, 10),
+    ],
+    "small": [
+        (10_000, 10),
+    ],
+}
+
+
+def trigger_import(*dfs):
+    from modin.experimental.engines.omnisci_on_ray.frame.omnisci_worker import (
+        OmnisciServer,
+    )
+
+    for df in dfs:
+        df.shape  # to trigger real execution
+        df._query_compiler._modin_frame._partitions[0][
+            0
+        ].frame_id = OmnisciServer().put_arrow_to_omnisci(
+            df._query_compiler._modin_frame._partitions[0][0].get()
+        )  # to trigger real execution
+
+
+class TimeMerge:
+    param_names = ["shapes", "how"]
+    params = [
+        BINARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        ["left"],
+    ]
+
+    def setup(self, shapes, how):
+        self.df1 = generate_dataframe(
+            ASV_USE_IMPL, "int", *shapes[0], RAND_LOW, RAND_HIGH
+        )
+        self.df2 = generate_dataframe(
+            ASV_USE_IMPL, "int", *shapes[1], RAND_LOW, RAND_HIGH
+        )
+        trigger_import((self.df1, self.df2))
+
+    def time_merge(self, shapes, how):
+        # merging dataframes by index is not supported, therefore we merge by column
+        # with arbitrary values, which leads to an unpredictable form of the operation result;
+        # it's need to get the predictable shape to get consistent performance results
+        execute(
+            self.df1.merge(self.df2, on="col1", how=how, suffixes=("left_", "right_"))
+        )
+
+
+class TimeIndexing:
+    param_names = ["shape", "indexer_type"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [
+            "scalar",
+            "bool",
+            "slice",
+            "list",
+            "function",
+        ],
+    ]
+
+    def setup(self, shape, indexer_type):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import((self.df,))
+        self.indexer = {
+            "bool": [False, True] * (shape[0] // 2),
+            "scalar": shape[0] // 2,
+            "slice": slice(0, shape[0], 2),
+            "list": list(range(shape[0])),
+            "function": lambda df: df.index[::-2],
+        }[indexer_type]
+
+    def time_iloc(self, shape, indexer_type):
+        execute(self.df.iloc[self.indexer])
+
+    def time_loc(self, shape, indexer_type):
+        execute(self.df.loc[self.indexer])
+
+
+class TimeHead:
+    param_names = ["shape", "head_count"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [5, 0.8],
+    ]
+
+    def setup(self, shape, head_count):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import((self.df,))
+        self.head_count = (
+            int(head_count * len(self.df.index))
+            if isinstance(head_count, float)
+            else head_count
+        )
+
+    def time_head(self, shape, head_count):
+        execute(self.df.head(self.head_count))
+
+
+class TimeProperties:
+    param_names = ["shape"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+    ]
+
+    def setup(self, shape):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import((self.df,))
+
+    def time_shape(self, shape):
+        return self.df.shape
+
+    def time_columns(self, shape):
+        return self.df.columns
+
+    def time_index(self, shape):
+        return self.df.index

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -18,8 +18,6 @@ import numpy as np
 
 from ..utils import (
     generate_dataframe,
-    RAND_LOW,
-    RAND_HIGH,
     ASV_USE_IMPL,
     ASV_DATASET_SIZE,
     GROUPBY_NGROUPS,
@@ -33,6 +31,8 @@ from ..utils import (
 from .utils import (
     BINARY_OP_DATA_SIZE,
     UNARY_OP_DATA_SIZE,
+    RAND_LOW,
+    RAND_HIGH,
     trigger_import,
 )
 

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -13,6 +13,8 @@
 
 """General Modin on OmniSci backend benchmarks."""
 
+import modin.pandas as pd
+import numpy as np
 
 from ..utils import (
     generate_dataframe,
@@ -20,7 +22,13 @@ from ..utils import (
     RAND_HIGH,
     ASV_USE_IMPL,
     ASV_DATASET_SIZE,
+    GROUPBY_NGROUPS,
+    IMPL,
     execute,
+    translator_groupby_ngroups,
+    get_shape_id,
+    random_columns,
+    random_booleans,
 )
 
 BINARY_OP_DATA_SIZE = {
@@ -150,3 +158,270 @@ class TimeProperties:
 
     def time_index(self, shape):
         return self.df.index
+
+
+def create_fillna_value(value_type: str, shape: tuple):
+    if value_type == "scalar":
+        value = 18.19
+    elif value_type == "dict":
+        value = {k: k * 1.23 for k in range(shape[0])}
+    else:
+        assert False
+    return value
+
+
+class TimeFillna:
+    param_names = ["value_type", "shape", "limit"]
+    params = [
+        ["scalar", "dict"],
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [None],
+    ]
+
+    def setup(self, value_type, shape, limit):
+        pd = IMPL[ASV_USE_IMPL]
+        columns = [f"col{x}" for x in range(shape[1])]
+        self.df = pd.DataFrame(np.nan, index=pd.RangeIndex(shape[0]), columns=columns)
+        trigger_import(self.df)
+
+        value = create_fillna_value(value_type, shape)
+        limit = int(limit * shape[0]) if limit else None
+        self.kw = {"value": value, "limit": limit}
+
+    def time_fillna(self, value_type, shape, limit):
+        execute(self.df.fillna(**self.kw))
+
+
+class TimeAstype:
+    param_names = ["shape", "dtype", "astype_ncolumns"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        ["float64"],
+        ["one", "all"],
+    ]
+
+    def setup(self, shape, dtype, astype_ncolumns):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df)
+
+        if astype_ncolumns == "all":
+            self.astype_arg = dtype
+        elif astype_ncolumns == "one":
+            self.astype_arg = {"col1": dtype}
+        else:
+            assert False
+
+    def time_astype(self, shape, dtype, astype_ncolumns):
+        execute(self.df.astype(self.astype_arg))
+
+
+class TimeArithmetic:
+    param_names = ["shape", "axis"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [0],
+    ]
+
+    def setup(self, shape, axis):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df)
+
+    def time_mean(self, shape, axis):
+        execute(self.df.agg("sum"))
+
+
+class TimeReadCsvNames:
+    param_names = ["shape"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+    ]
+
+    def setup_cache(self, test_filename="io_test_file_csv_names"):
+        # filenames with a metadata of saved dataframes
+        cache = {}
+        for shape in UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE]:
+            df = generate_dataframe("pandas", "int", *shape, RAND_LOW, RAND_HIGH)
+            file_id = get_shape_id(shape)
+            cache[file_id] = (
+                f"{test_filename}_{file_id}.csv",
+                df.columns.to_list(),
+                df.dtypes.to_dict(),
+            )
+            df.to_csv(cache[file_id][0], index=False)
+        return cache
+
+    def setup(self, cache, shape):
+        # ray init
+        if ASV_USE_IMPL == "modin":
+            pd.DataFrame([])
+        file_id = get_shape_id(shape)
+        self.filename, self.names, self.dtype = cache[file_id]
+
+    def time_read_csv_names(self, cache, shape):
+        execute(
+            IMPL[ASV_USE_IMPL].read_csv(
+                self.filename,
+                names=self.names,
+                header=0,
+                dtype=self.dtype,
+            )
+        )
+
+
+class TimeValueCountsSeries:
+    param_names = ["shape", "ngroups"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        GROUPBY_NGROUPS[ASV_DATASET_SIZE],
+    ]
+
+    def setup(self, shape, ngroups):
+        ngroups = translator_groupby_ngroups(ngroups, shape)
+        self.df, self.column_names = generate_dataframe(
+            ASV_USE_IMPL,
+            "int",
+            *shape,
+            RAND_LOW,
+            RAND_HIGH,
+            groupby_ncols=1,
+            count_groups=ngroups,
+        )
+        self.series = self.df[self.column_names[0]]
+        trigger_import(self.series)
+
+    def time_value_counts(self, shape, ngroups):
+        execute(self.series.value_counts())
+
+
+class TimeResetIndex:
+    param_names = ["shape", "drop", "level"]
+    params = [UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE], [False, True], [None, "level_1"]]
+
+    def setup(self, shape, drop, level):
+        if not drop or level == "level_1":
+            raise NotImplementedError
+
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        if level:
+            index = pd.MultiIndex.from_product(
+                [self.df.index[: shape[0] // 2], ["bar", "foo"]],
+                names=["level_1", "level_2"],
+            )
+            self.df.index = index
+        trigger_import(self.df)
+
+    def time_reset_index(self, shape, drop, level):
+        execute(self.df.reset_index(drop=drop, level=level))
+
+
+class TimeSortValues:
+    param_names = ["shape", "columns_number", "ascending_list"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [1, 5],
+        [False, True],
+    ]
+
+    def setup(self, shape, columns_number, ascending_list):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df)
+        self.columns = random_columns(self.df.columns, columns_number)
+        self.ascending = (
+            random_booleans(columns_number)
+            if ascending_list
+            else bool(random_booleans(1)[0])
+        )
+
+    def time_sort_values(self, shape, columns_number, ascending_list):
+        execute(self.df.sort_values(self.columns, ascending=self.ascending))
+
+
+class TimeDescribe:
+    param_names = ["shape"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+    ]
+
+    def setup(self, shape):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df)
+
+    def time_describe(self, shape):
+        execute(self.df.describe())
+
+
+class TimeBinaryOp:
+    param_names = ["shape", "binary_op"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        ["mul"],
+    ]
+
+    def setup(self, shape, binary_op):
+        self.df1 = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df1)
+
+    def time_mul_scalar(self, shape, binary_op):
+        execute(self.df1 * 2)
+
+    def time_mul_series(self, shape, binary_op):
+        execute(self.df1["col1"] * self.df1["col2"])
+
+    def time_mul_dataframes(self, shape, binary_op):
+        execute(self.df1 * self.df1)
+
+
+class TimeDrop:
+    param_names = ["shape", "drop_ncols"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [1, 0.8],
+    ]
+
+    def setup(self, shape, drop_ncols):
+        self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df)
+        drop_count = (
+            int(len(self.df.axes[1]) * drop_ncols)
+            if isinstance(drop_ncols, float)
+            else drop_ncols
+        )
+        self.labels = self.df.axes[1][:drop_count]
+
+    def time_drop(self, shape, drop_ncols):
+        execute(self.df.drop(self.labels, axis=1))
+
+
+class TimeJoin:
+    param_names = ["shape", "how"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        ["left", "inner"],
+    ]
+
+    def setup(self, shape, how):
+        self.df1 = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        self.df2 = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
+        trigger_import(self.df1, self.df2)
+
+    def time_join(self, shape, how):
+        # join dataframes on index to get the predictable shape
+        execute(self.df1.join(self.df2, how=how, lsuffix="left_"))
+
+
+class TimeAppend:
+    param_names = ["shapes"]
+    params = [
+        BINARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+    ]
+
+    def setup(self, shapes):
+        self.df1 = generate_dataframe(
+            ASV_USE_IMPL, "int", *shapes[0], RAND_LOW, RAND_HIGH
+        )
+        self.df2 = generate_dataframe(
+            ASV_USE_IMPL, "int", *shapes[1], RAND_LOW, RAND_HIGH
+        )
+
+    def time_append(self, shapes):
+        print(self.df1.append(self.df2))

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -376,3 +376,31 @@ class TimeProperties:
 
     def time_index(self, shape):
         return self.df.index
+
+
+class BaseTimeGroupBy:
+    def setup(self, shape, ngroups=5, groupby_ncols=1):
+        ngroups = translator_groupby_ngroups(ngroups, shape)
+        self.df, self.groupby_columns = generate_dataframe(
+            ASV_USE_IMPL,
+            "int",
+            *shape,
+            RAND_LOW,
+            RAND_HIGH,
+            groupby_ncols,
+            count_groups=ngroups,
+        )
+
+
+class TimeGroupByDefaultAggregations(BaseTimeGroupBy):
+    param_names = ["shape", "ngroups"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        GROUPBY_NGROUPS[ASV_DATASET_SIZE],
+    ]
+
+    def time_groupby_count(self, *args, **kwargs):
+        execute(self.df.groupby(by=self.groupby_columns).count())
+
+    def time_groupby_sum(self, *args, **kwargs):
+        execute(self.df.groupby(by=self.groupby_columns).sum())

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -259,7 +259,7 @@ class TimeFillna:
 class TimeValueCountsSeries:
     param_names = ["shape", "ngroups"]
     params = [
-        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        SERIES_DATA_SIZE[ASV_DATASET_SIZE],
         GROUPBY_NGROUPS[ASV_DATASET_SIZE],
     ]
 

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -30,6 +30,7 @@ from ..utils import (
 from .utils import (
     BINARY_OP_DATA_SIZE,
     UNARY_OP_DATA_SIZE,
+    SERIES_DATA_SIZE,
     RAND_LOW,
     RAND_HIGH,
     trigger_import,
@@ -97,7 +98,7 @@ class TimeAppend:
         execute(self.df1.append(self.df2))
 
 
-class TimeBinaryOp:
+class TimeBinaryOpDataFrame:
     param_names = ["shape", "binary_op"]
     params = [
         UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
@@ -107,15 +108,31 @@ class TimeBinaryOp:
     def setup(self, shape, binary_op):
         self.df1 = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
         trigger_import(self.df1)
+        self.op = getattr(self.df1, binary_op)
 
     def time_mul_scalar(self, shape, binary_op):
-        execute(self.df1 * 2)
-
-    def time_mul_series(self, shape, binary_op):
-        execute(self.df1["col1"] * self.df1["col2"])
+        execute(self.op(2))
 
     def time_mul_dataframes(self, shape, binary_op):
-        execute(self.df1 * self.df1)
+        execute(self.op(self.df1))
+
+
+class TimeBinaryOpSeries:
+    param_names = ["shape", "binary_op"]
+    params = [
+        SERIES_DATA_SIZE[ASV_DATASET_SIZE],
+        ["mul"],
+    ]
+
+    def setup(self, shape, binary_op):
+        self.series = generate_dataframe(
+            ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH
+        )["col0"]
+        trigger_import(self.series)
+        self.op = getattr(self.series, binary_op)
+
+    def time_mul_series(self, shape, binary_op):
+        execute(self.op(self.series))
 
 
 class TimeArithmetic:

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -70,7 +70,7 @@ class TimeMerge:
         self.df2 = generate_dataframe(
             ASV_USE_IMPL, "int", *shapes[1], RAND_LOW, RAND_HIGH
         )
-        trigger_import((self.df1, self.df2))
+        trigger_import(self.df1, self.df2)
 
     def time_merge(self, shapes, how):
         # merging dataframes by index is not supported, therefore we merge by column
@@ -96,7 +96,7 @@ class TimeIndexing:
 
     def setup(self, shape, indexer_type):
         self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
-        trigger_import((self.df,))
+        trigger_import(self.df)
         self.indexer = {
             "bool": [False, True] * (shape[0] // 2),
             "scalar": shape[0] // 2,
@@ -121,7 +121,7 @@ class TimeHead:
 
     def setup(self, shape, head_count):
         self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
-        trigger_import((self.df,))
+        trigger_import(self.df)
         self.head_count = (
             int(head_count * len(self.df.index))
             if isinstance(head_count, float)
@@ -140,7 +140,7 @@ class TimeProperties:
 
     def setup(self, shape):
         self.df = generate_dataframe(ASV_USE_IMPL, "int", *shape, RAND_LOW, RAND_HIGH)
-        trigger_import((self.df,))
+        trigger_import(self.df)
 
     def time_shape(self, shape):
         return self.df.shape

--- a/asv_bench/benchmarks/omnisci/io.py
+++ b/asv_bench/benchmarks/omnisci/io.py
@@ -1,0 +1,65 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""IO Modin on OmniSci backend benchmarks."""
+
+import modin.pandas as pd
+
+from ..utils import (
+    generate_dataframe,
+    RAND_LOW,
+    RAND_HIGH,
+    ASV_USE_IMPL,
+    ASV_DATASET_SIZE,
+    IMPL,
+    get_shape_id,
+)
+
+from .utils import UNARY_OP_DATA_SIZE, trigger_import
+
+
+class TimeReadCsvNames:
+    param_names = ["shape"]
+    params = [
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+    ]
+
+    def setup_cache(self, test_filename="io_test_file_csv_names"):
+        # filenames with a metadata of saved dataframes
+        cache = {}
+        for shape in UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE]:
+            df = generate_dataframe("pandas", "int", *shape, RAND_LOW, RAND_HIGH)
+            file_id = get_shape_id(shape)
+            cache[file_id] = (
+                f"{test_filename}_{file_id}.csv",
+                df.columns.to_list(),
+                df.dtypes.to_dict(),
+            )
+            df.to_csv(cache[file_id][0], index=False)
+        return cache
+
+    def setup(self, cache, shape):
+        # ray init
+        if ASV_USE_IMPL == "modin":
+            pd.DataFrame([])
+        file_id = get_shape_id(shape)
+        self.filename, self.names, self.dtype = cache[file_id]
+
+    def time_read_csv_names(self, cache, shape):
+        df = IMPL[ASV_USE_IMPL].read_csv(
+            self.filename,
+            names=self.names,
+            header=0,
+            dtype=self.dtype,
+        )
+        trigger_import(df)

--- a/asv_bench/benchmarks/omnisci/utils.py
+++ b/asv_bench/benchmarks/omnisci/utils.py
@@ -14,6 +14,9 @@
 """The module contains the functionality that is used when benchmarking Modin commits on OmniSci backend."""
 
 
+RAND_LOW = 0
+RAND_HIGH = 1_000_000_000
+
 BINARY_OP_DATA_SIZE = {
     "big": [
         ((500_000, 20), (1_000_000, 10)),

--- a/asv_bench/benchmarks/omnisci/utils.py
+++ b/asv_bench/benchmarks/omnisci/utils.py
@@ -37,6 +37,15 @@ UNARY_OP_DATA_SIZE = {
     ],
 }
 
+SERIES_DATA_SIZE = {
+    "big": [
+        (10_000_000, 1),
+    ],
+    "small": [
+        (100_000, 1),
+    ],
+}
+
 
 def trigger_import(*dfs):
     from modin.experimental.engines.omnisci_on_ray.frame.omnisci_worker import (

--- a/asv_bench/benchmarks/omnisci/utils.py
+++ b/asv_bench/benchmarks/omnisci/utils.py
@@ -14,6 +14,8 @@
 """The module contains the functionality that is used when benchmarking Modin commits on OmniSci backend."""
 
 
+from ..utils import ASV_USE_IMPL
+
 RAND_LOW = 0
 RAND_HIGH = 1_000_000_000
 
@@ -42,9 +44,12 @@ def trigger_import(*dfs):
     )
 
     for df in dfs:
-        df.shape  # to trigger real execution
-        df._query_compiler._modin_frame._partitions[0][
-            0
-        ].frame_id = OmnisciServer().put_arrow_to_omnisci(
-            df._query_compiler._modin_frame._partitions[0][0].get()
-        )  # to trigger real execution
+        if ASV_USE_IMPL == "modin":
+            df.shape  # to trigger real execution
+            df._query_compiler._modin_frame._partitions[0][
+                0
+            ].frame_id = OmnisciServer().put_arrow_to_omnisci(
+                df._query_compiler._modin_frame._partitions[0][0].get()
+            )  # to trigger real execution
+        elif ASV_USE_IMPL == "pandas":
+            pass

--- a/asv_bench/benchmarks/omnisci/utils.py
+++ b/asv_bench/benchmarks/omnisci/utils.py
@@ -1,0 +1,47 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""The module contains the functionality that is used when benchmarking Modin commits on OmniSci backend."""
+
+
+BINARY_OP_DATA_SIZE = {
+    "big": [
+        ((500_000, 20), (1_000_000, 10)),
+    ],
+    "small": [
+        ((10_000, 20), (25_000, 10)),
+    ],
+}
+
+UNARY_OP_DATA_SIZE = {
+    "big": [
+        (1_000_000, 10),
+    ],
+    "small": [
+        (10_000, 10),
+    ],
+}
+
+
+def trigger_import(*dfs):
+    from modin.experimental.engines.omnisci_on_ray.frame.omnisci_worker import (
+        OmnisciServer,
+    )
+
+    for df in dfs:
+        df.shape  # to trigger real execution
+        df._query_compiler._modin_frame._partitions[0][
+            0
+        ].frame_id = OmnisciServer().put_arrow_to_omnisci(
+            df._query_compiler._modin_frame._partitions[0][0].get()
+        )  # to trigger real execution

--- a/asv_bench/benchmarks/scalability/scalability_benchmarks.py
+++ b/asv_bench/benchmarks/scalability/scalability_benchmarks.py
@@ -13,7 +13,11 @@
 
 import modin.pandas as pd
 from modin.pandas.utils import from_pandas
-from modin.utils import to_pandas
+
+try:
+    from modin.utils import to_pandas
+except ImportError:
+    from modin.pandas.utils import to_pandas
 import pandas
 
 from ..utils import (

--- a/asv_bench/benchmarks/scalability/scalability_benchmarks.py
+++ b/asv_bench/benchmarks/scalability/scalability_benchmarks.py
@@ -17,6 +17,7 @@ from modin.pandas.utils import from_pandas
 try:
     from modin.utils import to_pandas
 except ImportError:
+    # This provides compatibility with older versions of the Modin, allowing us to test old commits.
     from modin.pandas.utils import to_pandas
 import pandas
 

--- a/asv_bench/benchmarks/utils.py
+++ b/asv_bench/benchmarks/utils.py
@@ -28,7 +28,7 @@ import uuid
 from typing import Optional, Union
 
 RAND_LOW = 0
-RAND_HIGH = 1_000_000_000
+RAND_HIGH = 100
 random_state = np.random.RandomState(seed=42)
 
 
@@ -67,10 +67,13 @@ assert ASV_USE_BACKEND in ("pandas", "omnisci", "pyarrow")
 BINARY_OP_DATA_SIZE = {
     "big": [
         ((5000, 5000), (5000, 5000)),
+        # the case extremely inefficient
+        # ((20, 500_000), (10, 1_000_000)),
         ((500_000, 20), (1_000_000, 10)),
     ],
     "small": [
         ((250, 250), (250, 250)),
+        ((20, 10_000), (10, 25_000)),
         ((10_000, 20), (25_000, 10)),
     ],
 }
@@ -78,10 +81,13 @@ BINARY_OP_DATA_SIZE = {
 UNARY_OP_DATA_SIZE = {
     "big": [
         (5000, 5000),
+        # the case extremely inefficient
+        # (10, 1_000_000),
         (1_000_000, 10),
     ],
     "small": [
         (250, 250),
+        (10, 10_000),
         (10_000, 10),
     ],
 }

--- a/asv_bench/benchmarks/utils.py
+++ b/asv_bench/benchmarks/utils.py
@@ -28,7 +28,7 @@ import uuid
 from typing import Optional, Union
 
 RAND_LOW = 0
-RAND_HIGH = 100
+RAND_HIGH = 1_000_000_000
 random_state = np.random.RandomState(seed=42)
 
 

--- a/asv_bench/benchmarks/utils.py
+++ b/asv_bench/benchmarks/utils.py
@@ -67,13 +67,10 @@ assert ASV_USE_BACKEND in ("pandas", "omnisci", "pyarrow")
 BINARY_OP_DATA_SIZE = {
     "big": [
         ((5000, 5000), (5000, 5000)),
-        # the case extremely inefficient
-        # ((20, 500_000), (10, 1_000_000)),
         ((500_000, 20), (1_000_000, 10)),
     ],
     "small": [
         ((250, 250), (250, 250)),
-        ((20, 10_000), (10, 25_000)),
         ((10_000, 20), (25_000, 10)),
     ],
 }
@@ -81,13 +78,10 @@ BINARY_OP_DATA_SIZE = {
 UNARY_OP_DATA_SIZE = {
     "big": [
         (5000, 5000),
-        # the case extremely inefficient
-        # (10, 1_000_000),
         (1_000_000, 10),
     ],
     "small": [
         (250, 250),
-        (10, 10_000),
         (10_000, 10),
     ],
 }

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -35,9 +35,9 @@ dependencies:
   - rpyc==4.1.5
   - cloudpickle==1.4.1
   - boto3
-  - asv
   - pip:
       - xgboost>=1.3
       - modin-spreadsheet>=0.1.1
       - tqdm
       - ray>=1.4
+      - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -27,7 +27,7 @@ msgpack
 pandas_gbq
 cloudpickle
 rpyc==4.1.5
-asv
+git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
 xgboost>=1.3
 tqdm
 modin-spreadsheet>=0.1.1

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -30,8 +30,8 @@ dependencies:
   - rpyc==4.1.5
   - cloudpickle==1.4.1
   - boto3
-  - asv
   - pip:
       - xgboost>=1.3
       - modin-spreadsheet>=0.1.1
       - tqdm
+      - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

* Add separate configuration for omnisci backend - `asv_bench/asv.conf.omnisci.json`, since the configuration name is different from the default (`asv.conf.json`) - we should explicitly specify it through the `--config` parameter
* Add trigger of omnisci execution via `frame._execute`
* Add new ASV version which is needed to be able to create an conda environment from yml file
* Benchmarking only working subset of all operations

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2951 <!-- issue must be created for each patch -->
- [ ] tests added and passing
