### PR TITLE
FIX-#3291, #3258: Fix `__setitem__` when key is unhashable list

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2542,15 +2542,12 @@ class DataFrame(BasePandasDataset):
                     key = DataFrame(key, columns=self.columns)
                 return self.mask(key, value, inplace=True)
 
-            def setitem_unhashable_key(df):
-                # Arrow makes memory-mapped objects immutable, so copy will allow them
-                # to be mutable again.
-                df = df.copy(True)
+            def setitem_unhashable_key(df, value):
                 df[key] = value
                 return df
 
             return self._update_inplace(
-                self._default_to_pandas(setitem_unhashable_key)._query_compiler
+                self._default_to_pandas(setitem_unhashable_key, value)._query_compiler
             )
         if is_list_like(value):
             if isinstance(value, (pandas.DataFrame, DataFrame)):

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1616,6 +1616,16 @@ def test_setitem_on_empty_df(data, value, convert_to_series, new_col_id):
     eval_general(modin_df, pandas_df, applyier)
 
 
+def test___setitem__unhashable_list():
+    # from #3258 and #3291
+    cols = ["a", "b"]
+    modin_df = pd.DataFrame([[0, 0]], columns=cols)
+    modin_df[cols] = modin_df[cols]
+    pandas_df = pandas.DataFrame([[0, 0]], columns=cols)
+    pandas_df[cols] = pandas_df[cols]
+    df_equals(modin_df, pandas_df)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test___len__(data):
     modin_df = pd.DataFrame(data)


### PR DESCRIPTION
Signed-off-by: Igoshev, Yaroslav <yaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3291, #3258 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
