### PR TITLE
FIX-#3475: pandas.read_gbq: remove deprecated parameters

### DIFF
--- a/modin/engines/base/io/io.py
+++ b/modin/engines/base/io/io.py
@@ -357,8 +357,6 @@ class BaseIO(object):
                 configuration=configuration,
                 credentials=credentials,
                 use_bqstorage_api=use_bqstorage_api,
-                private_key=private_key,
-                verbose=verbose,
                 progress_bar_type=progress_bar_type,
                 max_results=max_results,
             )


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3475 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
