### PR TITLE
FIX-#3480: Fix dtypes for astype result.

### DIFF
--- a/modin/experimental/engines/omnisci_on_native/frame/data.py
+++ b/modin/experimental/engines/omnisci_on_native/frame/data.py
@@ -723,12 +723,12 @@ class OmnisciOnNativeFrame(PandasFrame):
             The new frame.
         """
         columns = col_dtypes.keys()
-        new_dtypes = self.dtypes.copy()
+        new_dtypes = self._dtypes.copy()
         for column in columns:
             dtype = col_dtypes[column]
             if (
-                not isinstance(dtype, type(self.dtypes[column]))
-                or dtype != self.dtypes[column]
+                not isinstance(dtype, type(self._dtypes[column]))
+                or dtype != self._dtypes[column]
             ):
                 # Update the new dtype series to the proper pandas dtype
                 try:

--- a/modin/experimental/engines/omnisci_on_native/test/test_dataframe.py
+++ b/modin/experimental/engines/omnisci_on_native/test/test_dataframe.py
@@ -863,6 +863,13 @@ class TestGroupby:
 
         run_and_compare(df_astype, data=self.taxi_data)
 
+    def test_df_indexed_astype(self):
+        def df_astype(df, **kwargs):
+            df = df.groupby("a").agg({"b": "sum"})
+            return df.astype({"b": "float"})
+
+        run_and_compare(df_astype, data=self.taxi_data)
+
     @pytest.mark.parametrize("as_index", bool_arg_values)
     def test_taxi_q4(self, as_index):
         def taxi_q4(df, **kwargs):


### PR DESCRIPTION
## What do these changes do?
Fix unaligned dtypes issue.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Partly covers #3480? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
