### PR TITLE
FIX-#3242: Fix processing of `evals` parameter in Modin xgb

### DIFF
--- a/modin/experimental/xgboost/test/test_xgboost.py
+++ b/modin/experimental/xgboost/test/test_xgboost.py
@@ -218,9 +218,9 @@ def test_xgb_with_multiclass_classification_datasets(data, num_actors, modin_typ
     "num_actors",
     [
         1,
-        pytest.param(num_cpus, marks=pytest.mark.skip),
-        pytest.param(None, marks=pytest.mark.skip),
-        pytest.param(modin.config.NPartitions.get() + 1, marks=pytest.mark.skip),
+        num_cpus,
+        None,
+        modin.config.NPartitions.get() + 1,
     ],
 )
 @pytest.mark.parametrize(

--- a/modin/experimental/xgboost/xgboost_ray.py
+++ b/modin/experimental/xgboost/xgboost_ray.py
@@ -23,6 +23,7 @@ import logging
 from typing import Dict, List
 import math
 from collections import defaultdict
+import warnings
 
 import numpy as np
 import xgboost as xgb
@@ -497,6 +498,19 @@ def _train(
 
     if num_actors > len(X_row_parts):
         num_actors = len(X_row_parts)
+
+    if evals:
+        min_num_parts = num_actors
+        for (eval_X, _), eval_method in evals:
+            if len(eval_X) < min_num_parts:
+                min_num_parts = len(eval_X)
+                method_name = eval_method
+
+        if num_actors != min_num_parts:
+            num_actors = min_num_parts
+            warnings.warn(
+                f"`num_actors` is set to {num_actors}, because `evals` data with name `{method_name}` has only {num_actors} partition(s)."
+            )
 
     actors = create_actors(num_actors)
 


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3242  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
