### PR TITLE
Improve doc checker

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,13 +49,16 @@ jobs:
       - run: pytest scripts/test
       - run: pip install -e .[all]
       - run: |
-          python scripts/doc_checker.py \
+          python scripts/doc_checker.py --disable-numpydoc \
             modin/pandas/dataframe.py modin/pandas/series.py \
-            modin/pandas/groupby.py modin/pandas/base.py modin/pandas/io.py \
-            modin/pandas/series_utils.py modin/engines/base/io/io.py \
-            modin/backends/pandas/parsers.py modin/pandas/general.py \
+            modin/pandas/groupby.py modin/pandas/base.py \
+            modin/pandas/series_utils.py modin/pandas/general.py \
             modin/pandas/plotting.py modin/pandas/utils.py \
             modin/pandas/iterator.py modin/pandas/indexing.py \
+      - run: |
+          python scripts/doc_checker.py \
+            modin/pandas/io.py modin/engines/base/io/io.py \
+            modin/backends/pandas/parsers.py  \
             modin/engines/base/frame asv_bench/benchmarks/utils.py \
             asv_bench/benchmarks/__init__.py asv_bench/benchmarks/io/__init__.py \
             asv_bench/benchmarks/scalability/__init__.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,29 +49,14 @@ jobs:
       - run: pytest scripts/test
       - run: pip install -e .[all]
       - run: |
-          python scripts/doc_checker.py --add-ignore=D101,D102,D105 --disable-numpydoc \
+          python scripts/doc_checker.py \
             modin/pandas/dataframe.py modin/pandas/series.py \
-            modin/pandas/groupby.py modin/pandas/base.py
-      - run: python scripts/doc_checker.py modin/pandas/io.py
-      - run: |
-          python scripts/doc_checker.py --add-ignore=D101,D102 --disable-numpydoc \
-            modin/pandas/series_utils.py
-      - run: |
-          python scripts/doc_checker.py --add-ignore=D102 \
-            modin/engines/base/io/io.py
-      - run: |
-          python scripts/doc_checker.py --add-ignore=D101,D102 \
-            modin/backends/pandas/parsers.py
-      - run: |
-          python scripts/doc_checker.py --add-ignore=D103 --disable-numpydoc \
-            modin/pandas/general.py
-      - run: |
-          python scripts/doc_checker.py --disable-numpydoc \
+            modin/pandas/groupby.py modin/pandas/base.py modin/pandas/io.py \
+            modin/pandas/series_utils.py modin/engines/base/io/io.py \
+            modin/backends/pandas/parsers.py modin/pandas/general.py \
             modin/pandas/plotting.py modin/pandas/utils.py \
-            modin/pandas/iterator.py modin/pandas/indexing.py
-      - run: python scripts/doc_checker.py modin/engines/base/frame
-      - run: |
-          python scripts/doc_checker.py asv_bench/benchmarks/utils.py \
+            modin/pandas/iterator.py modin/pandas/indexing.py \
+            modin/engines/base/frame asv_bench/benchmarks/utils.py \
             asv_bench/benchmarks/__init__.py asv_bench/benchmarks/io/__init__.py \
             asv_bench/benchmarks/scalability/__init__.py \
             modin/engines/base/io/column_stores \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
       - run: pytest scripts/test
       - run: pip install -e .[all]
       - run: |
-          python scripts/doc_checker.py --disable-numpydoc \
+          python scripts/doc_checker.py --add-ignore=D101,D102,D103,D105 --disable-numpydoc \
             modin/pandas/dataframe.py modin/pandas/series.py \
             modin/pandas/groupby.py modin/pandas/base.py \
             modin/pandas/series_utils.py modin/pandas/general.py \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,8 @@ jobs:
         run: python -m pytest modin/test/test_envvar_npartitions.py
       - shell: bash -l {0}
         run: python -m pytest -n 2 modin/test/test_partition_api.py
+      - shell: bash -l {0}
+        run: python -m pytest modin/test/test_utils.py
 
   test-defaults:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           python-version: "3.7.x"
           architecture: "x64"
-      - run: pip install pytest pytest-cov pydocstyle numpydoc
+      - run: pip install pytest pytest-cov pydocstyle numpydoc==1.1.0
       - run: pytest scripts/test
       - run: pip install -e .[all]
       - run: |

--- a/asv_bench/benchmarks/utils.py
+++ b/asv_bench/benchmarks/utils.py
@@ -122,7 +122,7 @@ def translator_groupby_ngroups(groupby_ngroups: Union[str, int], shape: tuple) -
         return groupby_ngroups
 
 
-class weakdict(dict):  # noqa: D101
+class weakdict(dict):  # noqa: GL08
     __slots__ = ("__weakref__",)
 
 

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -58,7 +58,13 @@ class BasePandasFrame(object):
 
     @property
     def __constructor__(self):
