### PR TITLE
FEAT-#3444: support logical 'and' and 'or' in filters.

### DIFF
--- a/modin/experimental/backends/omnisci/query_compiler.py
+++ b/modin/experimental/backends/omnisci/query_compiler.py
@@ -218,11 +218,8 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
     def getitem_array(self, key):
         if isinstance(key, type(self)):
-            try:
-                new_modin_frame = self._modin_frame.filter(key._modin_frame)
-                return self.__constructor__(new_modin_frame, self._shape_hint)
-            except NotImplementedError:
-                key = key.to_pandas()
+            new_modin_frame = self._modin_frame.filter(key._modin_frame)
+            return self.__constructor__(new_modin_frame, self._shape_hint)
 
         if is_bool_indexer(key):
             return self.default_to_pandas(lambda df: df[key])
@@ -612,6 +609,12 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
     def ne(self, other, **kwargs):
         return self._bin_op(other, "ne", **kwargs)
+
+    def __and__(self, other, **kwargs):
+        return self._bin_op(other, "and", **kwargs)
+
+    def __or__(self, other, **kwargs):
+        return self._bin_op(other, "or", **kwargs)
 
     def reset_index(self, **kwargs):
         level = kwargs.get("level", None)

--- a/modin/experimental/engines/omnisci_on_native/frame/expr.py
+++ b/modin/experimental/engines/omnisci_on_native/frame/expr.py
@@ -103,6 +103,26 @@ def is_cmp_op(op):
     return op in _cmp_ops
 
 
+_logical_ops = {"and", "or"}
+
+
+def is_logical_op(op):
+    """
+    Check if operation is a logical one.
+
+    Parameters
+    ----------
+    op : str
+        Operation to check.
+
+    Returns
+    -------
+    bool
+        True for logical operations and False otherwise.
+    """
+    return op in _logical_ops
+
+
 class BaseExpr(abc.ABC):
     """
     An abstract base class for expression tree node.
@@ -133,6 +153,8 @@ class BaseExpr(abc.ABC):
         "le": "<=",
         "lt": "<",
         "ne": "<>",
+        "and": "AND",
+        "or": "OR",
     }
 
     preserve_dtype_math_ops = {"add", "sub", "mul", "mod", "floordiv", "pow"}
@@ -461,6 +483,8 @@ class BaseExpr(abc.ABC):
         elif op_name in self.promote_to_float_math_ops:
             return get_dtype(float)
         elif is_cmp_op(op_name):
+            return get_dtype(bool)
+        elif is_logical_op(op_name):
             return get_dtype(bool)
         else:
             raise NotImplementedError(f"unsupported binary operation {op_name}")

--- a/modin/experimental/engines/omnisci_on_native/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_native/test/test_dataframe.py
@@ -1720,6 +1720,16 @@ class TestBinaryOp:
 
         run_and_compare(filter, data=self.cmp_data)
 
+    def test_complex_filter(self):
+        def filter_and(df, **kwargs):
+            return df[(df.a < 5) & (df.b > 20)]
+
+        def filter_or(df, **kwargs):
+            return df[(df.a < 3) | (df.b > 40)]
+
+        run_and_compare(filter_and, data=self.cmp_data)
+        run_and_compare(filter_or, data=self.cmp_data)
+
 
 class TestDateTime:
     datetime_data = {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3444 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
