### PR TITLE
FIX-#3150: fix defaulting to pandas for reduction operations at OmniSci backend

### DIFF
--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -303,7 +303,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             return getattr(super(), agg)(axis=axis, level=level, **kwargs)
 
         skipna = kwargs.get("skipna", True)
-        if not skipna:
+        if skipna is False:
             return getattr(super(), agg)(axis=axis, level=level, **kwargs)
 
         new_frame = self._modin_frame.agg(agg)


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

This PR changes `not skipna` check to the `skipna is False` as the condition to do defaulting to pandas in the OmniSci reduction operations, so it won't do unnecessary fallbacks.

Please visit the [related issue](https://github.com/modin-project/modin/issues/3150) for more information.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3150 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
