### PR TITLE
FIX-#3197: do not pass lambdas to the backend in GroupBy

### DIFF
--- a/modin/core/dataframe/algebra/default2pandas/groupby.py
+++ b/modin/core/dataframe/algebra/default2pandas/groupby.py
@@ -95,14 +95,12 @@ class GroupBy:
 
     @classmethod
     # FIXME: `grp` parameter is redundant and should be removed
-    def get_func(cls, grp, key, **kwargs):
+    def get_func(cls, key, **kwargs):
         """
         Extract aggregation function from groupby arguments.
 
         Parameters
         ----------
-        grp : pandas.DataFrameGroupBy
-            GroupBy object to apply aggregation on.
         key : callable or str
             Default aggregation function. If aggregation function is not specified
             via groupby arguments, then `key` function is used.
@@ -160,7 +158,7 @@ class GroupBy:
             by = cls.validate_by(by)
 
             grp = df.groupby(by, axis=axis, **groupby_kwargs)
-            agg_func = cls.get_func(grp, key, **kwargs)
+            agg_func = cls.get_func(key, **kwargs)
             result = agg_func(grp, *agg_args, **agg_kwargs)
 
             return result
@@ -191,7 +189,7 @@ class GroupBy:
             if not isinstance(by, (pandas.Series, pandas.DataFrame)):
                 by = cls.validate_by(by)
                 grp = df.groupby(by, axis=axis, **groupby_kwargs)
-                grp_agg_func = cls.get_func(grp, agg_func, **kwargs)
+                grp_agg_func = cls.get_func(agg_func, **kwargs)
                 return grp_agg_func(
                     grp,
                     *agg_args,
@@ -216,7 +214,7 @@ class GroupBy:
             groupby_kwargs["as_index"] = True
 
             grp = df.groupby(by, axis=axis, **groupby_kwargs)
-            func = cls.get_func(grp, agg_func, **kwargs)
+            func = cls.get_func(agg_func, **kwargs)
             result = func(grp, *agg_args, **agg_kwargs)
 
             if isinstance(result, pandas.Series):

--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -69,20 +69,16 @@ class GroupByReduce(TreeReduce):
         )
 
     @classmethod
-    # FIXME:
-    #   1. Remove `drop` parameter since it isn't used.
-    #   2. `map_func` is not supposed to be `None`
-    #   3. Case when `map_args` or `groupby_args` is `None` (its default value) is unhandled.
     def map(
         cls,
         df,
+        map_func,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         other=None,
-        axis=0,
         by=None,
-        groupby_args=None,
-        map_func=None,
-        map_args=None,
-        drop=False,
     ):
         """
         Execute Map phase of GroupByReduce.
@@ -94,23 +90,23 @@ class GroupByReduce(TreeReduce):
         ----------
         df : pandas.DataFrame
             Serialized frame to group.
+        map_func : dict or callable(pandas.DataFrameGroupBy) -> pandas.DataFrame
+            Function to apply to the `GroupByObject`.
+        axis : {0, 1}
+            Axis to group and apply aggregation function along. 0 means index axis
+            when 1 means column axis.
+        groupby_kwargs : dict
+            Dictionary which carries arguments for `pandas.DataFrame.groupby`.
+        agg_args : list-like
+            Positional arguments to pass to the aggregation functions.
+        agg_kwargs : dict
+            Keyword arguments to pass to the aggregation functions.
         other : pandas.DataFrame, optional
             Serialized frame, whose columns are used to determine the groups.
             If not specified, `by` parameter is used.
-        axis : {0, 1}, default: 0
-            Axis to group and apply aggregation function along. 0 means index axis
-            when 1 means column axis.
         by : level index name or list of such labels, optional
             Index levels, that is used to determine groups.
             If not specified, `other` parameter is used.
-        groupby_args : dict, optional
-            Dictionary which carries arguments for `pandas.DataFrame.groupby`.
-        map_func : dict or callable(pandas.DataFrameGroupBy) -> pandas.DataFrame, default: None
-            Function to apply to the `GroupByObject`.
-        map_args : dict, optional
-            Arguments which will be passed to `map_func`.
-        drop : bool, default: False
-            Indicates whether or not by-data came from the `self` frame.
 
         Returns
         -------
@@ -120,8 +116,8 @@ class GroupByReduce(TreeReduce):
         # Set `as_index` to True to track the metadata of the grouping object
         # It is used to make sure that between phases we are constructing the
         # right index and placing columns in the correct order.
-        groupby_args["as_index"] = True
-        groupby_args["observed"] = True
+        groupby_kwargs["as_index"] = True
+        groupby_kwargs["observed"] = True
         # We have to filter func-dict BEFORE inserting broadcasted 'by' columns
         # to avoid multiple aggregation results for 'by' cols in case they're
         # present in the func-dict:
@@ -141,25 +137,21 @@ class GroupByReduce(TreeReduce):
             by_part = by
 
         result = apply_func(
-            df.groupby(by=by_part, axis=axis, **groupby_args), **map_args
+            df.groupby(by=by_part, axis=axis, **groupby_kwargs), *agg_args, **agg_kwargs
         )
         # Result could not always be a frame, so wrapping it into DataFrame
         return pandas.DataFrame(result)
 
     @classmethod
-    # FIXME:
-    #   1. spread `**kwargs` into an actual function arguments.
-    #   2. `reduce_func` is not supposed to be `None`
-    #   3. Case when `reduce_args` or `groupby_args` is `None` (its default value)
-    #      is unhandled.
     def reduce(
         cls,
         df,
+        reduce_func,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         partition_idx=0,
-        axis=0,
-        groupby_args=None,
-        reduce_func=None,
-        reduce_args=None,
         drop=False,
         method=None,
     ):
@@ -172,17 +164,19 @@ class GroupByReduce(TreeReduce):
         ----------
         df : pandas.DataFrame
             Serialized frame which contain groups to combine.
-        partition_idx : int, default: 0
-            Internal index of column partition to which this function is applied.
-        axis : {0, 1}, default: 0
+        reduce_func : dict or callable(pandas.DataFrameGroupBy) -> pandas.DataFrame
+            Function to apply to the `GroupByObject`.
+        axis : {0, 1}
             Axis to group and apply aggregation function along. 0 means index axis
             when 1 means column axis.
-        groupby_args : dict, optional
+        groupby_kwargs : dict
             Dictionary which carries arguments for `pandas.DataFrame.groupby`.
-        reduce_func : dict or callable(pandas.DataFrameGroupBy) -> pandas.DataFrame, default: None
-            Function to apply to the `GroupByObject`.
-        reduce_args : dict, optional
-            Arguments which will be passed to `reduce_func`.
+        agg_args : list-like
+            Positional arguments to pass to the aggregation functions.
+        agg_kwargs : dict
+            Keyword arguments to pass to the aggregation functions.
+        partition_idx : int, default: 0
+            Internal index of column partition to which this function is applied.
         drop : bool, default: False
             Indicates whether or not by-data came from the `self` frame.
         method : str, optional
@@ -204,18 +198,20 @@ class GroupByReduce(TreeReduce):
             if len(to_drop) > 0:
                 df.drop(columns=by_part, errors="ignore", inplace=True)
 
-        groupby_args = groupby_args.copy()
-        as_index = groupby_args["as_index"]
+        groupby_kwargs = groupby_kwargs.copy()
+        as_index = groupby_kwargs["as_index"]
 
         # Set `as_index` to True to track the metadata of the grouping object
-        groupby_args["as_index"] = True
+        groupby_kwargs["as_index"] = True
 
         # since now index levels contain out 'by', in the reduce phace
         # we want to group on these levels
