### PR TITLE
FIX-#3381: JSON dispatcher data file split correction

### DIFF
--- a/modin/engines/base/io/text/json_dispatcher.py
+++ b/modin/engines/base/io/text/json_dispatcher.py
@@ -17,7 +17,6 @@ from modin.engines.base.io.text.text_file_dispatcher import TextFileDispatcher
 from io import BytesIO
 import pandas
 import numpy as np
-from csv import QUOTE_NONE
 
 from modin.config import NPartitions
 
@@ -73,7 +72,6 @@ class JSONDispatcher(TextFileDispatcher):
             splits = cls.partitioned_file(
                 f,
                 num_partitions=NPartitions.get(),
-                is_quoting=(args.get("quoting", "") != QUOTE_NONE),
             )
             for start, end in splits:
                 args.update({"start": start, "end": end})


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
`read_json` function doesn't have quoting parameter, so `is_quoting` variable is always True (QUOTE_NONE == 3), but `is_quoting` parameter default value is also True, so we don't need to explicitly define this parameter here.

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3381  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