-        """Create a new instance of this object."""
+        """
+        Create a new instance of this object.
+
+        Returns
+        -------
+        BasePandasFrame
+        """
         return type(self)
 
     def __init__(
@@ -268,7 +274,14 @@ class BasePandasFrame(object):
 
     @property
     def axes(self):
-        """Get index and columns that can be accessed with an `axis` integer."""
+        """
+        Get index and columns that can be accessed with an `axis` integer.
+
+        Returns
+        -------
+        list
+            List with two values: index and columns.
+        """
         return [self.index, self.columns]
 
     def _compute_axis_labels(self, axis: int, partitions=None):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -14,11 +14,8 @@
 """
 Implement DataFrame/Series public API as Pandas does.
 
-Almost all docstrings for public and magic methods should be inherited from Pandas
-for better maintability. So some codes are ignored in pydocstyle check:
-    - D101: missing docstring in class
-    - D102: missing docstring in public method
-    - D105: missing docstring in magic method
+Almost all docstrings for public and magic methods should be inherited from pandas
+for better maintability.
 Manually add documentation for methods which are not presented in pandas.
 """
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -15,10 +15,7 @@
 Implement DataFrame public API as Pandas does.
 
 Almost all docstrings for public and magic methods should be inherited from Pandas
-for better maintability. So some codes are ignored in pydocstyle check:
-    - D101: missing docstring in class
-    - D102: missing docstring in public method
-    - D105: missing docstring in magic method
+for better maintability.
 Manually add documentation for methods which are not presented in pandas.
 """
 

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -15,8 +15,7 @@
 Implement Pandas general API.
 
 Almost all docstrings for public functions should be inherited from Pandas
-for better maintability. So some codes are ignored in pydocstyle check:
-    - D103: missing docstring in public function
+for better maintability.
 Manually add documentation for methods which are not presented in pandas.
 """
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -15,10 +15,7 @@
 Implement GroupBy public API as Pandas does.
 
 Almost all docstrings for public and magic methods should be inherited from Pandas
-for better maintability. So some codes are ignored in pydocstyle check:
-    - D101: missing docstring in class
-    - D102: missing docstring in public method
-    - D105: missing docstring in magic method
+for better maintability.
 Manually add documentation for methods which are not presented in pandas.
 """
 

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -15,10 +15,7 @@
 Implement I/O public API as pandas does.
 
 Almost all docstrings for public and magic methods should be inherited from pandas
-for better maintability. So some codes are ignored in pydocstyle check:
-    - D101: missing docstring in class
-    - D103: missing docstring in public function
-    - D105: missing docstring in magic method
+for better maintability.
 Manually add documentation for methods which are not presented in pandas.
 """
 
@@ -122,7 +119,7 @@ def read_csv(
     memory_map=False,
     float_precision=None,
     storage_options: StorageOptions = None,
-):  # noqa: D103
+):
     # ISSUE #2408: parse parameter shared with pandas read_csv and read_table and update with provided args
     _pd_read_csv_signature = {
         val.name for val in inspect.signature(pandas.read_csv).parameters.values()
@@ -187,7 +184,7 @@ def read_table(
     low_memory=True,
     memory_map=False,
     float_precision=None,
-):  # noqa: D103
+):
     # ISSUE #2408: parse parameter shared with pandas read_csv and read_table and update with provided args
     _pd_read_csv_signature = {
         val.name for val in inspect.signature(pandas.read_csv).parameters.values()
@@ -206,7 +203,7 @@ def read_parquet(
     columns=None,
     use_nullable_dtypes: bool = False,
     **kwargs,
-):  # noqa: D103
+):
     from modin.data_management.factories.dispatcher import EngineDispatcher
 
     Engine.subscribe(_update_engine)
@@ -239,7 +236,7 @@ def read_json(
     compression="infer",
     nrows: Optional[int] = None,
     storage_options: StorageOptions = None,
-):  # noqa: D103
+):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.data_management.factories.dispatcher import EngineDispatcher
@@ -263,7 +260,7 @@ def read_gbq(
     use_bqstorage_api: Optional[bool] = None,
     progress_bar_type: Optional[str] = None,
     max_results: Optional[int] = None,
-) -> DataFrame:  # noqa: D103
+) -> DataFrame:
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
@@ -290,7 +287,7 @@ def read_html(
     na_values=None,
     keep_default_na=True,
     displayed_only=True,
-):  # noqa: D103
+):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.data_management.factories.dispatcher import EngineDispatcher
@@ -300,7 +297,7 @@ def read_html(
 
 
 @_inherit_docstrings(pandas.read_clipboard)
-def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover # noqa: D103
+def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
@@ -338,7 +335,7 @@ def read_excel(
     convert_float=True,
     mangle_dupe_cols=True,
     storage_options: StorageOptions = None,
-):  # noqa: D103
+):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.data_management.factories.dispatcher import EngineDispatcher
@@ -367,7 +364,7 @@ def read_hdf(
     iterator=False,
     chunksize: Optional[int] = None,
     **kwargs,
-):  # noqa: D103
+):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
@@ -383,7 +380,7 @@ def read_feather(
     columns=None,
     use_threads: bool = True,
     storage_options: StorageOptions = None,
-):  # noqa: D103
+):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.data_management.factories.dispatcher import EngineDispatcher
@@ -405,7 +402,7 @@ def read_stata(
     chunksize=None,
     iterator=False,
     storage_options: StorageOptions = None,
-):  # noqa: D103
+):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.data_management.factories.dispatcher import EngineDispatcher
@@ -422,7 +419,7 @@ def read_sas(
     encoding=None,
     chunksize=None,
     iterator=False,
-):  # pragma: no cover # noqa: D103
+):  # pragma: no cover
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.data_management.factories.dispatcher import EngineDispatcher
@@ -436,7 +433,7 @@ def read_pickle(
     filepath_or_buffer: FilePathOrBuffer,
     compression: Optional[str] = "infer",
     storage_options: StorageOptions = None,
-):  # noqa: D103
+):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.data_management.factories.dispatcher import EngineDispatcher
@@ -455,7 +452,7 @@ def read_sql(
     parse_dates=None,
     columns=None,
     chunksize=None,
-):  # noqa: D103
+):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.data_management.factories.dispatcher import EngineDispatcher
@@ -477,7 +474,7 @@ def read_fwf(
     widths=None,
     infer_nrows=100,
     **kwds,
-):  # noqa: D103
+):
     from modin.data_management.factories.dispatcher import EngineDispatcher
 
     Engine.subscribe(_update_engine)
