### PR TITLE
FIX-#3063: Handle inplace side effect in `to_datetime`

### DIFF
--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -212,6 +212,37 @@ def copy_df_for_func(func, display_name: str = None):
     return caller
 
 
+def handle_readonly_buffer(func: callable, display_name: str = None):
+    """
+    Build a function that handles read-only buffers in the workers.
+
+    This utility is for operators that have in-place side effects in pandas,
+    but are not themselves inplace.
+
+    Parameters
+    ----------
+    func : callable(pandas.DataFrame)
+        The function, which should not update the dataframe inplace
+    display_name : str, optional
+        The function's name, which can be displayed by a progress bar.
+
+    Returns
+    -------
+    callable(pandas.DataFrame)
+        A callable function to be applied in the partitions
+    """
+
+    def caller(df, *args, **kwargs):
+        try:
+            return func(df, *args, **kwargs)
+        except ValueError:
+            return func(df.copy(), *args, **kwargs)
+
+    if display_name is not None:
+        caller.__name__ = display_name
+    return caller
+
+
 @_inherit_docstrings(BaseQueryCompiler)
 class PandasQueryCompiler(BaseQueryCompiler):
     """
@@ -788,12 +819,21 @@ class PandasQueryCompiler(BaseQueryCompiler):
     prod_min_count = ReductionFunction.register(pandas.DataFrame.prod)
     quantile_for_single_value = ReductionFunction.register(pandas.DataFrame.quantile)
     mad = ReductionFunction.register(pandas.DataFrame.mad)
-    to_datetime = ReductionFunction.register(
-        lambda df, *args, **kwargs: pandas.to_datetime(
-            df.squeeze(axis=1), *args, **kwargs
-        ),
-        axis=1,
-    )
+
+    def to_datetime(self, *args, **kwargs):
+        if len(self.columns) == 1:
+            return MapFunction.register(
+                # to_datetime has inplace side effects, see GH#3063
+                handle_readonly_buffer(
+                    lambda df, *args, **kwargs: pandas.to_datetime(
+                        df.squeeze(axis=1), *args, **kwargs
+                    ).to_frame()
+                ),
+            )(self, *args, **kwargs)
+        else:
+            return ReductionFunction.register(pandas.to_datetime, axis=1)(
+                self, *args, **kwargs
+            )
 
     # END Reduction operations
 

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -212,37 +212,6 @@ def copy_df_for_func(func, display_name: str = None):
     return caller
 
 
-def handle_readonly_buffer(func: callable, display_name: str = None):
-    """
-    Build a function that handles read-only buffers in the workers.
-
-    This utility is for operators that have in-place side effects in pandas,
-    but are not themselves inplace.
-
-    Parameters
-    ----------
-    func : callable(pandas.DataFrame)
-        The function, which should not update the dataframe inplace.
-    display_name : str, optional
-        The function's name, which can be displayed by a progress bar.
-
-    Returns
-    -------
-    callable(pandas.DataFrame)
-        A callable function to be applied in the partitions.
-    """
-
-    def caller(df, *args, **kwargs):
-        try:
-            return func(df, *args, **kwargs)
-        except ValueError:
-            return func(df.copy(), *args, **kwargs)
-
-    if display_name is not None:
-        caller.__name__ = display_name
-    return caller
-
-
 @_inherit_docstrings(BaseQueryCompiler)
 class PandasQueryCompiler(BaseQueryCompiler):
     """
@@ -824,11 +793,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if len(self.columns) == 1:
             return MapFunction.register(
                 # to_datetime has inplace side effects, see GH#3063
-                handle_readonly_buffer(
-                    lambda df, *args, **kwargs: pandas.to_datetime(
-                        df.squeeze(axis=1), *args, **kwargs
-                    ).to_frame()
-                ),
+                lambda df, *args, **kwargs: pandas.to_datetime(
+                    df.squeeze(axis=1), *args, **kwargs
+                ).to_frame()
             )(self, *args, **kwargs)
         else:
             return ReductionFunction.register(pandas.to_datetime, axis=1)(

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -222,14 +222,14 @@ def handle_readonly_buffer(func: callable, display_name: str = None):
     Parameters
     ----------
     func : callable(pandas.DataFrame)
-        The function, which should not update the dataframe inplace
+        The function, which should not update the dataframe inplace.
     display_name : str, optional
         The function's name, which can be displayed by a progress bar.
 
     Returns
     -------
     callable(pandas.DataFrame)
-        A callable function to be applied in the partitions
+        A callable function to be applied in the partitions.
     """
 
     def caller(df, *args, **kwargs):

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -644,6 +644,18 @@ def test_to_datetime():
     )
 
 
+def test_to_datetime_inplace_side_effect():
+    # See GH#3063
+    times = list(range(1617993360, 1618193360))
+    values = list(range(215441, 415441))
+    modin_df = pd.DataFrame({"time": times, "value": values})
+    pandas_df = pandas.DataFrame({"time": times, "value": values})
+    df_equals(
+        pd.to_datetime(modin_df["time"], unit="s"),
+        pandas.to_datetime(pandas_df["time"], unit="s"),
+    )
+
+
 @pytest.mark.parametrize(
     "data, errors, downcast",
     [


### PR DESCRIPTION
Resolves #3063

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3063 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
