### PR TITLE
FIX-#3151: Fix default size of Ray obj store memory

### DIFF
--- a/modin/engines/ray/utils.py
+++ b/modin/engines/ray/utils.py
@@ -16,6 +16,7 @@
 import os
 import sys
 import psutil
+import warnings
 
 from modin.config import (
     Backend,
@@ -136,17 +137,24 @@ def initialize_ray(
             object_store_memory = Memory.get()
             # In case anything failed above, we can still improve the memory for Modin.
             if object_store_memory is None:
-                # Round down to the nearest Gigabyte.
-                if sys.platform == "linux" or sys.platform == "linux2":
+                virtual_memory = psutil.virtual_memory().total
+                if sys.platform.startswith("linux"):
                     shm_fd = os.open("/dev/shm", os.O_RDONLY)
                     try:
                         shm_stats = os.fstatvfs(shm_fd)
                         system_memory = shm_stats.f_bsize * shm_stats.f_bavail
+                        if system_memory / (virtual_memory / 2) < 0.99:
+                            warnings.warn(
+                                f"The size of /dev/shm is too small ({system_memory} bytes). The required size "
+                                f"at least half of RAM ({virtual_memory // 2} bytes). Please, delete files in /dev/shm or "
+                                "increase size of /dev/shm with --shm-size in Docker. Also, you can set "
+                                "the required memory size for each Ray worker in bytes to MODIN_MEMORY environment variable."
+                            )
                     finally:
                         os.close(shm_fd)
                 else:
-                    system_memory = psutil.virtual_memory().total
-                object_store_memory = int(0.6 * system_memory // 10 ** 9 * 10 ** 9)
+                    system_memory = virtual_memory
+                object_store_memory = int(0.6 * system_memory // 1e9 * 1e9)
                 # If the memory pool is smaller than 2GB, just use the default in ray.
                 if object_store_memory == 0:
                     object_store_memory = None

--- a/modin/engines/ray/utils.py
+++ b/modin/engines/ray/utils.py
@@ -136,7 +136,11 @@ def initialize_ray(
             # In case anything failed above, we can still improve the memory for Modin.
             if object_store_memory is None:
                 # Round down to the nearest Gigabyte.
-                system_memory = ray._private.utils.get_shared_memory_bytes()
+                system_memory = (
+                    ray._private.utils.get_shared_memory_bytes()
+                    if sys.platform == "linux" or sys.platform == "linux2"
+                    else ray._private.utils.get_system_memory()
+                )
                 object_store_memory = int(0.6 * system_memory // 10 ** 9 * 10 ** 9)
                 # If the memory pool is smaller than 2GB, just use the default in ray.
                 if object_store_memory == 0:

--- a/modin/engines/ray/utils.py
+++ b/modin/engines/ray/utils.py
@@ -136,7 +136,7 @@ def initialize_ray(
             # In case anything failed above, we can still improve the memory for Modin.
             if object_store_memory is None:
                 # Round down to the nearest Gigabyte.
-                system_memory = ray._private.utils.get_system_memory()
+                system_memory = ray._private.utils.get_shared_memory_bytes()
                 object_store_memory = int(0.6 * system_memory // 10 ** 9 * 10 ** 9)
                 # If the memory pool is smaller than 2GB, just use the default in ray.
                 if object_store_memory == 0:


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3151  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
