### PR TITLE
FIX-#3252: Fix GroupBy.__getitem__

### DIFF
--- a/modin/backends/base/doc_utils.py
+++ b/modin/backends/base/doc_utils.py
@@ -658,7 +658,7 @@ def doc_groupby_method(result, refer_to, action=None):
     drop : bool, default: False
         If `by` is a QueryCompiler indicates whether or not by-data came
         from the `self`.
-    selection : list of labels, optional
+    selection : label or list of labels, optional
         Set of columns to apply aggregation on, by default aggregation is applied
         to all of the available columns.
 

--- a/modin/backends/base/doc_utils.py
+++ b/modin/backends/base/doc_utils.py
@@ -658,6 +658,9 @@ def doc_groupby_method(result, refer_to, action=None):
     drop : bool, default: False
         If `by` is a QueryCompiler indicates whether or not by-data came
         from the `self`.
+    selection : list of labels, optional
+        Set of columns to apply aggregation on, by default aggregation is applied
+        to all of the available columns.
 
     Returns
     -------

--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -2393,6 +2393,9 @@ class BaseQueryCompiler(abc.ABC):
         drop : bool, default: False
             If `by` is a QueryCompiler indicates whether or not by-data came
             from the `self`.
+        selection : list of labels, optional
+            Set of columns to apply aggregation on, by default aggregation is applied
+            to all of the available columns.
 
         Returns
         -------

--- a/modin/backends/base/query_compiler.py
+++ b/modin/backends/base/query_compiler.py
@@ -2157,6 +2157,7 @@ class BaseQueryCompiler(abc.ABC):
         reduce_args=None,
         numeric_only=True,
         drop=False,
+        selection=None,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.count)(
             self,
@@ -2167,6 +2168,7 @@ class BaseQueryCompiler(abc.ABC):
             reduce_args=reduce_args,
             numeric_only=numeric_only,
             drop=drop,
+            selection=selection,
         )
 
     @doc_utils.doc_groupby_method(
@@ -2183,6 +2185,7 @@ class BaseQueryCompiler(abc.ABC):
         reduce_args=None,
         numeric_only=True,
         drop=False,
+        selection=None,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.any)(
             self,
@@ -2193,6 +2196,7 @@ class BaseQueryCompiler(abc.ABC):
             reduce_args=reduce_args,
             numeric_only=numeric_only,
             drop=drop,
+            selection=selection,
         )
 
     @doc_utils.doc_groupby_method(
@@ -2207,6 +2211,7 @@ class BaseQueryCompiler(abc.ABC):
         reduce_args=None,
         numeric_only=True,
         drop=False,
+        selection=None,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.min)(
             self,
@@ -2217,6 +2222,7 @@ class BaseQueryCompiler(abc.ABC):
             reduce_args=reduce_args,
             numeric_only=numeric_only,
             drop=drop,
+            selection=selection,
         )
 
     @doc_utils.doc_groupby_method(result="product", refer_to="prod")
@@ -2229,6 +2235,7 @@ class BaseQueryCompiler(abc.ABC):
         reduce_args=None,
         numeric_only=True,
         drop=False,
+        selection=None,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.prod)(
             self,
@@ -2239,6 +2246,7 @@ class BaseQueryCompiler(abc.ABC):
             reduce_args=reduce_args,
             numeric_only=numeric_only,
             drop=drop,
+            selection=selection,
         )
 
     @doc_utils.doc_groupby_method(
@@ -2253,6 +2261,7 @@ class BaseQueryCompiler(abc.ABC):
         reduce_args=None,
         numeric_only=True,
         drop=False,
+        selection=None,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.max)(
             self,
@@ -2263,6 +2272,7 @@ class BaseQueryCompiler(abc.ABC):
             reduce_args=reduce_args,
             numeric_only=numeric_only,
             drop=drop,
+            selection=selection,
         )
 
     @doc_utils.doc_groupby_method(
@@ -2279,6 +2289,7 @@ class BaseQueryCompiler(abc.ABC):
         reduce_args=None,
         numeric_only=True,
         drop=False,
+        selection=None,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.all)(
             self,
@@ -2289,6 +2300,7 @@ class BaseQueryCompiler(abc.ABC):
             reduce_args=reduce_args,
             numeric_only=numeric_only,
             drop=drop,
+            selection=selection,
         )
 
     @doc_utils.doc_groupby_method(result="sum", refer_to="sum")
@@ -2301,6 +2313,7 @@ class BaseQueryCompiler(abc.ABC):
         reduce_args=None,
         numeric_only=True,
         drop=False,
+        selection=None,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.sum)(
             self,
@@ -2311,6 +2324,7 @@ class BaseQueryCompiler(abc.ABC):
             reduce_args=reduce_args,
             numeric_only=numeric_only,
             drop=drop,
+            selection=selection,
         )
 
     @doc_utils.doc_groupby_method(
@@ -2327,6 +2341,7 @@ class BaseQueryCompiler(abc.ABC):
         reduce_args=None,
         numeric_only=True,
         drop=False,
+        selection=None,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.size)(
             self,
@@ -2337,6 +2352,7 @@ class BaseQueryCompiler(abc.ABC):
             reduce_args=reduce_args,
             numeric_only=numeric_only,
             drop=drop,
+            selection=selection,
             method="size",
         )
 
@@ -2351,6 +2367,7 @@ class BaseQueryCompiler(abc.ABC):
         agg_kwargs,
         groupby_kwargs,
         drop=False,
+        selection=None,
     ):
         """
         Group QueryCompiler data and apply passed aggregation function.
@@ -2396,6 +2413,7 @@ class BaseQueryCompiler(abc.ABC):
             groupby_args=groupby_kwargs,
             agg_args=agg_kwargs,
             drop=drop,
+            selection=selection,
         )
 
     # END Manual Partitioning methods
@@ -2571,8 +2589,8 @@ class BaseQueryCompiler(abc.ABC):
         BaseQueryCompiler
             New masked QueryCompiler.
         """
-        index = [] if index is None else index
-        columns = [] if columns is None else columns
+        index = slice(None) if index is None else index
+        columns = slice(None) if columns is None else columns
 
         def applyier(df):
             return df.iloc[index, columns]

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2805,19 +2805,17 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 result.drop(columns=missmatched_cols, inplace=True, errors="ignore")
 
                 if not as_index:
