### PR TITLE
FIX-#3110: preserve partitions shape cache when masking with a slice 

### DIFF
--- a/modin/engines/base/frame/partition.py
+++ b/modin/engines/base/frame/partition.py
@@ -176,15 +176,11 @@ class PandasFramePartition(ABC):  # pragma: no cover
 
         def try_recompute_cache(indices, previous_cache):
             """Compute new axis-length cache for the masked frame based on its previous cache."""
-            return (
-                (
-                    compute_sliced_len(indices, previous_cache)
-                    if isinstance(previous_cache, int)
-                    else None
-                )
-                if isinstance(indices, slice)
-                else len(indices)
-            )
+            if not isinstance(indices, slice):
+                return len(indices)
+            if not isinstance(previous_cache, int):
+                return None
+            return compute_sliced_len(indices, previous_cache)
 
         new_obj._length_cache = try_recompute_cache(row_indices, self._length_cache)
         new_obj._width_cache = try_recompute_cache(col_indices, self._width_cache)

--- a/modin/engines/base/frame/partition.py
+++ b/modin/engines/base/frame/partition.py
@@ -133,6 +133,17 @@ class PandasFramePartition(ABC):  # pragma: no cover
         """
         pass
 
+    def __copy__(self):
+        """
+        Create a copy of this partition.
+
+        Returns
+        -------
+        PandasFramePartition
+            A copy of this partition.
+        """
+        pass
+
     def mask(self, row_indices, col_indices):
         """
         Lazily create a mask that extracts the indices provided.

--- a/modin/engines/base/frame/partition.py
+++ b/modin/engines/base/frame/partition.py
@@ -173,24 +173,21 @@ class PandasFramePartition(ABC):  # pragma: no cover
             return copy(self)
 
         new_obj = self.add_to_apply_calls(lambda df: df.iloc[row_indices, col_indices])