-        groupby_args["level"] = list(range(len(df.index.names)))
+        groupby_kwargs["level"] = list(range(len(df.index.names)))
 
         apply_func = cls.try_filter_dict(reduce_func, df)
-        result = apply_func(df.groupby(axis=axis, **groupby_args), **reduce_args)
+        result = apply_func(
+            df.groupby(axis=axis, **groupby_kwargs), *agg_args, **agg_kwargs
+        )
 
         if not as_index:
             GroupBy.handle_as_index_for_dataframe(
@@ -241,13 +237,12 @@ class GroupByReduce(TreeReduce):
         cls,
         query_compiler,
         by,
-        axis,
-        groupby_args,
-        map_args,
         map_func,
         reduce_func,
-        reduce_args,
-        numeric_only=True,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         drop=False,
         method=None,
         default_to_pandas_func=None,
@@ -261,21 +256,19 @@ class GroupByReduce(TreeReduce):
             Frame to group.
         by : BaseQueryCompiler, column or index label, Grouper or list of such
             Object that determine groups.
-        axis : {0, 1}, default: 0
-            Axis to group and apply aggregation function along. 0 means index axis
-            when 1 means column axis.
-        groupby_args : dict
-            Dictionary which carries arguments for pandas.DataFrame.groupby.
-        map_args : dict
-            Arguments which will be passed to `map_func`.
         map_func : dict or callable(pandas.DataFrameGroupBy) -> pandas.DataFrame
             Function to apply to the `GroupByObject` at the Map phase.
         reduce_func : dict or callable(pandas.DataFrameGroupBy) -> pandas.DataFrame
             Function to apply to the `GroupByObject` at the Reduce phase.
-        reduce_args : dict
-            Arguments which will be passed to `reduce_func`.
-        numeric_only : bool, default: True
-            Whether or not to drop non-numeric columns before executing GroupBy.
+        axis : {0, 1}
+            Axis to group and apply aggregation function along. 0 means index axis
+            when 1 means column axis.
+        groupby_kwargs : dict
+            Dictionary which carries arguments for pandas.DataFrame.groupby.
+        agg_args : list-like
+            Positional arguments to pass to the aggregation functions.
+        agg_kwargs : dict
+            Keyword arguments to pass to the aggregation functions.
         drop : bool, default: False
             Indicates whether or not by-data came from the `self` frame.
         method : str, optional
@@ -289,9 +282,13 @@ class GroupByReduce(TreeReduce):
         The same type as `query_compiler`
             QueryCompiler which carries the result of GroupBy aggregation.
         """
-        if groupby_args.get("level", None) is None and (
-            not (isinstance(by, (type(query_compiler))) or hashable(by))
-            or isinstance(by, pandas.Grouper)
+        if (
+            axis != 0
+            or groupby_kwargs.get("level", None) is None
+            and (
+                not (isinstance(by, (type(query_compiler))) or hashable(by))
+                or isinstance(by, pandas.Grouper)
+            )
         ):
             by = try_cast_to_pandas(by, squeeze=True)
             # Since 'by' may be a 2D query compiler holding columns to group by,
@@ -306,15 +303,18 @@ class GroupByReduce(TreeReduce):
                 )
             return query_compiler.default_to_pandas(
                 lambda df: default_to_pandas_func(
-                    df.groupby(by=by, axis=axis, **groupby_args), **map_args
+                    df.groupby(by=by, axis=axis, **groupby_kwargs),
+                    *agg_args,
+                    **agg_kwargs,
                 )
             )
-        assert axis == 0, "Can only groupby reduce with axis=0"
 
         # The bug only occurs in the case of Categorical 'by', so we might want to check whether any of
         # the 'by' dtypes is Categorical before going into this branch, however triggering 'dtypes'
         # computation if they're not computed may take time, so we don't do it
-        if not groupby_args.get("sort", True) and isinstance(by, type(query_compiler)):
+        if not groupby_kwargs.get("sort", True) and isinstance(
+            by, type(query_compiler)
+        ):
             ErrorMessage.missmatch_with_pandas(
                 operation="df.groupby(categorical_by, sort=False)",
                 message=(
@@ -323,24 +323,17 @@ class GroupByReduce(TreeReduce):
                     "https://github.com/modin-project/modin/issues/3571"
                 ),
             )
-            groupby_args = groupby_args.copy()
-            groupby_args["sort"] = True
-
-        if numeric_only:
-            qc = query_compiler.getitem_column_array(
-                query_compiler._modin_frame.numeric_columns(True)
-            )
-        else:
-            qc = query_compiler
+            groupby_kwargs = groupby_kwargs.copy()
+            groupby_kwargs["sort"] = True
 
         map_fn, reduce_fn = cls.build_map_reduce_functions(
             by=by,
             axis=axis,
-            groupby_args=groupby_args,
+            groupby_kwargs=groupby_kwargs,
             map_func=map_func,
-            map_args=map_args,
             reduce_func=reduce_func,
-            reduce_args=reduce_args,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
             drop=drop,
             method=method,
         )
@@ -350,7 +343,7 @@ class GroupByReduce(TreeReduce):
         # Otherwise `by` was already bound to the Map function in `build_map_reduce_functions`.
         broadcastable_by = getattr(by, "_modin_frame", None)
         apply_indices = list(map_func.keys()) if isinstance(map_func, dict) else None
-        new_modin_frame = qc._modin_frame.groupby_reduce(
+        new_modin_frame = query_compiler._modin_frame.groupby_reduce(
             axis, broadcastable_by, map_fn, reduce_fn, apply_indices=apply_indices
         )
 
@@ -389,12 +382,12 @@ class GroupByReduce(TreeReduce):
         cls,
         by,
         axis,
-        groupby_args,
+        groupby_kwargs,
         map_func,
-        map_args,
         reduce_func,
-        reduce_args,
-        drop,
+        agg_args,
+        agg_kwargs,
+        drop=False,
         method=None,
     ):
         """
@@ -404,19 +397,19 @@ class GroupByReduce(TreeReduce):
         ----------
         by : BaseQueryCompiler, column or index label, Grouper or list of such
             Object that determine groups.
-        axis : {0, 1}, default: 0
+        axis : {0, 1}
             Axis to group and apply aggregation function along. 0 means index axis
             when 1 means column axis.
-        groupby_args : dict
+        groupby_kwargs : dict
             Dictionary which carries arguments for pandas.DataFrame.groupby.
         map_func : dict or callable(pandas.DataFrameGroupBy) -> pandas.DataFrame
             Function to apply to the `GroupByObject` at the Map phase.
-        map_args : dict
-            Arguments which will be passed to `map_func`.
         reduce_func : dict or callable(pandas.DataFrameGroupBy) -> pandas.DataFrame
             Function to apply to the `GroupByObject` at the Reduce phase.
-        reduce_args : dict
-            Arguments which will be passed to `reduce_func`.
+        agg_args : list-like
+            Positional arguments to pass to the aggregation functions.
+        agg_kwargs : dict
+            Keyword arguments to pass to the aggregation functions.
         drop : bool, default: False
             Indicates whether or not by-data came from the `self` frame.
         method : str, optional
@@ -437,13 +430,13 @@ class GroupByReduce(TreeReduce):
             def wrapper(df, other=None):
                 return cls.map(
                     df,
-                    other,
+                    other=other,
                     axis=axis,
                     by=by,
-                    groupby_args=groupby_args.copy(),
+                    groupby_kwargs=groupby_kwargs.copy(),
                     map_func=map_func,
-                    map_args=map_args,
-                    drop=drop,
+                    agg_args=agg_args,
+                    agg_kwargs=agg_kwargs,
                     **kwargs,
                 )
 
@@ -460,9 +453,10 @@ class GroupByReduce(TreeReduce):
                 return cls.reduce(
                     df,
                     axis=axis,
-                    groupby_args=groupby_args,
+                    groupby_kwargs=groupby_kwargs,
                     reduce_func=reduce_func,
-                    reduce_args=reduce_args,
+                    agg_args=agg_args,
+                    agg_kwargs=agg_kwargs,
                     drop=drop,
                     method=method,
                     **call_kwargs,

--- a/modin/core/storage_formats/base/doc_utils.py
+++ b/modin/core/storage_formats/base/doc_utils.py
@@ -643,18 +643,14 @@ def doc_groupby_method(result, refer_to, action=None):
     by : BaseQueryCompiler, column or index label, Grouper or list of such
         Object that determine groups.
     axis : {{0, 1}}
-        Axis to group and apply reduce function along.
+        Axis to group and apply aggregation function along.
         0 is for index, when 1 is for columns.
-    groupby_args : dict
+    groupby_kwargs : dict
         GroupBy parameters as expected by ``modin.pandas.DataFrame.groupby`` signature.
-    map_args : dict
-        Keyword arguments to pass to the reduce function. If GroupBy is implemented via TreeReduce
-        approach, this argument is passed at the map phase only.
-    reduce_args : dict, optional
-        If GroupBy is implemented with TreeReduce approach, specifies arguments to pass to
-        the reduce function at the reduce phase, has no effect otherwise.
-    numeric_only : bool, default: True
-        Whether or not to drop non-numeric columns before executing GroupBy.
+    agg_args : list-like
+        Positional arguments to pass to the `agg_func`.
+    agg_kwargs : dict
+        Key arguments to pass to the `agg_func`.
     drop : bool, default: False
         If `by` is a QueryCompiler indicates whether or not by-data came
         from the `self`.

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -2389,16 +2389,7 @@ class BaseQueryCompiler(abc.ABC):
         elif drop and isinstance(by, type(self)):
             by = list(by.columns)
 
-        method_dict = {
-            "axis_wise": "aggregate",
-            "group_wise": "apply",
-            "transform": "transform",
-        }
-        method = method_dict[how]
-
-        return GroupByDefault.register(
-            getattr(pandas.core.groupby.DataFrameGroupBy, method)
-        )(
+        return GroupByDefault.register(GroupByDefault.get_aggregation_method(how))(
             self,
             by=by,
             agg_func=agg_func,

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -2166,20 +2166,18 @@ class BaseQueryCompiler(abc.ABC):
         self,
         by,
         axis,
-        groupby_args,
-        map_args,
-        reduce_args=None,
-        numeric_only=True,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         drop=False,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.count)(
             self,
             by=by,
             axis=axis,
-            groupby_args=groupby_args,
-            map_args=map_args,
-            reduce_args=reduce_args,
-            numeric_only=numeric_only,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
             drop=drop,
         )
 
@@ -2192,20 +2190,18 @@ class BaseQueryCompiler(abc.ABC):
         self,
         by,
         axis,
-        groupby_args,
-        map_args,
-        reduce_args=None,
-        numeric_only=True,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         drop=False,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.any)(
             self,
             by=by,
             axis=axis,
-            groupby_args=groupby_args,
-            map_args=map_args,
-            reduce_args=reduce_args,
-            numeric_only=numeric_only,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
             drop=drop,
         )
 
@@ -2216,20 +2212,18 @@ class BaseQueryCompiler(abc.ABC):
         self,
         by,
         axis,
-        groupby_args,
-        map_args,
-        reduce_args=None,
-        numeric_only=True,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         drop=False,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.min)(
             self,
             by=by,
             axis=axis,
-            groupby_args=groupby_args,
-            map_args=map_args,
-            reduce_args=reduce_args,
-            numeric_only=numeric_only,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
             drop=drop,
         )
 
@@ -2238,20 +2232,18 @@ class BaseQueryCompiler(abc.ABC):
         self,
         by,
         axis,
-        groupby_args,
-        map_args,
-        reduce_args=None,
-        numeric_only=True,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         drop=False,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.prod)(
             self,
             by=by,
             axis=axis,
-            groupby_args=groupby_args,
-            map_args=map_args,
-            reduce_args=reduce_args,
-            numeric_only=numeric_only,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
             drop=drop,
         )
 