-                    if partition_idx == 0 and drop:
-                        drop, lvls_to_drop = GroupByDefault.handle_as_index(
-                            result_cols,
-                            result.index.names,
-                            internal_by_cols,
-                            selection=selection,
-                            partition_selection=partition_selection,
-                        )
-                        if len(lvls_to_drop) > 0:
-                            result.index = result.index.droplevel(lvls_to_drop)
-                    else:
-                        drop = True
-
+                    drop, lvls_to_drop = GroupByDefault.handle_as_index(
+                        result_cols,
+                        result.index.names,
+                        internal_by_cols,
+                        selection=selection,
+                        partition_selection=partition_selection,
+                        partition_idx=partition_idx,
+                        drop=drop,
+                    )
+                    if len(lvls_to_drop) > 0:
+                        result.index = result.index.droplevel(lvls_to_drop)
                     result.reset_index(drop=drop, inplace=True)
 
                 new_index_names = [

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2864,7 +2864,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
         # that means that exception in `compute_groupby` was raised
         # in every partition, so we also should raise it
-        # breakpoint()
         if len(result.columns) == 0 and len(self.columns) != 0:
             # determening type of raised exception by applying `aggfunc`
             # to empty DataFrame

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2833,9 +2833,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 if len(result.columns) > 1:
                     result.drop(columns=cols_to_drop, inplace=True)
 
-                if result.empty and not as_index and len(result) > 0:
-                    result.index = []
-
                 return result
 
             try:

--- a/modin/backends/pandas/query_compiler.py
+++ b/modin/backends/pandas/query_compiler.py
@@ -2735,7 +2735,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
             groupby_kwargs["as_index"] = True
 
             partition_selection = (
-                selection if selection is None else df.columns.intersection(selection)
+                selection
+                if selection is None
+                else (
+                    df.columns.intersection(selection)
+                    if is_list_like(selection)
+                    else selection
+                )
             )
 
             internal_by_cols = pandas.Index([])
@@ -2846,7 +2852,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if isinstance(agg_func, dict):
             apply_indices = tuple(agg_func.keys())
         if selection is not None and apply_indices is None:
-            apply_indices = selection
+            apply_indices = selection if is_list_like(selection) else (selection,)
 
         new_modin_frame = self._modin_frame.broadcast_apply_full_axis(
             axis=axis,

--- a/modin/data_management/functions/default_methods/groupby_default.py
+++ b/modin/data_management/functions/default_methods/groupby_default.py
@@ -132,6 +132,27 @@ class GroupBy:
 
     @staticmethod
     def is_external_by(df, axis, by):
+        """
+        Check whether passed `by` is external.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+            Source DataFrame to group.
+        axis : {0, 1}
+            Grouping axis.
+        by : object
+            Object to determine groups for the GroupBy.
+
+        Returns
+        -------
+        bool
+
+        Notes
+        -----
+        External 'by' means such kind of 'by' that does not belong to the source
+        frame anyhow.
+        """
         if not is_list_like(by) or isinstance(by, (pandas.DataFrame, pandas.Series)):
             return False
         return all(

--- a/modin/data_management/functions/default_methods/groupby_default.py
+++ b/modin/data_management/functions/default_methods/groupby_default.py
@@ -363,10 +363,24 @@ class GroupByDefault(DefaultMethod):
 
     @staticmethod
     def handle_as_index(
-        result_cols, result_index_names, internal_by_cols, selection=None, method=None
+        result_cols,
+        result_index_names,
+        internal_by_cols,
+        selection=None,
+        partition_selection=None,
+        method=None,
     ):  # TODO: add docstring
         # We want to insert such internal-by-cols which are not presented
         # in the result in order to not create naming conflicts
+        if selection is not None:
+            if partition_selection is None:
+                partition_selection = selection
+            if len(result_cols) != len(partition_selection):
+                cols_failed_to_select = pandas.Index(partition_selection).difference(
+                    result_cols
+                )
+                selection = pandas.Index(selection).difference(cols_failed_to_select)
+
         if not isinstance(internal_by_cols, pandas.Index):
             if not is_list_like(internal_by_cols):
                 internal_by_cols = [internal_by_cols]

--- a/modin/data_management/functions/default_methods/groupby_default.py
+++ b/modin/data_management/functions/default_methods/groupby_default.py
@@ -14,7 +14,6 @@
 """Module houses default GroupBy functions builder class."""
 
 from .default import DefaultMethod
-from modin.utils import hashable
 
 import pandas
 from pandas.core.dtypes.common import is_list_like, is_numeric_dtype
@@ -129,36 +128,6 @@ class GroupBy:
             return cls.inplace_applyier_builder(key, kwargs["func_dict"])
         else:
             return cls.inplace_applyier_builder(key)
-
-    @staticmethod
-    def is_external_by(df, axis, by):
-        """
-        Check whether passed `by` is external.
-
-        Parameters
-        ----------
-        df : pandas.DataFrame
-            Source DataFrame to group.
-        axis : {0, 1}
-            Grouping axis.
-        by : object
-            Object to determine groups for the GroupBy.
-
-        Returns
-        -------
-        bool
-
-        Notes
-        -----
-        External 'by' means such kind of 'by' that does not belong to the source
-        frame anyhow.
-        """
-        if not is_list_like(by) or isinstance(by, (pandas.DataFrame, pandas.Series)):
-            return False
-        return all(
-            not (hashable(current_by) and current_by in df.axes[axis ^ 1])
-            for current_by in by
-        )
 
     @classmethod
     def build_aggregate_method(cls, key):

--- a/modin/data_management/functions/default_methods/groupby_default.py
+++ b/modin/data_management/functions/default_methods/groupby_default.py
@@ -266,18 +266,16 @@ class GroupBy:
                     if (drop or method == "size") and isinstance(by, pandas.Series)
                     else by
                 )
-                if drop or method == "size":
-                    drop, lvls_to_drop = GroupByDefault.handle_as_index(
-                        result.columns,
-                        result.index.names,
-                        internal_by,
-                        selection=selection,
-                        method=method,
-                    )
-                    if len(lvls_to_drop) > 0:
-                        result.index = result.index.droplevel(lvls_to_drop)
-                else:
-                    drop = True
+                drop, lvls_to_drop = GroupByDefault.handle_as_index(
+                    result.columns,
+                    result.index.names,
+                    internal_by,
+                    selection=selection,
+                    drop=drop,
+                    method=method,
+                )
+                if len(lvls_to_drop) > 0:
+                    result.index = result.index.droplevel(lvls_to_drop)
                 result = result.reset_index(drop=drop)
 
             if (
@@ -354,8 +352,61 @@ class GroupByDefault(DefaultMethod):
         internal_by_cols,
         selection=None,
         partition_selection=None,
+        partition_idx=0,
+        drop=True,
         method=None,
-    ):  # TODO: add docstring
+    ):
+        """
+        Help to handle ``as_index=False`` parameter for the GroupBy result.
+
+        This function resolve naming conflicts of the index levels to insert and the column labels
+        for the GroupBy result. The logic of this function assumes that the initial GroupBy result
+        was computed as ``as_index=True``.
+
+        Parameters
+        ----------
+        result_cols : pandas.Index
+            Columns of the GroupBy result.
+        result_index_names : list-like
+            Index names of the GroupBy result.
+        internal_by_cols : list-like
+            Internal 'by' columns.
+        selection : label or list of labels, optional
+            Set of columns to which aggregation was applied. If not specified
+            assuming that aggregation was applied to all of the available columns.
+        partition_selection : label or list of labels, optional
+            Set of columns at this particular partition to which aggregation was applied.
+            If not specified assuming that aggregation at this partition was applied
+            to all of the columns listed in the `selection` parameter.
+        partition_idx : int, default: 0
+            Positional index of the current partition.
+        drop : bool, default: True
+            Indicates whether or not all of the `by` data came from the same frame.
+        method : str, optional
+            Name of the groupby function. This is a hint to be able to do special casing.
+
+        Returns
+        -------
+        drop : bool
+            Indicates whether to drop all index levels (True) or insert them into the
+            resulting columns (False).
+        lvls_to_drop : list of ints
+            Contains numeric indices of the levels of the result index to drop as intersected.
+
+        Examples
+        --------
+        >>> groupby_result = compute_groupby_without_processing_as_index_parameter()
+        >>> if not as_index:
+        >>>     drop, lvls_to_drop = handle_as_index(**extract_required_params(groupby_result))
+        >>>     if len(lvls_to_drop) > 0:
+        >>>         groupby_result.index = groupby_result.index.droplevel(lvls_to_drop)
+        >>>     groupby_result_with_processed_as_index_parameter = groupby_result.reset_index(drop=drop)
+        >>> else:
+        >>>     groupby_result_with_processed_as_index_parameter = groupby_result
+        """
+        if partition_idx != 0 or (not drop and method != "size"):
+            return True, []
+
         # We want to insert such internal-by-cols which are not presented
         # in the result in order to not create naming conflicts
         if selection is not None:

--- a/modin/data_management/functions/groupby_function.py
+++ b/modin/data_management/functions/groupby_function.py
@@ -131,16 +131,14 @@ class GroupbyReduceFunction(MapReduceFunction):
             selection if selection is None else df.columns.intersection(selection)
         )
 
