### PR TITLE
FIX-#3198: Rewrite arrow row slice

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -153,6 +153,30 @@ def is_integer_slice(x):
     return True
 
 
+def is_range_like(obj):
+    """
+    Check if the object is range-like.
+
+    Objects that are considered range-like have information about the range (start and
+    stop positions, and step) and also have to be iterable. Examples of range-like
+    objects are: Python range, pandas.RangeIndex.
+
+    Parameters
+    ----------
+    obj : object
+
+    Returns
+    -------
+    bool
+    """
+    return (
+        hasattr(obj, "__iter__")
+        and hasattr(obj, "start")
+        and hasattr(obj, "stop")
+        and hasattr(obj, "step")
+    )
+
+
 _ILOC_INT_ONLY_ERROR = """
 Location based indexing can only have [integer, integer slice (START point is
 INCLUDED, END point is EXCLUDED), listlike of integers, boolean array] types.


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Rewritten `OmnisciOnRayFrame._arrow_row_slice` function so now instead of slicing a table into small parts when the row indices are not continuous it just takes the specified indices by a single call of `pyarrow.Table.take`.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3198 <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

Performance changes at ASV:
```
MODIN_TEST_DATASET_SIZE=Big asv continuous origin/master HEAD --launch-method=forkserver --config asv.conf.omnisci.json -b omnisci.benchmarks.TimeIndexing --show-stderr --split --no-only-changed -a repeat=3

Benchmarks that have improved:
       before           after         ratio
     [a946564e]       [3157289b]
     <master>       <slow-indexing>
-       318±0.3ms         188±20ms     0.59  omnisci.benchmarks.TimeIndexing.time_iloc((1000000, 10), 'list')
-        994±20ms          599±3ms     0.60  omnisci.benchmarks.TimeIndexing.time_loc((1000000, 10), 'list')
-       11.1±0.2s         122±10ms     0.01  omnisci.benchmarks.TimeIndexing.time_iloc((1000000, 10), 'bool')
-       11.6±0.3s          491±8ms     0.04  omnisci.benchmarks.TimeIndexing.time_loc((1000000, 10), 'bool')
-       11.9±0.7s         73.6±7ms     0.01  omnisci.benchmarks.TimeIndexing.time_iloc((1000000, 10), 'function')
-       12.0±0.9s          350±9ms     0.03  omnisci.benchmarks.TimeIndexing.time_loc((1000000, 10), 'function')
-       11.4±0.7s         26.5±6ms     0.00  omnisci.benchmarks.TimeIndexing.time_iloc((1000000, 10), 'slice')
-       11.8±0.3s          252±9ms     0.02  omnisci.benchmarks.TimeIndexing.time_loc((1000000, 10), 'slice')

Benchmarks that have stayed the same:

       before           after         ratio
     [a946564e]       [3157289b]
     <master>       <slow-indexing>
      11.0±0.07ms       11.0±0.2ms     1.00  omnisci.benchmarks.TimeIndexing.time_iloc((1000000, 10), 'scalar')
       8.91±0.5ms      9.44±0.05ms     1.06  omnisci.benchmarks.TimeIndexing.time_loc((1000000, 10), 'scalar')

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```