### PR TITLE
FIX-#3234: Allow more callables in DataFrame.loc.

### DIFF
--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -223,6 +223,12 @@ def test_iloc(request, data):
             modin_df.iloc[lambda df: df.index.get_indexer_for(df.index[:5])],
             pandas_df.iloc[lambda df: df.index.get_indexer_for(df.index[:5])],
         )
+
+        # Read values, selecting rows with callable and a column with a scalar.
+        df_equals(
+            pandas_df.iloc[lambda df: df.index.get_indexer_for(df.index[:5]), 0],
+            modin_df.iloc[lambda df: df.index.get_indexer_for(df.index[:5]), 0],
+        )
     else:
         with pytest.raises(IndexError):
             modin_df.iloc[0, 1]
@@ -323,10 +329,30 @@ def test_loc(data):
     pandas_df_copy.loc[[1, 2]] = 42
     df_equals(modin_df_copy, pandas_df_copy)
 
+    # Write an item, selecting rows with a callable.
+    modin_df_copy2 = modin_df.copy()
+    pandas_df_copy2 = pandas_df.copy()
+    modin_df_copy2.loc[lambda df: df[key1].isin(list(range(1000)))] = 42
+    pandas_df_copy2.loc[lambda df: df[key1].isin(list(range(1000)))] = 42
+    df_equals(modin_df_copy2, pandas_df_copy2)
+
+    # Write an item, selecting rows with a callable and a column with a scalar.
+    modin_df_copy3 = modin_df.copy()
+    pandas_df_copy3 = pandas_df.copy()
+    modin_df_copy3.loc[lambda df: df[key1].isin(list(range(1000))), key1] = 42
+    pandas_df_copy3.loc[lambda df: df[key1].isin(list(range(1000))), key1] = 42
+    df_equals(modin_df_copy3, pandas_df_copy3)
+
     # From issue #1775
     df_equals(
         modin_df.loc[lambda df: df.iloc[:, 0].isin(list(range(1000)))],
         pandas_df.loc[lambda df: df.iloc[:, 0].isin(list(range(1000)))],
+    )
+
+    # Read values, selecting rows with a callable and a column with a scalar.
+    df_equals(
+        pandas_df.loc[lambda df: df[key1].isin(list(range(1000))), key1],
+        modin_df.loc[lambda df: df[key1].isin(list(range(1000))), key1],
     )
 
     # From issue #1374
@@ -485,15 +511,16 @@ def test_iloc_assignment():
     modin_df.iloc[0]["col1"] = 11
     modin_df.iloc[1]["col1"] = 21
     modin_df.iloc[2]["col1"] = 31
-    modin_df.iloc[0]["col2"] = 12
-    modin_df.iloc[1]["col2"] = 22
-    modin_df.iloc[2]["col2"] = 32
+    modin_df.iloc[lambda df: 0]["col2"] = 12
+    modin_df.iloc[1][lambda df: ["col2"]] = 22
+    modin_df.iloc[lambda df: 2][lambda df: ["col2"]] = 32
     pandas_df.iloc[0]["col1"] = 11
     pandas_df.iloc[1]["col1"] = 21
     pandas_df.iloc[2]["col1"] = 31
-    pandas_df.iloc[0]["col2"] = 12
-    pandas_df.iloc[1]["col2"] = 22
-    pandas_df.iloc[2]["col2"] = 32
+    pandas_df.iloc[lambda df: 0]["col2"] = 12
+    pandas_df.iloc[1][lambda df: ["col2"]] = 22
+    pandas_df.iloc[lambda df: 2][lambda df: ["col2"]] = 32
+
     df_equals(modin_df, pandas_df)
 
 


### PR DESCRIPTION
- For getting values, allow using a callable to specify rows while using a non-callable to specify columns.
- For setting values, allow using a callable to specify rows.
- For setting values, allow using a callable to specify rows while using a non-collable to specify columns.

The new test case fails without this change.

Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

- ✅  commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- ✅  passes `flake8 modin`
- ✅  passes `black --check modin`
- ✅  signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- ✅  Resolves #3234
- ✅  tests added and passing
- ✅  module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