-        missmatched_cols = pandas.Index([])
         if other is not None:
             # Other is a broadcasted partition that represents 'by' columns
             # Concatenate it with 'df' to group on its columns names
             if not drop:
                 other = other.squeeze(axis=axis ^ 1)
             if isinstance(other, pandas.DataFrame):
-                missmatched_cols = other.columns.difference(df.columns)
                 df = pandas.concat(
-                    [df] + [other[missmatched_cols]],
+                    [df, other[other.columns.difference(df.columns)]],
                     axis=1,
                 )
                 other = list(other.columns)
@@ -265,9 +263,6 @@ class GroupbyReduceFunction(MapReduceFunction):
             else:
                 drop = True
             result = result.reset_index(drop=drop)
-
-        if result.empty and not as_index and len(result) > 0:
-            result.index = []
 
         # Result could not always be a frame, so wrapping it into DataFrame
         return pandas.DataFrame(result)

--- a/modin/engines/base/frame/data.py
+++ b/modin/engines/base/frame/data.py
@@ -2105,8 +2105,9 @@ class PandasFrame(object):
         new_columns : pandas.Index, optional
             Columns of the result. We may know this in advance,
             and if not provided it must be computed.
-        selection : list-like, default: None
-            Indices of `axis ^ 1` to apply groupby over.
+        selection : list of labels, optional
+            Indices of `axis ^ 1` to apply groupby over. If not specified
+            apply to all of the available indices.
 
         Returns
         -------
@@ -2115,7 +2116,7 @@ class PandasFrame(object):
         """
         by_parts = by if by is None else by._partitions
 
-        per_partition_selection, apply_indices = None, None
+        per_partition_selection = None
         if selection is not None:
             numeric_indices = self.axes[axis ^ 1].get_indexer_for(selection)
             apply_indices = self._get_dict_of_block_index(axis ^ 1, numeric_indices)

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -455,7 +455,7 @@ class PandasFramePartitionManager(ABC):
 
         if apply_indices is None:
             apply_indices = np.arange(len(left_partitions))
-        # breakpoint()
+
         result_blocks = np.array(
             [
                 left_partitions[i].apply(

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -222,11 +222,9 @@ class PandasFramePartitionManager(ABC):
         """
         partitions_kwargs = None
         if selection is not None:
-            partition_indices = list(selection.keys())
+            parts_to_select = list(selection.keys())
             partitions = (
-                partitions[partition_indices]
-                if axis
-                else partitions[:, partition_indices]
+                partitions[parts_to_select] if axis else partitions[:, parts_to_select]
             )
             partitions_kwargs = tuple(
                 {"partition_selection": labels} for labels in selection.values()
@@ -398,7 +396,6 @@ class PandasFramePartitionManager(ABC):
         enumerate_partitions=False,
         lengths=None,
         partitions_kwargs=None,
-        **kwargs,
     ):
         """
         Broadcast the `right` partitions to `left` and apply `apply_func` along full `axis`.
@@ -533,7 +530,7 @@ class PandasFramePartitionManager(ABC):
         keep_partitioning=False,
         lengths=None,
         enumerate_partitions=False,
-        **kwargs,
+        partitions_kwargs=None,
     ):
         """
         Apply `map_func` to every partition in `partitions` along given `axis`.
@@ -573,7 +570,7 @@ class PandasFramePartitionManager(ABC):
             right=None,
             lengths=lengths,
             enumerate_partitions=enumerate_partitions,
-            **kwargs,
+            partitions_kwargs=partitions_kwargs,
         )
 
     @classmethod

--- a/modin/engines/base/frame/partition_manager.py
+++ b/modin/engines/base/frame/partition_manager.py
@@ -212,8 +212,10 @@ class PandasFramePartitionManager(ABC):
             Map function.
         reduce_func : callable,
             Reduce function.
-        apply_indices : list of ints, default: None
-            Indices of `axis ^ 1` to apply function over.
+        selection : dict[int] -> list of labels, default: None
+            Set of indices/columns to apply aggregation on, where the dictionary indices
+            are numeric indices of partitions to apply and the values are the indices/columns
+            to apply in this particular partitions.
 
         Returns
         -------