@@ -2262,20 +2254,18 @@ class BaseQueryCompiler(abc.ABC):
         self,
         by,
         axis,
-        groupby_args,
-        map_args,
-        reduce_args=None,
-        numeric_only=True,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         drop=False,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.max)(
             self,
             by=by,
             axis=axis,
-            groupby_args=groupby_args,
-            map_args=map_args,
-            reduce_args=reduce_args,
-            numeric_only=numeric_only,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
             drop=drop,
         )
 
@@ -2288,20 +2278,18 @@ class BaseQueryCompiler(abc.ABC):
         self,
         by,
         axis,
-        groupby_args,
-        map_args,
-        reduce_args=None,
-        numeric_only=True,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         drop=False,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.all)(
             self,
             by=by,
             axis=axis,
-            groupby_args=groupby_args,
-            map_args=map_args,
-            reduce_args=reduce_args,
-            numeric_only=numeric_only,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
             drop=drop,
         )
 
@@ -2310,20 +2298,18 @@ class BaseQueryCompiler(abc.ABC):
         self,
         by,
         axis,
-        groupby_args,
-        map_args,
-        reduce_args=None,
-        numeric_only=True,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         drop=False,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.sum)(
             self,
             by=by,
             axis=axis,
-            groupby_args=groupby_args,
-            map_args=map_args,
-            reduce_args=reduce_args,
-            numeric_only=numeric_only,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
             drop=drop,
         )
 
@@ -2336,20 +2322,18 @@ class BaseQueryCompiler(abc.ABC):
         self,
         by,
         axis,
-        groupby_args,
-        map_args,
-        reduce_args=None,
-        numeric_only=True,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
         drop=False,
     ):
         return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.size)(
             self,
             by=by,
             axis=axis,
-            groupby_args=groupby_args,
-            map_args=map_args,
-            reduce_args=reduce_args,
-            numeric_only=numeric_only,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
             drop=drop,
             method="size",
         )
