### PR TITLE
FIX-#3541: add fsspec to modin dependencies

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -8,6 +8,7 @@ dependencies:
   - libthrift<0.14.1  # ref: modin gh-2840
   - dask[complete]>=2.22.0
   - distributed>=2.22.0
+  - fsspec
   - xarray
   - Jinja2
   - pathlib

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,6 +5,7 @@ dask[complete]>=2.22.0
 distributed>=2.22.0
 ray[default]>=1.4.0
 psutil==5.6.6
+fsspec
 xarray
 Jinja2
 pathlib

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -6,6 +6,7 @@ dependencies:
   - pyarrow==3.0.0
   - libthrift
   - numpy>=1.16.5
+  - fsspec
   - pip
   - pytest>=6.0.1
   - pytest-cov>=2.10.1

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -4,6 +4,7 @@ dependencies:
   - pandas==1.3.3
   - numpy>=1.16.5
   - pyarrow>=1.0.0
+  - fsspec
   - xarray
   - Jinja2
   - pathlib

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ setup(
     url="https://github.com/modin-project/modin",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    install_requires=["pandas==1.3.3", "packaging", "numpy>=1.16.5"],
+    install_requires=["pandas==1.3.3", "packaging", "numpy>=1.16.5", "fsspec"],
     extras_require={
         # can be installed by pip install modin[dask]
         "dask": dask_deps,


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

`fsspec` is needed for almost all IO functions (including `read_csv`) so it should be considered as required dependency(after #3529) and added into `setup.py` and env `.yml` files.
<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3541 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
