### PR TITLE
FIX-#3395: Make `label` param of DMatrix optional

### DIFF
--- a/modin/experimental/xgboost/xgboost.py
+++ b/modin/experimental/xgboost/xgboost.py
@@ -35,7 +35,7 @@ class DMatrix:
     ----------
     data : modin.pandas.DataFrame
         Data source of DMatrix.
-    label : modin.pandas.DataFrame or modin.pandas.Series
+    label : modin.pandas.DataFrame or modin.pandas.Series, optional
         Labels used for training.
 
     Notes
@@ -43,16 +43,20 @@ class DMatrix:
     Currently DMatrix supports only `data` and `label` parameters.
     """
 
-    def __init__(self, data, label):
+    def __init__(self, data, label=None):
         assert isinstance(
             data, pd.DataFrame
         ), f"Type of `data` is {type(data)}, but expected {pd.DataFrame}."
-        assert isinstance(
-            label, (pd.DataFrame, pd.Series)
-        ), f"Type of `data` is {type(label)}, but expected {pd.DataFrame} or {pd.Series}."
+
+        if label is not None:
+            assert isinstance(
+                label, (pd.DataFrame, pd.Series)
+            ), f"Type of `data` is {type(label)}, but expected {pd.DataFrame} or {pd.Series}."
+            self.label = unwrap_partitions(label, axis=0)
+        else:
+            self.label = None
 
         self.data = unwrap_partitions(data, axis=0, get_ip=True)
-        self.label = unwrap_partitions(label, axis=0)
 
         self.metadata = (
             data.index,


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3395  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
