### PR TITLE
FIX-#0000: optimize `__getitem__` flow of loc/iloc

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -954,7 +954,12 @@ class PandasDataframe(object):
         if isinstance(indices, slice) or (is_range_like(indices) and indices.step == 1):
             # Converting range-like indexer to slice
             indices = slice(indices.start, indices.stop, indices.step)
-            if indices == slice(None) or indices == slice(0, None):
+            # Detecting full-axis grab
+            if (
+                indices.start in (None, 0)
+                and indices.step in (None, 1)
+                and (indices.stop is None or indices.stop >= len(self.axes[axis]))
+            ):
                 return OrderedDict(
                     zip(
                         range(self._partitions.shape[axis]),


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

<details><summary>Pandas backend perf difference</summary>

```

       before           after         ratio
     [670f327d]       [63384ec4]
     <master>        <fix_slow_getitem>
+         314±3ms          360±3ms     1.15  benchmarks.TimeIndexing.time_loc([1000000, 10], 'bool')
          648±2ms          663±2ms     1.02  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'list')
          145±7ms          142±2ms     0.98  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'slice')
          144±4ms          137±9ms     0.95  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'bool')
          149±9ms          142±8ms     0.95  benchmarks.TimeIndexing.time_loc([5000, 5000], 'slice')
         22.3±2ms       20.9±0.5ms     0.94  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'scalar')
          395±4ms          369±6ms     0.94  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'bool')
       22.2±0.1ms         20.7±5ms     0.93  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'list')
         10.3±1ms       9.12±0.3ms    ~0.89  benchmarks.TimeIndexing.time_loc([1000000, 10], 'scalar')
         150±10ms          128±6ms    ~0.86  benchmarks.TimeIndexing.time_loc([5000, 5000], 'bool')
         29.2±3ms       22.4±0.8ms    ~0.77  benchmarks.TimeIndexing.time_loc([5000, 5000], 'scalar')
-         245±3ms          164±1ms     0.67  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'slice')
-      32.3±0.3ms         21.5±2ms     0.67  benchmarks.TimeIndexing.time_loc([5000, 5000], 'list')
-         1.09±0s          657±4ms     0.60  benchmarks.TimeIndexing.time_loc([1000000, 10], 'list')
-        16.8±1ms       9.52±0.9ms     0.57  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'scalar')
-         443±9ms          162±3ms     0.37  benchmarks.TimeIndexing.time_loc([1000000, 10], 'slice')
-        476±10ms          158±6ms     0.33  benchmarks.TimeIndexing.time_loc([5000, 5000], 'function')
-        963±30ms          170±4ms     0.18  benchmarks.TimeIndexing.time_loc([1000000, 10], 'function')
-         776±2ms       32.7±0.1ms     0.04  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'function')
-        244±20ms          434±6μs     0.00  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'function')

```

</details>

<details><summary>OmniSci backend perf difference</summary>

```
       before           after         ratio
     [670f327d]       [63384ec4]
     <master>        <fix_slow_getitem>
          196±9ms          179±2ms     0.91  omnisci.benchmarks.TimeIndexing.time_iloc([1000000, 10], 'list')
      6.54±0.09ms      5.96±0.04ms     0.91  omnisci.benchmarks.TimeIndexing.time_loc([1000000, 10], 'scalar')
-      47.0±0.3ms       39.6±0.7ms     0.84  omnisci.benchmarks.TimeIndexing.time_iloc([1000000, 10], 'slice')
-         150±4ms         94.9±1ms     0.63  omnisci.benchmarks.TimeIndexing.time_iloc([1000000, 10], 'bool')
-         309±7ms          176±4ms     0.57  omnisci.benchmarks.TimeIndexing.time_loc([1000000, 10], 'function')
-      13.2±0.1ms      5.79±0.06ms     0.44  omnisci.benchmarks.TimeIndexing.time_iloc([1000000, 10], 'scalar')
-      89.7±0.2ms       31.7±0.2ms     0.35  omnisci.benchmarks.TimeIndexing.time_iloc([1000000, 10], 'function')
-        605±10ms          182±3ms     0.30  omnisci.benchmarks.TimeIndexing.time_loc([1000000, 10], 'list')
-         360±2ms       94.9±0.9ms     0.26  omnisci.benchmarks.TimeIndexing.time_loc([1000000, 10], 'bool')
-       188±0.9ms       39.0±0.4ms     0.21  omnisci.benchmarks.TimeIndexing.time_loc([1000000, 10], 'slice')
```

</details>
