### PR TITLE
FIX-#3171: compute shape hint at the QueryCompiler constructor

### DIFF
--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -86,7 +86,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
     def __init__(self, frame, shape_hint=None):
         assert frame is not None
         self._modin_frame = frame
-        if len(self._modin_frame.columns) == 1 and shape_hint is None:
+        if shape_hint is None and len(self._modin_frame.columns) == 1:
             shape_hint = "column"
         self._shape_hint = shape_hint
 

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -86,6 +86,8 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
     def __init__(self, frame, shape_hint=None):
         assert frame is not None
         self._modin_frame = frame
+        if len(self._modin_frame.columns) == 1 and shape_hint is None:
+            shape_hint = "column"
         self._shape_hint = shape_hint
 
     def finalize():
@@ -97,11 +99,23 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
     @classmethod
     def from_pandas(cls, df, data_cls):
-        return cls(data_cls.from_pandas(df))
+        if len(df.columns) == 1:
+            shape_hint = "column"
+        elif len(df) == 1:
+            shape_hint = "row"
+        else:
+            shape_hint = None
+        return cls(data_cls.from_pandas(df), shape_hint=shape_hint)
 
     @classmethod
     def from_arrow(cls, at, data_cls):
-        return cls(data_cls.from_arrow(at))
+        if len(at.columns) == 1:
+            shape_hint = "column"
+        elif len(at) == 1:
+            shape_hint = "row"
+        else:
+            shape_hint = None
+        return cls(data_cls.from_arrow(at), shape_hint=shape_hint)
 
     default_to_pandas = PandasQueryCompiler.default_to_pandas
 

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -1788,7 +1788,7 @@ class TestConstructor:
         df = pd.DataFrame({"a": [1, 2, 3], "b": [1, 2, 3]}, index=index)
         assert df._query_compiler._shape_hint is None
 
-        df = pd.DataFrame({"a": [1]})
+        df = pd.DataFrame({"a": [1]}, index=None if index is None else index[:1])
         assert df._query_compiler._shape_hint == "column"
 
     def test_shape_hint_detection_from_arrow(self):


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3171 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
