### PR TITLE
FIX-#2194: fix experimental read_sql

### DIFF
--- a/modin/experimental/engines/pandas_on_ray/io_exp.py
+++ b/modin/experimental/engines/pandas_on_ray/io_exp.py
@@ -168,9 +168,11 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
             )
             index_ids.append(partition_id[-1])
         new_index = pandas.RangeIndex(sum(ray.get(index_ids)))
-        return cls.query_compiler_cls(
+        new_query_compiler = cls.query_compiler_cls(
             cls.frame_cls(np.array(partition_ids), new_index, cols_names)
         )
+        new_query_compiler._modin_frame._apply_index_objs(axis=0)
+        return new_query_compiler
 
 
 @ray.remote

--- a/modin/experimental/engines/pandas_on_ray/io_exp.py
+++ b/modin/experimental/engines/pandas_on_ray/io_exp.py
@@ -130,7 +130,7 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
             )
         #  starts the distributed alternative
         cols_names, query = get_query_info(sql, con, partition_column)
-        num_parts = min(NPartitions.get(), max_sessions)
+        num_parts = min(NPartitions.get(), max_sessions if max_sessions else 1)
         num_splits = min(len(cols_names), num_parts)
         diff = (upper_bound - lower_bound) + 1
         min_size = diff // num_parts

--- a/modin/experimental/engines/pandas_on_ray/sql.py
+++ b/modin/experimental/engines/pandas_on_ray/sql.py
@@ -12,7 +12,7 @@
 # governing permissions and limitations under the License.
 
 from collections import OrderedDict
-from sqlalchemy import MetaData, Table, create_engine
+from sqlalchemy import MetaData, Table, create_engine, inspect
 
 
 def is_distributed(partition_column, lower_bound, upper_bound):
@@ -54,7 +54,7 @@ def is_table(engine, sql):
     Returns:
         True for table or False if not
     """
-    if engine.dialect.has_table(engine, sql):
+    if inspect(engine).has_table(sql):
         return True
     return False
 
@@ -132,7 +132,7 @@ def get_query_columns(engine, query):
     con = engine.connect()
     result = con.execute(query).fetchone()
     values = list(result)
-    cols_names = result.keys()
+    cols_names = list(result.keys())
     cols = OrderedDict()
     for i in range(len(cols_names)):
         cols[cols_names[i]] = type(values[i]).__name__

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -24,7 +24,6 @@ from modin.pandas.test.utils import df_equals
 )
 def test_from_sql_distributed(make_sql_connection):  # noqa: F811
     if Engine.get() == "Ray":
-        pytest.xfail("Distributed read_sql is broken, see GH#2194")
         filename = "test_from_sql_distributed.db"
         table = "test_from_sql_distributed"
         conn = make_sql_connection(filename, table)

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -31,10 +31,20 @@ def test_from_sql_distributed(make_sql_connection):  # noqa: F811
 
         pandas_df = pandas.read_sql(query, conn)
         modin_df_from_query = pd.read_sql(
-            query, conn, partition_column="col1", lower_bound=0, upper_bound=6
+            query,
+            conn,
+            partition_column="col1",
+            lower_bound=0,
+            upper_bound=6,
+            max_sessions=2,
         )
         modin_df_from_table = pd.read_sql(
-            table, conn, partition_column="col1", lower_bound=0, upper_bound=6
+            table,
+            conn,
+            partition_column="col1",
+            lower_bound=0,
+            upper_bound=6,
+            max_sessions=2,
         )
 
         df_equals(modin_df_from_query, pandas_df)


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Experimental `read_sql` was disabled for a long time, so some functions it is uses were deprecated and interconnections with the rest of the Modin code was outdated. This PR aims to fix this.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2194  <!-- issue must be created for each patch -->
- [x] tests added and passing