-        new_obj._length_cache = (
-            (
-                compute_sliced_len(row_indices, self._length_cache)
-                if isinstance(self._length_cache, int)
-                else None
+
+        def try_recompute_cache(indices, previous_cache):
+            """Compute new axis-length cache for the masked frame based on its previous cache."""
+            return (
+                (
+                    compute_sliced_len(indices, previous_cache)
+                    if isinstance(previous_cache, int)
+                    else None
+                )
+                if isinstance(indices, slice)
+                else len(indices)
             )
-            if isinstance(row_indices, slice)
-            else len(row_indices)
-        )
-        new_obj._width_cache = (
-            (
-                compute_sliced_len(col_indices, self._width_cache)
-                if isinstance(self._width_cache, int)
-                else None
-            )
-            if isinstance(col_indices, slice)
-            else len(col_indices)
-        )
+
+        new_obj._length_cache = try_recompute_cache(row_indices, self._length_cache)
+        new_obj._width_cache = try_recompute_cache(col_indices, self._width_cache)
         return new_obj
 
     @classmethod

--- a/modin/engines/dask/pandas_on_dask/frame/partition.py
+++ b/modin/engines/dask/pandas_on_dask/frame/partition.py
@@ -167,9 +167,9 @@ class PandasOnDaskFramePartition(PandasFramePartition):
 
         Parameters
         ----------
-        row_indices : list-like
+        row_indices : list-like, slice or label
             The indices for the rows to extract.
-        col_indices : list-like
+        col_indices : list-like, slice or label
             The indices for the columns to extract.
 
         Returns

--- a/modin/engines/python/pandas_on_python/frame/partition.py
+++ b/modin/engines/python/pandas_on_python/frame/partition.py
@@ -48,22 +48,6 @@ class PandasOnPythonFramePartition(PandasFramePartition):
         self.drain_call_queue()
         return self.data.copy()
 
-    def __copy__(self):
-        """
-        Create a copy of this partition.
-
-        Returns
-        -------
-        PandasOnPythonFramePartition
-            A copy of this partition.
-        """
-        return type(self)(
-            data=self.data,
-            length=self._length_cache,
-            width=self._width_cache,
-            call_queue=self.call_queue,
-        )
-
     def apply(self, func, **kwargs):
         """Apply some callable function to the data in this partition.
 

--- a/modin/engines/python/pandas_on_python/frame/partition.py
+++ b/modin/engines/python/pandas_on_python/frame/partition.py
@@ -48,6 +48,22 @@ class PandasOnPythonFramePartition(PandasFramePartition):
         self.drain_call_queue()
         return self.data.copy()
 
+    def __copy__(self):
+        """
+        Create a copy of this partition.
+
+        Returns
+        -------
+        PandasOnPythonFramePartition
+            A copy of this partition.
+        """
+        return type(self)(
+            data=self.data,
+            length=self._length_cache,
+            width=self._width_cache,
+            call_queue=self.call_queue,
+        )
+
     def apply(self, func, **kwargs):
         """Apply some callable function to the data in this partition.
 

--- a/modin/engines/python/pandas_on_python/frame/partition.py
+++ b/modin/engines/python/pandas_on_python/frame/partition.py
@@ -90,16 +90,6 @@ class PandasOnPythonFramePartition(PandasFramePartition):
     def wait(self):
         self.drain_call_queue()
 
-    def mask(self, row_indices=None, col_indices=None):
-        new_obj = self.add_to_apply_calls(
-            lambda df: pandas.DataFrame(df.iloc[row_indices, col_indices])
-        )
-        if not isinstance(row_indices, slice):
-            new_obj._length_cache = len(row_indices)
-        if not isinstance(col_indices, slice):
-            new_obj._width_cache = len(col_indices)
-        return new_obj
-
     def to_pandas(self):
         """Convert the object stored in this partition to a Pandas DataFrame.
 

--- a/modin/engines/ray/pandas_on_ray/frame/partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition.py
@@ -18,6 +18,7 @@ import pandas
 from modin.data_management.utils import length_fn_pandas, width_fn_pandas
 from modin.engines.base.frame.partition import PandasFramePartition
 from modin.engines.ray.utils import handle_ray_task_error
+from modin.pandas.indexing import compute_sliced_len
 
 import ray
 from ray.worker import RayTaskError
@@ -29,6 +30,8 @@ if version.parse(ray.__version__) >= version.parse("1.2.0"):
     from ray.util.client.common import ClientObjectRef
 
     ObjectIDType = (ray.ObjectRef, ClientObjectRef)
+
+compute_sliced_len = ray.remote(compute_sliced_len)
 
 
 class PandasOnRayFramePartition(PandasFramePartition):
@@ -209,30 +212,19 @@ class PandasOnRayFramePartition(PandasFramePartition):
         PandasOnRayFramePartition
             A new ``PandasOnRayFramePartition`` object.
         """
-        if (
-            (isinstance(row_indices, slice) and row_indices == slice(None))
-            or (
-                not isinstance(row_indices, slice)
-                and self._length_cache is not None
-                and len(row_indices) == self._length_cache
-            )
-        ) and (
-            (isinstance(col_indices, slice) and col_indices == slice(None))
-            or (
-                not isinstance(col_indices, slice)
-                and self._width_cache is not None
-                and len(col_indices) == self._width_cache
-            )
+        new_obj = super().mask(row_indices, col_indices)
+        if isinstance(row_indices, slice) and isinstance(
+            self._length_cache, ObjectIDType
         ):
-            return self.__copy__()
-
-        new_obj = self.add_to_apply_calls(
-            lambda df: pandas.DataFrame(df.iloc[row_indices, col_indices])
-        )
-        if not isinstance(row_indices, slice):
-            new_obj._length_cache = len(row_indices)
-        if not isinstance(col_indices, slice):
-            new_obj._width_cache = len(col_indices)
+            new_obj._length_cache = compute_sliced_len.remote(
+                row_indices, self._length_cache
+            )
+        if isinstance(col_indices, slice) and isinstance(
+            self._width_cache, ObjectIDType
+        ):
+            new_obj._width_cache = compute_sliced_len.remote(
+                col_indices, self._width_cache
+            )
         return new_obj
 
     @classmethod

--- a/modin/engines/ray/pandas_on_ray/frame/partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition.py
@@ -202,9 +202,9 @@ class PandasOnRayFramePartition(PandasFramePartition):
 
         Parameters
         ----------
-        row_indices : list-like
+        row_indices : list-like, slice or label
             The indices for the rows to extract.
-        col_indices : list-like
+        col_indices : list-like, slice or label
             The indices for the columns to extract.
 
         Returns

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -45,6 +45,7 @@ def test_top_level_api_equality():
     ]
 
     ignore_modin = [
+        "indexing",
         "iterator",
         "series",
         "accessor",

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -20,7 +20,6 @@ from modin.distributed.dataframe.pandas import unwrap_partitions, from_partition
 from modin.config import Engine, NPartitions
 from modin.pandas.test.utils import df_equals
 from modin.pandas.indexing import compute_sliced_len
-
 from modin.data_management.factories.dispatcher import EngineDispatcher
 
 PartitionClass = (
@@ -119,8 +118,8 @@ def test_from_partitions(axis):
     df_equals(expected_df, actual_df)
 
 
-@pytest.mark.parametrize("row_indices", [[0, 2], slice(None, None, 2)])
-@pytest.mark.parametrize("col_indices", [[0, 2], slice(None, None, 2)])
+@pytest.mark.parametrize("row_indices", [[0, 2], slice(None)])
+@pytest.mark.parametrize("col_indices", [[0, 2], slice(None)])
 @pytest.mark.parametrize("is_length_future", [False, True])
 @pytest.mark.parametrize("is_width_future", [False, True])
 def test_mask_preserve_cache(

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -39,10 +39,14 @@ elif Engine.get() == "Dask":
     put_func = lambda x: get_client().scatter(x)  # noqa: E731
     get_func = lambda x: x.result()  # noqa: E731
     FutureType = Future
-else:
+elif Engine.get() == "Python":
     put_func = lambda x: x  # noqa: E731
     get_func = lambda x: x  # noqa: E731
     FutureType = object
+else:
+    raise NotImplementedError(
+        f"'{Engine.get()}' engine is not supported by these test suites"
+    )
 
 NPartitions.put(4)
 # HACK: implicit engine initialization (Modin issue #2989)

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -125,7 +125,7 @@ def test_from_partitions(axis):
 def test_mask_preserve_cache(
     row_indices, col_indices, is_length_future, is_width_future
 ):
-    def serialize(obj):
+    def deserialize(obj):
         if isinstance(obj, FutureType):
             return get_func(obj)
         return obj
@@ -152,8 +152,8 @@ def test_mask_preserve_cache(
     expected_width = compute_length(col_indices, len(df.columns))
 
     # Check that the cache is preserved
-    assert expected_length == serialize(masked_partition._length_cache)
-    assert expected_width == serialize(masked_partition._width_cache)
+    assert expected_length == deserialize(masked_partition._length_cache)
+    assert expected_width == deserialize(masked_partition._width_cache)
     # Check that the cache is interpreted properly
     assert expected_length == masked_partition.length()
     assert expected_width == masked_partition.width()


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

This PR adds logic of partition's shape cache re-computing for the result of `.mask(slice)` based on the self shape cache. The common `.mask` logic was moved to the base pandas partition class, the differences of the shape re-computing based on the cache futures of different engines remained to the inheritors.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3110 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
