### PR TITLE
FIX-#3447: Add attribute `api` in `modin.pandas`

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -85,6 +85,7 @@ from pandas import (
     datetime,
     NamedAgg,
     NA,
+    api,
 )
 import os
 import multiprocessing
@@ -323,6 +324,7 @@ __all__ = [
     "value_counts",
     "datetime",
     "NamedAgg",
+    "api",
 ]
 
 del pandas, Engine, Parameter

--- a/modin/pandas/test/test_rolling.py
+++ b/modin/pandas/test/test_rolling.py
@@ -16,7 +16,7 @@ import numpy as np
 import pandas
 import modin.pandas as pd
 
-from .utils import df_equals, test_data_values, test_data_keys
+from .utils import df_equals, test_data_values, test_data_keys, create_test_dfs
 from modin.config import NPartitions
 
 NPartitions.put(4)
@@ -204,3 +204,11 @@ def test_series_dt_index(closed):
     )
     df_equals(modin_rolled.aggregate(np.sum), pandas_rolled.aggregate(np.sum))
     df_equals(modin_rolled.quantile(0.1), pandas_rolled.quantile(0.1))
+
+
+def test_api_indexer():
+    modin_df, pandas_df = create_test_dfs(test_data_values[0])
+    indexer = pd.api.indexers.FixedForwardWindowIndexer(window_size=3)
+    pandas_rolled = pandas_df.rolling(window=indexer)
+    modin_rolled = modin_df.rolling(window=indexer)
+    df_equals(modin_rolled.sum(), pandas_rolled.sum())


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3447  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