@@ -229,6 +231,7 @@ class PandasFramePartitionManager(ABC):
             )
 
             def reduce_func_proxy(*args, partition_idx=0, **kwargs):
+                """Pass `selection` for this particular partition to the reduction function based on the partition index."""
                 return reduce_func(
                     *args,
                     partition_idx=partition_idx,

--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -323,6 +323,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         agg_kwargs,
         groupby_kwargs,
         drop=False,
+        selection=None,
     ):
         # TODO: handle `is_multi_by`, `agg_args`, `drop` args
         if callable(agg_func):
@@ -330,7 +331,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
                 "Python callable is not a valid aggregation function for OmniSci backend."
             )
         new_frame = self._modin_frame.groupby_agg(
-            by, axis, agg_func, groupby_kwargs, **agg_kwargs
+            by, axis, agg_func, groupby_kwargs, selection=selection, **agg_kwargs
         )
         return self.__constructor__(new_frame)
 

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -395,7 +395,7 @@ class OmnisciOnRayFrame(PandasFrame):
             Aggregates to compute.
         groupby_args : dict
             Additional groupby args.
-        selection : list of labels, optional
+        selection : label or list of labels, optional
             Set of columns to apply aggregation on, by default aggregation is applied
             to all of the available columns.
         **kwargs : dict
@@ -406,6 +406,8 @@ class OmnisciOnRayFrame(PandasFrame):
         OmnisciOnRayFrame
             The new frame.
         """
+        if selection is not None and not is_list_like(selection):
+            selection = (selection,)
         # Currently we only expect 'by' to be a projection of the same frame.
         # If 'by' holds a list of columns/series, then we create such projection
         # to re-use code.

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -395,6 +395,9 @@ class OmnisciOnRayFrame(PandasFrame):
             Aggregates to compute.
         groupby_args : dict
             Additional groupby args.
+        selection : list of labels, optional
+            Set of columns to apply aggregation on, by default aggregation is applied
+            to all of the available columns.
         **kwargs : dict
             Keyword args. Currently ignored.
 

--- a/modin/experimental/engines/omnisci_on_ray/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/data.py
@@ -381,7 +381,7 @@ class OmnisciOnRayFrame(PandasFrame):
         """
         return [expr._dtype for expr in exprs.values()]
 
