### PR TITLE
FEAT-#3310: Support left_on and right_on params in merge for OmniSci …

### DIFF
--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -239,23 +239,32 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
     def merge(self, right, **kwargs):
         on = kwargs.get("on", None)
+        left_on = kwargs.get("left_on", None)
+        right_on = kwargs.get("right_on", None)
         left_index = kwargs.get("left_index", False)
         right_index = kwargs.get("right_index", False)
         """Only non-index joins with explicit 'on' are supported"""
         if left_index is False and right_index is False:
-            if on is None:
-                on = [c for c in self.columns if c in right.columns]
+            if left_on is None and right_on is None:
+                if on is None:
+                    on = [c for c in self.columns if c in right.columns]
+                left_on = on
+                right_on = on
+
+            if not isinstance(left_on, list):
+                left_on = [left_on]
+            if not isinstance(right_on, list):
+                right_on = [right_on]
 
             how = kwargs.get("how", "inner")
             sort = kwargs.get("sort", False)
             suffixes = kwargs.get("suffixes", None)
-            if not isinstance(on, list):
-                on = [on]
             return self.__constructor__(
                 self._modin_frame.join(
                     right._modin_frame,
                     how=how,
-                    on=on,
+                    left_on=left_on,
+                    right_on=right_on,
                     sort=sort,
                     suffixes=suffixes,
                 )

--- a/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_ray/test/test_dataframe.py
@@ -1420,6 +1420,34 @@ class TestMerge:
 
         run_and_compare(merge, data=self.dt_data1, data2=self.dt_data2)
 
+    left_data = {"a": [1, 2, 3, 4], "b": [10, 20, 30, 40], "c": [11, 12, 13, 14]}
+    right_data = {"c": [1, 2, 3, 4], "b": [10, 20, 30, 40], "d": [100, 200, 300, 400]}
+
+    @pytest.mark.parametrize("how", how_values)
+    @pytest.mark.parametrize(
+        "left_on, right_on", [["a", "c"], [["a", "b"], ["c", "b"]]]
+    )
+    def test_merge_left_right_on(self, how, left_on, right_on):
+        def merge(df1, df2, how, left_on, right_on, **kwargs):
+            return df1.merge(df2, how=how, left_on=left_on, right_on=right_on)
+
+        run_and_compare(
+            merge,
+            data=self.left_data,
+            data2=self.right_data,
+            how=how,
+            left_on=left_on,
+            right_on=right_on,
+        )
+        run_and_compare(
+            merge,
+            data=self.right_data,
+            data2=self.left_data,
+            how=how,
+            left_on=right_on,
+            right_on=left_on,
+        )
+
 
 class TestBinaryOp:
     data = {


### PR DESCRIPTION
## What do these changes do?

Support `left_on` and `right_on` merge parameters in OmniSci backend/engine.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3310 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
