### PR TITLE
FIX-#3292: Fix `shift` function when index has duplicates

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2336,20 +2336,15 @@ class BasePandasDataset(object):
 
         if freq is None:
             if axis == "index" or axis == 0:
-                if periods > 0:
-                    dropped_df = self.drop(self.index[-periods:])
-                    new_frame = filled_df.append(dropped_df, ignore_index=True)
-                    new_frame.index = self.index.copy()
-                    if isinstance(self, DataFrame):
-                        new_frame.columns = self.columns.copy()
-                    return new_frame
-                else:
-                    dropped_df = self.drop(self.index[:-periods])
-                    new_frame = dropped_df.append(filled_df, ignore_index=True)
-                    new_frame.index = self.index.copy()
-                    if isinstance(self, DataFrame):
-                        new_frame.columns = self.columns.copy()
-                    return new_frame
+                new_frame = (
+                    filled_df.append(self.iloc[:-periods], ignore_index=True)
+                    if periods > 0
+                    else self.iloc[-periods:].append(filled_df, ignore_index=True)
+                )
+                new_frame.index = self.index.copy()
+                if isinstance(self, DataFrame):
+                    new_frame.columns = self.columns.copy()
+                return new_frame
             else:
                 if not isinstance(self, DataFrame):
                     raise ValueError(
@@ -2358,16 +2353,13 @@ class BasePandasDataset(object):
                 res_columns = self.columns
                 from .general import concat
 
-                if periods > 0:
-                    dropped_df = self.drop(self.columns[-periods:], axis="columns")
-                    new_frame = concat([filled_df, dropped_df], axis="columns")
-                    new_frame.columns = res_columns
-                    return new_frame
-                else:
-                    dropped_df = self.drop(self.columns[:-periods], axis="columns")
-                    new_frame = concat([dropped_df, filled_df], axis="columns")
-                    new_frame.columns = res_columns
-                    return new_frame
+                new_frame = (
+                    concat([filled_df, self.iloc[:, :-periods]], axis="columns")
+                    if periods > 0
+                    else concat([self.iloc[:, -periods:], filled_df], axis="columns")
+                )
+                new_frame.columns = res_columns
+                return new_frame
         else:
             return self.tshift(periods, freq)
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2353,13 +2353,16 @@ class BasePandasDataset(object):
                 res_columns = self.columns
                 from .general import concat
 
-                new_frame = (
-                    concat([filled_df, self.iloc[:, :-periods]], axis="columns")
-                    if periods > 0
-                    else concat([self.iloc[:, -periods:], filled_df], axis="columns")
-                )
-                new_frame.columns = res_columns
-                return new_frame
+                if periods > 0:
+                    dropped_df = self.drop(self.columns[-periods:], axis="columns")
+                    new_frame = concat([filled_df, dropped_df], axis="columns")
+                    new_frame.columns = res_columns
+                    return new_frame
+                else:
+                    dropped_df = self.drop(self.columns[:-periods], axis="columns")
+                    new_frame = concat([dropped_df, filled_df], axis="columns")
+                    new_frame.columns = res_columns
+                    return new_frame
         else:
             return self.tshift(periods, freq)
 

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -764,18 +764,16 @@ def test_resample_specific(rule, closed, label, on, level):
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-@pytest.mark.parametrize("index", ["default", "ndarray"])
+@pytest.mark.parametrize("index", ["default", "ndarray", "has_duplicates"])
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize("periods", [0, 1, -1, 10, -10, 1000000000, -1000000000])
 def test_shift(data, index, axis, periods):
-    if index == "default":
-        modin_df = pd.DataFrame(data)
-        pandas_df = pandas.DataFrame(data)
-    elif index == "ndarray":
+    modin_df, pandas_df = create_test_dfs(data)
+    if index == "ndarray":
         data_column_length = len(data[next(iter(data))])
-        index_data = np.arange(2, data_column_length + 2)
-        modin_df = pd.DataFrame(data, index=index_data)
-        pandas_df = pandas.DataFrame(data, index=index_data)
+        modin_df.index = pandas_df.index = np.arange(2, data_column_length + 2)
+    elif index == "has_duplicates":
+        modin_df.index = pandas_df.index = list(modin_df.index[:-3]) + [0, 1, 2]
 
     df_equals(
         modin_df.shift(periods=periods, axis=axis),


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

This PR does the next:

- fixes #3292 
- improves performance of `shift` operation

<details><summary>Performance results</summary>
The average time from 10 runs is shown (in seconds) in the tables below.

`df.shift(periods=10)`.
| nrows x ncols  | master  | PR #3345  | pandas  |
|---|---|---|---|
| 1k x 100 | 0.036  | 0.030| 0.0006  | 
| 1m x 100 |  0.871  | 0.042  | 0.729  | 
| 10m x 100  | 9.706   | 0.087 | 7.588  |
| 1k x 1k | 0.120   | 0.117 | 0.006   | 
| 10k x 10k | 1.062  | 1.087 | 0.733  | 
| 1m x 1k  | 1.124  |  0.293 | 7.156  | 

`df.shift(periods=500)`.
| nrows x ncols  | master  | PR #3345  | pandas  |
|---|---|---|---|
| 1k x 1k | 0.659   | 0.661 | 0.005 | 
| 10k x 10k | 3.498 | 3.480 | 0.710 | 
| 1m x 1k  | 1.626 |  0.833  | 7.114| 


<details><summary>Script</summary>

```python
import argparse
import time

import ray
import numpy as np
import modin.pandas as pd
import pandas as pd
ray.init()


def get_time(df, shift):
    start = time.time()
    df.shift(periods=shift)
    duration = time.time() - start
    return duration

if __name__ == "__main__":
    parser = argparse.ArgumentParser(description="Benchmark shift")
    parser.add_argument("--num_repeats", type=int, default=5)
    parser.add_argument("--num_rows", type=int, default=1_000)
    parser.add_argument("--num_cols", type=int, default=100)
    parser.add_argument("--shift", type=int, default=10)

    args = parser.parse_args()

    data = np.random.randint(0, 100, size=(args.num_rows, args.num_cols))
    df = pd.DataFrame(data)

    times = []
    for i in range(args.num_repeats):
        times.append(get_time(df, args.shift))
        print(times[-1])

    print(
    f"1st iter: {times[0]:5f} s, min: {min(times):5f} s, aver: {sum(times) / args.num_repeats:5f} s"
)

```

</details>

The results in synchronous mode (request from https://github.com/modin-project/modin/pull/3345#issuecomment-901359611):

`execute(df.shift(periods=10))`.
| nrows x ncols  | master  | PR #3345  | pandas  |
|---|---|---|---|
| 1k x 100 | 0.125 | 0.136| 0.0006  | 
| 1m x 100 |  1.202  | 0.377  | 0.729  | 
| 10m x 100  | 10.560   | 1.012 | 7.588  |
| 1k x 1k | 0.635   | 0.627 | 0.006   | 
| 10k x 10k | 6.953  | 6.985 | 0.733  | 
| 1m x 1k  | 3.613  |  2.667 | 7.156  | 

`execute(df.shift(periods=500))`.
| nrows x ncols  | master  | PR #3345  | pandas  |
|---|---|---|---|
| 1k x 1k | 1.165   | 1.132 | 0.005 | 
| 10k x 10k | 10.199 | 10.252 | 0.710 | 
| 1m x 1k  | 4.417 |  3.329  | 7.114| 

</details>

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3292 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