-    def groupby_agg(self, by, axis, agg, groupby_args, **kwargs):
+    def groupby_agg(self, by, axis, agg, groupby_args, selection=None, **kwargs):
         """
         Groupby with aggregation operation.
 
@@ -443,6 +443,8 @@ class OmnisciOnRayFrame(PandasFrame):
         groupby_cols = by_frame.columns
         if isinstance(agg, dict):
             agg_cols = agg.keys()
+        elif selection is not None:
+            agg_cols = selection
         elif not drop:
             # If 'by' data came from a different frame then 'self-aggregation'
             # columns are more prioritized.

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -859,19 +859,31 @@ class TestGroupby:
     @pytest.mark.parametrize("by", [["a"], ["a", "b", "c"]])
     @pytest.mark.parametrize("agg", ["sum", "size"])
     @pytest.mark.parametrize("as_index", [True, False])
-    def test_groupby_agg_by_col(self, by, agg, as_index):
+    @pytest.mark.parametrize(
+        "selection", [None, ["a"], ["b"], ["b", "c"], ["a", "b", "c"]]
+    )
+    def test_groupby_agg_by_col(self, by, agg, as_index, selection):
         def simple_agg(df, **kwargs):
-            return df.groupby(by, as_index=as_index).agg(agg)
+            grp = df.groupby(by, as_index=as_index)
+            if selection is not None:
+                grp = grp[selection]
+            return grp.agg(agg)
 
         run_and_compare(simple_agg, data=self.data)
 
         def dict_agg(df, **kwargs):
-            return df.groupby(by, as_index=as_index).agg({by[0]: agg})
+            grp = df.groupby(by, as_index=as_index)
+            if selection is not None:
+                grp = grp[selection]
+            return grp.agg({by[0]: agg})
 
         run_and_compare(dict_agg, data=self.data)
 
         def dict_agg_all_cols(df, **kwargs):
-            return df.groupby(by, as_index=as_index).agg({col: agg for col in by})
+            grp = df.groupby(by, as_index=as_index)
+            if selection is not None:
+                grp = grp[selection]
+            return grp.agg({col: agg for col in by})
 
         run_and_compare(dict_agg_all_cols, data=self.data)
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -471,6 +471,7 @@ class DataFrame(BasePandasDataset):
                 )
                 for o in by
             ):
+                # breakpoint()
                 # We want to split 'by's into those that belongs to the self (internal_by)
                 # and those that doesn't (external_by)
                 internal_by, external_by = [], []

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -471,7 +471,6 @@ class DataFrame(BasePandasDataset):
                 )
                 for o in by
             ):
-                # breakpoint()
                 # We want to split 'by's into those that belongs to the self (internal_by)
                 # and those that doesn't (external_by)
                 internal_by, external_by = [], []

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -457,6 +457,15 @@ class DataFrameGroupBy(object):
         ------
         NotImplementedError
             Column lookups on GroupBy with arbitrary Series in by is not yet supported.
+        IndexError
+            If this GroupBy object already has a selection.
+
+        Notes
+        -----
+        Unlike pandas, modin always selects columns in the same order as they're located
+        in the source frame, discarding the order provided to the `__getitem__`. If the
+        order is matters, you can reindex GroupBy result with the selection:
+        ``result.reindex(columns=result.columns[:result.shape[1] - len(selection)].tolist() + selection)``
         """
         if self._selection is not None:
             raise IndexError(f"Column(s) {self._selection} already selected")

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -1162,8 +1162,10 @@ class DataFrameGroupBy(object):
         agg_func : callable or dict,
             Aggregation function which was applied to the GroupBy object to get the `result`.
         """
+        if not isinstance(result, BaseQueryCompiler):
+            result = result._query_compiler
         # that means that `agg_func` arisen an exception for every aggregated column
-        if result.empty and not self._df.empty:
+        if len(result.columns) == 0 and len(self._query_compiler.columns) != 0:
             # determening type of raised exception by applying `agg_func`
             # to empty DataFrame
             try:

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -371,8 +371,9 @@ class DataFrameGroupBy(object):
             internal_by = self._internal_by
             selection = [col for col in self._selection_list if col not in internal_by]
             if self.ndim == 1:
-                assert (
-                    len(selection) == 1 or len(selection) == 0
+                assert len(selection) in (
+                    0,
+                    1,
                 ), f"Single-dimensional object has non-single dimensional selection: {selection}."
                 selection = selection[0] if len(selection) == 1 else []
 
@@ -420,8 +421,9 @@ class DataFrameGroupBy(object):
                 if col not in internal_by
             ]
             if self.ndim == 1:
-                assert (
-                    len(selection) == 1 or len(selection) == 0
+                assert len(selection) in (
+                    0,
+                    1,
                 ), f"Single-dimensional object has non-single dimensional selection: {selection}."
                 selection = selection[0] if len(selection) == 1 else []
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -462,7 +462,7 @@ class DataFrameGroupBy(object):
 
         Notes
         -----
-        Unlike pandas, modin always selects columns in the same order as they're located
+        Unlike pandas, Modin always selects columns in the same order as they're located
         in the source frame, discarding the order provided to the `__getitem__`. If the
         order is matters, you can reindex GroupBy result with the selection:
         ``result.reindex(columns=result.columns[:result.shape[1] - len(selection)].tolist() + selection)``

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -930,14 +930,17 @@ class DataFrameGroupBy(object):
         # so dropping intersection from the selection
         if (
             self._is_multi_by
-            and selection is not None
             and not self._as_index
             and any(
                 isinstance(dtype, pandas.CategoricalDtype)
                 for dtype in self._df.dtypes[internal_by]
             )
         ):
-            selection = [col for col in selection if col not in internal_by]
+            selection = [
+                col
+                for col in (self._df.columns if selection is None else selection)
+                if col not in internal_by
+            ]
 
         groupby_qc = self._query_compiler
         result = type(self._df)(
@@ -983,14 +986,17 @@ class DataFrameGroupBy(object):
         selection = self._selection
         if (
             self._is_multi_by
-            and selection is not None
             and not self._as_index
             and any(
                 isinstance(dtype, pandas.CategoricalDtype)
                 for dtype in self._df.dtypes[internal_by]
             )
         ):
-            selection = [col for col in selection if col not in internal_by]
+            selection = [
+                col
+                for col in (self._df.columns if selection is None else selection)
+                if col not in internal_by
+            ]
 
         new_manager = self._query_compiler.groupby_agg(
             by=self._by,

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -543,13 +543,13 @@ class DataFrameGroupBy(object):
             )
             func_dict = {col: try_get_str_func(fn) for col, fn in func_dict.items()}
             if any(
-                i
+                col
                 not in (
                     self._df.columns
                     if self._selection is None
                     else self._selection_list
                 )
-                for i in func_dict.keys()
+                for col in func_dict.keys()
             ):
                 if self.ndim == 2:
                     raise KeyError("Non existed column provided to the aggregation")
@@ -1064,10 +1064,9 @@ class DataFrameGroupBy(object):
         if selection is None:
             selection = self._non_conflict_selection
 
-        groupby_qc = self._query_compiler
         result = type(self._df)(
             query_compiler=qc_method(
-                groupby_qc,
+                self._query_compiler,
                 by=self._by,
                 axis=self._axis,
                 groupby_args=self._kwargs,

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -441,17 +441,19 @@ class DataFrameGroupBy(object):
             raise IndexError(f"Column(s) {self._selection} already selected")
 
         kwargs = {**self._kwargs.copy(), "squeeze": self._squeeze}
-        # Most of time indexing DataFrameGroupBy results in another DataFrameGroupBy object unless circumstances are
-        # special in which case SeriesGroupBy has to be returned. Such circumstances are when key equals to a single
-        # column name and is not a list of column names or list of one column name.
+        # The rules of type deduction for the resulted object is the following:
+        #   1. If `key` is a list-like or `as_index is False`, then the resulted object is a DataFrameGroupBy
+        #   2. Otherwise, the resulted object is SeriesGroupBy
         if is_list_like(key):
             make_dataframe = True
         else:
+            # If `key` is not list-like then the selected object is always a single-dimensional
+            # (going by pandas notation)
+            kwargs["ndim"] = 1
             if self._as_index:
                 kwargs["squeeze"] = True
                 make_dataframe = False
             else:
-                kwargs["ndim"] = 1
                 make_dataframe = True
                 key = [key]
         if make_dataframe:

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -339,12 +339,23 @@ class DataFrameGroupBy(object):
         return internal_by
 
     def _get_non_by_selection(self):
+        """
+        Filter selection from the `by` columns in it.
+
+        Returns
+        -------
+        same type as ``self._selection``
+            ``self._selection`` without `by` columns in it.
+        """
         selection = self._selection
         if selection is not None:
             internal_by = self._get_internal_by()
             selection = [col for col in self._selection_list if col not in internal_by]
             if self.ndim == 1:
-                selection = selection[0]
+                assert (
+                    len(selection) == 1 or len(selection) == 0
+                ), f"Single-dimensional object has non-single dimensional selection: {selection}."
+                selection = selection[0] if len(selection) == 1 else []
         return selection
 
     def __getitem__(self, key):
@@ -824,6 +835,13 @@ class DataFrameGroupBy(object):
 
     @property
     def _selection_list(self):
+        """
+        Get list of selected columns.
+
+        Returns
+        -------
+        list
+        """
         if self._selection is None:
             return []
         return self._selection if is_list_like(self._selection) else [self._selection]
@@ -965,6 +983,9 @@ class DataFrameGroupBy(object):
             Whether or not to the grouping columns should be dropped on this operation.
         numeric_only : bool, default: True
             True for numeric only computations, False otherwise.
+        selection : label or list of labels, optional
+            Set of columns to apply aggregation on. If not specified will be infered
+            based on ``self._selection``.
         **kwargs : dict
             The keyword arguments to be passed to the calling function.
 
@@ -1028,6 +1049,9 @@ class DataFrameGroupBy(object):
         ----------
         f : callable
             The function to apply to each group.
+        selection : label or list of labels, optional
+            Set of columns to apply aggregation on. If not specified will be infered
+            based on ``self._selection``.
         *args : list
             Extra positional arguments to pass to `f`.
         **kwargs : dict

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -615,7 +615,7 @@ class DataFrameGroupBy(object):
             drop=False,
             idx_name=None,
             squeeze=self._squeeze,
-            selection=self._selection,
+            selection=None,
             **self._kwargs,
         )
         result = work_object._wrap_aggregation(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -614,9 +614,7 @@ class DataFrameGroupBy(object):
             result.name = (
                 self._df.name
                 if isinstance(self._df, Series)
-                else self._selection[0]
-                if self._selection is not None
-                else None
+                else (self._selection[0] if self._selection is not None else None)
             )
         else:
             result.name = None

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -309,6 +309,13 @@ class DataFrameGroupBy(object):
         return self.bfill(limit)
 
     def _get_internal_by(self):
+        """
+        Get only those components of 'by' that are column labels of the source frame.
+
+        Returns
+        -------
+        list of labels
+        """
         internal_by = []
         if self._drop:
             for by in self._by if is_list_like(self._by) else [self._by]:

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -464,7 +464,7 @@ class DataFrameGroupBy(object):
         -----
         Unlike pandas, Modin always selects columns in the same order as they're located
         in the source frame, discarding the order provided to the `__getitem__`. If the
-        order is matters, you can reindex GroupBy result with the selection:
+        order matters, you can reindex GroupBy result with the selection:
         ``result.reindex(columns=result.columns[:result.shape[1] - len(selection)].tolist() + selection)``
         """
         if self._selection is not None:

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1698,7 +1698,6 @@ def test_multi_column_groupby_different_partitions(
     md_grp, pd_grp = md_df.groupby(by, as_index=as_index), pd_df.groupby(
         by, as_index=as_index
     )
-
     eval_general(md_grp, pd_grp, func_to_apply)
     eval___getitem__(md_grp, pd_grp, additional_tests=func_to_apply)
 

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -221,7 +221,8 @@ def test_mixed_dtypes_groupby(as_index):
             modin_groupby, pandas_groupby, lambda df: df.take(), is_default=True
         )
         eval___getattr__(modin_groupby, pandas_groupby, "col2")
