### PR TITLE
FIX-#3311: Fix part of warnings in docs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,7 @@ instance/
 
 # Sphinx documentation
 docs/_build/
+docs/flow/modin/configs_help.csv
 
 # PyBuilder
 target/

--- a/docs/developer/architecture.rst
+++ b/docs/developer/architecture.rst
@@ -318,9 +318,8 @@ by documentation for now, the rest is coming soon...).
    │   │       │   └─── :doc:`io </flow/modin/engines/ray/cudf_on_ray/io>`
    │   │       └───pandas_on_ray
    │   │           └─── :doc:`frame </flow/modin/engines/ray/pandas_on_ray/frame/index>`
-   │   ├───experimental
    │   ├── :doc:`experimental </flow/modin/experimental/experimental>`
-   │   │   ├───backends
+   │   │   ├─── :doc:`backends </flow/modin/experimental/backends/index>`
    │   │   │   └─── :doc:`omnisci </flow/modin/experimental/backends/omnisci/index>`
    │   │   │       └─── :doc:`query_compiler </flow/modin/experimental/backends/omnisci/query_compiler>`
    │   │   ├───cloud

--- a/docs/flow/modin/backends/index.rst
+++ b/docs/flow/modin/backends/index.rst
@@ -44,7 +44,7 @@ High-level module overview
 This module houses submodules of all of the stable query compilers:
 
 ..
