### PR TITLE
FIX-#3401: all shapes don't depend on MODIN_BACKEND env

### DIFF
--- a/asv_bench/benchmarks/utils/data_shapes.py
+++ b/asv_bench/benchmarks/utils/data_shapes.py
@@ -80,22 +80,6 @@ OMNISCI_SERIES_DATA_SIZE = {
     ],
 }
 
-BINARY_SHAPES = (
-    OMNISCI_BINARY_OP_DATA_SIZE[ASV_DATASET_SIZE]
-    if ASV_USE_BACKEND == "omnisci"
-    else BINARY_OP_DATA_SIZE[ASV_DATASET_SIZE]
-)
-UNARY_SHAPES = (
-    OMNISCI_UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE]
-    if ASV_USE_BACKEND == "omnisci"
-    else UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE]
-)
-SERIES_SHAPES = (
-    OMNISCI_SERIES_DATA_SIZE[ASV_DATASET_SIZE]
-    if ASV_USE_BACKEND == "omnisci"
-    else SERIES_DATA_SIZE[ASV_DATASET_SIZE]
-)
-
 DEFAULT_GROUPBY_NGROUPS = {
     "big": [100, "huge_amount_groups"],
     "small": [5],
@@ -104,7 +88,7 @@ GROUPBY_NGROUPS = DEFAULT_GROUPBY_NGROUPS[ASV_DATASET_SIZE]
 
 _DEFAULT_CONFIG_T = [
     (
-        UNARY_SHAPES,
+        UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
         [
             # Pandas backend benchmarks
             "TimeGroupByMultiColumn",
@@ -133,7 +117,32 @@ _DEFAULT_CONFIG_T = [
             # Scalability benchmarks
             "TimeFromPandas",
             "TimeToPandas",
-            # OmniSci backend benchmarks
+        ],
+    ),
+    (
+        BINARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [
+            # Pandas backend benchmarks
+            "TimeJoin",
+            "TimeMerge",
+            "TimeConcat",
+            "TimeAppend",
+            "TimeBinaryOp",
+        ],
+    ),
+    (
+        SERIES_DATA_SIZE[ASV_DATASET_SIZE],
+        [
+            # Pandas backend benchmarks
+            "TimeFillnaSeries",
+        ],
+    ),
+]
+
+_DEFAULT_OMNISCI_CONFIG_T = [
+    (
+        OMNISCI_UNARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
+        [
             "omnisci.TimeJoin",
             "omnisci.TimeBinaryOpDataFrame",
             "omnisci.TimeArithmetic",
@@ -149,38 +158,28 @@ _DEFAULT_CONFIG_T = [
             "omnisci.TimeGroupByDefaultAggregations",
             "omnisci.TimeGroupByMultiColumn",
             "omnisci.TimeValueCountsDataFrame",
-            # OmniSci backend IO benchmarks
             "omnisci.TimeReadCsvNames",
         ],
     ),
     (
-        BINARY_SHAPES,
+        OMNISCI_BINARY_OP_DATA_SIZE[ASV_DATASET_SIZE],
         [
-            # Pandas backend benchmarks
-            "TimeJoin",
-            "TimeMerge",
-            "TimeConcat",
-            "TimeAppend",
-            "TimeBinaryOp",
-            # OmniSci backend benchmarks
             "omnisci.TimeMerge",
             "omnisci.TimeAppend",
         ],
     ),
     (
-        SERIES_SHAPES,
+        OMNISCI_SERIES_DATA_SIZE[ASV_DATASET_SIZE],
         [
-            # Pandas backend benchmarks
-            "TimeFillnaSeries",
-            # OmniSci backend benchmarks
             "omnisci.TimeBinaryOpSeries",
             "omnisci.TimeValueCountsSeries",
         ],
     ),
 ]
 DEFAULT_CONFIG = {}
-for _shape, _names in _DEFAULT_CONFIG_T:
-    DEFAULT_CONFIG.update({_name: _shape for _name in _names})
+for config in (_DEFAULT_CONFIG_T, _DEFAULT_OMNISCI_CONFIG_T):
+    for _shape, _names in config:
+        DEFAULT_CONFIG.update({_name: _shape for _name in _names})
 
 CONFIG_FROM_FILE = None
 


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3401 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
