### PR TITLE
Fix-#3296: Patch __array__ method for RPyC proxy objects

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,6 +560,9 @@ jobs:
       - shell: bash -l {0}
         run: python -m pytest --simulate-cloud=normal modin/pandas/test/test_io.py::TestCsv
       - shell: bash -l {0}
+      # When running without parameters, some of the tests fall
+        run: python -m pytest --simulate-cloud=normal modin/pandas/test/dataframe/test_binary.py::test_math_functions[add-rows-scalar]
+      - shell: bash -l {0}
         run: |
           curl -o codecov https://codecov.io/bash
           VERSION=$(grep -o 'VERSION=\"[0-9\.]*\"' codecov | cut -d'"' -f2);

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -560,7 +560,7 @@ jobs:
       - shell: bash -l {0}
         run: python -m pytest --simulate-cloud=normal modin/pandas/test/test_io.py::TestCsv
       - shell: bash -l {0}
-      # When running without parameters, some of the tests fall
+      # When running without parameters, some of the tests fail
         run: python -m pytest --simulate-cloud=normal modin/pandas/test/dataframe/test_binary.py::test_math_functions[add-rows-scalar]
       - shell: bash -l {0}
         run: |

--- a/modin/experimental/cloud/rpyc_patches.py
+++ b/modin/experimental/cloud/rpyc_patches.py
@@ -1,3 +1,16 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 import numpy
 from rpyc.core import netref
 

--- a/modin/experimental/cloud/rpyc_patches.py
+++ b/modin/experimental/cloud/rpyc_patches.py
@@ -1,0 +1,25 @@
+import numpy
+from rpyc.core import netref
+
+
+def apply_pathes():
+    def fixed_make_method(name, doc, orig=netref._make_method):
+        if name == "__array__":
+
+            def __array__(self, dtype=None):
+                # Note that protocol=-1 will only work between python
+                # interpreters of the same version.
+                res = netref.pickle.loads(
+                    netref.syncreq(self, netref.consts.HANDLE_PICKLE, -1)
+                )
+
+                if dtype is not None:
+                    res = numpy.asarray(res, dtype=dtype)
+
+                return res
+
+            __array__.__doc__ = doc
+            return __array__
+        return orig(name, doc)
+
+    netref._make_method = fixed_make_method

--- a/modin/experimental/cloud/rpyc_patches.py
+++ b/modin/experimental/cloud/rpyc_patches.py
@@ -23,7 +23,7 @@ def apply_pathes():
                 # Note that protocol=-1 will only work between python
                 # interpreters of the same version.
                 res = netref.pickle.loads(
-                    netref.syncreq(self, netref.consts.HANDLE_PICKLE, -1)
+                    netref.syncreq(self, netref.consts.HANDLE_PICKLE, pickle.HIGHEST_PROTOCOL)
                 )
 
                 if dtype is not None:

--- a/modin/experimental/cloud/rpyc_patches.py
+++ b/modin/experimental/cloud/rpyc_patches.py
@@ -23,7 +23,11 @@ def apply_pathes():
                 # Note that protocol=-1 will only work between python
                 # interpreters of the same version.
                 res = netref.pickle.loads(
-                    netref.syncreq(self, netref.consts.HANDLE_PICKLE, pickle.HIGHEST_PROTOCOL)
+                    netref.syncreq(
+                        self,
+                        netref.consts.HANDLE_PICKLE,
+                        netref.pickle.HIGHEST_PROTOCOL,
+                    )
                 )
 
                 if dtype is not None:

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -24,6 +24,11 @@ from . import get_connection
 from .meta_magic import _LOCAL_ATTRS, RemoteMeta, _KNOWN_DUALS
 from modin.config import DoTraceRpyc
 
+from .rpyc_patches import apply_pathes
+
+
+apply_pathes()
+
 
 def _batch_loads(items):
     return tuple(pickle.loads(item) for item in items)
@@ -209,11 +214,7 @@ class WrappingConnection(rpyc.Connection):
                         return res
                 return orig_getattribute(this, name)
 
-            def __array__(this):
-                return pickle.loads(self._remote_pickled_array(this))
-
             cls.__getattribute__ = __getattribute__
-            cls.__array__ = __array__
         return result
 
     def _netref_factory(self, id_pack):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [X] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [X] passes `flake8 modin`
- [X] passes `black --check modin`
- [X] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [X] Resolves #3296? 
- [X] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

## Solution description

The error was in the module `rpyc.core.netref`. 

 For the solution, it was necessary to patch the `_make_method` method. In the `_make_method` method, in the `name == "__array__ "` block, the `_array__` method must accept two parameters: `self` and `type`. Adding logic from `rpyc_patches.py`, I am correcting this error. Now the `__array__` method accepts the `type` parameter and processes it correctly. More information about the solution is written in https://github.com/modin-project/modin/issues/3296.