### PR TITLE
TEST-#3214: Add test for df/series.index after PandasFrame.to_pandas is called

### DIFF
--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -674,9 +674,10 @@ def test_to_numeric(data, errors, downcast):
     df_equals(modin_result, pandas_result)
 
 
-def test_to_pandas_indices():
-    data = test_data_values[0]
-
+@pytest.mark.parametrize(
+    "data", [test_data_values[0], []], ids=["test_data_values[0]", "[]"]
+)
+def test_to_pandas_indices(data):
     md_df = pd.DataFrame(data)
     index = pandas.MultiIndex.from_tuples(
         [(i, i * 2) for i in np.arange(len(md_df) + 1)], names=["A", "B"]

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -506,6 +506,7 @@ def test___repr__(name, dt_index, data):
         # TODO: Remove this when default `dtype` of empty Series will be `object` in pandas (see #3142).
         assert modin_series.dtype == np.object
         assert pandas_series.dtype == np.float64
+        df_equals(modin_series.index, pandas_series.index)
     else:
         assert repr(modin_series) == repr(pandas_series)
 


### PR DESCRIPTION
Signed-off-by: Maria Rubtsova <maria.rubtsova@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3214  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