-        eval___getitem__(modin_groupby, pandas_groupby)
+        if get_current_backend() != "BaseOnPython":
+            eval___getitem__(modin_groupby, pandas_groupby)
         eval_groups(modin_groupby, pandas_groupby)
 
 

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1202,7 +1202,7 @@ def eval___getitem__(md_grp, pd_grp, additional_tests=None):
     half_columns = all_columns[: len(all_columns) // 2]
     test_function(md_grp, pd_grp, half_columns)
 
-    non_by_items = all_columns.difference(md_grp._get_internal_by()).tolist()
+    non_by_items = all_columns.difference(md_grp._internal_by).tolist()
 
     if len(non_by_items) == 0:
         return

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -34,6 +34,7 @@ NPartitions.put(4)
 
 
 def modin_groupby_equals_pandas(modin_groupby, pandas_groupby):
+    assert modin_groupby.ndim == pandas_groupby.ndim
     for g1, g2 in zip(modin_groupby, pandas_groupby):
         assert g1[0] == g2[0]
         df_equals(g1[1], g2[1])

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1141,6 +1141,13 @@ def eval___getitem__(md_grp, pd_grp, additional_tests=None):
         md_grp, pd_grp = md_grp[selection], pd_grp[selection]
 
         assert md_grp.ndim == pd_grp.ndim
+        assert (
+            isinstance(md_grp, pd.groupby.DataFrameGroupBy)
+            and isinstance(pd_grp, pandas.core.groupby.DataFrameGroupBy)
+        ) or (
+            isinstance(md_grp, pd.groupby.SeriesGroupBy)
+            and isinstance(pd_grp, pandas.core.groupby.SeriesGroupBy)
+        ), f"Diffirent types of GroupBy objects.\nModin: {type(md_grp)}, Pandas: {type(pd_grp)}"
         # Non-numeric aggregation test, MapReduce
         eval_general(md_grp, pd_grp, lambda grp: grp.count(), comparator=comparator)
         eval_general(md_grp, pd_grp, lambda grp: grp.any(), comparator=comparator)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -317,7 +317,6 @@ def test_simple_row_groupby(by, as_index, col1_category):
 
     modin_groupby_equals_pandas(modin_groupby, pandas_groupby)
     eval_ngroups(modin_groupby, pandas_groupby)
-
     eval_shift(modin_groupby, pandas_groupby)
     eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill(), is_default=True)
     eval_general(
@@ -846,6 +845,7 @@ def test_series_groupby(by, as_index_series_or_dataframe):
         modin_groupby = modin_series.groupby(by, as_index=as_index)
         if as_index_series_or_dataframe == 2:
             modin_groupby = modin_groupby["col1"]
+
         modin_groupby_equals_pandas(modin_groupby, pandas_groupby)
         eval_ngroups(modin_groupby, pandas_groupby)
         eval_shift(modin_groupby, pandas_groupby)
@@ -1139,15 +1139,8 @@ def eval___getitem__(md_grp, pd_grp, additional_tests=None):
 
     def test_function(md_grp, pd_grp, selection):
         md_grp, pd_grp = md_grp[selection], pd_grp[selection]
+        modin_groupby_equals_pandas(md_grp, pd_grp)
 
-        assert md_grp.ndim == pd_grp.ndim
-        assert (
-            isinstance(md_grp, pd.groupby.DataFrameGroupBy)
-            and isinstance(pd_grp, pandas.core.groupby.DataFrameGroupBy)
-        ) or (
-            isinstance(md_grp, pd.groupby.SeriesGroupBy)
-            and isinstance(pd_grp, pandas.core.groupby.SeriesGroupBy)
-        ), f"Diffirent types of GroupBy objects.\nModin: {type(md_grp)}, Pandas: {type(pd_grp)}"
         # Non-numeric aggregation test, MapReduce
         eval_general(md_grp, pd_grp, lambda grp: grp.count(), comparator=comparator)
         eval_general(md_grp, pd_grp, lambda grp: grp.any(), comparator=comparator)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1245,15 +1245,11 @@ def eval_shift(modin_groupby, pandas_groupby):
         pandas_groupby,
         lambda groupby: groupby.shift(periods=-3),
     )
-    # Modin does not raise an exception when trying to call any function
-    # with 'axis=1' against SeriesGroupByObject.
-    # TODO: create an issue and add its id here
-    if pandas_groupby.ndim == 2:
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda groupby: groupby.shift(axis=1, fill_value=777),
-        )
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda groupby: groupby.shift(axis=1, fill_value=777),
+    )
 
 
 def test_groupby_on_index_values_with_loop():

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1417,17 +1417,22 @@ def test_dict_agg_rename_mi_columns(as_index, by_length, agg_fns):
     md_df.columns, pd_df.columns = mi_columns, mi_columns
 
     by = list(md_df.columns[:by_length])
-    agg_cols = list(md_df.columns[by_length : by_length + 3])
+    list_of_agg_cols = [
+        md_df.columns[by_length : by_length + 3],
+        md_df.columns[: by_length + 3],
+    ]
 
-    agg_dict = {
-        f"custom-{i}" + str(agg_fns[i % len(agg_fns)]): (col, agg_fns[i % len(agg_fns)])
-        for i, col in enumerate(agg_cols)
-    }
+    for agg_cols in list_of_agg_cols:
+        agg_dict = {
+            f"custom-{i}"
+            + str(agg_fns[i % len(agg_fns)]): (col, agg_fns[i % len(agg_fns)])
+            for i, col in enumerate(agg_cols)
+        }
 