@@ -2358,12 +2342,12 @@ class BaseQueryCompiler(abc.ABC):
     def groupby_agg(
         self,
         by,
-        is_multi_by,
-        axis,
         agg_func,
+        axis,
+        groupby_kwargs,
         agg_args,
         agg_kwargs,
-        groupby_kwargs,
+        how="axis_wise",
         drop=False,
     ):
         """
@@ -2373,20 +2357,23 @@ class BaseQueryCompiler(abc.ABC):
         ----------
         by : BaseQueryCompiler, column or index label, Grouper or list of such
             Object that determine groups.
-        is_multi_by : bool
-            If `by` is a QueryCompiler or list of such indicates whether it's
-            grouping on multiple columns/rows.
+        agg_func : str, dict or callable(Series | DataFrame) -> scalar | Series | DataFrame
+            Function to apply to the GroupBy object.
         axis : {0, 1}
             Axis to group and apply aggregation function along.
             0 is for index, when 1 is for columns.
-        agg_func : dict or callable(DataFrameGroupBy) -> DataFrame
-            Function to apply to the GroupBy object.
-        agg_args : dict
+        groupby_kwargs : dict
+            GroupBy parameters as expected by ``modin.pandas.DataFrame.groupby`` signature.
+        agg_args : list-like
             Positional arguments to pass to the `agg_func`.
         agg_kwargs : dict
             Key arguments to pass to the `agg_func`.
-        groupby_kwargs : dict
-            GroupBy parameters as expected by ``modin.pandas.DataFrame.groupby`` signature.
+        how : {'axis_wise', 'group_wise', 'transform'}, default: 'axis_wise'
+            How to apply passed `agg_func`:
+                - 'axis_wise': apply the function against each row/column.
+                - 'group_wise': apply the function against every group.
+                - 'transform': apply the function against every group and broadcast
+                  the result to the original Query Compiler shape.
         drop : bool, default: False
             If `by` is a QueryCompiler indicates whether or not by-data came
             from the `self`.
@@ -2402,14 +2389,369 @@ class BaseQueryCompiler(abc.ABC):
         elif drop and isinstance(by, type(self)):
             by = list(by.columns)
 
-        return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.aggregate)(
+        method_dict = {
+            "axis_wise": "aggregate",
+            "group_wise": "apply",
+            "transform": "transform",
+        }
+        method = method_dict[how]
+
+        return GroupByDefault.register(
+            getattr(pandas.core.groupby.DataFrameGroupBy, method)
+        )(
             self,
             by=by,
-            is_multi_by=is_multi_by,
-            axis=axis,
             agg_func=agg_func,
-            groupby_args=groupby_kwargs,
-            agg_args=agg_kwargs,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="compute the mean value", result="mean value", refer_to="mean"
+    )
+    def groupby_mean(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="mean",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="compute unbiased skew", result="unbiased skew", refer_to="skew"
+    )
+    def groupby_skew(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="skew",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="compute cumulative sum",
+        result="sum of all the previous values",
+        refer_to="cumsum",
+    )
+    def groupby_cumsum(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="cumsum",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="get cumulative maximum",
+        result="maximum of all the previous values",
+        refer_to="cummax",
+    )
+    def groupby_cummax(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="cummax",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="get cumulative minimum",
+        result="minimum of all the previous values",
+        refer_to="cummin",
+    )
+    def groupby_cummin(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="cummin",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="get cumulative production",
+        result="production of all the previous values",
+        refer_to="cumprod",
+    )
+    def groupby_cumprod(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="cumprod",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="compute standart deviation", result="standart deviation", refer_to="std"
+    )
+    def groupby_std(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="std",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="compute numerical rank", result="numerical rank", refer_to="rank"
+    )
+    def groupby_rank(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="rank",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="compute variance", result="variance", refer_to="var"
+    )
+    def groupby_var(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="var",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="get the number of unique values",
+        result="number of unique values",
+        refer_to="nunique",
+    )
+    def groupby_nunique(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="nunique",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="get the median value", result="median value", refer_to="median"
+    )
+    def groupby_median(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="median",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="compute specified quantile",
+        result="quantile value",
+        refer_to="quantile",
+    )
+    def groupby_quantile(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="quantile",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="fill NaN values",
+        result="`fill_value` if it was NaN, original value otherwise",
+        refer_to="fillna",
+    )
+    def groupby_fillna(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="fillna",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="get data types", result="data type", refer_to="dtypes"
+    )
+    def groupby_dtypes(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="dtypes",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="shift data with the specified settings",
+        result="shifted value",
+        refer_to="shift",
+    )
+    def groupby_shift(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            agg_func="shift",
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
             drop=drop,
         )
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -20,6 +20,7 @@ queries for the ``PandasDataframe``.
 
 import numpy as np
 import pandas
+import functools
 from pandas.core.common import is_bool_indexer
 from pandas.core.indexing import check_bool_indexer
 from pandas.core.indexes.api import ensure_index_from_sequences
@@ -2647,10 +2648,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 how == "axis_wise"
             ), f"Only 'axis_wise' aggregation is supported with dictionary functions, got: {how}"
         else:
-            grp_agg_func = agg_func
-            method = GroupByDefault.get_aggregation_method(how)
-            agg_func = lambda grp, *args, **kwargs: method(  # noqa: E731
-                grp, grp_agg_func, *args, **kwargs
+            agg_func = functools.partial(
+                GroupByDefault.get_aggregation_method(how), func=agg_func
             )
 
         # since we're going to modify `groupby_kwargs` dict in a `groupby_agg_builder`,

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2468,20 +2468,26 @@ class PandasQueryCompiler(BaseQueryCompiler):
     groupby_sum = GroupByReduce.register("sum")
 
     def groupby_size(
-        self, by, axis, groupby_args, map_args, reduce_args, numeric_only, drop
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
     ):
         result = self._groupby_dict_reduce(
             by=by,
             axis=axis,
             agg_func={self.columns[0]: [("__size_col__", "size")]},
-            agg_args=[],
-            agg_kwargs={},
-            groupby_kwargs=groupby_args,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            groupby_kwargs=groupby_kwargs,
             drop=drop,
             method="size",
             default_to_pandas_func=lambda grp: grp.size(),
         )
-        if groupby_args.get("as_index", True):
+        if groupby_kwargs.get("as_index", True):
             result.columns = ["__reduced__"]
         elif isinstance(result.columns, pandas.MultiIndex):
             # Dropping one extra-level which was added because of renaming aggregation
@@ -2493,11 +2499,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def _groupby_dict_reduce(
         self,
         by,
-        axis,
         agg_func,
+        axis,
+        groupby_kwargs,
         agg_args,
         agg_kwargs,
-        groupby_kwargs,
         drop=False,
         **kwargs,
     ):
@@ -2511,20 +2517,20 @@ class PandasQueryCompiler(BaseQueryCompiler):
         ----------
         by : PandasQueryCompiler, column or index label, Grouper or list of such
             Object that determine groups.
-        axis : {0, 1}
-            Axis to group and apply aggregation function along.
-            0 is for index, when 1 is for columns.
         agg_func : dict(label) -> str
             Dictionary that maps row/column labels to the function names.
             **Note:** specified functions have to be supported by ``modin.core.dataframe.algebra.GroupByReduce``.
             Supported functions are listed in the ``modin.core.dataframe.algebra.GroupByReduce.groupby_reduce_functions``
             dictionary.
-        agg_args : list
+        axis : {0, 1}
+            Axis to group and apply aggregation function along.
+            0 is for index, when 1 is for columns.
+        groupby_kwargs : dict
+            GroupBy parameters in the format of ``modin.pandas.DataFrame.groupby`` signature.
+        agg_args : list-like
             Serves the compatibility purpose. Does not affect the result.
         agg_kwargs : dict
             Arguments to pass to the aggregation functions.
-        groupby_kwargs : dict
-            GroupBy parameters in the format of ``modin.pandas.DataFrame.groupby`` signature.
         drop : bool, default: False
             If `by` is a QueryCompiler indicates whether or not by-data came
             from the `self`.
@@ -2571,22 +2577,43 @@ class PandasQueryCompiler(BaseQueryCompiler):
             query_compiler=self,
             by=by,
             axis=axis,
-            groupby_args=groupby_kwargs,
-            map_args=agg_kwargs,
-            reduce_args=agg_kwargs,
-            numeric_only=False,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    def groupby_dtypes(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
+    ):
+        return self.groupby_agg(
+            by=by,
+            axis=axis,
+            agg_func=lambda df: df.dtypes,
+            # passing 'group_wise' will make the function be applied to the 'by' columns as well,
+            # this is exactly what we want when 'as_index=False'
+            how="axis_wise" if groupby_kwargs.get("as_index", True) else "group_wise",
+            agg_args=tuple(),
+            agg_kwargs=dict(),
+            groupby_kwargs=groupby_kwargs,
             drop=drop,
         )
 
     def groupby_agg(
         self,
         by,
-        is_multi_by,
-        axis,
         agg_func,
+        axis,
+        groupby_kwargs,
         agg_args,
         agg_kwargs,
-        groupby_kwargs,
+        how="axis_wise",
         drop=False,
     ):
         def is_reduce_fn(fn, deep_level=0):
@@ -2612,11 +2639,25 @@ class PandasQueryCompiler(BaseQueryCompiler):
             is_reduce_fn(x) for x in agg_func.values()
         ):
             return self._groupby_dict_reduce(
-                by, axis, agg_func, agg_args, agg_kwargs, groupby_kwargs, drop
+                by, agg_func, axis, groupby_kwargs, agg_args, agg_kwargs, drop
             )
 
-        if callable(agg_func):
-            agg_func = wrap_udf_function(agg_func)
+        method_dict = {
+            "axis_wise": "aggregate",
+            "group_wise": "apply",
+            "transform": "transform",
+        }
+        method = method_dict[how]
+
+        if isinstance(agg_func, dict):
+            assert (
+                how == "axis_wise"
+            ), f"Only 'axis_wise' aggregation is supported with dictionary functions, got: {how}"
+        else:
+            grp_agg_func = agg_func
+            agg_func = lambda grp, *args, **kwargs: getattr(grp, method)(  # noqa: E731
+                grp_agg_func, *args, **kwargs
+            )
 
         # since we're going to modify `groupby_kwargs` dict in a `groupby_agg_builder`,
         # we want to copy it to not propagate these changes into source dict, in case
@@ -2717,7 +2758,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 """Compute groupby aggregation for a single partition."""
                 grouped_df = df.groupby(by=by, axis=axis, **groupby_kwargs)
                 try:
-                    result = partition_agg_func(grouped_df, **agg_kwargs)
+                    result = partition_agg_func(grouped_df, *agg_args, **agg_kwargs)
                 except (DataError, TypeError):
                     # This happens when the partition is filled with non-numeric data and a
                     # numeric operation is done. We need to build the index here to avoid

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
@@ -730,9 +730,6 @@ class TestGroupby:
 
         run_and_compare(groupby_count, data=self.data, cols=cols, as_index=as_index)
 
-    @pytest.mark.xfail(
-        reason="Currently mean() passes a lambda into query compiler which cannot be executed on OmniSci engine"
-    )
     @pytest.mark.parametrize("cols", cols_value)
     @pytest.mark.parametrize("as_index", bool_arg_values)
     def test_groupby_mean(self, cols, as_index):
@@ -769,9 +766,6 @@ class TestGroupby:
 
         run_and_compare(lambda_func, data=self.data, force_lazy=False)
 
-    @pytest.mark.xfail(
-        reason="Function specified as a string should be passed into query compiler API, but currently it is transformed into a lambda"
-    )
     @pytest.mark.parametrize("cols", cols_value)
     @pytest.mark.parametrize("as_index", bool_arg_values)
     def test_groupby_agg_mean(self, cols, as_index):
@@ -815,7 +809,7 @@ class TestGroupby:
         run_and_compare(groupby, data=self.data)
 
     @pytest.mark.parametrize("by", [["a"], ["a", "b", "c"]])
-    @pytest.mark.parametrize("agg", ["sum", "size"])
+    @pytest.mark.parametrize("agg", ["sum", "size", "mean"])
     @pytest.mark.parametrize("as_index", [True, False])
     def test_groupby_agg_by_col(self, by, agg, as_index):
         def simple_agg(df, **kwargs):

--- a/modin/experimental/core/storage_formats/omnisci/query_compiler.py
+++ b/modin/experimental/core/storage_formats/omnisci/query_compiler.py
@@ -276,9 +276,10 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         self,
         by,
         axis,
-        groupby_args,
-        map_args,
-        **kwargs,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+        drop=False,
     ):
         # Grouping on empty frame or on index level.
         if len(self.columns) == 0:
@@ -286,16 +287,18 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
                 "Grouping on empty frame or on index level is not yet implemented."
             )
 
-        groupby_args = groupby_args.copy()
-        as_index = groupby_args.get("as_index", True)
+        groupby_kwargs = groupby_kwargs.copy()
+        as_index = groupby_kwargs.get("as_index", True)
         # Setting 'as_index' to True to avoid 'by' and 'agg' columns naming conflict
-        groupby_args["as_index"] = True
+        groupby_kwargs["as_index"] = True
         new_frame = self._modin_frame.groupby_agg(
             by,
             axis,
             {self._modin_frame.columns[0]: "size"},
-            groupby_args,
-            **kwargs,
+            groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
         )
         if as_index:
             shape_hint = "column"
@@ -305,36 +308,59 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             new_frame = new_frame._set_columns(["size"]).reset_index(drop=False)
         return self.__constructor__(new_frame, shape_hint=shape_hint)
 
-    def groupby_sum(self, by, axis, groupby_args, map_args, **kwargs):
+    def groupby_sum(self, by, axis, groupby_kwargs, agg_args, agg_kwargs, drop=False):
         new_frame = self._modin_frame.groupby_agg(
-            by, axis, "sum", groupby_args, **kwargs
+            by,
+            axis,
+            "sum",
+            groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
         )
         return self.__constructor__(new_frame)
 
-    def groupby_count(self, by, axis, groupby_args, map_args, **kwargs):
+    def groupby_count(self, by, axis, groupby_kwargs, agg_args, agg_kwargs, drop=False):
         new_frame = self._modin_frame.groupby_agg(
-            by, axis, "count", groupby_args, **kwargs
+            by,
+            axis,
+            "count",
+            groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
         )
         return self.__constructor__(new_frame)
 
     def groupby_agg(
         self,
         by,
-        is_multi_by,
-        axis,
         agg_func,
+        axis,
+        groupby_kwargs,
         agg_args,
         agg_kwargs,
-        groupby_kwargs,
+        how="axis_wise",
         drop=False,
     ):
-        # TODO: handle `is_multi_by`, `agg_args`, `drop` args
+        # TODO: handle `drop` args
         if callable(agg_func):
             raise NotImplementedError(
                 "Python callable is not a valid aggregation function for OmniSci storage format."
             )
+        if how != "axis_wise":
+            raise NotImplementedError(
+                f"'{how}' type of groupby-aggregation functions is not supported for OmniSci storage format."
+            )
+
         new_frame = self._modin_frame.groupby_agg(
-            by, axis, agg_func, groupby_kwargs, **agg_kwargs
+            by,
+            axis,
+            agg_func,
+            groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
         )
         return self.__constructor__(new_frame)
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -257,12 +257,14 @@ class DataFrameGroupBy(object):
             )
             result = result.dropna(subset=self._by.columns).sort_index()
         else:
-            result = self._wrap_aggregation(
-                type(self._query_compiler).groupby_shift,
-                numeric_only=False,
-                agg_kwargs=dict(
-                    periods=periods, freq=freq, axis=axis, fill_value=fill_value
-                ),
+            result = self._check_index_name(
+                self._wrap_aggregation(
+                    type(self._query_compiler).groupby_shift,
+                    numeric_only=False,
+                    agg_kwargs=dict(
+                        periods=periods, freq=freq, axis=axis, fill_value=fill_value
+                    ),
+                )
             )
         return result
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -116,8 +116,13 @@ class DataFrameGroupBy(object):
     def ngroups(self):
         return len(self)
 
-    def skew(self, **kwargs):
-        return self._apply_agg_function(lambda df: df.skew(**kwargs))
+    def skew(self, *args, **kwargs):
+        return self._wrap_aggregation(
+            type(self._query_compiler).groupby_skew,
+            agg_args=args,
+            agg_kwargs=kwargs,
+            numeric_only=True,
+        )
 
     def ffill(self, limit=None):
         return self._default_to_pandas(lambda df: df.ffill(limit=limit))
@@ -125,15 +130,19 @@ class DataFrameGroupBy(object):
     def sem(self, ddof=1):
         return self._default_to_pandas(lambda df: df.sem(ddof=ddof))
 
-    def mean(self, *args, **kwargs):
-        return self._apply_agg_function_check_index(lambda df: df.mean(*args, **kwargs))
+    def mean(self, numeric_only=None):
+        return self._check_index(
+            self._wrap_aggregation(
+                type(self._query_compiler).groupby_mean,
+                numeric_only=numeric_only,
+            )
+        )
 
-    def any(self, **kwargs):
+    def any(self, skipna=True):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_any,
-            lambda df, **kwargs: df.any(**kwargs),
             numeric_only=False,
-            **kwargs,
+            agg_kwargs=dict(skipna=skipna),
         )
 
     @property
@@ -174,12 +183,11 @@ class DataFrameGroupBy(object):
         self._groups_cache = self._compute_index_grouped(numerical=False)
         return self._groups_cache
 
-    def min(self, **kwargs):
+    def min(self, numeric_only=False, min_count=-1):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_min,
-            lambda df, **kwargs: df.min(**kwargs),
-            numeric_only=False,
-            **kwargs,
+            numeric_only=numeric_only,
+            agg_kwargs=dict(min_count=min_count),
         )
 
     def idxmax(self):
@@ -249,8 +257,12 @@ class DataFrameGroupBy(object):
             )
             result = result.dropna(subset=self._by.columns).sort_index()
         else:
-            result = self._apply_agg_function_check_index_name(
-                lambda df: df.shift(periods, freq, axis, fill_value)
+            result = self._wrap_aggregation(
+                type(self._query_compiler).groupby_shift,
+                numeric_only=False,
+                agg_kwargs=dict(
+                    periods=periods, freq=freq, axis=axis, fill_value=fill_value
+                ),
             )
         return result
 
@@ -258,8 +270,13 @@ class DataFrameGroupBy(object):
         return self._default_to_pandas(lambda df: df.nth(n, dropna=dropna))
 
     def cumsum(self, axis=0, *args, **kwargs):
-        return self._apply_agg_function_check_index_name(
-            lambda df: df.cumsum(axis, *args, **kwargs)
+        return self._check_index_name(
+            self._wrap_aggregation(
+                type(self._query_compiler).groupby_cumsum,
+                agg_args=args,
+                agg_kwargs=dict(axis=axis, **kwargs),
+                numeric_only=True,
+            )
         )
 
     _indices_cache = no_default
@@ -283,26 +300,39 @@ class DataFrameGroupBy(object):
         )
 
     def cummax(self, axis=0, **kwargs):
-        return self._apply_agg_function_check_index_name(
-            lambda df: df.cummax(axis, **kwargs)
+        return self._check_index_name(
+            self._wrap_aggregation(
+                type(self._query_compiler).groupby_cummax,
+                agg_kwargs=dict(axis=axis, **kwargs),
+                numeric_only=False,
+            )
         )
 
     def apply(self, func, *args, **kwargs):
         if not isinstance(func, BuiltinFunctionType):
             func = wrap_udf_function(func)
 
-        return self._apply_agg_function_check_index(
-            lambda df: df.apply(func, *args, **kwargs)
+        return self._check_index(
+            self._wrap_aggregation(
+                qc_method=type(self._query_compiler).groupby_agg,
+                numeric_only=False,
+                agg_func=func,
+                agg_args=args,
+                agg_kwargs=kwargs,
+                how="group_wise",
+            )
         )
 
     @property
     def dtypes(self):
         if self._axis == 1:
             raise ValueError("Cannot call dtypes on groupby with axis=1")
-        if not self._as_index:
-            return self.apply(lambda df: df.dtypes)
-        else:
-            return self._apply_agg_function(lambda df: df.dtypes)
+        return self._check_index(
+            self._wrap_aggregation(
+                type(self._query_compiler).groupby_dtypes,
+                numeric_only=False,
+            )
+        )
 
     def first(self, **kwargs):
         return self._default_to_pandas(lambda df: df.first(**kwargs))
@@ -419,8 +449,12 @@ class DataFrameGroupBy(object):
         )
 
     def cummin(self, axis=0, **kwargs):
-        return self._apply_agg_function_check_index_name(
-            lambda df: df.cummin(axis=axis, **kwargs)
+        return self._check_index_name(
+            self._wrap_aggregation(
+                type(self._query_compiler).groupby_cummin,
+                agg_kwargs=dict(axis=axis, **kwargs),
+                numeric_only=False,
+            )
         )
 
     def bfill(self, limit=None):
@@ -429,15 +463,19 @@ class DataFrameGroupBy(object):
     def idxmin(self):
         return self._default_to_pandas(lambda df: df.idxmin())
 
-    def prod(self, **kwargs):
+    def prod(self, numeric_only=None, min_count=0):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_prod,
-            lambda df, **kwargs: df.prod(**kwargs),
-            **kwargs,
+            agg_kwargs=dict(min_count=min_count),
+            numeric_only=numeric_only,
         )
 
-    def std(self, ddof=1, *args, **kwargs):
-        return self._apply_agg_function(lambda df: df.std(ddof, *args, **kwargs))
+    def std(self, ddof=1):
+        return self._wrap_aggregation(
+            type(self._query_compiler).groupby_std,
+            agg_kwargs=dict(ddof=ddof),
+            numeric_only=True,
+        )
 
     def aggregate(self, func=None, *args, **kwargs):
         if self._axis != 0:
@@ -495,10 +533,15 @@ class DataFrameGroupBy(object):
                 **kwargs,
             )
         elif callable(func):
-            return self._apply_agg_function_check_index(
-                lambda grp, *args, **kwargs: grp.aggregate(func, *args, **kwargs),
-                *args,
-                **kwargs,
+            return self._check_index(
+                self._wrap_aggregation(
+                    qc_method=type(self._query_compiler).groupby_agg,
+                    numeric_only=False,
+                    agg_func=func,
+                    agg_args=args,
+                    agg_kwargs=kwargs,
+                    how="axis_wise",
+                )
             )
         elif isinstance(func, str):
             # Using "getattr" here masks possible AttributeError which we throw
@@ -507,10 +550,13 @@ class DataFrameGroupBy(object):
             if callable(agg_func):
                 return agg_func(*args, **kwargs)
 
-        result = self._apply_agg_function(
-            func,
-            *args,
-            **kwargs,
+        result = self._wrap_aggregation(
+            qc_method=type(self._query_compiler).groupby_agg,
+            numeric_only=False,
+            agg_func=func,
+            agg_args=args,
+            agg_kwargs=kwargs,
+            how="axis_wise",
         )
 
         if relabeling_required:
@@ -541,7 +587,11 @@ class DataFrameGroupBy(object):
         return self._default_to_pandas(lambda df: df.mad(**kwargs))
 
     def rank(self, **kwargs):
-        result = self._apply_agg_function(lambda df: df.rank(**kwargs))
+        result = self._wrap_aggregation(
+            type(self._query_compiler).groupby_rank,
+            agg_kwargs=kwargs,
+            numeric_only=False,
+        )
         # pandas does not name the index on rank
         result._query_compiler.set_index_name(None)
         return result
@@ -553,16 +603,19 @@ class DataFrameGroupBy(object):
     def pad(self, limit=None):
         return self._default_to_pandas(lambda df: df.pad(limit=limit))
 
-    def max(self, **kwargs):
+    def max(self, numeric_only=False, min_count=-1):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_max,
-            lambda df, **kwargs: df.max(**kwargs),
-            numeric_only=False,
-            **kwargs,
+            numeric_only=numeric_only,
+            agg_kwargs=dict(min_count=min_count),
         )
 
-    def var(self, ddof=1, *args, **kwargs):
-        return self._apply_agg_function(lambda df: df.var(ddof, *args, **kwargs))
+    def var(self, ddof=1):
+        return self._wrap_aggregation(
+            type(self._query_compiler).groupby_var,
+            agg_kwargs=dict(ddof=ddof),
+            numeric_only=True,
+        )
 
     def get_group(self, name, obj=None):
         return self._default_to_pandas(lambda df: df.get_group(name, obj=obj))
@@ -570,12 +623,11 @@ class DataFrameGroupBy(object):
     def __len__(self):
         return len(self.indices)
 
-    def all(self, **kwargs):
+    def all(self, skipna=True):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_all,
-            lambda df, **kwargs: df.all(**kwargs),
             numeric_only=False,
-            **kwargs,
+            agg_kwargs=dict(skipna=skipna),
         )
 
     def size(self):
@@ -600,7 +652,6 @@ class DataFrameGroupBy(object):
         )
         result = work_object._wrap_aggregation(
             type(work_object._query_compiler).groupby_size,
-            lambda df: df.size(),
             numeric_only=False,
         )
         if not isinstance(result, Series):
@@ -618,11 +669,11 @@ class DataFrameGroupBy(object):
             result.name = None
         return result.fillna(0)
 
-    def sum(self, **kwargs):
+    def sum(self, numeric_only=None, min_count=0):
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_sum,
-            lambda df, **kwargs: df.sum(**kwargs),
-            **kwargs,
+            agg_kwargs=dict(min_count=min_count),
+            numeric_only=numeric_only,
         )
 
     def describe(self, **kwargs):
@@ -660,20 +711,36 @@ class DataFrameGroupBy(object):
         return self._default_to_pandas(lambda df: df.ngroup(ascending))
 
     def nunique(self, dropna=True):
-        return self._apply_agg_function_check_index(lambda df: df.nunique(dropna))
+        return self._check_index(
+            self._wrap_aggregation(
+                type(self._query_compiler).groupby_nunique,
+                numeric_only=False,
+                agg_kwargs=dict(dropna=dropna),
+            )
+        )
 
     def resample(self, rule, *args, **kwargs):
         return self._default_to_pandas(lambda df: df.resample(rule, *args, **kwargs))
 
-    def median(self, **kwargs):
-        return self._apply_agg_function_check_index(lambda df: df.median(**kwargs))
+    def median(self, numeric_only=None):
+        return self._check_index(
+            self._wrap_aggregation(
+                type(self._query_compiler).groupby_median,
+                numeric_only=numeric_only,
+            )
+        )
 
     def head(self, n=5):
         return self._default_to_pandas(lambda df: df.head(n))
 
     def cumprod(self, axis=0, *args, **kwargs):
-        return self._apply_agg_function_check_index_name(
-            lambda df: df.cumprod(axis, *args, **kwargs)
+        return self._check_index_name(
+            self._wrap_aggregation(
+                type(self._query_compiler).groupby_cumprod,
+                agg_args=args,
+                agg_kwargs=dict(axis=axis, **kwargs),
+                numeric_only=True,
+            )
         )
 
     def __iter__(self):
@@ -683,14 +750,21 @@ class DataFrameGroupBy(object):
         return self._default_to_pandas(lambda df: df.cov())
 
     def transform(self, func, *args, **kwargs):
-        return self._apply_agg_function_check_index_name(
-            lambda df: df.transform(func, *args, **kwargs)
+        return self._check_index_name(
+            self._wrap_aggregation(
+                qc_method=type(self._query_compiler).groupby_agg,
+                numeric_only=False,
+                agg_func=func,
+                agg_args=args,
+                agg_kwargs=kwargs,
+                how="transform",
+            )
         )
 
     def corr(self, **kwargs):
         return self._default_to_pandas(lambda df: df.corr(**kwargs))
 
-    def fillna(self, **kwargs):
+    def fillna(self, *args, **kwargs):
         new_groupby_kwargs = self._kwargs.copy()
         new_groupby_kwargs["as_index"] = True
         work_object = type(self)(
@@ -702,16 +776,19 @@ class DataFrameGroupBy(object):
             squeeze=self._squeeze,
             **new_groupby_kwargs,
         )
-        return work_object._apply_agg_function_check_index_name(
-            lambda df: df.fillna(**kwargs)
+        return work_object._check_index_name(
+            work_object._wrap_aggregation(
+                type(self._query_compiler).groupby_fillna,
+                numeric_only=False,
+                agg_args=args,
+                agg_kwargs=kwargs,
+            )
         )
 
-    def count(self, **kwargs):
+    def count(self):
         result = self._wrap_aggregation(
             type(self._query_compiler).groupby_count,
-            lambda df, **kwargs: df.count(**kwargs),
             numeric_only=False,
-            **kwargs,
         )
         # pandas do it in case of Series
         if isinstance(result, Series):
@@ -741,11 +818,19 @@ class DataFrameGroupBy(object):
     def hist(self):
         return self._default_to_pandas(lambda df: df.hist())
 
-    def quantile(self, q=0.5, **kwargs):
+    def quantile(self, q=0.5, interpolation="linear"):
         if is_list_like(q):
-            return self._default_to_pandas(lambda df: df.quantile(q=q, **kwargs))
+            return self._default_to_pandas(
+                lambda df: df.quantile(q=q, interpolation=interpolation)
+            )
 
-        return self._apply_agg_function_check_index(lambda df: df.quantile(q, **kwargs))
+        return self._check_index(
+            self._wrap_aggregation(
+                type(self._query_compiler).groupby_quantile,
+                numeric_only=False,
+                agg_kwargs=dict(q=q, interpolation=interpolation),
+            )
+        )
 
     def diff(self):
         return self._default_to_pandas(lambda df: df.diff())
@@ -921,7 +1006,12 @@ class DataFrameGroupBy(object):
                 return groupby_obj.indices if numerical else groupby_obj.groups
 
     def _wrap_aggregation(
-        self, qc_method, default_func, drop=True, numeric_only=True, **kwargs
+        self,
+        qc_method,
+        numeric_only=None,
+        agg_args=None,
+        agg_kwargs=None,
+        **kwargs,
     ):
         """
         Perform common metadata transformations and apply groupby functions.
