### PR TITLE
FIX-#3426: Use ray.util instead of ray.services for get_node_ip_address

### DIFF
--- a/modin/engines/ray/pandas_on_ray/frame/axis_partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/axis_partition.py
@@ -19,7 +19,7 @@ from modin.engines.base.frame.axis_partition import PandasFrameAxisPartition
 from .partition import PandasOnRayFramePartition
 
 import ray
-from ray.services import get_node_ip_address
+from ray.util import get_node_ip_address
 
 
 class PandasOnRayFrameAxisPartition(PandasFrameAxisPartition):

--- a/modin/engines/ray/pandas_on_ray/frame/partition.py
+++ b/modin/engines/ray/pandas_on_ray/frame/partition.py
@@ -20,7 +20,7 @@ from modin.engines.base.frame.partition import PandasFramePartition
 from modin.pandas.indexing import compute_sliced_len
 
 import ray
-from ray.services import get_node_ip_address
+from ray.util import get_node_ip_address
 from packaging import version
 
 ObjectIDType = ray.ObjectRef

--- a/modin/experimental/xgboost/xgboost_ray.py
+++ b/modin/experimental/xgboost/xgboost_ray.py
@@ -27,7 +27,7 @@ from collections import defaultdict
 import numpy as np
 import xgboost as xgb
 import ray
-from ray.services import get_node_ip_address
+from ray.util import get_node_ip_address
 import pandas
 
 from modin.distributed.dataframe.pandas import from_partitions


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3426 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
