### PR TITLE
TEST-#3085: Add testing for ray-client to push-to-master.yml

### DIFF
--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -59,3 +59,55 @@ jobs:
       - name: Docstring URL validity check
         shell: bash -l {0}
         run: python -m pytest modin/test/test_docstring_urls.py
+
+  test-ray-client:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        python-version: ["3.7", "3.8"]
+        test-task:
+          - modin/pandas/test/dataframe/test_binary.py
+          - modin/pandas/test/dataframe/test_default.py
+          - modin/pandas/test/dataframe/test_indexing.py
+          - modin/pandas/test/dataframe/test_iter.py
+          - modin/pandas/test/dataframe/test_join_sort.py
+          - modin/pandas/test/dataframe/test_map_metadata.py
+          - modin/pandas/test/dataframe/test_reduction.py
+          - modin/pandas/test/dataframe/test_udf.py
+          - modin/pandas/test/dataframe/test_window.py
+          - modin/pandas/test/dataframe/test_pickle.py
+          - modin/pandas/test/test_series.py
+          - modin/pandas/test/test_rolling.py
+          - modin/pandas/test/test_concat.py
+          - modin/pandas/test/test_groupby.py
+          - modin/pandas/test/test_reshape.py
+          - modin/pandas/test/test_general.py
+          - modin/pandas/test/test_io.py
+    env:
+      MODIN_ENGINE: ray
+      MODIN_MEMORY: 1000000000
+      MODIN_TEST_RAY_CLIENT: "True"
+    name: "test-ray-client"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: modin
+          python-version: ${{matrix.python-version}}
+          channel-priority: strict
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+      - run: pip install -r requirements-dev.txt
+      # Use a ray master commit that includes the fix here: https://github.com/ray-project/ray/pull/16278
+      # Can be changed after a Ray version > 1.4 is released.
+      - run: pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c8e3ed9eec30119092ef966ee7b8982c8954c333/ray-2.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl
+        if: matrix.python-version == '3.7'
+      - run: pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c8e3ed9eec30119092ef966ee7b8982c8954c333/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl
+        if: matrix.python-version == '3.8'
+      - name: Install HDF5
+        run: sudo apt update && sudo apt install -y libhdf5-dev
+      - run: python -m pytest ${{matrix.test-task}}

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -239,6 +239,16 @@ class TestDatasetSize(EnvironmentVariable, type=str):
     choices = ("Small", "Normal", "Big")
 
 
+class TestRayClient(EnvironmentVariable, type=bool):
+    """
+    Set to true to start and connect ray client before a testing session
+    starts.
+    """
+
+    varname = "MODIN_TEST_RAY_CLIENT"
+    default = False
+
+
 class TrackFileLeaks(EnvironmentVariable, type=bool):
     """
     Whether to track for open file handles leakage during testing


### PR DESCRIPTION
Signed-off-by: Chris Wong <chriskw.xyz@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Same as #3140 but puts the ray client tests in push-to-master instead. Feel free to merge whichever of these PRs works better on your end, and close the other.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3085? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
