### PR TITLE
FIX-#2301: Add support of `storage_options` in `read_*`

### DIFF
--- a/modin/core/io/column_stores/feather_dispatcher.py
+++ b/modin/core/io/column_stores/feather_dispatcher.py
@@ -17,6 +17,7 @@ from modin.core.io.column_stores.column_store_dispatcher import (
     ColumnStoreDispatcher,
 )
 from modin.utils import import_optional_dependency
+from modin.core.io.file_dispatcher import OpenFile
 
 
 class FeatherDispatcher(ColumnStoreDispatcher):
@@ -60,7 +61,11 @@ class FeatherDispatcher(ColumnStoreDispatcher):
             )
             from pyarrow.feather import read_feather
 
-            df = read_feather(path)
+            with OpenFile(
+                path,
+                **(kwargs.get("storage_options", None) or {}),
+            ) as file:
+                df = read_feather(file)
             # pyarrow.feather.read_feather doesn't support columns as pandas.Index
             columns = list(df.columns)
         return cls.build_query_compiler(path, columns, use_threads=False)

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -81,7 +81,10 @@ class OpenFile:
         try:
             from botocore.exceptions import NoCredentialsError
 
-            credential_error_type = (NoCredentialsError,)
+            credential_error_type = (
+                NoCredentialsError,
+                PermissionError,
+            )
         except ModuleNotFoundError:
             credential_error_type = ()
 
@@ -91,7 +94,8 @@ class OpenFile:
         try:
             return self.file.open()
         except credential_error_type:
-            self.file = fsspec.open(*args, anon=True)
+            self.kwargs["anon"] = True
+            self.file = fsspec.open(*args, **self.kwargs)
         return self.file.open()
 
     def __exit__(self, *args):

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -46,6 +46,8 @@ class OpenFile:
         String, which defines which mode file should be open.
     compression : str, default: "infer"
         File compression name.
+    **kwargs : dict
+        Keywords arguments to be passed into ``fsspec.open`` function.
 
     Attributes
     ----------
@@ -57,12 +59,15 @@ class OpenFile:
         File compression name.
     file : fsspec.core.OpenFile
         The opened file.
+    kwargs : dict
+        Keywords arguments to be passed into ``fsspec.open`` function.
     """
 
-    def __init__(self, file_path, mode="rb", compression="infer"):
+    def __init__(self, file_path, mode="rb", compression="infer", **kwargs):
         self.file_path = file_path
         self.mode = mode
         self.compression = compression
+        self.kwargs = kwargs
 
     def __enter__(self):
         """
@@ -82,7 +87,7 @@ class OpenFile:
 
         args = (self.file_path, self.mode, self.compression)
 
-        self.file = fsspec.open(*args, anon=False)
+        self.file = fsspec.open(*args, **self.kwargs)
         try:
             return self.file.open()
         except credential_error_type:

--- a/modin/core/io/text/csv_dispatcher.py
+++ b/modin/core/io/text/csv_dispatcher.py
@@ -131,7 +131,12 @@ class CSVDispatcher(TextFileDispatcher):
             compression=compression_infered,
         )
 
-        with OpenFile(filepath_or_buffer_md, "rb", compression_infered) as f:
+        with OpenFile(
+            filepath_or_buffer_md,
+            "rb",
+            compression_infered,
+            **(kwargs.get("storage_options") or {}),
+        ) as f:
             old_pos = f.tell()
             fio = io.TextIOWrapper(f, encoding=encoding, newline="")
             newline, quotechar = cls.compute_newline(

--- a/modin/core/io/text/csv_dispatcher.py
+++ b/modin/core/io/text/csv_dispatcher.py
@@ -135,7 +135,6 @@ class CSVDispatcher(TextFileDispatcher):
             filepath_or_buffer_md,
             "rb",
             compression_infered,
-            **(kwargs.get("storage_options") or {}),
         ) as f:
             old_pos = f.tell()
             fio = io.TextIOWrapper(f, encoding=encoding, newline="")

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -370,7 +370,12 @@ class PandasFWFParser(PandasParser):
         index_col = kwargs.get("index_col", None)
         if start is not None and end is not None:
             # pop "compression" from kwargs because bio is uncompressed
