### PR TITLE
DOCS-#3153: add API section for `modin.pandas.series` in the documentation

### DIFF
--- a/docs/developer/architecture.rst
+++ b/docs/developer/architecture.rst
@@ -120,6 +120,11 @@ the entire pandas/dataframe API. See `experimental features`_ for more informati
 
    /flow/modin/pandas/dataframe
 
+.. toctree::
+   :caption: modin.pandas.Series API
+
+   /flow/modin/pandas/series
+
 Query Compiler
 """"""""""""""
 

--- a/docs/flow/modin/pandas/series.rst
+++ b/docs/flow/modin/pandas/series.rst
@@ -5,6 +5,7 @@ Series Module Overview
 
 Modin's ``pandas.Series`` API
 '''''''''''''''''''''''''''''
+
 Modin's ``pandas.Series`` API is backed by a distributed object providing an identical
 API to pandas. After the user calls some ``Series`` function, this call is internally rewritten
 into a representation that can be processed in parallel by the partitions. These
@@ -22,12 +23,13 @@ Public API
 
 Usage Guide
 '''''''''''
+
 The most efficient way to create Modin ``Series`` is to import data from external
 storage using the highly efficient Modin IO methods (for example using ``pd.read_csv``,
 see details for Modin IO methods in the :doc:`separate section </flow/modin/engines/base/io>`),
 but even if the data does not originate from a file, any pandas supported data type or
-``pandas.Series`` can be used. Internally, the ``Series`` data is distributed across all
-partitions, which usually corresponds to the number of the user's hardware CPUs. If needed,
+``pandas.Series`` can be used. Internally, the ``Series`` data is divided into
+partitions, which number along an axis usually corresponds to the number of the user's hardware CPUs. If needed,
 the number of partitions can be changed by setting ``modin.config.NPartitions``.
 
 Let's consider simple example of creation and interacting with Modin ``Series``:
@@ -36,7 +38,7 @@ Let's consider simple example of creation and interacting with Modin ``Series``:
 
     import modin.config
 
-    # This explicitely sets the number of partitions
+    # This explicitly sets the number of partitions
     modin.config.NPartitions.put(4)
 
     import modin.pandas as pd
@@ -103,4 +105,4 @@ Let's consider simple example of creation and interacting with Modin ``Series``:
     [65 rows x 1 columns]
 
 As we show in the example above, Modin ``Series`` can be easily created, and supports any input that pandas ``Series`` supports.
-Also note that tuning of the ``Series`` partitioning can be done by setting of a single config.
+Also note that tuning of the ``Series`` partitioning can be done by just setting a single config.

--- a/docs/flow/modin/pandas/series.rst
+++ b/docs/flow/modin/pandas/series.rst
@@ -6,9 +6,7 @@ Series Module Overview
 Modin's ``pandas.Series`` API
 '''''''''''''''''''''''''''''
 Modin's ``pandas.Series`` API is backed by a distributed object providing an identical
-API to pandas. Internally, the data is divided into partitions in order to
-parallelize computations and utilize the user's hardware as much as possible.
-After the user calls some ``Series`` function, this call is internally rewritten
+API to pandas. After the user calls some ``Series`` function, this call is internally rewritten
 into a representation that can be processed in parallel by the partitions. These
 results can be e.g., reduced to single output, identical to the single threaded
 pandas ``Series`` method output.
@@ -16,6 +14,11 @@ pandas ``Series`` method output.
 ..
     TODO: add link to the docs with detailed description of queries compilation
     and execution ater DOCS-#2996 is merged.
+
+Public API
+----------
+
+.. autoclass:: modin.pandas.series.Series
 
 Usage Guide
 '''''''''''

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -87,7 +87,7 @@ class Series(BasePandasDataset):
     """
     Modin distributed representation of `pandas.Series`.
 
-    Internally passed data is divided into partitions in order to parallelize
+    Internally, the data can be divided into partitions in order to parallelize
     computations and utilize the user's hardware as much as possible.
 
     Inherit common for DataFrames and Series functionality from the


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3153 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
