### PR TITLE
FIX-#3313: Fix `read_json` metadata definition

### DIFF
--- a/modin/engines/base/io/text/json_dispatcher.py
+++ b/modin/engines/base/io/text/json_dispatcher.py
@@ -75,12 +75,15 @@ class JSONDispatcher(TextFileDispatcher):
                 column_widths = [len(columns)]
                 num_splits = 1
             else:
-                column_widths = [
-                    column_chunksize
-                    if i != num_splits - 1
-                    else len(columns) - (column_chunksize * (num_splits - 1))
-                    for i in range(num_splits)
-                ]
+                column_widths = []
+                for i in range(num_splits):
+                    if len(columns) > (column_chunksize * i):
+                        if len(columns) > (column_chunksize * (i + 1)):
+                            column_widths.append(column_chunksize)
+                        else:
+                            column_widths.append(len(columns) - (column_chunksize * i))
+                    else:
+                        column_widths.append(0)
 
             args = {"fname": path_or_buf, "num_splits": num_splits, **kwargs}
 


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3313  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
