### PR TITLE
FEAT-#3191: make OmniSci engine configurable

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -57,8 +57,6 @@ class EnvironmentVariable(Parameter, type=str, abstract=True):
         help = f"{cls.varname}: {dedent(cls.__doc__ or 'Unknown').strip()}\n\tProvide {_TYPE_PARAMS[cls.type].help}"
         if cls.choices:
             help += f" (valid examples are: {', '.join(str(c) for c in cls.choices)})"
-        if cls.default is not None:
-            help += f"\nDefault value is: {cls.default}"
         return help
 
 

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -75,6 +75,22 @@ _TYPE_PARAMS = {
         or (isinstance(value, str) and value.strip().isdigit()),
         help="an integer value",
     ),
+    dict: TypeDescriptor(
+        decode=lambda value: {
+            key.strip(): int(val) if val.strip().isdigit() else val.strip()
+            for key_value in value.split(",")
+            for key, val in [key_value.split("=")]
+        },
+        normalize=lambda value: value
+        if isinstance(value, dict)
+        else {
+            key.strip(): int(val) if val.strip().isdigit() else val.strip()
+            for key_value in value.split(",")
+            for key, val in [key_value.split("=")]
+        },
+        verify=lambda value: isinstance(value, dict) or isinstance(value, str),
+        help="a sequence of KEY=VALUE values separated by comma (Example: 'KEY1=VALUE1,KEY2=VALUE2,KEY3=VALUE3')",
+    ),
 }
 
 # special marker to distinguish unset value from None value

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -77,16 +77,16 @@ _TYPE_PARAMS = {
     ),
     dict: TypeDescriptor(
         decode=lambda value: {
-            key.strip(): int(val) if val.strip().isdigit() else val.strip()
+            key: int(val) if val.isdigit() else val
             for key_value in value.split(",")
-            for key, val in [key_value.split("=")]
+            for key, val in [[v.strip() for v in key_value.split("=", maxsplit=1)]]
         },
         normalize=lambda value: value
         if isinstance(value, dict)
         else {
-            key.strip(): int(val) if val.strip().isdigit() else val.strip()
+            key: int(val) if val.isdigit() else val
             for key_value in value.split(",")
-            for key, val in [key_value.split("=")]
+            for key, val in [[v.strip() for v in key_value.split("=", maxsplit=1)]]
         },
         verify=lambda value: isinstance(value, dict) or isinstance(value, str),
         help="a sequence of KEY=VALUE values separated by comma (Example: 'KEY1=VALUE1,KEY2=VALUE2,KEY3=VALUE3')",

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -88,7 +88,14 @@ _TYPE_PARAMS = {
             for key_value in value.split(",")
             for key, val in [[v.strip() for v in key_value.split("=", maxsplit=1)]]
         },
-        verify=lambda value: isinstance(value, dict) or isinstance(value, str),
+        verify=lambda value: isinstance(value, dict)
+        or (
+            isinstance(value, str)
+            and all(
+                key_value.find("=") not in (-1, len(key_value) - 1)
+                for key_value in value.split(",")
+            )
+        ),
         help="a sequence of KEY=VALUE values separated by comma (Example: 'KEY1=VALUE1,KEY2=VALUE2,KEY3=VALUE3')",
     ),
 }

--- a/modin/config/test/test_parameter.py
+++ b/modin/config/test/test_parameter.py
@@ -72,6 +72,18 @@ def test_triggers(prefilled_parameter):
     [
         (make_prefilled(bool, "false"), {"1": True, False: False}, ["nope", 2]),
         (make_prefilled(int, "10"), {" 15\t": 15, 25: 25}, ["-10", 1.0, "foo"]),
+        (
+            make_prefilled(dict, "key = value"),
+            {
+                "KEY1 = VALUE1, KEY2=VALUE2,KEY3=0": {
+                    "KEY1": "VALUE1",
+                    "KEY2": "VALUE2",
+                    "KEY3": 0,
+                },
+                "KEY=1": {"KEY": 1},
+            },
+            ["random,string", "random string"],
+        ),
     ],
 )
 def test_validation(parameter, good, bad):
@@ -83,7 +95,7 @@ def test_validation(parameter, good, bad):
             parameter.put(inval)
 
 
-@pytest.mark.parametrize("vartype", [bool, int])
+@pytest.mark.parametrize("vartype", [bool, int, dict])
 def test_init_validation(vartype):
     parameter = make_prefilled(vartype, "bad value")
     with pytest.raises(ValueError):

--- a/modin/config/test/test_parameter.py
+++ b/modin/config/test/test_parameter.py
@@ -82,7 +82,7 @@ def test_triggers(prefilled_parameter):
                 },
                 "KEY=1": {"KEY": 1},
             },
-            ["random,string", "random string"],
+            ["key1=some,string", "key1=value1,key2=", "random string"],
         ),
     ],
 )

--- a/modin/config/test/test_parameter.py
+++ b/modin/config/test/test_parameter.py
@@ -75,9 +75,9 @@ def test_triggers(prefilled_parameter):
         (
             make_prefilled(dict, "key = value"),
             {
-                "KEY1 = VALUE1, KEY2=VALUE2,KEY3=0": {
+                "KEY1 = VALUE1, KEY2=VALUE2=VALUE3,KEY3=0": {
                     "KEY1": "VALUE1",
-                    "KEY2": "VALUE2",
+                    "KEY2": "VALUE2=VALUE3",
                     "KEY3": 0,
                 },
                 "KEY=1": {"KEY": 1},

--- a/modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/omnisci_worker.py
@@ -30,7 +30,7 @@ except ModuleNotFoundError:  # fallback for older omniscidbe4py package naming
 if sys.platform == "linux":
     sys.setdlopenflags(prev)
 
-from modin.config import OmnisciFragmentSize
+from modin.config import OmnisciFragmentSize, OmnisciLaunchParameters
 
 
 class OmnisciServer:
@@ -39,13 +39,7 @@ class OmnisciServer:
     @classmethod
     def start_server(cls):
         if cls._server is None:
-            cls._server = PyDbEngine(
-                enable_union=1,
-                enable_columnar_output=1,
-                enable_lazy_fetch=0,
-                null_div_by_zero=1,
-                enable_watchdog=0,
-            )
+            cls._server = PyDbEngine(**OmnisciLaunchParameters.get())
 
     @classmethod
     def stop_server(cls):


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3191 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
