### PR TITLE
FIX-#3027: Removed unnecessary 'str.repeats' function, fixed test

### DIFF
--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -203,9 +203,6 @@ class StringMethods(object):
             )
         )
 
-    def repeats(self, repeats):
-        return Series(query_compiler=self._query_compiler.str_repeats(repeats))
-
     def pad(self, width, side="left", fillchar=" "):
         if len(fillchar) != 1:
             raise TypeError("fillchar must be a character, not str")

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3633,16 +3633,16 @@ def test_str_replace(data, pat, repl, n, case):
 
 @pytest.mark.parametrize("data", test_string_data_values, ids=test_string_data_keys)
 @pytest.mark.parametrize("repeats", int_arg_values, ids=int_arg_keys)
-def test_str_repeats(data, repeats):
+def test_str_repeat(data, repeats):
     modin_series, pandas_series = create_test_series(data)
 
     try:
-        pandas_result = pandas_series.str.repeats(repeats)
+        pandas_result = pandas_series.str.repeat(repeats)
     except Exception as e:
         with pytest.raises(type(e)):
-            modin_series.str.repeats(repeats)
+            modin_series.str.repeat(repeats)
     else:
-        modin_result = modin_series.str.repeats(repeats)
+        modin_result = modin_series.str.repeat(repeats)
         df_equals(modin_result, pandas_result)
 
 


### PR DESCRIPTION
Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3027 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
