### PR TITLE
TEST-#3085: Add testing for Ray Client

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -665,19 +665,17 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8"]
         test-task:
-          # The following are broken on Ray 1.3+ (Unrelated to ray client)
-          # - modin/pandas/test/dataframe/test_binary.py
-          # - modin/pandas/test/dataframe/test_map_metadata.py
-          # - modin/pandas/test/dataframe/test_reduction.py
-          # - modin/pandas/test/dataframe/test_udf.py
-          # - modin/pandas/test/test_series.py
-          # - modin/experimental/pandas/test/test_io_exp.py
+          - modin/pandas/test/dataframe/test_binary.py
           - modin/pandas/test/dataframe/test_default.py
           - modin/pandas/test/dataframe/test_indexing.py
           - modin/pandas/test/dataframe/test_iter.py
           - modin/pandas/test/dataframe/test_join_sort.py
+          - modin/pandas/test/dataframe/test_map_metadata.py
+          - modin/pandas/test/dataframe/test_reduction.py
+          - modin/pandas/test/dataframe/test_udf.py
           - modin/pandas/test/dataframe/test_window.py
           - modin/pandas/test/dataframe/test_pickle.py
+          - modin/pandas/test/test_series.py
           - modin/pandas/test/test_rolling.py
           - modin/pandas/test/test_concat.py
           - modin/pandas/test/test_groupby.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -654,3 +654,68 @@ jobs:
           conda list
       - shell: bash -l {0}
         run: python -m pytest modin/spreadsheet/test/test_general.py
+
+  test-ray-client:
+    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8"]
+        test-task:
+          # The following are broken on Ray 1.3+ (Unrelated to ray client)
+          # - modin/pandas/test/dataframe/test_binary.py
+          # - modin/pandas/test/dataframe/test_map_metadata.py
+          # - modin/pandas/test/dataframe/test_reduction.py
+          # - modin/pandas/test/dataframe/test_udf.py
+          # - modin/pandas/test/test_series.py
+          # - modin/experimental/pandas/test/test_io_exp.py
+          - modin/pandas/test/dataframe/test_default.py
+          - modin/pandas/test/dataframe/test_indexing.py
+          - modin/pandas/test/dataframe/test_iter.py
+          - modin/pandas/test/dataframe/test_join_sort.py
+          - modin/pandas/test/dataframe/test_window.py
+          - modin/pandas/test/dataframe/test_pickle.py
+          - modin/pandas/test/test_rolling.py
+          - modin/pandas/test/test_concat.py
+          - modin/pandas/test/test_groupby.py
+          - modin/pandas/test/test_reshape.py
+          - modin/pandas/test/test_general.py
+          - modin/pandas/test/test_io.py
+    env:
+      MODIN_ENGINE: ray
+      MODIN_MEMORY: 1000000000
+      MODIN_TEST_RAY_CLIENT: "True"
+    name: "test-ray-client"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: modin
+          python-version: ${{matrix.python-version}}
+          channel-priority: strict
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+      - run: pip install -r requirements-dev.txt
+      # Use a ray master commit that includes the fix here: https://github.com/ray-project/ray/pull/16278
+      # Can be changed after a Ray version > 1.4 is released.
+      - run: pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c8e3ed9eec30119092ef966ee7b8982c8954c333/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
+        if: matrix.python-version == '3.7'
+      - run: pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c8e3ed9eec30119092ef966ee7b8982c8954c333/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+        if: matrix.python-version == '3.8'
+      - name: Install HDF5
+        run: sudo apt update && sudo apt install -y libhdf5-dev
+      - run: python -m pytest ${{matrix.test-task}}
+      - run: |
+          curl -o codecov https://codecov.io/bash
+          VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+          curl -o SHA512SUM "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM"
+          if sha512sum -c --ignore-missing --status SHA512SUM; then
+              bash ./codecov
+          else
+              echo 'CORRUPTED CODECOV SCRIPT!!!'
+              exit 10
+          fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -308,3 +308,67 @@ jobs:
           conda list
       - shell: bash -l {0}
         run: python -m pytest modin/spreadsheet/test/test_general.py
