### PR TITLE
FIX-#3031: Added -n 2 to long running pytest tasks and paralellized windows tasks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           python-version: "3.7.x"
           architecture: "x64"
-      - run: pip install pytest pytest-cov pydocstyle numpydoc
+      - run: pip install pytest pytest-cov pytest-xdist pydocstyle numpydoc
       - run: pytest scripts/test
       - run: pip install -e .[all]
       - run: |
@@ -219,7 +219,7 @@ jobs:
       - shell: bash -l {0}
         run: python -m pytest modin/test/test_envvar_npartitions.py
       - shell: bash -l {0}
-        run: python -m pytest modin/test/test_partition_api.py
+        run: python -m pytest -n 2 modin/test/test_partition_api.py
 
   test-defaults:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
@@ -252,39 +252,39 @@ jobs:
       - shell: bash -l {0}
         run: pytest modin/experimental/xgboost/test/test_default.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/test/backends/base/test_internals.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/test/backends/base/test_internals.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_binary.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_default.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_indexing.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_iter.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_join_sort.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_map_metadata.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_reduction.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_udf.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_window.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_pickle.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_series.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_series.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_rolling.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_concat.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_concat.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_groupby.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_reshape.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_general.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_general.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash)
 
@@ -406,39 +406,39 @@ jobs:
       - shell: bash -l {0}
         run: MODIN_BENCHMARK_MODE=True pytest modin/pandas/test/internals/test_benchmark_mode.py
       - shell: bash -l {0}
-        run: pytest modin/experimental/xgboost/test/test_default.py
+        run: pytest -n 2 modin/experimental/xgboost/test/test_default.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_binary.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_default.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_indexing.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_iter.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_join_sort.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_map_metadata.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_reduction.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_udf.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_window.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_pickle.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_series.py
+        run: python -m pytest -n 2 modin/pandas/test/test_series.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_rolling.py
+        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_concat.py
+        run: python -m pytest -n 2 modin/pandas/test/test_concat.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_groupby.py
+        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_reshape.py
+        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_general.py
+        run: python -m pytest -n 2 modin/pandas/test/test_general.py
       - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_io.py
       - shell: bash -l {0}
@@ -473,9 +473,9 @@ jobs:
           conda info
           conda list
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/dataframe/test_map_metadata.py
+        run: python -m pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_series.py
+        run: python -m pytest -n 2 modin/pandas/test/test_series.py
       - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_io.py
       - shell: bash -l {0}
@@ -540,52 +540,52 @@ jobs:
           conda info
           conda list
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_binary.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_default.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_indexing.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_iter.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_join_sort.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_map_metadata.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_reduction.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_udf.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_window.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_pickle.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_series.py
+        run: python -m pytest -n 2 modin/pandas/test/test_series.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_rolling.py
+        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_concat.py
+        run: python -m pytest -n 2 modin/pandas/test/test_concat.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_groupby.py
+        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_reshape.py
+        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_general.py
+        run: python -m pytest -n 2 modin/pandas/test/test_general.py
         if: matrix.part == 3
       - shell: bash -l {0}
         timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -573,7 +573,7 @@ jobs:
         if: matrix.part == 3
       - run: python -m pytest modin/pandas/test/test_general.py
         if: matrix.part == 3
-      - timeout-minutes: 20
+      - timeout-minutes: 30
         run: python -m pytest modin/pandas/test/test_io.py
         if: matrix.part == 3
       - run: choco install codecov

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,52 +540,52 @@ jobs:
           conda info
           conda list
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py
+        run: pytest modin/pandas/test/dataframe/test_binary.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py
+        run: pytest modin/pandas/test/dataframe/test_default.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py
+        run: pytest modin/pandas/test/dataframe/test_indexing.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py
+        run: pytest modin/pandas/test/dataframe/test_iter.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py
+        run: pytest modin/pandas/test/dataframe/test_join_sort.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
+        run: pytest modin/pandas/test/dataframe/test_map_metadata.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py
+        run: pytest modin/pandas/test/dataframe/test_reduction.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py
+        run: pytest modin/pandas/test/dataframe/test_udf.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py
+        run: pytest modin/pandas/test/dataframe/test_window.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py
+        run: pytest modin/pandas/test/dataframe/test_pickle.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_series.py
+        run: python -m pytest modin/pandas/test/test_series.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
+        run: python -m pytest modin/pandas/test/test_rolling.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_concat.py
+        run: python -m pytest modin/pandas/test/test_concat.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
+        run: python -m pytest modin/pandas/test/test_groupby.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
+        run: python -m pytest modin/pandas/test/test_reshape.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_general.py
+        run: python -m pytest modin/pandas/test/test_general.py
         if: matrix.part == 3
       - shell: bash -l {0}
         timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -405,9 +405,9 @@ jobs:
       - run: python -m pytest -n 2 modin/pandas/test/test_series.py
       - run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
       - run: python -m pytest -n 2 modin/pandas/test/test_concat.py
