### PR TITLE
FIX-#3017: Fix formatting for new `black` package

### DIFF
--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -28,7 +28,7 @@ def make_unknown_env():
 @pytest.fixture(params=[str, ExactStr])
 def make_custom_envvar(request):
     class CustomVar(EnvironmentVariable, type=request.param):
-        """ custom var """
+        """custom var"""
 
         default = 10
         varname = "MODIN_CUSTOM"

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -157,7 +157,7 @@ class TestCSV:
     }
 
     def test_usecols_csv(self):
-        """ check with the following arguments: names, dtype, skiprows, delimiter """
+        """check with the following arguments: names, dtype, skiprows, delimiter"""
         csv_file = os.path.join(self.root, "modin/pandas/test/data", "test_usecols.csv")
 
         for kwargs in (


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3017  <!-- issue must be created for each patch -->
- [ ] tests added and passing
