### PR TITLE
REFACTOR-#3176: Use ray from conda instead of pip

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,6 +31,7 @@ dependencies:
   - packaging
   - coverage<5.0
   - pygithub==1.53
+  - ray-default
   - rpyc==4.1.5
   - cloudpickle
   - boto3
@@ -39,5 +40,4 @@ dependencies:
       - xgboost>=1.3
       - modin-spreadsheet>=0.1.1
       - tqdm
-      - ray[default]>=1.4
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3176
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
