### PR TITLE
Fix docstring inheritance

### DIFF
--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -97,6 +97,7 @@ def test_doc_inherit_clslevel(wrapped_cls):
     _check_doc(wrapped_cls, BaseChild)
 
 
+
 def test_doc_inherit_methods(wrapped_cls):
     _check_doc(wrapped_cls.method, BaseChild.method)
     _check_doc(wrapped_cls.base_method, BaseParent.base_method)

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -97,7 +97,6 @@ def test_doc_inherit_clslevel(wrapped_cls):
     _check_doc(wrapped_cls, BaseChild)
 
 
-
 def test_doc_inherit_methods(wrapped_cls):
     _check_doc(wrapped_cls.method, BaseChild.method)
     _check_doc(wrapped_cls.base_method, BaseParent.base_method)

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -115,3 +115,18 @@ def test_doc_inherit_props(wrapped_cls):
     assert type(wrapped_cls.method) == type(BaseChild.method)  # noqa: E721
     _check_doc(wrapped_cls.prop, BaseChild.prop)
     _check_doc(wrapped_cls.F, BaseChild.F)
+
+
+def test_doc_inherit_prop_builder():
+    def builder(name):
+        return property(lambda self: name)
+
+    class Parent:
+        prop = builder("Parent")
+
+    @modin.utils._inherit_docstrings(Parent)
+    class Child(Parent):
+        prop = builder("Child")
+
+    assert Parent().prop == "Parent"
+    assert Child().prop == "Child"

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -156,8 +156,8 @@ def _inherit_docstrings(parent, excluded=[], overwrite_existing=False, apilink=N
     Create a decorator which overwrites decorated object docstring(s).
 
     It takes `parent` __doc__ attribute. Also overwrites __doc__ of
-    methods and properties defined in the target if it's a class with the __doc__ of
-    matching methods and properties from the `parent`.
+    methods and properties defined in the target or its ancestors if it's a class
+    with the __doc__ of matching methods and properties from the `parent`.
 
     Parameters
     ----------
@@ -177,6 +177,12 @@ def _inherit_docstrings(parent, excluded=[], overwrite_existing=False, apilink=N
     -------
     callable
         Decorator which replaces the decorated object's documentation with `parent` documentation.
+
+    Notes
+    -----
+    Keep in mind that the function will override docstrings even for attributes which
+    are not defined in target class (but are defined in the ancestor class),
+    which means that ancestor class attribute docstrings could also change.
     """
 
     def _documentable_obj(obj):

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -192,10 +192,14 @@ def _inherit_docstrings(parent, excluded=[], overwrite_existing=False, apilink=N
             _replace_doc(parent, cls_or_func, overwrite_existing, apilink)
 
         if not isinstance(cls_or_func, types.FunctionType):
+            seen = set()
             for base in cls_or_func.__mro__:
                 if base is object:
                     continue
                 for attr, obj in base.__dict__.items():
+                    if attr in seen:
+                        continue
+                    seen.add(attr)
                     parent_obj = getattr(parent, attr, None)
                     if (
                         parent_obj in excluded


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Fix handling `@staticmethod` and `@classmethod` decorators, add tests for `@_inherit_docstrings` (finally 🤣, should have made those from the start).

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3033 
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
