### PR TITLE
FIX-#3387: Fix `read_csv` with `skiprows` parameter

### DIFF
--- a/modin/engines/base/io/text/csv_dispatcher.py
+++ b/modin/engines/base/io/text/csv_dispatcher.py
@@ -330,8 +330,17 @@ class CSVDispatcher(TextFileDispatcher):
             nrows = kwargs.get("nrows", None)
             index_range = pandas.RangeIndex(len(new_query_compiler.index))
             if is_list_like(skiprows_md):
+                skiprows_md = skiprows_md - header_size
+                index_max = index_range.stop - 1
+                if skiprows_md[-1] > index_max:
+                    # cut off `skiprows` values, which are outside of index
+                    # boundaries
+                    skiprows_md = skiprows_md[
+                        : skiprows_md.searchsorted(index_max, side="right")
+                    ]
+
                 new_query_compiler = new_query_compiler.view(
-                    index=index_range.delete(skiprows_md - header_size)
+                    index=index_range.delete(skiprows_md)
                 )
             elif callable(skiprows_md):
                 mod_index = skiprows_md(index_range + header_size)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -18,7 +18,7 @@ from pandas.errors import ParserWarning
 import pandas._libs.lib as lib
 from pandas.core.dtypes.common import is_list_like
 from collections import OrderedDict
-from modin.config import TestDatasetSize, Engine, Backend, IsExperimental
+from modin.config import Engine, Backend, IsExperimental
 from modin.utils import to_pandas
 from modin.pandas.utils import from_arrow
 import pyarrow as pa
@@ -44,6 +44,7 @@ from .utils import (
     COMP_TO_EXT,
     teardown_test_files,
     generate_dataframe,
+    NROWS,
 )
 
 if Backend.get() == "Pandas":
@@ -59,9 +60,6 @@ DATASET_SIZE_DICT = {
     "Normal": 2000,
     "Big": 20000,
 }
-
-# Number of rows in the test file
-NROWS = DATASET_SIZE_DICT.get(TestDatasetSize.get(), DATASET_SIZE_DICT["Small"])
 
 TEST_DATA = {
     "col1": [0, 1, 2, 3],
@@ -1145,6 +1143,23 @@ class TestCsv:
             filepath_or_buffer=pytest.csvs_names["test_read_csv_regular"],
             usecols=["col1"],
             index_col="col1",
+        )
+
+    @pytest.mark.parametrize(
+        "skiprows",
+        [
+            lambda x: True,
+            np.arange(10, 2 * NROWS, 2),
+            np.arange(10, 2 * NROWS - 1, 2),
+        ],
+    )
+    def test_read_csv_incorrect_skiprows(self, skiprows):
+        eval_io(
+            fn_name="read_csv",
+            check_kwargs_callable=not callable(skiprows),
+            # read_csv kwargs
+            filepath_or_buffer=pytest.csvs_names["test_read_csv_regular"],
+            skiprows=skiprows,
         )
 
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1149,8 +1149,13 @@ class TestCsv:
         "skiprows",
         [
             lambda x: True,
-            np.arange(10, 2 * NROWS, 2),
-            np.arange(10, 2 * NROWS - 1, 2),
+            pytest.param(
+                np.arange(10, 2 * NROWS, 2),
+                marks=pytest.mark.xfail(
+                    condition="config.getoption('--simulate-cloud').lower() != 'off'",
+                    reason="The reason of tests fail in `cloud` mode is unknown for now - issue #2340",
+                ),
+            ),
         ],
     )
     def test_read_csv_incorrect_skiprows(self, skiprows):


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3387 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
