### PR TITLE
FIX-#3470: fix dtypes for OmniSci dataframes.

### DIFF
--- a/modin/experimental/engines/omnisci_on_native/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_native/frame/data.py
@@ -2002,6 +2002,20 @@ class OmnisciOnNativeFrame(PandasFrame):
     columns = property(_get_columns)
     index = property(_get_index)
 
+    @property
+    def dtypes(self):
+        """
+        Return column data types.
+
+        Returns
+        -------
+        pandas.Series
+            A pandas Series containing the data types for this dataframe.
+        """
+        if self._index_cols is not None:
+            return self._dtypes[len(self._index_cols) :]
+        return self._dtypes
+
     def has_multiindex(self):
         """
         Check for multi-index usage.

--- a/modin/experimental/engines/omnisci_on_native/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_native/test/test_dataframe.py
@@ -1711,6 +1711,12 @@ class TestBinaryOp:
 
         run_and_compare(cmp, data=data, cmp_fn=cmp_fn, value=value)
 
+    def test_filter_dtypes(self):
+        def filter(df, **kwargs):
+            return df[df.a < 4].dtypes
+
+        run_and_compare(filter, data=self.cmp_data)
+
     @pytest.mark.xfail(
         reason="Requires fix in OmniSci: https://github.com/intel-ai/omniscidb/pull/178"
     )


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Fix `DataFrame.dtypes` for OmniSci backend by excluding index types from it.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3470  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