@@ -504,7 +501,7 @@ def read_sql_table(
     parse_dates=None,
     columns=None,
     chunksize=None,
-):  # noqa: D103
+):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.data_management.factories.dispatcher import EngineDispatcher
@@ -522,7 +519,7 @@ def read_sql_query(
     params=None,
     parse_dates=None,
     chunksize=None,
-):  # noqa: D103
+):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.data_management.factories.dispatcher import EngineDispatcher
@@ -536,7 +533,7 @@ def read_spss(
     path: Union[str, pathlib.Path],
     usecols: Union[Sequence[str], type(None)] = None,
     convert_categoricals: bool = True,
-):  # noqa: D103
+):
     from modin.data_management.factories.dispatcher import EngineDispatcher
 
     Engine.subscribe(_update_engine)
@@ -552,7 +549,7 @@ def to_pickle(
     compression: Optional[str] = "infer",
     protocol: int = pickle.HIGHEST_PROTOCOL,
     storage_options: StorageOptions = None,
-):  # noqa: D103
+):
     from modin.data_management.factories.dispatcher import EngineDispatcher
 
     Engine.subscribe(_update_engine)
@@ -573,7 +570,7 @@ def json_normalize(
     errors: Optional[str] = "raise",
     sep: str = ".",
     max_level: Optional[int] = None,
-) -> DataFrame:  # noqa: D103
+) -> DataFrame:
     ErrorMessage.default_to_pandas("json_normalize")
     Engine.subscribe(_update_engine)
     return DataFrame(
@@ -586,15 +583,15 @@ def json_normalize(
 @_inherit_docstrings(pandas.read_orc)
 def read_orc(
     path: FilePathOrBuffer, columns: Optional[List[str]] = None, **kwargs
-) -> DataFrame:  # noqa: D103
+) -> DataFrame:
     ErrorMessage.default_to_pandas("read_orc")
     Engine.subscribe(_update_engine)
     return DataFrame(pandas.read_orc(path, columns, **kwargs))
 
 
 @_inherit_docstrings(pandas.HDFStore)
-class HDFStore(pandas.HDFStore):  # noqa: D101
-    def __getattribute__(self, item):  # noqa: D105
+class HDFStore(pandas.HDFStore):
+    def __getattribute__(self, item):
         default_behaviors = ["__init__", "__class__"]
         method = super(HDFStore, self).__getattribute__(item)
         if item not in default_behaviors:
@@ -642,8 +639,8 @@ class HDFStore(pandas.HDFStore):  # noqa: D101
 
 
 @_inherit_docstrings(pandas.ExcelFile)
-class ExcelFile(pandas.ExcelFile):  # noqa: D101
-    def __getattribute__(self, item):  # noqa: D105
+class ExcelFile(pandas.ExcelFile):
+    def __getattribute__(self, item):
         default_behaviors = ["__init__", "__class__"]
         method = super(ExcelFile, self).__getattribute__(item)
         if item not in default_behaviors:

--- a/modin/pandas/plotting.py
+++ b/modin/pandas/plotting.py
@@ -15,18 +15,8 @@
 
 from pandas import plotting as pdplot
 
-from modin.utils import to_pandas
+from modin.utils import instancer, to_pandas
 from .dataframe import DataFrame
-
-
-def instancer(cls):
-    """
-    Create a dummy instance each time this is imported.
-
-    This serves the purpose of allowing us to use all of pandas plotting methods
-    without aliasing and writing each of them ourselves.
-    """
-    return cls()
 
 
 @instancer

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -15,10 +15,7 @@
 Implement Series public API as Pandas does.
 
 Almost all docstrings for public and magic methods should be inherited from Pandas
-for better maintability. So some codes are ignored in pydocstyle check:
-    - D101: missing docstring in class
-    - D102: missing docstring in public method
-    - D105: missing docstring in magic method
+for better maintability.
 Manually add documentation for methods which are not presented in pandas.
 """
 

--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -17,9 +17,7 @@ Implement Series's accessors public API as Pandas does.
 Accessors: `Series.cat`, `Series.str`, `Series.dt`
 
 Almost all docstrings for public and magic methods should be inherited from Pandas
-for better maintability. So some codes are ignored in pydocstyle check:
-    - D101: missing docstring in class
-    - D102: missing docstring in public method
+for better maintability.
 Manually add documentation for methods which are not presented in pandas.
 """
 

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -15,6 +15,8 @@ import pytest
 import modin.utils
 
 
+# Note: classes below are used for purely testing purposes - they
+# simulate real-world use cases for _inherit_docstring
 class BaseParent:
     def method(self):
         """ordinary method (base)"""

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -82,8 +82,10 @@ def wrapped_cls():
 
     return Wrapped
 
+
 def test_doc_inherit_clslevel(wrapped_cls):
     assert wrapped_cls.__doc__ == BaseChild.__doc__
+
 
 def test_doc_inherit_methods(wrapped_cls):
     assert wrapped_cls.method.__doc__ == BaseChild.method.__doc__
@@ -98,6 +100,6 @@ def test_doc_inherit_special(wrapped_cls):
 
 
 def test_doc_inherit_props(wrapped_cls):
-    assert type(wrapped_cls.method) == type(BaseChild.method)
+    assert type(wrapped_cls.method) == type(BaseChild.method)  # noqa: E721
     assert wrapped_cls.prop.__doc__ == BaseChild.prop.__doc__
     assert wrapped_cls.F.__doc__ == BaseChild.F.__doc__

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -1,0 +1,103 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pytest
+import modin.utils
+
+
+class BaseParent:
+    def method(self):
+        """ordinary method (base)"""
+
+    def base_method(self):
+        """ordinary method in base only"""
+
+    @property
+    def prop(self):
+        """property"""
+
+    @staticmethod
+    def static():
+        """static method"""
+
+    @classmethod
+    def clsmtd(cls):
+        """class method"""
+
+
+class BaseChild(BaseParent):
+    """this is class docstring"""
+
+    def method(self):
+        """ordinary method (child)"""
+
+    def own_method(self):
+        """own method"""
+
+    def no_overwrite(self):
+        """another own method"""
+
+    F = property(method)
+
+
+@pytest.fixture(scope="module")
+def wrapped_cls():
+    @modin.utils._inherit_docstrings(BaseChild)
+    class Wrapped:
+        def method(self):
+            pass
+
+        def base_method(self):
+            pass
+
+        def own_method(self):
+            pass
+
+        def no_overwrite(self):
+            """not overwritten doc"""
+
+        @property
+        def prop(self):
+            return None
+
+        @staticmethod
+        def static():
+            pass
+
+        @classmethod
+        def clsmtd(cls):
+            pass
+
+        F = property(method)
+
+    return Wrapped
+
+def test_doc_inherit_clslevel(wrapped_cls):
+    assert wrapped_cls.__doc__ == BaseChild.__doc__
+
+def test_doc_inherit_methods(wrapped_cls):
+    assert wrapped_cls.method.__doc__ == BaseChild.method.__doc__
+    assert wrapped_cls.base_method.__doc__ == BaseParent.base_method.__doc__
+    assert wrapped_cls.own_method.__doc__ == BaseChild.own_method.__doc__
+    assert wrapped_cls.no_overwrite.__doc__ != BaseChild.no_overwrite.__doc__
+
+
+def test_doc_inherit_special(wrapped_cls):
+    assert wrapped_cls.static.__doc__ == BaseChild.static.__doc__
+    assert wrapped_cls.clsmtd.__doc__ == BaseChild.clsmtd.__doc__
+
+
+def test_doc_inherit_props(wrapped_cls):
+    assert type(wrapped_cls.method) == type(BaseChild.method)
+    assert wrapped_cls.prop.__doc__ == BaseChild.prop.__doc__
+    assert wrapped_cls.F.__doc__ == BaseChild.F.__doc__

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -85,23 +85,32 @@ def wrapped_cls():
     return Wrapped
 
 
+def _check_doc(wrapped, orig):
+    assert wrapped.__doc__ == orig.__doc__
+    if isinstance(wrapped, property):
+        assert wrapped.fget.__doc_inherited__
+    else:
+        assert wrapped.__doc_inherited__
+
+
 def test_doc_inherit_clslevel(wrapped_cls):
-    assert wrapped_cls.__doc__ == BaseChild.__doc__
+    _check_doc(wrapped_cls, BaseChild)
 
 
 def test_doc_inherit_methods(wrapped_cls):
-    assert wrapped_cls.method.__doc__ == BaseChild.method.__doc__
-    assert wrapped_cls.base_method.__doc__ == BaseParent.base_method.__doc__
-    assert wrapped_cls.own_method.__doc__ == BaseChild.own_method.__doc__
+    _check_doc(wrapped_cls.method, BaseChild.method)
+    _check_doc(wrapped_cls.base_method, BaseParent.base_method)
+    _check_doc(wrapped_cls.own_method, BaseChild.own_method)
     assert wrapped_cls.no_overwrite.__doc__ != BaseChild.no_overwrite.__doc__
+    assert not getattr(wrapped_cls.no_overwrite, "__doc_inherited__", False)
 
 
 def test_doc_inherit_special(wrapped_cls):
-    assert wrapped_cls.static.__doc__ == BaseChild.static.__doc__
-    assert wrapped_cls.clsmtd.__doc__ == BaseChild.clsmtd.__doc__
+    _check_doc(wrapped_cls.static, BaseChild.static)
+    _check_doc(wrapped_cls.clsmtd, BaseChild.clsmtd)
 
 
 def test_doc_inherit_props(wrapped_cls):
     assert type(wrapped_cls.method) == type(BaseChild.method)  # noqa: E721
-    assert wrapped_cls.prop.__doc__ == BaseChild.prop.__doc__
-    assert wrapped_cls.F.__doc__ == BaseChild.F.__doc__
+    _check_doc(wrapped_cls.prop, BaseChild.prop)
+    _check_doc(wrapped_cls.F, BaseChild.F)

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -104,7 +104,8 @@ def _replace_doc(
 
     source_doc = source_obj.__doc__ or ""
     target_doc = target_obj.__doc__ or ""
-    doc = source_doc if overwrite or not target_doc else target_doc
+    overwrite = overwrite or not target_doc
+    doc = source_doc if overwrite else target_doc
 
     if parent_cls and not attr_name:
         if isinstance(target_obj, property):
@@ -125,15 +126,19 @@ def _replace_doc(
         else:
             token = apilink
         url = _make_api_url(token)
-        doc += f"\n\n{' ' * _get_indent(doc)}See `Pandas API documentation for {token} <{url}>`_ for more."
+        doc += f"\n{' ' * _get_indent(doc)}See `pandas API documentation for {token} <{url}>`_ for more.\n"
 
     if parent_cls and isinstance(target_obj, property):
+        if overwrite:
+            target_obj.fget.__doc_inherited__ = True
         setattr(
             parent_cls,
             attr_name,
             property(target_obj.fget, target_obj.fset, target_obj.fdel, doc),
         )
     else:
+        if overwrite:
+            target_obj.__doc_inherited__ = True
         target_obj.__doc__ = doc
 
 

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -72,6 +72,11 @@ def _replace_doc(
         Gives the name to `target_obj` if it's an attribute of `parent_cls`.
         Needed to handle some special cases and in most cases could be determined automatically.
     """
+    if isinstance(target_obj, (staticmethod, classmethod)):
+        # we cannot replace docs on decorated objects, we must replace them
+        # on original functions instead
+        target_obj = target_obj.__func__
+
     source_doc = source_obj.__doc__ or ""
     target_doc = target_obj.__doc__ or ""
     doc = source_doc if overwrite or not target_doc else target_doc
@@ -137,7 +142,11 @@ def _inherit_docstrings(parent, excluded=[], overwrite_existing=False, apilink=N
 
     def _documentable_obj(obj):
         """Check if `obj` docstring could be patched."""
-        return callable(obj) or (isinstance(obj, property) and obj.fget)
+        return (
+            callable(obj)
+            or (isinstance(obj, property) and obj.fget)
+            or (isinstance(obj, (staticmethod, classmethod)) and obj.__func__)
+        )
 
     def decorator(cls_or_func):
         if parent not in excluded:

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -100,7 +100,7 @@ def _replace_doc(
     if parent_cls and isinstance(target_obj, property):
         setattr(
             parent_cls,
-            target_obj.fget.__name__,
+            attr_name,
             property(target_obj.fget, target_obj.fset, target_obj.fdel, doc),
         )
     else:
@@ -144,7 +144,7 @@ def _inherit_docstrings(parent, excluded=[], overwrite_existing=False, apilink=N
             _replace_doc(parent, cls_or_func, overwrite_existing, apilink)
 
         if not isinstance(cls_or_func, types.FunctionType):
-            for base in cls_or_func.__bases__:
+            for base in cls_or_func.__mro__:
                 if base is object:
                     continue
                 for attr, obj in base.__dict__.items():

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -375,11 +375,20 @@ def get_current_backend():
     return f"{'Experimental' if IsExperimental.get() else ''}{Backend.get()}On{Engine.get()}"
 
 
-def instancer(cls):
+def instancer(_class):
     """
     Create a dummy instance each time this is imported.
 
     This serves the purpose of allowing us to use all of pandas plotting methods
     without aliasing and writing each of them ourselves.
+
+    Parameters
+    ----------
+    _class : object
+
+    Returns
+    -------
+    object
+        Instance of `_class`.
     """
-    return cls()
+    return _class()

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -364,3 +364,13 @@ def get_current_backend():
         Returns <Backend>On<Engine>-like string.
     """
     return f"{'Experimental' if IsExperimental.get() else ''}{Backend.get()}On{Engine.get()}"
+
+
+def instancer(cls):
+    """
+    Create a dummy instance each time this is imported.
+
+    This serves the purpose of allowing us to use all of pandas plotting methods
+    without aliasing and writing each of them ourselves.
+    """
+    return cls()

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -44,6 +44,31 @@ def _make_api_url(token):
     return PANDAS_API_URL_TEMPLATE.format(token)
 
 
+def _get_indent(doc: str) -> int:
+    """
+    Compute indentation in docstring.
+
+    Parameters
+    ----------
+    doc : str
+        The docstring to compute indentation for.
+
+    Returns
+    -------
+    int
+        Minimal indent (excluding empty lines).
+    """
+    indents = []
+    for line in doc.splitlines():
+        if not line.strip():
+            continue
+        for pos, ch in enumerate(line):
+            if ch != " ":
+                break
+        indents.append(pos)
+    return min(indents) if indents else 0
+
+
 def _replace_doc(
     source_obj, target_obj, overwrite, apilink, parent_cls=None, attr_name=None
 ):
@@ -92,7 +117,7 @@ def _replace_doc(
     if (
         source_doc.strip()
         and apilink
-        and "Pandas API documentation <" not in target_doc
+        and "`Pandas API documentation for " not in target_doc
         and (not (attr_name or "").startswith("_"))
     ):
         if attr_name:
@@ -100,7 +125,7 @@ def _replace_doc(
         else:
             token = apilink
         url = _make_api_url(token)
-        doc += f"\n\nSee `Pandas API documentation <{url}>`_ for more."
+        doc += f"\n\n{' ' * _get_indent(doc)}See `Pandas API documentation for {token} <{url}>`_ for more."
 
     if parent_cls and isinstance(target_obj, property):
         setattr(

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -118,7 +118,7 @@ def _replace_doc(
     if (
         source_doc.strip()
         and apilink
-        and "`Pandas API documentation for " not in target_doc
+        and "`pandas API documentation for " not in target_doc
         and (not (attr_name or "").startswith("_"))
     ):
         if attr_name:
@@ -232,8 +232,8 @@ def hashable(obj):
 
     Parameters
     ----------
-        obj : object
-            The object to check.
+    obj : object
+        The object to check.
 
     Returns
     -------
@@ -336,8 +336,8 @@ def wrap_udf_function(func):
 
     Parameters
     ----------
-        func : callable
-            Function to wrap.
+    func : callable
+        Function to wrap.
 
     Returns
     -------

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -126,7 +126,16 @@ def _replace_doc(
         else:
             token = apilink
         url = _make_api_url(token)
-        doc += f"\n{' ' * _get_indent(doc)}See `pandas API documentation for {token} <{url}>`_ for more.\n"
+
+        indent_line = " " * _get_indent(doc)
+        notes_section = f"\n{indent_line}Notes\n{indent_line}-----\n"
+        url_line = f"{indent_line}See `pandas API documentation for {token} <{url}>`_ for more.\n"
+        notes_section_with_url = notes_section + url_line
+
+        if notes_section in doc:
+            doc = doc.replace(notes_section, notes_section_with_url)
+        else:
+            doc += notes_section_with_url
 
     if parent_cls and isinstance(target_obj, property):
         if overwrite:

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -167,6 +167,12 @@ def check_spelling_words(doc: Docstring) -> list:
         for line in doc.raw_doc.splitlines()
     ]
 
+    docstring_start_line = None
+    for idx, line in enumerate(inspect.getsourcelines(doc.code_obj)[0]):
+        if '"""' in line:
+            docstring_start_line = doc.source_file_def_line + idx
+            break
+
     errors = []
     for line_idx, words_in_line in enumerate(results):
         for word in words_in_line:
@@ -175,7 +181,7 @@ def check_spelling_words(doc: Docstring) -> list:
                 (
                     "MD02",
                     MODIN_ERROR_CODES["MD02"].format(
-                        line=line_idx,
+                        line=docstring_start_line + line_idx,
                         word=word,
                         reference=reference,
                     ),

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -429,10 +429,11 @@ def numpydoc_validate(path: pathlib.Path) -> bool:
                 + methods
             )
             results = list(map(validate_object, to_validate))
-            is_successfull = not any(results)
-            if not is_successfull:
+            is_successfull_file = not any(results)
+            if not is_successfull_file:
                 logging.info(f"NUMPYDOC OUTPUT FOR {current_path}")
             [logging.error(error) for errors in results for error in errors]
+            is_successfull &= is_successfull_file
     return is_successfull
 
 

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -307,8 +307,15 @@ def get_noqa_checks(doc: Docstring) -> list:
                 noqa_str = line
                 break
     else:
-        # pydocstyle only check first line; aling with it
-        noqa_str = source.split("\n", 1)[0]
+        # noqa string is defined as the first line before the docstring
+        if not doc.raw_doc:
+            # noqa string is meaningless if there is no docstring in module
+            return []
+        lines = source.split("\n")
+        for idx, line in enumerate(lines):
+            if '"""' in line or "'''" in line:
+                noqa_str = lines[idx - 1]
+                break
 
     if "# noqa:" in noqa_str:
         noqa_checks = noqa_str.split("# noqa:", 1)[1].split(",")

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -29,7 +29,6 @@ import sys
 import inspect
 import shutil
 import logging
-import functools
 from numpydoc.validate import Docstring
 
 logging.basicConfig(
@@ -50,6 +49,7 @@ NUMPYDOC_BASE_ERROR_CODES = {
 MODIN_ERROR_CODES = {
     "MD01": "'{parameter}' description should be '[type], default: [value]', found: '{found}'",
     "MD02": "Spelling error in line: {line}, found: '{word}', reference: '{reference}'",
+    "MD03": "Indents for parameters: {{{parameters}}} should match the indentation for the Parameters section",
 }
 
 
@@ -183,6 +183,64 @@ def check_spelling_words(doc: Docstring) -> list:
     return errors
 
 
+def check_parameters_indention(doc: Docstring) -> list:
+    """
+    Check parameters indention since numpydoc reports weird results.
+
+    Parameters
+    ----------
+    doc : numpydoc.validate.Docstring
+        Docstring handler.
+
+    Returns
+    -------
+    list
+        List of tuples with Modin error code and its description.
+    """
+    if "Parameters" not in doc.section_titles:
+        return []
+
+    section_indent = None
+    parameters_section_startline = None
+
+    lines = doc.raw_doc.splitlines()
+    # Find the beginning of the "Parameters" section and its indent;
+    # The case when the section itself has the wrong indentation is handled by
+    # pydocstyle.
+    for idx, line in enumerate(lines):
+        if "Parameters" in line:
+            parameters_section_startline = idx
+            section_indent = " " * (len(line) - len(line.lstrip(" ")))
+            break
+
+    # For the lines where the parameters are described, find the indents.
+    params_name = "|".join(doc.signature_parameters)
+    pattern = r"(^ *)({params_name})(?: *:)".format(params_name=params_name)
+    params_indents = []
+    for line in lines[parameters_section_startline + 1 :]:
+        if not line:
+            break
+        params_indents.append(re.match(pattern, line))
+
+    # For parameters with an error in indentation, create Modin errors.
+    errors = []
+    params_with_erors = [
+        param_indent.group(2)
+        for param_indent in params_indents
+        if param_indent is not None and section_indent != param_indent.group(1)
+    ]
+    if any(params_with_erors):
+        errors.append(
+            (
+                "MD03",
+                MODIN_ERROR_CODES["MD03"].format(
+                    parameters=",".join(params_with_erors),
+                ),
+            )
+        )
+    return errors
+
+
 def validate_modin_error(doc: Docstring, results: dict) -> list:
     """
     Validate custom Modin errors.
@@ -201,6 +259,8 @@ def validate_modin_error(doc: Docstring, results: dict) -> list:
     """
     errors = check_optional_args(doc)
     errors += check_spelling_words(doc)
+    if any((error_code == "PR01" for error_code, _ in results["errors"])):
+        errors += check_parameters_indention(doc)
     results["errors"].extend(errors)
     return results
 

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -29,6 +29,7 @@ import sys
 import inspect
 import shutil
 import logging
+import functools
 from numpydoc.validate import Docstring
 from numpydoc.docscrape import NumpyDocString
 
@@ -486,7 +487,12 @@ def monkeypatching():
         return lambda cls_or_func: cls_or_func
 
     ray.remote = monkeypatch
-    modin.utils.instancer = lambda cls: cls
+
+    @functools.wraps(modin.utils.instancer)
+    def instancer(cls):
+        return cls
+
+    modin.utils.instancer = instancer
 
     # monkey-patch numpydoc for working correctly with properties
     def load_obj(name, old_load_obj=Docstring._load_obj):

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -169,7 +169,7 @@ def check_spelling_words(doc: Docstring) -> list:
 
     docstring_start_line = None
     for idx, line in enumerate(inspect.getsourcelines(doc.code_obj)[0]):
-        if '"""' in line:
+        if '"""' in line or "'''" in line:
             docstring_start_line = doc.source_file_def_line + idx
             break
 

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -481,10 +481,8 @@ def monkeypatching():
     ray.remote = monkeypatch
     modin.utils.instancer = lambda cls: cls
 
-    # monkey patch numpydoc for correct work with properties
-    old_load_obj = Docstring._load_obj
-
-    def load_obj(name):
+    # monkey-patch numpydoc for working correctly with properties
+    def load_obj(name, old_load_obj=Docstring._load_obj):
         obj = old_load_obj(name)
         if isinstance(obj, property):
             obj = obj.fget

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -285,7 +285,7 @@ def get_noqa_checks(doc: Docstring) -> list:
         if not source:
             return []
 
-    noqa_str = None
+    noqa_str = ""
     if not inspect.ismodule(doc.obj):
         # find last line of obj definition
         for line in source.split("\n"):

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -50,7 +50,7 @@ NUMPYDOC_BASE_ERROR_CODES = {
 MODIN_ERROR_CODES = {
     "MD01": "'{parameter}' description should be '[type], default: [value]', found: '{found}'",
     "MD02": "Spelling error in line: {line}, found: '{word}', reference: '{reference}'",
-    "MD03": "Section underline is over-indented (in section '{section}')",
+    "MD03": "Section contents is over-indented (in section '{section}')",
 }
 
 
@@ -184,9 +184,9 @@ def check_spelling_words(doc: Docstring) -> list:
     return errors
 
 
-def check_parameters_indention(doc: Docstring) -> list:
+def check_docstring_indention(doc: Docstring) -> list:
     """
-    Check indention since numpydoc reports weird results.
+    Check indention of docstring since numpydoc reports weird results.
 
     Parameters
     ----------
@@ -232,8 +232,7 @@ def validate_modin_error(doc: Docstring, results: dict) -> list:
     """
     errors = check_optional_args(doc)
     errors += check_spelling_words(doc)
-    if any((error_code == "PR01" for error_code, _ in results["errors"])):
-        errors += check_parameters_indention(doc)
+    errors += check_docstring_indention(doc)
     results["errors"].extend(errors)
     return results
 

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -151,13 +151,16 @@ def check_spelling_words(doc: Docstring) -> list:
 
     # comments work only with re.VERBOSE
     pattern = r"""
-    (?:\W|^)                # non-capturing group of either non-word symbol or line start
+    (?:                     # non-capturing group
+        [^-\\\w\/]          # any symbol except: '-', '\', '/' and any from [a-zA-Z0-9_]
+        | ^                 # or line start
+    )
     ({check_words})         # words to check, example - "modin|pandas|numpy"
     (?:                     # non-capturing group
-        [^"\.\/\w\\]        # any symbol except: '"', '.', '\', '/' and any from [a-zA-Z0-9_]
+        [^-"\.\/\w\\]       # any symbol except: '-', '"', '.', '\', '/' and any from [a-zA-Z0-9_]
         | \.\s              # or '.' and any whitespace
-        | \.$               # or '.' and end
-        | $                 # or end
+        | \.$               # or '.' and line end
+        | $                 # or line end
     )
     """.format(
         check_words=check_words

--- a/scripts/test/examples.py
+++ b/scripts/test/examples.py
@@ -46,6 +46,8 @@ def square_summary(number: int) -> int:  # noqa: PR01, GL08
     """
     Square `number`.
 
+    See https://github.com/ray-project/ray.
+
     Examples
     --------
     The function that will never be used in modin.pandas.DataFrame same as in

--- a/scripts/test/examples.py
+++ b/scripts/test/examples.py
@@ -12,7 +12,7 @@
 # governing permissions and limitations under the License.
 
 
-class weakdict(dict):  # noqa: D101
+class weakdict(dict):  # noqa: GL08
     __slots__ = ("__weakref__",)
 
 
@@ -42,7 +42,7 @@ def optional_square_empty_parameters(number: int = 5) -> int:
     return number ** 2
 
 
-def square_summary(number: int) -> int:  # noqa: D103, GL08
+def square_summary(number: int) -> int:  # noqa: PR01, GL08
     """
     Square `number`.
 

--- a/scripts/test/examples.py
+++ b/scripts/test/examples.py
@@ -1,3 +1,4 @@
+# noqa: MD01
 # Licensed to Modin Development Team under one or more contributor license agreements.
 # See the NOTICE file distributed with this work for additional information regarding
 # copyright ownership.  The Modin Development Team licenses this file to you under the
@@ -11,6 +12,8 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+# noqa: MD02
+"""Function examples for docstring testing."""
 
 class weakdict(dict):  # noqa: GL08
     __slots__ = ("__weakref__",)

--- a/scripts/test/test_doc_checker.py
+++ b/scripts/test/test_doc_checker.py
@@ -98,8 +98,8 @@ def test_check_spelling_words(import_path, result):
     [
         ("scripts.test.examples.optional_square", ["all"]),
         ("scripts.test.examples.optional_square_empty_parameters", []),
-        ("scripts.test.examples.square_summary", ["D103", "GL08"]),
-        ("scripts.test.examples.weakdict", ["D101"]),
+        ("scripts.test.examples.square_summary", ["PR01", "GL08"]),
+        ("scripts.test.examples.weakdict", ["GL08"]),
         ("scripts.test.examples", []),
     ],
 )

--- a/scripts/test/test_doc_checker.py
+++ b/scripts/test/test_doc_checker.py
@@ -67,8 +67,8 @@ def test_check_optional_args(import_path, result):
         (
             "scripts.test.examples.square_summary",
             [
-                ("MD02", 54, "Pandas", "pandas"),
-                ("MD02", 54, "Numpy", "NumPy"),
+                ("MD02", 57, "Pandas", "pandas"),
+                ("MD02", 57, "Numpy", "NumPy"),
             ],
         ),
         ("scripts.test.examples.optional_square_empty_parameters", []),
@@ -100,7 +100,7 @@ def test_check_spelling_words(import_path, result):
         ("scripts.test.examples.optional_square_empty_parameters", []),
         ("scripts.test.examples.square_summary", ["PR01", "GL08"]),
         ("scripts.test.examples.weakdict", ["GL08"]),
-        ("scripts.test.examples", []),
+        ("scripts.test.examples", ["MD02"]),
     ],
 )
 def test_get_noqa_checks(import_path, result):

--- a/scripts/test/test_doc_checker.py
+++ b/scripts/test/test_doc_checker.py
@@ -67,8 +67,8 @@ def test_check_optional_args(import_path, result):
         (
             "scripts.test.examples.square_summary",
             [
-                ("MD02", 6, "Pandas", "pandas"),
-                ("MD02", 6, "Numpy", "NumPy"),
+                ("MD02", 52, "Pandas", "pandas"),
+                ("MD02", 52, "Numpy", "NumPy"),
             ],
         ),
         ("scripts.test.examples.optional_square_empty_parameters", []),

--- a/scripts/test/test_doc_checker.py
+++ b/scripts/test/test_doc_checker.py
@@ -67,8 +67,8 @@ def test_check_optional_args(import_path, result):
         (
             "scripts.test.examples.square_summary",
             [
-                ("MD02", 52, "Pandas", "pandas"),
-                ("MD02", 52, "Numpy", "NumPy"),
+                ("MD02", 54, "Pandas", "pandas"),
+                ("MD02", 54, "Numpy", "NumPy"),
             ],
         ),
         ("scripts.test.examples.optional_square_empty_parameters", []),


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->
**Note**: this is based on #3034 and should be rebased when that one is merged.

## What do these changes do?
Improve `doc_checker.py` to handle a few specific corner cases.
Also make it skip numpydoc-validating inherited docstrings without requiring to disable numpydoc check.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2995 <!-- issue must be created for each patch -->
- [x] tests added and passing