-    TODO: Insert link for <cuDF module> when it will be added (issue #3323)
+    TODO: Insert a link to <cuDF module> when it is added (issue #3323)
 
 - :doc:`Base module <base/query_compiler>` contains an abstract query compiler class which defines common API.
 - :doc:`Pandas module <pandas/index>` contains query compiler and text parsers for pandas backend.

--- a/docs/flow/modin/backends/index.rst
+++ b/docs/flow/modin/backends/index.rst
@@ -6,7 +6,6 @@ Query Compiler
 
     base/query_compiler
     pandas/index
-    cudf/index
     pyarrow/index
 
 Modin supports several execution backends. Calling any DataFrame API function will end up in
@@ -46,7 +45,7 @@ This module houses submodules of all of the stable query compilers:
 
 - :doc:`Base module <base/query_compiler>` contains an abstract query compiler class which defines common API.
 - :doc:`Pandas module <pandas/index>` contains query compiler and text parsers for pandas backend.
-- :doc:`cuDF module <cudf/index>` contains query compiler and text parsers for cuDF backend.
+- cuDF module contains query compiler and text parsers for cuDF backend.
 - :doc:`Pyarrow module <pyarrow/index>` contains query compiler and text parsers for Pyarrow backend.
 
-You can find more in the :doc:`experimental section </flow/modin/experimental/backends/>`.
+You can find more in the :doc:`experimental section </flow/modin/experimental/backends/index>`.

--- a/docs/flow/modin/backends/index.rst
+++ b/docs/flow/modin/backends/index.rst
@@ -43,6 +43,9 @@ High-level module overview
 ''''''''''''''''''''''''''
 This module houses submodules of all of the stable query compilers:
 
+..
+    TODO: Insert link for <cuDF module> when it will be added (issue #3323)
+
 - :doc:`Base module <base/query_compiler>` contains an abstract query compiler class which defines common API.
 - :doc:`Pandas module <pandas/index>` contains query compiler and text parsers for pandas backend.
 - cuDF module contains query compiler and text parsers for cuDF backend.

--- a/docs/flow/modin/data_management/factories.rst
+++ b/docs/flow/modin/data_management/factories.rst
@@ -27,7 +27,7 @@ responsible for dispatching calls of IO functions to their actual implementation
 underlying IO module. For more information about IO module visit :doc:`related doc </flow/modin/engines/base/io>`.
 
 Factory Dispatcher
-'''''''''''''''''
+''''''''''''''''''
 The ``modin.data_management.factories.dispatcher.FactoryDispatcher`` class provides public methods whose interface corresponds to
 pandas IO functions, the only difference is that they return `QueryCompiler` of the
 selected backend instead of DataFrame. ``FactoryDispatcher`` is responsible for routing

--- a/docs/flow/modin/experimental/backends/index.rst
+++ b/docs/flow/modin/experimental/backends/index.rst
@@ -3,7 +3,7 @@
 Experimental backends
 """""""""""""""""""""
 
-``modin.experimental.backends`` holds experimental backends that is under development right now
+``modin.experimental.backends`` holds experimental backends that are under development right now
 and provides a limited set of functionality:
 
 * :doc:`omnisci <omnisci/index>`

--- a/docs/flow/modin/experimental/backends/index.rst
+++ b/docs/flow/modin/experimental/backends/index.rst
@@ -1,0 +1,15 @@
+:orphan:
+
+Experimental backends
+"""""""""""""""""""""
+
+``modin.experimental.backends`` holds experimental backends that is under development right now
+and provides a limited set of functionality:
+
+* :doc:`omnisci <omnisci/index>`
+
+
+.. toctree::
+    :hidden:
+
+    omnisci/index

--- a/docs/flow/modin/experimental/backends/omnisci/index.rst
+++ b/docs/flow/modin/experimental/backends/omnisci/index.rst
@@ -1,5 +1,3 @@
-:orphan:
-
 OmniSci backend
 """""""""""""""
 

--- a/docs/flow/modin/experimental/engines/omnisci_on_ray/frame/index.rst
+++ b/docs/flow/modin/experimental/engines/omnisci_on_ray/frame/index.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 OmniSciOnRay Frame Implementation
 =================================
 
@@ -36,7 +38,7 @@ class.
     partition
     axis_partition
     partition_manager
-    omnisci_engine
+    ../omnisci_engine
     df_algebra
     expr
     calcite_algebra

--- a/docs/flow/modin/experimental/engines/omnisci_on_ray/omnisci_engine.rst
+++ b/docs/flow/modin/experimental/engines/omnisci_on_ray/omnisci_engine.rst
@@ -127,7 +127,7 @@ Column name mangling
 ''''''''''''''''''''
 
 In ``pandas.DataFrame`` columns might have names not allowed in SQL (e. g.
-an empty string). To handle this we simply add 'F_' prefix to
+an empty string). To handle this we simply add '`F_`' prefix to
 column names. Index labels are more tricky because they might be non-unique.
 Indexes are represented as regular columns, and we have to perform a special
 mangling to get valid and unique column names. Demangling is done when we

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -95,7 +95,7 @@ or explicitly
   conda install -c conda-forge modin-ray modin-dask modin-omnisci
 
 Using Intel\ |reg| Distribution of Modin
-"""""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""
 
 With ``conda`` it is also possible to install Intel Distribution of Modin, a special version of Modin 
 that is part of Intel\ |reg| oneAPI AI Analytics Toolkit. This version of Modin is powered by :doc:`OmniSci</UsingOmnisci/index>` 

--- a/modin/experimental/engines/omnisci_on_ray/frame/df_algebra.py
+++ b/modin/experimental/engines/omnisci_on_ray/frame/df_algebra.py
@@ -24,7 +24,7 @@ class TransformMapper:
 
     This class is used to map column references to expressions used
     for their computation. This mapper is used to fold expressions
-    from multiple `TransformNode`s into a single expression.
+    from multiple ``TransformNode``-s into a single expression.
 
     Parameters
     ----------
@@ -549,7 +549,7 @@ class TransformNode(DFAlgNode):
 
     def fold(self):
         """
-        Fold two ``TransformNode``s.
+        Fold two ``TransformNode``-s.
 
         If base of this node is another `TransformNode`, then translate all
         expressions in `expr` to its base.

--- a/modin/spreadsheet/general.py
+++ b/modin/spreadsheet/general.py
@@ -110,7 +110,7 @@ def from_dataframe(
 
     The first group of options are SlickGrid "grid options" which are
     described in the `SlickGrid documentation
-    <https://github.com/mleibman/SlickGrid/wiki/Grid-Options>`_.
+    <https://github.com/mleibman/SlickGrid/wiki/Grid-Options>`__.
 
     The second group of option are options that were added specifically
     for modin-spreadsheet and therefore are not documented in the SlickGrid documentation.
@@ -148,7 +148,7 @@ def from_dataframe(
 
     The first group of options are SlickGrid "column options" which are
     described in the `SlickGrid documentation
-    <https://github.com/mleibman/SlickGrid/wiki/Column-Options>`_.
+    <https://github.com/mleibman/SlickGrid/wiki/Column-Options>`__.
 
     The ``editable`` option was added specifically for modin-spreadsheet and therefore is
     not documented in the SlickGrid documentation.  This option specifies


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3311  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