-    md_res = md_df.groupby(by, as_index=as_index).agg(**agg_dict)
-    pd_res = pd_df.groupby(by, as_index=as_index).agg(**agg_dict)
+        md_res = md_df.groupby(by, as_index=as_index).agg(**agg_dict)
+        pd_res = pd_df.groupby(by, as_index=as_index).agg(**agg_dict)
 
-    df_equals(md_res, pd_res)
+        df_equals(md_res, pd_res)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

@dchigarev writes:

**Note:** `GroupBy.__getitem__` allows to select specific columns of the source frame to apply aggregation functions on.

<details><summary>Usage examples</summary>

```python
>>> df = pandas.DataFrame({"a": [1, 2, 2], "b": [3, 4, 5], "c": [7, 8, 9], "d": [9, 8, 7]})
>>> df.groupby("a").sum() # No selection, applying 'sum' for each non-by column
   b   c   d
a
1  3   7   9
2  9  17  15
>>> df.groupby("a")[["b", "c"]].sum() # Selecting "b" and "c" columns to aggregate
   b   c
a
1  3   7
2  9  17
>>> df.groupby("a")[["a", "b"]].sum() # Can even select 'by' columns to be aggregated
   a  b
a
1  1  3
2  4  9
```

</details>

This PR changes the way of handling columns selection for aggregation in GroupBy. Previously the selection was done by masking the source frame with the `key` columns:
https://github.com/modin-project/modin/blob/253ecd98d91d636243d1ba33e7981a4fca9f053b/modin/pandas/groupby.py#L341-L348
this approach does not grab 'by' columns to the resulted source frame which leads to `KeyError`s if `self._by` is presented by a list of column names, it also does not allow to select 'by' columns to be aggregated, because by default pandas don't aggregate 'by' columns and masking can't make it do so.

It was decided to get rid of masking the source frame at `__getitem__` and extend GroupBy backend's API by adding `selection` parameter that caries information about columns to aggregate. 

This parameter could help not only for the `__getitem__` selection, but to offload backends of mimicking pandas behavior in terms of resolving naming conflicts when `as_index=False`. Ideally, the following code should be located at the front-end, `selection` parameter allows to move this to the front and pass the proper columns to aggregate as a `selection` to the backend:
https://github.com/modin-project/modin/blob/253ecd98d91d636243d1ba33e7981a4fca9f053b/modin/experimental/engines/omnisci_on_ray/frame/data.py#L444-L456

### ASV results

Launch command:
```
MODIN_TEST_DATASET_SIZE=Big MODIN_CPUS=16 asv continuous src/master HEAD --launch-method=spawn --no-only-changed --show-stderr -a repeat=3 -a number=3 -b "^benchmarks.TimeGroupByDefaultAggregations" -b "^benchmarks.TimeGroupByMultiColumn" -b "^benchmarks.TimeGroupByDictionaryAggregation"
```

