### PR TITLE
FIX-#3195: Do not pass None parameters value to the backend, when it can be replaced by default one

### DIFF
--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -354,9 +354,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             return getattr(super(), agg)(axis=axis, level=level, **kwargs)
 
         # TODO: Do filtering on numeric columns if `numeric_only=True`
-        if (
-            kwargs.get("skipna", True) is not None and not kwargs.get("skipna", True)
-        ) or kwargs.get("numeric_only"):
+        if not kwargs.get("skipna", True) or kwargs.get("numeric_only"):
             return getattr(super(), agg)(axis=axis, level=level, **kwargs)
         # Processed above, so can be omitted
         kwargs.pop("skipna", None)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1461,6 +1461,8 @@ class BasePandasDataset(object):
 
     def kurt(self, axis=None, skipna=None, level=None, numeric_only=None, **kwargs):
         axis = self._get_axis_number(axis)
+        if skipna is None:
+            skipna = True
         if level is not None:
             func_kwargs = {
                 "skipna": skipna,
@@ -1513,7 +1515,8 @@ class BasePandasDataset(object):
 
     def mad(self, axis=None, skipna=None, level=None):
         axis = self._get_axis_number(axis)
-
+        if skipna is None:
+            skipna = True
         if level is not None:
             if (
                 not self._query_compiler.has_multiindex(axis=axis)
@@ -1550,6 +1553,8 @@ class BasePandasDataset(object):
         )
 
     def max(self, axis=None, skipna=None, level=None, numeric_only=None, **kwargs):
+        if skipna is None:
+            skipna = True
         if level is not None:
             return self._default_to_pandas(
                 "max",
@@ -1609,6 +1614,8 @@ class BasePandasDataset(object):
             `DataFrame` - self is DataFrame and level is specified.
         """
         axis = self._get_axis_number(axis)
+        if skipna is None:
+            skipna = True
         if level is not None:
             return self._default_to_pandas(
                 op_name,
@@ -1659,6 +1666,8 @@ class BasePandasDataset(object):
         )
 
     def min(self, axis=None, skipna=None, level=None, numeric_only=None, **kwargs):
+        if skipna is None:
+            skipna = True
         if level is not None:
             return self._default_to_pandas(
                 "min",

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1313,6 +1313,15 @@ class DataFrame(BasePandasDataset):
         """
         Unpivot a ``DataFrame`` from wide to long format, optionally leaving identifiers set.
         """
+        if id_vars is None:
+            id_vars = []
+        if not is_list_like(id_vars):
+            id_vars = [id_vars]
+        if value_vars is None:
+            value_vars = self.columns.difference(id_vars)
+        if var_name is None:
+            columns_name = self._query_compiler.get_index_name(axis=1)
+            var_name = columns_name if columns_name is not None else "variable"
         return self.__constructor__(
             query_compiler=self._query_compiler.melt(
                 id_vars=id_vars,
@@ -1605,6 +1614,8 @@ class DataFrame(BasePandasDataset):
         Return the product of the values over the requested axis.
         """
         axis = self._get_axis_number(axis)
+        if skipna is None:
+            skipna = True
         if level is not None:
             if (
                 not self._query_compiler.has_multiindex(axis=axis)
@@ -2004,6 +2015,8 @@ class DataFrame(BasePandasDataset):
         Return the sum of the values over the requested axis.
         """
         axis = self._get_axis_number(axis)
+        if skipna is None:
+            skipna = True
         axis_to_apply = self.columns if axis else self.index
         if (
             skipna is not False

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1414,6 +1414,8 @@ class Series(BasePandasDataset):
         Return the product of the values over the requested `axis`.
         """
         axis = self._get_axis_number(axis)
+        if skipna is None:
+            skipna = True
         if level is not None:
             if (
                 not self._query_compiler.has_multiindex(axis=axis)
@@ -1773,6 +1775,8 @@ class Series(BasePandasDataset):
         Return the sum of the values.
         """
         axis = self._get_axis_number(axis)
+        if skipna is None:
+            skipna = True
         if numeric_only is True:
             raise NotImplementedError("Series.sum does not implement numeric_only")
         if level is not None:


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3195 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