-            with OpenFile(fname, "rb", kwargs.pop("compression", "infer")) as bio:
+            with OpenFile(
+                fname,
+                "rb",
+                kwargs.pop("compression", "infer"),
+                **(kwargs.pop("storage_options", None) or {}),
+            ) as bio:
                 if kwargs.get("encoding", None) is not None:
                     header = b"" + bio.readline()
                 else:

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -687,7 +687,12 @@ class PandasFeatherParser(PandasParser):
         num_splits = kwargs.pop("num_splits", None)
         if num_splits is None:
             return pandas.read_feather(fname, **kwargs)
-        df = feather.read_feather(fname, **kwargs)
+
+        with OpenFile(
+            fname,
+            **(kwargs.pop("storage_options", None) or {}),
+        ) as file:
+            df = feather.read_feather(file, **kwargs)
         # Append the length of the index here to build it externally
         return _split_result_for_readers(0, num_splits, df) + [len(df.index), df.dtypes]
 

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -235,8 +235,14 @@ class PandasCSVParser(PandasParser):
         encoding = kwargs.get("encoding", None)
         if start is not None and end is not None:
             # pop "compression" from kwargs because bio is uncompressed
-            with OpenFile(fname, "rb", kwargs.pop("compression", "infer")) as bio:
-                # In this case we beware that first line can contain BOM, so
+            with OpenFile(
+                fname,
+                "rb",
+                kwargs.pop("compression", "infer"),
+                **(kwargs.pop("storage_options", None) or {}),
+            ) as bio:
+                header = b""
+                # In this case we beware that fisrt line can contain BOM, so
                 # adding this line to the `header` for reading and then skip it
                 header = b""
                 if encoding and (

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -610,7 +610,12 @@ class PandasJSONParser(PandasParser):
         end = kwargs.pop("end", None)
         if start is not None and end is not None:
             # pop "compression" from kwargs because bio is uncompressed
-            with OpenFile(fname, "rb", kwargs.pop("compression", "infer")) as bio:
+            with OpenFile(
+                fname,
+                "rb",
+                kwargs.pop("compression", "infer"),
+                **(kwargs.pop("storage_options", None) or {}),
+            ) as bio:
                 bio.seek(start)
                 to_read = b"" + bio.read(end - start)
             columns = kwargs.pop("columns")

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -869,13 +869,16 @@ class TestCsv:
             encoding_errors=encoding_errors,
         )
 
-    @pytest.mark.parametrize("is_use_storage_options", [True, False])
-    def test_read_csv_s3(self, is_use_storage_options):
+    @pytest.mark.parametrize(
+        "storage_options",
+        [{"anon": False}, {"anon": True}, {"key": "123", "secret": "123"}, None],
+    )
+    def test_read_csv_s3(self, storage_options):
         eval_io(
             fn_name="read_csv",
             # read_csv kwargs
             filepath_or_buffer="s3://noaa-ghcn-pds/csv/1788.csv",
-            storage_options={"anon": True} if is_use_storage_options else None,
+            storage_options=storage_options,
         )
 
     @pytest.mark.parametrize("names", [list("XYZ"), None])
@@ -1270,7 +1273,7 @@ class TestParquet:
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
     )
     def test_read_parquet_s3(self, path_type):
-        dataset_url = "s3://aws-roda-hcls-datalake/chembl_27/chembl_27_public_tissue_dictionary/part-00000-66508102-96fa-4fd9-a0fd-5bc072a74293-c000.snappy.parquet"
+        dataset_url = "s3://modin-datasets/testing/test_data.parquet"
         if path_type == "object":
             import s3fs
 
@@ -1354,14 +1357,17 @@ class TestJson:
             lines=lines,
         )
 
-    @pytest.mark.parametrize("is_use_storage_options", [True, False])
-    def test_read_json_s3(self, is_use_storage_options):
+    @pytest.mark.parametrize(
+        "storage_options",
+        [{"anon": False}, {"anon": True}, {"key": "123", "secret": "123"}, None],
+    )
+    def test_read_json_s3(self, storage_options):
         eval_io(
             fn_name="read_json",
             path_or_buf="s3://modin-datasets/testing/test_data.json",
             lines=True,
             orient="records",
-            storage_options={"anon": True} if is_use_storage_options else None,
+            storage_options=storage_options,
         )
 
     def test_read_json_categories(self):
@@ -1961,12 +1967,15 @@ class TestFwf:
 
         df_equals(modin_df, pandas_df)
 
