### PR TITLE
FIX-#3559: remove support of 'S3://...' like paths

### DIFF
--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -24,7 +24,7 @@ import re
 from modin.config import Backend
 import numpy as np
 
-S3_ADDRESS_REGEX = re.compile("[sS]3://(.*?)/(.*)")
+S3_ADDRESS_REGEX = re.compile("s3://(.*?)/(.*)")
 NOT_IMPLEMENTED_MESSAGE = "Implement in children classes!"
 
 
@@ -240,8 +240,6 @@ class FileDispatcher:
         if isinstance(file_path, str):
             match = S3_ADDRESS_REGEX.search(file_path)
             if match is not None:
-                if file_path[0] == "S":
-                    file_path = "{}{}".format("s", file_path[1:])
                 import s3fs as S3FS
                 from botocore.exceptions import NoCredentialsError
 

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -285,8 +285,6 @@ class CSVGlobDispatcher(CSVDispatcher):
         if isinstance(file_path, str):
             match = S3_ADDRESS_REGEX.search(file_path)
             if match is not None:
-                if file_path[0] == "S":
-                    file_path = "{}{}".format("s", file_path[1:])
                 import s3fs as S3FS
                 from botocore.exceptions import NoCredentialsError
 
@@ -316,10 +314,6 @@ class CSVGlobDispatcher(CSVDispatcher):
             List of strings of absolute file paths.
         """
         if S3_ADDRESS_REGEX.search(file_path):
-            # S3FS does not allow captial S in s3 addresses.
-            if file_path[0] == "S":
-                file_path = "{}{}".format("s", file_path[1:])
-
             import s3fs as S3FS
             from botocore.exceptions import NoCredentialsError
 

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -116,7 +116,7 @@ class TestCsvGlob:
     Engine.get() != "Ray", reason="Currently only support Ray engine for glob paths."
 )
 def test_read_multiple_csv_s3():
-    modin_df = pd.read_csv_glob("S3://noaa-ghcn-pds/csv/178*.csv")
+    modin_df = pd.read_csv_glob("s3://noaa-ghcn-pds/csv/178*.csv")
 
     # We have to specify the columns because the column names are not identical. Since we specified the column names, we also have to skip the original column names.
     pandas_dfs = [


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3559 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
