### PR TITLE
FIX-#3116: Add variable to be able to set Redis password

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -16,6 +16,7 @@ import sys
 from textwrap import dedent
 import warnings
 from packaging import version
+import secrets
 
 from .pubsub import Parameter, _TYPE_PARAMS, ExactStr, ValueSource
 
@@ -119,6 +120,15 @@ class RayRedisAddress(EnvironmentVariable, type=ExactStr):
     """
 
     varname = "MODIN_REDIS_ADDRESS"
+
+
+class RayRedisPassword(EnvironmentVariable, type=ExactStr):
+    """
+    What password to use for connecting to Redis
+    """
+
+    varname = "MODIN_REDIS_PASSWORD"
+    default = secrets.token_hex(32)
 
 
 class CpuCount(EnvironmentVariable, type=int):

--- a/modin/engines/ray/utils.py
+++ b/modin/engines/ray/utils.py
@@ -21,6 +21,7 @@ from modin.config import (
     Backend,
     IsRayCluster,
     RayRedisAddress,
+    RayRedisPassword,
     CpuCount,
     GpuCount,
     Memory,
@@ -132,16 +133,14 @@ def initialize_ray(
         If not specified, ``modin.config.RayRedisAddress`` is used.
     override_redis_password : str, optional
         What password to use when connecting to Redis.
-        If not specified, a new random one is generated.
+        If not specified, ``modin.config.RayRedisPassword`` is used.
     """
     import ray
 
     if not ray.is_initialized() or override_is_cluster:
-        import secrets
-
         cluster = override_is_cluster or IsRayCluster.get()
         redis_address = override_redis_address or RayRedisAddress.get()
-        redis_password = override_redis_password or secrets.token_hex(32)
+        redis_password = override_redis_password or RayRedisPassword.get()
 
         if cluster:
             # We only start ray in a cluster setting for the head node.


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Add `MODIN_REDIS_PASSWORD` environment variable (and corresponding `RayRedisPassword` configuration object) to allow controlling Redis password to be used during Ray initialization. This should allow connecting to an already spawned cluster in a non-cloud mode.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3116
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