-    @pytest.mark.parametrize("is_use_storage_options", [True, False])
-    def test_read_fwf_s3(self, is_use_storage_options):
+    @pytest.mark.parametrize(
+        "storage_options",
+        [{"anon": False}, {"anon": True}, {"key": "123", "secret": "123"}, None],
+    )
+    def test_read_fwf_s3(self, storage_options):
         eval_io(
             fn_name="read_fwf",
             filepath_or_buffer="s3://modin-datasets/testing/test_data.fwf",
-            storage_options={"anon": True} if is_use_storage_options else None,
+            storage_options=storage_options,
         )
 
 
@@ -2020,12 +2029,15 @@ class TestFeather:
         condition="config.getoption('--simulate-cloud').lower() != 'off'",
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
     )
-    @pytest.mark.parametrize("is_use_storage_options", [True, False])
-    def test_read_feather_s3(self, is_use_storage_options):
+    @pytest.mark.parametrize(
+        "storage_options",
+        [{"anon": False}, {"anon": True}, {"key": "123", "secret": "123"}, None],
+    )
+    def test_read_feather_s3(self, storage_options):
         eval_io(
             fn_name="read_feather",
             path="s3://modin-datasets/testing/test_data.feather",
-            storage_options={"anon": True} if is_use_storage_options else None,
+            storage_options=storage_options,
         )
 
     @pytest.mark.xfail(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1951,6 +1951,14 @@ class TestFwf:
 
         df_equals(modin_df, pandas_df)
 
+    @pytest.mark.parametrize("is_use_storage_options", [True, False])
+    def test_read_fwf_s3(self, is_use_storage_options):
+        eval_io(
+            fn_name="read_fwf",
+            filepath_or_buffer="s3://modin-datasets/testing/test_data.fwf",
+            storage_options={"anon": True} if is_use_storage_options else None,
+        )
+
 
 class TestGbq:
     @pytest.mark.xfail(reason="Need to verify GBQ access")

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1354,6 +1354,16 @@ class TestJson:
             lines=lines,
         )
 
+    @pytest.mark.parametrize("is_use_storage_options", [True, False])
+    def test_read_json_s3(self, is_use_storage_options):
+        eval_io(
+            fn_name="read_json",
+            path_or_buf="s3://modin-datasets/testing/test_data.json",
+            lines=True,
+            orient="records",
+            storage_options={"anon": True} if is_use_storage_options else None,
+        )
+
     def test_read_json_categories(self):
         eval_io(
             fn_name="read_json",

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -2016,6 +2016,14 @@ class TestFeather:
             path=make_feather_file(),
         )
 
+    @pytest.mark.parametrize("is_use_storage_options", [True, False])
+    def test_read_feather_s3(self, is_use_storage_options):
+        eval_io(
+            fn_name="read_feather",
+            path="s3://modin-datasets/testing/test_data.feather",
+            storage_options={"anon": True} if is_use_storage_options else None,
+        )
+
     @pytest.mark.xfail(
         condition="config.getoption('--simulate-cloud').lower() != 'off'",
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -2016,6 +2016,10 @@ class TestFeather:
             path=make_feather_file(),
         )
 
+    @pytest.mark.xfail(
+        condition="config.getoption('--simulate-cloud').lower() != 'off'",
+        reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
+    )
     @pytest.mark.parametrize("is_use_storage_options", [True, False])
     def test_read_feather_s3(self, is_use_storage_options):
         eval_io(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -869,11 +869,13 @@ class TestCsv:
             encoding_errors=encoding_errors,
         )
 
-    def test_read_csv_s3(self):
+    @pytest.mark.parametrize("is_use_storage_options", [True, False])
+    def test_read_csv_s3(self, is_use_storage_options):
         eval_io(
             fn_name="read_csv",
             # read_csv kwargs
             filepath_or_buffer="s3://noaa-ghcn-pds/csv/1788.csv",
+            storage_options={"anon": True} if is_use_storage_options else None,
         )
 
     @pytest.mark.parametrize("names", [list("XYZ"), None])


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

PR adds support of `storage_options` parameter for (`read*` functions which have distributed implementation):

- `read_csv`
- `read_fwf`
- `read_json`
- `read_feather`

Support of `storage_options` for `read_excel` will be added in a separate PR #3565.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2301? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