+
+  test-ray-client:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8"]
+        test-task:
+          # The following are broken on Ray 1.3+ (Unrelated to ray client)
+          # - modin/pandas/test/dataframe/test_binary.py
+          # - modin/pandas/test/dataframe/test_map_metadata.py
+          # - modin/pandas/test/dataframe/test_reduction.py
+          # - modin/pandas/test/dataframe/test_udf.py
+          # - modin/pandas/test/test_series.py
+          # - modin/experimental/pandas/test/test_io_exp.py
+          - modin/pandas/test/dataframe/test_default.py
+          - modin/pandas/test/dataframe/test_indexing.py
+          - modin/pandas/test/dataframe/test_iter.py
+          - modin/pandas/test/dataframe/test_join_sort.py
+          - modin/pandas/test/dataframe/test_window.py
+          - modin/pandas/test/dataframe/test_pickle.py
+          - modin/pandas/test/test_rolling.py
+          - modin/pandas/test/test_concat.py
+          - modin/pandas/test/test_groupby.py
+          - modin/pandas/test/test_reshape.py
+          - modin/pandas/test/test_general.py
+          - modin/pandas/test/test_io.py
+    env:
+      MODIN_ENGINE: ray
+      MODIN_MEMORY: 1000000000
+      MODIN_TEST_RAY_CLIENT: "True"
+    name: "test-ray-client"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: modin
+          python-version: ${{matrix.python-version}}
+          channel-priority: strict
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+      - run: pip install -r requirements-dev.txt
+      # Use a ray master commit that includes the fix here: https://github.com/ray-project/ray/pull/16278
+      # Can be changed after a Ray version > 1.4 is released.
+      - run: pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c8e3ed9eec30119092ef966ee7b8982c8954c333/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
+        if: matrix.python-version == '3.7'
+      - run: pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c8e3ed9eec30119092ef966ee7b8982c8954c333/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+        if: matrix.python-version == '3.8'
+      - name: Install HDF5
+        run: sudo apt update && sudo apt install -y libhdf5-dev
+      - run: python -m pytest ${{matrix.test-task}}
+      - run: |
+          curl -o codecov https://codecov.io/bash
+          VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);
+          curl -o SHA512SUM "https://raw.githubusercontent.com/codecov/codecov-bash/${VERSION}/SHA512SUM"
+          if sha512sum -c --ignore-missing --status SHA512SUM; then
+              bash ./codecov
+          else
+              echo 'CORRUPTED CODECOV SCRIPT!!!'
+              exit 10
+          fi

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -318,19 +318,17 @@ jobs:
       matrix:
         python-version: ["3.7", "3.8"]
         test-task:
-          # The following are broken on Ray 1.3+ (Unrelated to ray client)
-          # - modin/pandas/test/dataframe/test_binary.py
-          # - modin/pandas/test/dataframe/test_map_metadata.py
-          # - modin/pandas/test/dataframe/test_reduction.py
-          # - modin/pandas/test/dataframe/test_udf.py
-          # - modin/pandas/test/test_series.py
-          # - modin/experimental/pandas/test/test_io_exp.py
+          - modin/pandas/test/dataframe/test_binary.py
           - modin/pandas/test/dataframe/test_default.py
           - modin/pandas/test/dataframe/test_indexing.py
           - modin/pandas/test/dataframe/test_iter.py
           - modin/pandas/test/dataframe/test_join_sort.py
+          - modin/pandas/test/dataframe/test_map_metadata.py
+          - modin/pandas/test/dataframe/test_reduction.py
+          - modin/pandas/test/dataframe/test_udf.py
           - modin/pandas/test/dataframe/test_window.py
           - modin/pandas/test/dataframe/test_pickle.py
+          - modin/pandas/test/test_series.py
           - modin/pandas/test/test_rolling.py
           - modin/pandas/test/test_concat.py
           - modin/pandas/test/test_groupby.py

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -239,6 +239,16 @@ class TestDatasetSize(EnvironmentVariable, type=str):
     choices = ("Small", "Normal", "Big")
 
 
+class TestRayClient(EnvironmentVariable, type=bool):
+    """
+    Set to true to start and connect ray client before a testing session
+    starts.
+    """
+
+    varname = "MODIN_TEST_RAY_CLIENT"
+    default = False
+
+
 class TrackFileLeaks(EnvironmentVariable, type=bool):
     """
     Whether to track for open file handles leakage during testing

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -474,7 +474,7 @@ def pytest_sessionstart(session):
         ray.util.connect(f"localhost:{port}")
 
 
-def pytest_sessionfinish(session):
+def pytest_sessionfinish(session, exitstatus):
     if TestRayClient.get():
         import ray
         import subprocess


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->
Signed-off-by: Chris Wong <chriskw.xyz@gmail.com>

## What do these changes do?

On code side there's a new environment variable that can be set to start a ray client connection before the test session starts. 

For push/ci, currently installing a wheel slightly ahead of Ray 1.4 to fix the import deserialization race condition, which seemed to crop up extra frequently when using ray client. Since client is a bit finicky with multiple connections at the moment the `-n 2` flag with pytest doesn't work, so I separated out the tests in the matrix so that they wouldn't bottleneck the completion time (similar to what's being done for test windows). I've also left out the following tests which are failing due to reasons unrelated to ray client (primarily seems like there's been a change with how errors are propagated since 1.1 which the test suite doesn't yet handle)
- `modin/pandas/test/dataframe/test_binary.py`
- `modin/pandas/test/dataframe/test_map_metadata.py`
- `modin/pandas/test/dataframe/test_reduction.py`
- `modin/pandas/test/dataframe/test_udf.py`
- `modin/pandas/test/test_series.py`
- `modin/experimental/pandas/test/test_io_exp.py`

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3085 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
