### PR TITLE
FIX-#3215: fix handling of `parse_dates` parameter by `read_csv` with OmniSci backend

### DIFF
--- a/modin/experimental/engines/omnisci_on_ray/io.py
+++ b/modin/experimental/engines/omnisci_on_ray/io.py
@@ -472,7 +472,7 @@ class OmnisciOnRayIO(RayIO, TextFileDispatcher):
             return (
                 False,
                 "read_csv with 'arrow' engine supports only bool and "
-                "flattened lists `parse_dates` parameter",
+                "flattened lists 'parse_dates' parameter",
             )
         if names and names != lib.no_default:
             if header not in [None, 0, "infer"]:

--- a/modin/experimental/engines/omnisci_on_ray/io.py
+++ b/modin/experimental/engines/omnisci_on_ray/io.py
@@ -425,6 +425,7 @@ class OmnisciOnRayIO(RayIO, TextFileDispatcher):
         engine = read_csv_kwargs.get("engine", None)
         skiprows = read_csv_kwargs.get("skiprows", None)
         delimiter = read_csv_kwargs.get("delimiter", None)
+        parse_dates = read_csv_kwargs.get("parse_dates", False)
 
         if read_csv_kwargs.get("compression", "infer") != "infer":
             return (
@@ -464,6 +465,15 @@ class OmnisciOnRayIO(RayIO, TextFileDispatcher):
                 "Specified a delimiter with both sep and delim_whitespace=True; you can only specify one."
             )
 
+        parse_dates_unsupported = isinstance(parse_dates, dict) or (
+            isinstance(parse_dates, list) and isinstance(parse_dates[0], list)
+        )
+        if parse_dates_unsupported:
+            return (
+                False,
+                "read_csv with 'arrow' engine supports only bool and "
+                "flattened lists `parse_dates` parameter",
+            )
         if names and names != lib.no_default:
             if header not in [None, 0, "infer"]:
                 return (
@@ -471,6 +481,8 @@ class OmnisciOnRayIO(RayIO, TextFileDispatcher):
                     "read_csv with 'arrow' engine and provided 'names' parameter supports only 0, None and "
                     "'infer' header values",
                 )
+            if isinstance(parse_dates, list) and not set(parse_dates).issubset(names):
+                raise ValueError("Missing column provided to 'parse_dates'")
 
             empty_pandas_df = pandas.read_csv(
                 **dict(
@@ -481,6 +493,7 @@ class OmnisciOnRayIO(RayIO, TextFileDispatcher):
                     usecols=None,
                     index_col=None,
                     names=None,
+                    parse_dates=None,
                     engine=None if engine == "arrow" else engine,
                 ),
             )
@@ -498,6 +511,20 @@ class OmnisciOnRayIO(RayIO, TextFileDispatcher):
                     "read_csv with 'arrow' engine without 'names' parameter provided supports only 0 and 'infer' "
                     "header values",
                 )
+            if isinstance(parse_dates, list):
+                empty_pandas_df = pandas.read_csv(
+                    **dict(
+                        read_csv_kwargs,
+                        nrows=0,
+                        skiprows=None,
+                        skipfooter=0,
+                        usecols=None,
+                        index_col=None,
+                        engine=None if engine == "arrow" else engine,
+                    ),
+                )
+                if not set(parse_dates).issubset(empty_pandas_df.columns):
+                    raise ValueError("Missing column provided to 'parse_dates'")
 
         if not read_csv_kwargs.get("skip_blank_lines", True):
             # in some corner cases empty lines are handled as '',

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -317,20 +317,29 @@ class TestCSV:
             True,
             False,
             ["col2"],
+            ["c2"],
+            [["col2", "col3"]],
+            {"col23": ["col2", "col3"]},
         ],
     )
+    @pytest.mark.parametrize("names", [None, [f"c{x}" for x in range(1, 7)]])
     def test_read_csv_datetime(
         self,
         engine,
         parse_dates,
+        names,
     ):
 
+        parse_dates_unsupported = isinstance(parse_dates, dict) or (
+            isinstance(parse_dates, list) and isinstance(parse_dates[0], list)
+        )
         eval_io(
             fn_name="read_csv",
-            md_extra_kwargs={"engine": engine},
+            md_extra_kwargs={"engine": None if parse_dates_unsupported else engine},
             # read_csv kwargs
             filepath_or_buffer=pytest.csvs_names["test_read_csv_regular"],
             parse_dates=parse_dates,
+            names=names,
         )
 
     @pytest.mark.parametrize("engine", [None, "arrow"])

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -333,9 +333,15 @@ class TestCSV:
         parse_dates_unsupported = isinstance(parse_dates, dict) or (
             isinstance(parse_dates, list) and isinstance(parse_dates[0], list)
         )
+        if parse_dates_unsupported and engine == "arrow":
+            pytest.skip(
+                "In this specific cases Modin raises `ArrowEngineException` while pandas "
+                "raises `ValueError` that causes tests fails"
+            )
+
         eval_io(
             fn_name="read_csv",
-            md_extra_kwargs={"engine": None if parse_dates_unsupported else engine},
+            md_extra_kwargs={"engine": engine},
             # read_csv kwargs
             filepath_or_buffer=pytest.csvs_names["test_read_csv_regular"],
             parse_dates=parse_dates,

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -346,7 +346,7 @@ class TestCSV:
         eval_io(
             fn_name="read_csv",
             md_extra_kwargs={"engine": engine},
-            check_exception_type=False if skip_exc_type_check else True,
+            check_exception_type=not skip_exc_type_check,
             raising_exceptions=None if skip_exc_type_check else io_ops_bad_exc,
             # read_csv kwargs
             filepath_or_buffer=pytest.csvs_names["test_read_csv_regular"],


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3215  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