@@ -930,67 +1020,78 @@ class DataFrameGroupBy(object):
         ----------
         qc_method : callable
             The query compiler method to call.
-        default_func : callable
-            The function to call if we need to default to pandas.
-        drop : bool, default: True
-            Whether or not to the grouping columns should be dropped on this operation.
-        numeric_only : bool, default: True
+        numeric_only : bool, default: None
             True for numeric only computations, False otherwise.
+        agg_args : list-like, optional
+            Positional arguments to pass to the aggregation function.
+        agg_kwargs : dict-like, optional
+            Keyword arguments to pass to the aggregation function.
         **kwargs : dict
-            The keyword arguments to be passed to the calling function.
+            Keyword arguments to pass to the specified query compiler's method.
 
         Returns
         -------
         DataFrame or Series
             Returns the same type as `self._df`.
         """
-        if self._axis != 0:
-            return self._default_to_pandas(default_func, **kwargs)
-        # For aggregations, pandas behavior does this for the result.
-        # For other operations it does not, so we wait until there is an aggregation to
-        # actually perform this operation.
-        if not self._is_multi_by and drop and self._drop and self._as_index:
-            groupby_qc = self._query_compiler.drop(columns=self._by.columns)
+        agg_args = tuple() if agg_args is None else agg_args
+        agg_kwargs = dict() if agg_kwargs is None else agg_kwargs
+
+        if numeric_only is None:
+            # pandas behaviour: if `numeric_only` wasn't explicitly specified then
+            # the parameter is considered to be `False` if there are no numeric types
+            # in the frame and `True` otherwise.
+            numeric_only = any(
+                is_numeric_dtype(dtype) for dtype in self._query_compiler.dtypes
+            )
+
+        if numeric_only and self.ndim == 2:
+            by_cols = self._internal_by
+            mask_cols = [
+                col
+                for col, dtype in self._df.dtypes.items()
+                if (
+                    is_numeric_dtype(dtype)
+                    or (
+                        isinstance(dtype, pandas.CategoricalDtype)
+                        and is_numeric_dtype(dtype.categories.dtype)
+                    )
+                    or col in by_cols
+                )
+            ]
+            groupby_qc = self._query_compiler.getitem_column_array(mask_cols)
         else:
             groupby_qc = self._query_compiler
-
-        if all(not is_numeric_dtype(dtype) for dtype in groupby_qc.dtypes):
-            numeric_only = False
 
         result = type(self._df)(
             query_compiler=qc_method(
                 groupby_qc,
                 by=self._by,
                 axis=self._axis,
-                groupby_args=self._kwargs,
-                map_args=kwargs,
-                reduce_args=kwargs,
-                numeric_only=numeric_only,
+                groupby_kwargs=self._kwargs,
+                agg_args=agg_args,
+                agg_kwargs=agg_kwargs,
                 drop=self._drop,
+                **kwargs,
             )
         )
         if self._squeeze:
             return result.squeeze()
         return result
 
-    def _apply_agg_function_check_index(self, *args, **kwargs):
+    def _check_index(self, result):
         """