-        if: matrix.engine != 'ray'
-      - run: python -m pytest modin/pandas/test/test_concat.py # Ray version fails with -n 2
-        if: matrix.engine == 'ray'
+        if: matrix.engine == 'python'
+      - run: python -m pytest modin/pandas/test/test_concat.py # Ray and Dask versions fails with -n 2
+        if: matrix.engine != 'python'
       - run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
       - run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
       - run: python -m pytest -n 2 modin/pandas/test/test_general.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           python-version: "3.7.x"
           architecture: "x64"
-      - run: pip install pytest pytest-cov pytest-xdist pydocstyle numpydoc
+      - run: pip install pytest pytest-cov pydocstyle numpydoc
       - run: pytest scripts/test
       - run: pip install -e .[all]
       - run: |
@@ -224,6 +224,9 @@ jobs:
   test-defaults:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         backend: [BaseOnPython]
@@ -249,44 +252,25 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
-      - shell: bash -l {0}
-        run: pytest modin/experimental/xgboost/test/test_default.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/test/backends/base/test_internals.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_series.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_concat.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_general.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: bash <(curl -s https://codecov.io/bash)
+      - run: pytest modin/experimental/xgboost/test/test_default.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/test/backends/base/test_internals.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_default.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_window.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_series.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_rolling.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_concat.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_groupby.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_reshape.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_general.py --backend=${{ matrix.backend }}
+      - run: bash <(curl -s https://codecov.io/bash)
 
   test-omnisci:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
@@ -377,6 +361,9 @@ jobs:
   test-all:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         python-version: ["3.7", "3.8"]
@@ -403,50 +390,31 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
-      - shell: bash -l {0}
-        run: MODIN_BENCHMARK_MODE=True pytest modin/pandas/test/internals/test_benchmark_mode.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/experimental/xgboost/test/test_default.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_series.py
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_concat.py # Ray version fails with -n 2
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_general.py
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_io.py
-      - shell: bash -l {0}
-        run: python -m pytest modin/experimental/pandas/test/test_io_exp.py
-      - shell: bash -l {0}
-        run: pip install dfsql && pytest modin/experimental/sql/test/test_sql.py
-      - shell: bash -l {0}
-        run: bash <(curl -s https://codecov.io/bash)
+      - run: MODIN_BENCHMARK_MODE=True pytest modin/pandas/test/internals/test_benchmark_mode.py
+      - run: pytest -n 2 modin/experimental/xgboost/test/test_default.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_default.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_window.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py
+      - run: python -m pytest -n 2 modin/pandas/test/test_series.py
+      - run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
+      - run: python -m pytest -n 2 modin/pandas/test/test_concat.py
+        if: matrix.engine != 'ray'
+      - run: python -m pytest modin/pandas/test/test_concat.py # Ray version fails with -n 2
+        if: matrix.engine == 'ray'
+      - run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
+      - run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
+      - run: python -m pytest -n 2 modin/pandas/test/test_general.py
+      - run: python -m pytest modin/pandas/test/test_io.py
+      - run: python -m pytest modin/experimental/pandas/test/test_io_exp.py
+      - run: pip install dfsql && pytest modin/experimental/sql/test/test_sql.py
+      - run: bash <(curl -s https://codecov.io/bash)
 
   test-experimental:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
@@ -537,6 +505,7 @@ jobs:
           - modin/pandas/test/test_groupby.py
           - modin/pandas/test/test_reshape.py
           - modin/pandas/test/test_general.py
+          - modin/pandas/test/test_io.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -432,7 +432,7 @@ jobs:
       - shell: bash -l {0}
         run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_concat.py
+        run: python -m pytest modin/pandas/test/test_concat.py # Ray version fails with -n 2
       - shell: bash -l {0}
         run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
       - shell: bash -l {0}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,6 +513,9 @@ jobs:
   test-windows:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         python-version: ["3.7", "3.8"]
@@ -535,66 +538,46 @@ jobs:
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
           auto-update-conda: true # this enable `use-only-tar-bz2` feature on Windows
       - name: Conda environment
-        shell: bash -l {0}
         run: |
           conda info
           conda list
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_binary.py
+      - run: pytest modin/pandas/test/dataframe/test_binary.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_default.py
+      - run: pytest modin/pandas/test/dataframe/test_default.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_indexing.py
+      - run: pytest modin/pandas/test/dataframe/test_indexing.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_iter.py
+      - run: pytest modin/pandas/test/dataframe/test_iter.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_join_sort.py
+      - run: pytest modin/pandas/test/dataframe/test_join_sort.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_map_metadata.py
+      - run: pytest modin/pandas/test/dataframe/test_map_metadata.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_reduction.py
+      - run: pytest modin/pandas/test/dataframe/test_reduction.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_udf.py
+      - run: pytest modin/pandas/test/dataframe/test_udf.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_window.py
+      - run: pytest modin/pandas/test/dataframe/test_window.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_pickle.py
+      - run: pytest modin/pandas/test/dataframe/test_pickle.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_series.py
+      - run: python -m pytest modin/pandas/test/test_series.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_rolling.py
+      - run: python -m pytest modin/pandas/test/test_rolling.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_concat.py
+      - run: python -m pytest modin/pandas/test/test_concat.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_groupby.py
+      - run: python -m pytest modin/pandas/test/test_groupby.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_reshape.py
+      - run: python -m pytest modin/pandas/test/test_reshape.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_general.py
+      - run: python -m pytest modin/pandas/test/test_general.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        timeout-minutes: 20
+      - timeout-minutes: 20
         run: python -m pytest modin/pandas/test/test_io.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: choco install codecov
-      - shell: bash -l {0}
-        run: codecov -f ./coverage.xml
+      - run: choco install codecov
+      - run: codecov -f ./coverage.xml
 
   test-pyarrow:
     needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,7 +520,9 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8"]
         engine: ["ray", "dask"]
-        part: ["DataFrame", 3]
+        part:
+          - DataFrame
+          - 3
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -520,9 +520,23 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8"]
         engine: ["ray", "dask"]
-        part:
-          - DataFrame
-          - 3
+        test-task:
+          - modin/pandas/test/dataframe/test_binary.py
+          - modin/pandas/test/dataframe/test_default.py
+          - modin/pandas/test/dataframe/test_indexing.py
+          - modin/pandas/test/dataframe/test_iter.py
+          - modin/pandas/test/dataframe/test_join_sort.py
+          - modin/pandas/test/dataframe/test_map_metadata.py
+          - modin/pandas/test/dataframe/test_reduction.py
+          - modin/pandas/test/dataframe/test_udf.py
+          - modin/pandas/test/dataframe/test_window.py
+          - modin/pandas/test/dataframe/test_pickle.py
+          - modin/pandas/test/test_series.py
+          - modin/pandas/test/test_rolling.py
+          - modin/pandas/test/test_concat.py
+          - modin/pandas/test/test_groupby.py
+          - modin/pandas/test/test_reshape.py
+          - modin/pandas/test/test_general.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000
@@ -543,41 +557,11 @@ jobs:
         run: |
           conda info
           conda list
-      - run: pytest modin/pandas/test/dataframe/test_binary.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_default.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_indexing.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_iter.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_join_sort.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_map_metadata.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_reduction.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_udf.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_window.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_pickle.py
-        if: matrix.part == 'DataFrame'
-      - run: python -m pytest modin/pandas/test/test_series.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_rolling.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_concat.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_groupby.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_reshape.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_general.py
-        if: matrix.part == 3
+      - run: python -m pytest ${{matrix.test-task}}
+        if: matrix.test-task != 'modin/pandas/test/test_io.py'
       - timeout-minutes: 30
         run: python -m pytest modin/pandas/test/test_io.py
-        if: matrix.part == 3
+        if: matrix.test-task == 'modin/pandas/test/test_io.py'
       - run: choco install codecov
       - run: codecov -f ./coverage.xml
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -160,9 +160,9 @@ jobs:
       - run: python -m pytest -n 2 modin/pandas/test/test_series.py
       - run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
       - run: python -m pytest -n 2 modin/pandas/test/test_concat.py
-        if: matrix.engine != 'ray'
-      - run: python -m pytest modin/pandas/test/test_concat.py # Ray version fails with -n 2
-        if: matrix.engine == 'ray'
+        if: matrix.engine == 'python'
+      - run: python -m pytest modin/pandas/test/test_concat.py # Ray and Dask versions fails with -n 2
+        if: matrix.engine != 'python'
       - run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
       - run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
       - run: python -m pytest -n 2 modin/pandas/test/test_general.py

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -261,7 +261,7 @@ jobs:
         if: matrix.part == 3
       - run: python -m pytest modin/pandas/test/test_general.py
         if: matrix.part == 3
-      - timeout-minutes: 20
+      - timeout-minutes: 30
         run: python -m pytest modin/pandas/test/test_io.py
         if: matrix.part == 3
       - run: choco install codecov

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -185,7 +185,7 @@ jobs:
       - shell: bash -l {0}
         run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_concat.py
+        run: python -m pytest modin/pandas/test/test_concat.py # Ray version fails with -n 2
       - shell: bash -l {0}
         run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
       - shell: bash -l {0}

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -62,39 +62,39 @@ jobs:
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
       - shell: bash -l {0}
-        run: pytest modin/experimental/xgboost/test/test_default.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/experimental/xgboost/test/test_default.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_binary.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_default.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_indexing.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_iter.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_join_sort.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_map_metadata.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_reduction.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_udf.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_window.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_pickle.py --backend=${{ matrix.backend }}
+        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_series.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_series.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_rolling.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_concat.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_concat.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_groupby.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_reshape.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_general.py --backend=${{ matrix.backend }}
+        run: python -m pytest -n 2 modin/pandas/test/test_general.py --backend=${{ matrix.backend }}
       - shell: bash -l {0}
         run: bash <(curl -s https://codecov.io/bash)
 
@@ -159,39 +159,39 @@ jobs:
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
       - shell: bash -l {0}
-        run: pytest modin/experimental/xgboost/test/test_default.py
+        run: pytest -n 2 modin/experimental/xgboost/test/test_default.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_binary.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_default.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_indexing.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_iter.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_join_sort.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_map_metadata.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_reduction.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_udf.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_window.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_pickle.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_series.py
+        run: python -m pytest -n 2 modin/pandas/test/test_series.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_rolling.py
+        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_concat.py
+        run: python -m pytest -n 2 modin/pandas/test/test_concat.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_groupby.py
+        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_reshape.py
+        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_general.py
+        run: python -m pytest -n 2 modin/pandas/test/test_general.py
       - shell: bash -l {0}
         run: python -m pytest modin/pandas/test/test_io.py
       - shell: bash -l {0}
@@ -228,52 +228,52 @@ jobs:
           conda info
           conda list
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_binary.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_default.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_indexing.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_iter.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_join_sort.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_map_metadata.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_reduction.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_udf.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_window.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_pickle.py
+        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_series.py
+        run: python -m pytest -n 2 modin/pandas/test/test_series.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_rolling.py
+        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_concat.py
+        run: python -m pytest -n 2 modin/pandas/test/test_concat.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_groupby.py
+        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_reshape.py
+        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_general.py
+        run: python -m pytest -n 2 modin/pandas/test/test_general.py
         if: matrix.part == 3
       - shell: bash -l {0}
         timeout-minutes: 20

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -208,7 +208,9 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8"]
         engine: ["ray", "dask"]
-        part: ["DataFrame", 3]
+        part:
+          - DataFrame
+          - 3
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -201,6 +201,9 @@ jobs:
 
   test-windows:
     runs-on: windows-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         python-version: ["3.7", "3.8"]
@@ -223,66 +226,46 @@ jobs:
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
           auto-update-conda: true # this enable `use-only-tar-bz2` feature on Windows
       - name: Conda environment
-        shell: bash -l {0}
         run: |
           conda info
           conda list
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_binary.py
+      - run: pytest modin/pandas/test/dataframe/test_binary.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_default.py
+      - run: pytest modin/pandas/test/dataframe/test_default.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_indexing.py
+      - run: pytest modin/pandas/test/dataframe/test_indexing.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_iter.py
+      - run: pytest modin/pandas/test/dataframe/test_iter.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_join_sort.py
+      - run: pytest modin/pandas/test/dataframe/test_join_sort.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_map_metadata.py
+      - run: pytest modin/pandas/test/dataframe/test_map_metadata.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_reduction.py
+      - run: pytest modin/pandas/test/dataframe/test_reduction.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_udf.py
+      - run: pytest modin/pandas/test/dataframe/test_udf.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_window.py
+      - run: pytest modin/pandas/test/dataframe/test_window.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: pytest modin/pandas/test/dataframe/test_pickle.py
+      - run: pytest modin/pandas/test/dataframe/test_pickle.py
         if: matrix.part == 'DataFrame'
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_series.py
+      - run: python -m pytest modin/pandas/test/test_series.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_rolling.py
+      - run: python -m pytest modin/pandas/test/test_rolling.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_concat.py
+      - run: python -m pytest modin/pandas/test/test_concat.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_groupby.py
+      - run: python -m pytest modin/pandas/test/test_groupby.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_reshape.py
+      - run: python -m pytest modin/pandas/test/test_reshape.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_general.py
+      - run: python -m pytest modin/pandas/test/test_general.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        timeout-minutes: 20
+      - timeout-minutes: 20
         run: python -m pytest modin/pandas/test/test_io.py
         if: matrix.part == 3
-      - shell: bash -l {0}
-        run: choco install codecov
-      - shell: bash -l {0}
-        run: codecov -f ./coverage.xml
+      - run: choco install codecov
+      - run: codecov -f ./coverage.xml
 
   test-pyarrow:
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -208,9 +208,23 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8"]
         engine: ["ray", "dask"]
-        part:
-          - DataFrame
-          - 3
+        test-task:
+          - modin/pandas/test/dataframe/test_binary.py
+          - modin/pandas/test/dataframe/test_default.py
+          - modin/pandas/test/dataframe/test_indexing.py
+          - modin/pandas/test/dataframe/test_iter.py
+          - modin/pandas/test/dataframe/test_join_sort.py
+          - modin/pandas/test/dataframe/test_map_metadata.py
+          - modin/pandas/test/dataframe/test_reduction.py
+          - modin/pandas/test/dataframe/test_udf.py
+          - modin/pandas/test/dataframe/test_window.py
+          - modin/pandas/test/dataframe/test_pickle.py
+          - modin/pandas/test/test_series.py
+          - modin/pandas/test/test_rolling.py
+          - modin/pandas/test/test_concat.py
+          - modin/pandas/test/test_groupby.py
+          - modin/pandas/test/test_reshape.py
+          - modin/pandas/test/test_general.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000
@@ -231,41 +245,11 @@ jobs:
         run: |
           conda info
           conda list
-      - run: pytest modin/pandas/test/dataframe/test_binary.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_default.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_indexing.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_iter.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_join_sort.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_map_metadata.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_reduction.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_udf.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_window.py
-        if: matrix.part == 'DataFrame'
-      - run: pytest modin/pandas/test/dataframe/test_pickle.py
-        if: matrix.part == 'DataFrame'
-      - run: python -m pytest modin/pandas/test/test_series.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_rolling.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_concat.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_groupby.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_reshape.py
-        if: matrix.part == 3
-      - run: python -m pytest modin/pandas/test/test_general.py
-        if: matrix.part == 3
+      - run: python -m pytest ${{matrix.test-task}}
+        if: matrix.test-task != 'modin/pandas/test/test_io.py'
       - timeout-minutes: 30
         run: python -m pytest modin/pandas/test/test_io.py
-        if: matrix.part == 3
+        if: matrix.test-task == 'modin/pandas/test/test_io.py'
       - run: choco install codecov
       - run: codecov -f ./coverage.xml
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,6 +36,9 @@ jobs:
 
   test-defaults:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         backend: [BaseOnPython]
@@ -61,42 +64,24 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/experimental/xgboost/test/test_default.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_series.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_concat.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_general.py --backend=${{ matrix.backend }}
-      - shell: bash -l {0}
-        run: bash <(curl -s https://codecov.io/bash)
+      - run: pytest -n 2 modin/experimental/xgboost/test/test_default.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_default.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_window.py --backend=${{ matrix.backend }}
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_series.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_rolling.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_concat.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_groupby.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_reshape.py --backend=${{ matrix.backend }}
+      - run: python -m pytest -n 2 modin/pandas/test/test_general.py --backend=${{ matrix.backend }}
+      - run: bash <(curl -s https://codecov.io/bash)
 
   test-omnisci:
     runs-on: ubuntu-latest
@@ -132,6 +117,9 @@ jobs:
 
   test-all:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
     strategy:
       matrix:
         python-version: ["3.7", "3.8"]
@@ -158,46 +146,29 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/experimental/xgboost/test/test_default.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py
-      - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_series.py
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_concat.py # Ray version fails with -n 2
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
-      - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_general.py
-      - shell: bash -l {0}
-        run: python -m pytest modin/pandas/test/test_io.py
-      - shell: bash -l {0}
-        run: python -m pytest modin/experimental/pandas/test/test_io_exp.py
-      - shell: bash -l {0}
-        run: bash <(curl -s https://codecov.io/bash)
+      - run: pytest -n 2 modin/experimental/xgboost/test/test_default.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_default.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_window.py
+      - run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py
+      - run: python -m pytest -n 2 modin/pandas/test/test_series.py
+      - run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
+      - run: python -m pytest -n 2 modin/pandas/test/test_concat.py
+        if: matrix.engine != 'ray'
+      - run: python -m pytest modin/pandas/test/test_concat.py # Ray version fails with -n 2
+        if: matrix.engine == 'ray'
+      - run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
+      - run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
+      - run: python -m pytest -n 2 modin/pandas/test/test_general.py
+      - run: python -m pytest modin/pandas/test/test_io.py
+      - run: python -m pytest modin/experimental/pandas/test/test_io_exp.py
+      - run: bash <(curl -s https://codecov.io/bash)
 
   test-windows:
     runs-on: windows-latest
@@ -225,6 +196,7 @@ jobs:
           - modin/pandas/test/test_groupby.py
           - modin/pandas/test/test_reshape.py
           - modin/pandas/test/test_general.py
+          - modin/pandas/test/test_io.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: 1000000000

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -228,52 +228,52 @@ jobs:
           conda info
           conda list
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py
+        run: pytest modin/pandas/test/dataframe/test_binary.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_default.py
+        run: pytest modin/pandas/test/dataframe/test_default.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_indexing.py
+        run: pytest modin/pandas/test/dataframe/test_indexing.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_iter.py
+        run: pytest modin/pandas/test/dataframe/test_iter.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_join_sort.py
+        run: pytest modin/pandas/test/dataframe/test_join_sort.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
+        run: pytest modin/pandas/test/dataframe/test_map_metadata.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_reduction.py
+        run: pytest modin/pandas/test/dataframe/test_reduction.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_udf.py
+        run: pytest modin/pandas/test/dataframe/test_udf.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_window.py
+        run: pytest modin/pandas/test/dataframe/test_window.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: pytest -n 2 modin/pandas/test/dataframe/test_pickle.py
+        run: pytest modin/pandas/test/dataframe/test_pickle.py
         if: matrix.part == 'DataFrame'
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_series.py
+        run: python -m pytest modin/pandas/test/test_series.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_rolling.py
+        run: python -m pytest modin/pandas/test/test_rolling.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_concat.py
+        run: python -m pytest modin/pandas/test/test_concat.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
+        run: python -m pytest modin/pandas/test/test_groupby.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
+        run: python -m pytest modin/pandas/test/test_reshape.py
         if: matrix.part == 3
       - shell: bash -l {0}
-        run: python -m pytest -n 2 modin/pandas/test/test_general.py
+        run: python -m pytest modin/pandas/test/test_general.py
         if: matrix.part == 3
       - shell: bash -l {0}
         timeout-minutes: 20


### PR DESCRIPTION
Signed-off-by: Gregory Shimansky <gregory.shimansky@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3031 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
