### PR TITLE
REFACTOR-#3528: Use fsspec to open files.

### DIFF
--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -28,11 +28,11 @@ S3_ADDRESS_REGEX = re.compile("[sS]3://(.*?)/(.*)")
 NOT_IMPLEMENTED_MESSAGE = "Implement in children classes!"
 
 
-class File:
+class OpenFile:
     """
-    File is a context manager for an input file.
+    OpenFile is a context manager for an input file.
 
-    File uses fsspec to open files on __enter__. On __exit__, it closes the
+    OpenFile uses fsspec to open files on __enter__. On __exit__, it closes the
     fsspec file. This class exists to encapsulate the special behavior in
     __enter__ around anon=False and anon=True for s3 buckets.
 

--- a/modin/core/io/text/csv_dispatcher.py
+++ b/modin/core/io/text/csv_dispatcher.py
@@ -133,7 +133,7 @@ class CSVDispatcher(TextFileDispatcher):
             compression=compression_infered,
         )
 
-        with File(filepath_or_buffer_md, "rb", compression_infered) as f:
+        with OpenFile(filepath_or_buffer_md, "rb", compression_infered) as f:
             splits = cls.partitioned_file(
                 f,
                 num_partitions=NPartitions.get(),

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -132,7 +132,7 @@ class CSVGlobDispatcher(CSVDispatcher):
         if usecols is not None and usecols_md[1] != "integer":
             del kwargs["usecols"]
             all_cols = pandas.read_csv(
-                File(filepath_or_buffer, "rb"),
+                OpenFile(filepath_or_buffer, "rb"),
                 **dict(kwargs, nrows=0, skipfooter=0),
             ).columns
             usecols = all_cols.get_indexer_for(list(usecols_md[0]))
@@ -154,7 +154,7 @@ class CSVGlobDispatcher(CSVDispatcher):
 
         with ExitStack() as stack:
             files = [
-                stack.enter_context(File(fname, "rb", compression_type))
+                stack.enter_context(OpenFile(fname, "rb", compression_type))
                 for fname in glob_filepaths
             ]
 

--- a/modin/core/io/text/fwf_dispatcher.py
+++ b/modin/core/io/text/fwf_dispatcher.py
@@ -109,7 +109,7 @@ class FWFDispatcher(TextFileDispatcher):
         usecols_md = cls._validate_usecols_arg(usecols)
         if usecols is not None and usecols_md[1] != "integer":
             del kwargs["usecols"]
-            with File(filepath_or_buffer, "rb") as f:
+            with OpenFile(filepath_or_buffer, "rb") as f:
                 all_cols = pandas.read_fwf(
                     f,
                     **dict(kwargs, nrows=0, skipfooter=0),
@@ -130,7 +130,7 @@ class FWFDispatcher(TextFileDispatcher):
             encoding if encoding is not None else "UTF-8"
         )
         is_quoting = kwargs.get("quoting", "") != QUOTE_NONE
-        with File(filepath_or_buffer, "rb", compression_type) as f:
+        with OpenFile(filepath_or_buffer, "rb", compression_type) as f:
             # Skip the header since we already have the header information and skip the
             # rows we are told to skip.
             if isinstance(skiprows, int) or skiprows is None:

--- a/modin/core/io/text/json_dispatcher.py
+++ b/modin/core/io/text/json_dispatcher.py
@@ -55,12 +55,12 @@ class JSONDispatcher(TextFileDispatcher):
             return cls.single_worker_read(path_or_buf, **kwargs)
         if not kwargs.get("lines", False):
             return cls.single_worker_read(path_or_buf, **kwargs)
-        with File(path_or_buf, "rb") as f:
+        with OpenFile(path_or_buf, "rb") as f:
             columns = pandas.read_json(BytesIO(b"" + f.readline()), lines=True).columns
         kwargs["columns"] = columns
         empty_pd_df = pandas.DataFrame(columns=columns)
 
-        with File(path_or_buf, "rb", kwargs.get("compression", "infer")) as f:
+        with OpenFile(path_or_buf, "rb", kwargs.get("compression", "infer")) as f:
             partition_ids = []
             index_ids = []
             dtypes_ids = []

--- a/modin/core/storage_formats/cudf/parser.py
+++ b/modin/core/storage_formats/cudf/parser.py
@@ -20,7 +20,6 @@ from pandas.core.dtypes.concat import union_categoricals
 from pandas.io.common import infer_compression
 import warnings
 
-from modin.core.io import FileDispatcher
 from modin.core.io.file_dispatcher import OpenFile
 from modin.core.execution.ray.implementations.cudf_on_ray.partitioning.partition_manager import (
     GPU_MANAGERS,
@@ -107,7 +106,7 @@ class cuDFCSVParser(cuDFParser):
             put_func = cls.frame_partition_cls.put
 
             # pop "compression" from kwargs because bio is uncompressed
-            with File(fname, "rb", kwargs.pop("compression", "infer")) as bio:
+            with OpenFile(fname, "rb", kwargs.pop("compression", "infer")) as bio:
                 if kwargs.get("encoding", None) is not None:
                     header = b"" + bio.readline()
                 else:

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -49,7 +49,6 @@ from pandas.io.common import infer_compression
 from pandas.util._decorators import doc
 import warnings
 
-from modin.core.io import FileDispatcher
 from modin.core.io.file_dispatcher import OpenFile
 from modin.core.storage_formats.pandas.utils import split_result_of_axis_func_pandas
 from modin.error_message import ErrorMessage
@@ -235,7 +234,7 @@ class PandasCSVParser(PandasParser):
         header_size = kwargs.pop("header_size", None)
         if start is not None and end is not None:
             # pop "compression" from kwargs because bio is uncompressed
-            with File(fname, "rb", kwargs.pop("compression", "infer")) as bio:
+            with OpenFile(fname, "rb", kwargs.pop("compression", "infer")) as bio:
                 header = b""
                 # In this case we beware that fisrt line can contain BOM, so
                 # adding this line to the `header` for reading and then skip it
@@ -282,7 +281,7 @@ class PandasCSVGlobParser(PandasCSVParser):
         for fname, start, end in chunks:
             if start is not None and end is not None:
                 # pop "compression" from kwargs because bio is uncompressed
-                with File(fname, "rb", kwargs.pop("compression", "infer")) as bio:
+                with OpenFile(fname, "rb", kwargs.pop("compression", "infer")) as bio:
                     if kwargs.get("encoding", None) is not None:
                         header = b"" + bio.readline()
                     else:
@@ -346,7 +345,7 @@ class PandasFWFParser(PandasParser):
         index_col = kwargs.get("index_col", None)
         if start is not None and end is not None:
             # pop "compression" from kwargs because bio is uncompressed
-            with File(fname, "rb", kwargs.pop("compression", "infer")) as bio:
+            with OpenFile(fname, "rb", kwargs.pop("compression", "infer")) as bio:
                 if kwargs.get("encoding", None) is not None:
                     header = b"" + bio.readline()
                 else:
@@ -581,7 +580,7 @@ class PandasJSONParser(PandasParser):
         end = kwargs.pop("end", None)
         if start is not None and end is not None:
             # pop "compression" from kwargs because bio is uncompressed
-            with File(fname, "rb", kwargs.pop("compression", "infer")) as bio:
+            with OpenFile(fname, "rb", kwargs.pop("compression", "infer")) as bio:
                 bio.seek(start)
                 to_read = b"" + bio.read(end - start)
             columns = kwargs.pop("columns")


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

- ✅  commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- ✅  passes `flake8 modin`
- ✅  passes `black --check modin`
- ✅  signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- ✅  Resolves #3528 
- ❌  no tests added for this refactoring.
- ✅  module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