-        Perform `self._apply_agg_function` with additional check.
-
-        Check the result of `self._apply_agg_function` on the need of resetting index.
+        Check the result of groupby aggregation on the need of resetting index.
 
         Parameters
         ----------
-        *args : list
-            Positional arguments to pass to `self._apply_agg_function`.
-        **kwargs : dict
-            Keyword arguments to pass to `self._apply_agg_function`.
+        result : DataFrame
+            Group by aggregation result.
 
         Returns
         -------
         DataFrame
         """
-        result = self._apply_agg_function(*args, **kwargs)
         if self._by is None and not self._as_index:
             # This is a workaround to align behavior with pandas. In this case pandas
             # resets index, but Modin doesn't do that. More details are in https://github.com/modin-project/modin/issues/3716.
@@ -998,68 +1099,22 @@ class DataFrameGroupBy(object):
 
         return result
 
-    def _apply_agg_function_check_index_name(self, *args, **kwargs):
+    def _check_index_name(self, result):
         """
-        Perform `self._apply_agg_function` with additional check.
-
-        Check the result of `self._apply_agg_function` on the need of resetting index name.
+        Check the result of groupby aggregation on the need of resetting index name.
 
         Parameters
         ----------
-        *args : list
-            Positional arguments to pass to `self._apply_agg_function`.
-        **kwargs : dict
-            Keyword arguments to pass to `self._apply_agg_function`.
+        result : DataFrame
+            Group by aggregation result.
 
         Returns
         -------
         DataFrame
         """
-        result = self._apply_agg_function(*args, **kwargs)
         if self._by is not None:
             # pandas does not name the index for this case
             result._query_compiler.set_index_name(None)
-        return result
-
-    def _apply_agg_function(self, f, *args, **kwargs):
-        """
-        Perform aggregation and combine stages based on a given function.
-
-        Parameters
-        ----------
-        f : callable
-            The function to apply to each group.
-        *args : list
-            Extra positional arguments to pass to `f`.
-        **kwargs : dict
-            Extra keyword arguments to pass to `f`.
-
-        Returns
-        -------
-        DataFrame
-            A new combined DataFrame with the result of all groups.
-        """
-        assert callable(f) or isinstance(
-            f, dict
-        ), "'{0}' object is not callable and not a dict".format(type(f))
-
-        new_manager = self._query_compiler.groupby_agg(
-            by=self._by,
-            is_multi_by=self._is_multi_by,
-            axis=self._axis,
-            agg_func=f,
-            agg_args=args,
-            agg_kwargs=kwargs,
-            groupby_kwargs=self._kwargs,
-            drop=self._drop,
-        )
-        if self._idx_name is not None and self._as_index:
-            new_manager.set_index_name(self._idx_name)
-        result = type(self._df)(query_compiler=new_manager)
-        if result._query_compiler.get_index_name() == "__reduced__":
-            result._query_compiler.set_index_name(None)
-        if self._squeeze:
-            return result.squeeze()
         return result
 
     def _default_to_pandas(self, f, *args, **kwargs):

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -1022,8 +1022,12 @@ class DataFrameGroupBy(object):
         ----------
         qc_method : callable
             The query compiler method to call.
-        numeric_only : bool, default: None
-            True for numeric only computations, False otherwise.
+        numeric_only : {None, True, False}, default: None
+            Specifies whether to aggregate non numeric columns:
+                - True: include only numeric columns (including categories that holds a numeric dtype)
+                - False: include all columns
+                - None: infer the parameter, ``False`` if there are no numeric types in the frame,
+                  ``True`` otherwise.
         agg_args : list-like, optional
             Positional arguments to pass to the aggregation function.
         agg_kwargs : dict-like, optional
@@ -1051,7 +1055,7 @@ class DataFrameGroupBy(object):
             by_cols = self._internal_by
             mask_cols = [
                 col
-                for col, dtype in self._df.dtypes.items()
+                for col, dtype in self._query_compiler.dtypes.items()
                 if (
                     is_numeric_dtype(dtype)
                     or (


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

### Do not pass lambdas to backend

This PR gets rid of passing Python lambdas to the backend as an implementation for basic GroupBy aggregations. Instead of passing lambdas to a single `groupby_agg` method, different aggregations were dedicated into separate query compiler methods. This PR adds 15 new methods to the query compilers API, all of them implemented like:
```python
def groupby_some_aggregation(self, *args, **kwargs):
    return self.groupby_agg(agg_func="some_aggregation", *args, **kwargs)
```
this allows for previous implementations at the different query compilers to work the same as before, because actual computations are still performed by the `groupby_agg`, the only difference is that it now takes string function names instead of callable. It's supposed that if `groupby_agg` does not support passed aggregation it'll default to pandas by calling `groupby_agg` of the ancestor query compiler.

Also, look at the [original issue](https://github.com/modin-project/modin/issues/3197) for discussion about query compilers API bloating and its potential solutions.

### Align backend's GroupBy API
There were some differences in interfaces of different `groupby_*` methods, to not introduce the differ one with the new 15 methods, this PR unifies interface for all of the `groupby_*` methods.

The new interface for every groupby method is the following:
```python
def groupby_method(
    self,
    by,
    axis,
    groupby_kwargs,
    agg_args,
    agg_kwargs
    drop=False,
)
```
Changes to highlight:
1. Removed `is_multi_by` parameter as unusable
2. `QueryCompiler.groupby_agg` now takes "how" parameter, specifying applying strategy of the passed aggregation function: axis-wise (apply the function to each column/row in every group), group-wise (apply the function to every group), or transform-like (apply the function to every group and broadcast the output to the original shape). Previously, `groupby_agg` took a function, that expected a `pandas.DataFrameGroupbyObject` and decided the applying strategy by itself, this approach was pandas-dependent and couldn't be implemented in any other storage formats. 
3. Moved handling of `numeric_only` parameter to the front-end
4. Removed `map_args` and `reduce_args` parameters as they were implementation-specific, replaced them by `agg_args` and `agg_kwargs`, in the case of MapReduce implementation these aggregation parameters are the same for both phases
5. `groupby_args -> groupby_kwargs`

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3197 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
