### PR TITLE
FIX-#3384: Fix `test_io.py::TestHdf::test_HDFStore` test

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1636,11 +1636,13 @@ class TestHdf:
             modin_store["foo"] = modin_df
             pandas_store["foo"] = pandas_df
 
-            assert assert_files_eq(unique_filename_modin, unique_filename_pandas)
             modin_df = modin_store.get("foo")
             pandas_df = pandas_store.get("foo")
             df_equals(modin_df, pandas_df)
 
+            modin_store.close()
+            pandas_store.close()
+            assert assert_files_eq(unique_filename_modin, unique_filename_pandas)
             assert isinstance(modin_store, pd.HDFStore)
 
             handle, hdf_file = tempfile.mkstemp(suffix=".hdf5", prefix="test_read")

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1625,9 +1625,10 @@ class TestHdf:
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
     )
     def test_HDFStore(self):
+        hdf_file = None
+        unique_filename_modin = get_unique_filename(extension="hdf")
+        unique_filename_pandas = get_unique_filename(extension="hdf")
         try:
-            unique_filename_modin = get_unique_filename(extension="hdf")
-            unique_filename_pandas = get_unique_filename(extension="hdf")
             modin_store = pd.HDFStore(unique_filename_modin)
             pandas_store = pandas.HDFStore(unique_filename_pandas)
 
@@ -1655,7 +1656,8 @@ class TestHdf:
             pandas_df = pandas.read_hdf(hdf_file, key="data/df1", mode="r")
             df_equals(modin_df, pandas_df)
         finally:
-            os.unlink(hdf_file)
+            if hdf_file:
+                os.unlink(hdf_file)
             teardown_test_files([unique_filename_modin, unique_filename_pandas])
 
 


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3384 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
