### PR TITLE
FEAT-#3193: support non-string column names for merge in OmniSci backend

### DIFF
--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -150,7 +150,6 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             sort = kwargs.get("sort", False)
             suffixes = kwargs.get("suffixes", None)
             if not isinstance(on, list):
-                assert isinstance(on, str), f"unsupported 'on' value {on}"
                 on = [on]
             return self.__constructor__(
                 self._modin_frame.join(

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -555,13 +555,13 @@ class OmnisciOnRayFrame(PandasFrame):
 
         conflicting_cols = set(self.columns) & set(other.columns) - set(on)
         for c in self.columns:
-            new_name = str(c) + suffixes[0] if c in conflicting_cols else c
+            new_name = f"{c}{suffixes[0]}" if c in conflicting_cols else c
             new_columns.append(new_name)
             new_dtypes.append(self._dtypes[c])
             exprs[new_name] = self.ref(c)
         for c in other.columns:
             if c not in on:
-                new_name = str(c) + suffixes[1] if c in conflicting_cols else c
+                new_name = f"{c}{suffixes[1]}" if c in conflicting_cols else c
                 new_columns.append(new_name)
                 new_dtypes.append(other._dtypes[c])
                 exprs[new_name] = other.ref(c)

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -555,16 +555,16 @@ class OmnisciOnRayFrame(PandasFrame):
 
         conflicting_cols = set(self.columns) & set(other.columns) - set(on)
         for c in self.columns:
-            suffix = suffixes[0] if c in conflicting_cols else ""
-            new_columns.append(c + suffix)
+            new_name = str(c) + suffixes[0] if c in conflicting_cols else c
+            new_columns.append(new_name)
             new_dtypes.append(self._dtypes[c])
-            exprs[c + suffix] = self.ref(c)
+            exprs[new_name] = self.ref(c)
         for c in other.columns:
             if c not in on:
-                suffix = suffixes[1] if c in conflicting_cols else ""
-                new_columns.append(c + suffix)
+                new_name = str(c) + suffixes[1] if c in conflicting_cols else c
+                new_columns.append(new_name)
                 new_dtypes.append(other._dtypes[c])
-                exprs[c + suffix] = other.ref(c)
+                exprs[new_name] = other.ref(c)
 
         condition = self._build_equi_join_condition(other, on, on)
 
@@ -576,7 +576,7 @@ class OmnisciOnRayFrame(PandasFrame):
             condition=condition,
         )
 
-        new_columns = Index.__new__(Index, data=new_columns, dtype=self.columns.dtype)
+        new_columns = Index.__new__(Index, data=new_columns)
         res = self.__constructor__(
             dtypes=new_dtypes,
             columns=new_columns,

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -1161,6 +1161,12 @@ class TestMerge:
             merge, data=self.data, data2=self.data2, on=on, how=how, sort=sort
         )
 
+    def test_merge_non_str_column_name(self):
+        def merge(lib, df1, df2, on, **kwargs):
+            return df1.merge(df2, on=on, how="inner")
+
+        run_and_compare(merge, data=[[1, 2], [3, 4]], data2=[[1, 2], [3, 4]], on=1)
+
     h2o_data = {
         "id1": ["id1", "id10", "id100", "id1000"],
         "id2": ["id2", "id20", "id200", "id2000"],


### PR DESCRIPTION
## What do these changes do?

Remove the restriction for `on` param in merge operation in OmniSci backend to be a string. 

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3193 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