Benchmarks were run at [this commit](https://github.com/dchigarev/modin/commit/5ccfe294d113e2eca4c6949c89e36249054f2956) which adds groupby benchmarks for the 'selection' parameter

There are some cases for which performance has decreased (ASV marked them by pluses), they're related to the selection for wide frames, reasons for that are described [here](https://github.com/modin-project/modin/pull/3298#issuecomment-908486835).

<details><summary>Performance results</summary>

```
       before           after         ratio			benchmark(shape, number_of_groups, number_of_columns_to_select)
     [0bc409d6]       [98198eab]
     <master>       <dev/yigoshev-issue3252>
+      82.6±0.7ms       98.0±0.5ms     1.19  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((5000, 5000), 'huge_amount_groups', 3)
+        82.5±1ms         97.3±1ms     1.18  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((5000, 5000), 100, 3)
+         365±8ms          428±9ms     1.17  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((5000, 5000), 'huge_amount_groups', 'all')
          125±3ms          138±6ms    ~1.10  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((5000, 5000), 'huge_amount_groups', 3, 6)
          108±3ms          117±8ms     1.08  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((5000, 5000), 100, 3, 6)
          166±7ms          178±5ms     1.07  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((5000, 5000), 100, 3, 6)
          271±9ms          288±5ms     1.06  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((5000, 5000), 100, 'all')
        247±0.7ms          261±2ms     1.06  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((1000000, 10), 'huge_amount_groups', 'all')
         101±50ms          107±3ms     1.06  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((1000000, 10), 'huge_amount_groups', 'all')
         400±10ms          423±7ms     1.06  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((5000, 5000), 'huge_amount_groups', None)
          538±6ms         569±10ms     1.06  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((1000000, 10), 100, 'all', 6)
         298±20ms          313±4ms     1.05  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((5000, 5000), 100, 'all')
          236±5ms          248±4ms     1.05  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((5000, 5000), 100, None)
         78.4±4ms       81.9±0.9ms     1.05  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((1000000, 10), 100, None, 'reduction')
        82.7±60ms       85.8±0.4ms     1.04  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((1000000, 10), 100, 'all')
          144±8ms          150±4ms     1.04  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((5000, 5000), 100, None)
         79.2±2ms         82.0±2ms     1.04  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((5000, 5000), 'huge_amount_groups', None, 'reduction')
         109±40ms          112±4ms     1.03  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((1000000, 10), 'huge_amount_groups', 'all')
        88.7±50ms         91.6±2ms     1.03  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((1000000, 10), 100, None)
          231±3ms          238±3ms     1.03  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((1000000, 10), 100, 'all')
       3.33±0.02s       3.43±0.09s     1.03  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((5000, 5000), 'huge_amount_groups', 'all', 6)
         81.5±3ms         83.7±1ms     1.03  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((1000000, 10), 100, None)
         76.7±1ms         78.6±1ms     1.02  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((5000, 5000), 100, None, 'reduction')
          1.22±0s          1.24±0s     1.02  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((1000000, 10), 100, 'all', 6)
         455±40ms          465±9ms     1.02  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((5000, 5000), 'huge_amount_groups', 'all')
          549±2ms          558±8ms     1.02  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((5000, 5000), 'huge_amount_groups', 'all', 6)
          104±3ms          106±1ms     1.02  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((5000, 5000), 'huge_amount_groups', None)
          126±3ms          128±3ms     1.01  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((1000000, 10), 'huge_amount_groups', None)
        97.4±40ms         98.7±2ms     1.01  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((1000000, 10), 'huge_amount_groups', None)
       3.45±0.02s       3.50±0.03s     1.01  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((1000000, 10), 'huge_amount_groups', 'all', 6)
          292±7ms          295±2ms     1.01  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((5000, 5000), 100, 'all', 6)
          402±2ms          405±3ms     1.01  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((1000000, 10), 100, None, 'aggregation')
          229±2ms          231±1ms     1.01  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((1000000, 10), 100, None)
         462±20ms         464±10ms     1.00  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((5000, 5000), 100, 'all', 6)
       3.31±0.01s       3.32±0.01s     1.00  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((5000, 5000), 'huge_amount_groups', None, 6)
         293±10ms          293±9ms     1.00  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((5000, 5000), 100, None)
          405±4ms          405±2ms     1.00  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((1000000, 10), 100, 'all', 'aggregation')
        440±0.8ms          440±1ms     1.00  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((1000000, 10), 'huge_amount_groups', None, 'aggregation')
          103±4ms          103±1ms     1.00  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((1000000, 10), 100, None)
       1.43±0.01s          1.42±0s     1.00  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((1000000, 10), 'huge_amount_groups', None, 6)
          440±2ms          439±2ms     1.00  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((1000000, 10), 'huge_amount_groups', 'all', 'aggregation')
          249±1ms          248±4ms     1.00  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((1000000, 10), 'huge_amount_groups', None)
         96.5±1ms         96.1±4ms     1.00  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((5000, 5000), 100, None, 'aggregation')
       1.42±0.01s       1.42±0.03s     0.99  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((1000000, 10), 'huge_amount_groups', 'all', 6)
         286±10ms          284±9ms     0.99  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((5000, 5000), 100, None, 6)
       3.53±0.03s       3.50±0.01s     0.99  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((1000000, 10), 'huge_amount_groups', None, 6)
         534±10ms         529±10ms     0.99  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((5000, 5000), 'huge_amount_groups', None, 6)
       1.22±0.01s       1.21±0.01s     0.99  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((1000000, 10), 100, None, 6)
         104±60ms          103±5ms     0.99  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((1000000, 10), 100, 3)
        91.9±50ms         90.4±1ms     0.98  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((1000000, 10), 100, 'all')
          540±2ms          531±8ms     0.98  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((1000000, 10), 100, None, 6)
          1.05±0s       1.03±0.01s     0.98  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((1000000, 10), 100, 3, 6)
          127±4ms          125±2ms     0.98  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((1000000, 10), 'huge_amount_groups', 'all')
         111±60ms          109±2ms     0.98  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((1000000, 10), 'huge_amount_groups', None)
         464±10ms         454±10ms     0.98  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((5000, 5000), 100, None, 6)
          154±8ms          151±6ms     0.98  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((5000, 5000), 100, 'all')
         128±50ms        125±0.4ms     0.98  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((1000000, 10), 'huge_amount_groups', 3)
         99.3±2ms         96.6±2ms     0.97  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((5000, 5000), 'huge_amount_groups', None, 'aggregation')
          105±5ms        102±0.6ms     0.97  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((1000000, 10), 100, 'all')
       1.57±0.01s       1.53±0.03s     0.97  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((5000, 5000), 'huge_amount_groups', 3, 6)
          102±4ms         99.2±6ms     0.97  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((5000, 5000), 100, None)
        94.5±50ms         91.3±2ms     0.97  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((1000000, 10), 'huge_amount_groups', 3)
         237±10ms          228±9ms     0.96  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((5000, 5000), 'huge_amount_groups', 'all')
       1.25±0.01s       1.20±0.03s     0.96  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_quan((1000000, 10), 'huge_amount_groups', 3, 6)
          198±3ms          189±3ms     0.95  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((1000000, 10), 'huge_amount_groups', 3)
         236±10ms          225±9ms     0.95  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((5000, 5000), 'huge_amount_groups', None)
         91.8±1ms         86.9±3ms     0.95  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((1000000, 10), 'huge_amount_groups', None, 'reduction')
         92.5±1ms         87.0±3ms     0.94  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((1000000, 10), 'huge_amount_groups', 'all', 'reduction')
       3.56±0.01s       3.34±0.03s     0.94  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((1000000, 10), 'huge_amount_groups', 3, 6)
        81.7±60ms       76.3±0.9ms     0.93  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((5000, 5000), 100, 3)
          183±3ms          170±1ms     0.93  benchmarks.TimeGroupByDefaultAggregations.time_groupby_mean((1000000, 10), 100, 3)
        86.0±50ms       79.5±0.5ms     0.92  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((1000000, 10), 100, 3)
        93.3±60ms         86.3±2ms     0.92  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((1000000, 10), 'huge_amount_groups', 3)
         85.9±2ms         79.3±2ms     0.92  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((1000000, 10), 100, 'all', 'reduction')
         109±50ms          100±2ms     0.92  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((5000, 5000), 100, 3)
         385±30ms          351±3ms     0.91  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((5000, 5000), 'huge_amount_groups', None)
          116±2ms          104±3ms    ~0.90  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((5000, 5000), 100, 'all')
        88.2±50ms         78.3±2ms    ~0.89  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((5000, 5000), 100, 3)
         117±40ms        104±0.9ms    ~0.89  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((5000, 5000), 'huge_amount_groups', 3)
-         118±5ms          103±1ms     0.87  benchmarks.TimeGroupByDefaultAggregations.time_groupby_size((5000, 5000), 'huge_amount_groups', 'all')
-         110±5ms         95.8±2ms     0.87  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((5000, 5000), 'huge_amount_groups', 'all', 'aggregation')
-         112±4ms         97.6±1ms     0.87  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((5000, 5000), 100, 'all', 'aggregation')
        90.8±40ms       79.1±0.8ms    ~0.87  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((5000, 5000), 'huge_amount_groups', 3)
        86.1±50ms         74.3±5ms    ~0.86  benchmarks.TimeGroupByDefaultAggregations.time_groupby_sum((5000, 5000), 'huge_amount_groups', 3)
-        91.9±4ms         78.8±2ms     0.86  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((5000, 5000), 'huge_amount_groups', 'all', 'reduction')
-        89.9±5ms         76.8±1ms     0.85  benchmarks.TimeGroupByDictionaryAggregation.time_groupby_dict_agg((5000, 5000), 100, 'all', 'reduction')
        93.2±40ms         79.1±2ms    ~0.85  benchmarks.TimeGroupByDefaultAggregations.time_groupby_count((1000000, 10), 100, 3)
-         599±8ms          498±3ms     0.83  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_mean((1000000, 10), 100, 3, 6)
```

</details>


### TODO list

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3252, #3262 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
