### PR TITLE
FIX-#3551: fix hanging behaviour for to_csv

### DIFF
--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -17,6 +17,9 @@ import os
 import sys
 import psutil
 import warnings
+import asyncio
+
+import ray
 
 from modin.config import (
     StorageFormat,
@@ -107,8 +110,6 @@ def initialize_ray(
         What password to use when connecting to Redis.
         If not specified, ``modin.config.RayRedisPassword`` is used.
     """
-    import ray
-
     if not ray.is_initialized() or override_is_cluster:
         cluster = override_is_cluster or IsRayCluster.get()
         redis_address = override_redis_address or RayRedisAddress.get()
@@ -196,3 +197,54 @@ def initialize_ray(
         NPartitions._put(num_gpus)
     else:
         NPartitions._put(num_cpus)
+
+
+@ray.remote
+class SignalActor:  # pragma: no cover
+    """
+    Help synchronize across tasks and actors on cluster.
+
+    For details see: https://docs.ray.io/en/latest/advanced.html?highlight=signalactor#multi-node-synchronization-using-an-actor
+
+    Parameters
+    ----------
+    event_count : int
+        Number of events required for synchronization.
+    """
+
+    def __init__(self, event_count: int):
+        self.events = [asyncio.Event() for _ in range(event_count)]
+
+    def send(self, event_idx: int):
+        """
+        Indicate that event with `event_idx` has occured.
+
+        Parameters
+        ----------
+        event_idx : int
+        """
+        self.events[event_idx].set()
+
+    async def wait(self, event_idx: int):
+        """
+        Wait until event with `event_idx` has occured.
+
+        Parameters
+        ----------
+        event_idx : int
+        """
+        await self.events[event_idx].wait()
+
+    def is_set(self, event_idx: int) -> bool:
+        """
+        Check that event with `event_idx` had occured or not.
+
+        Parameters
+        ----------
+        event_idx : int
+
+        Returns
+        -------
+        bool
+        """
+        return self.events[event_idx].is_set()

--- a/modin/core/execution/ray/generic/io/io.py
+++ b/modin/core/execution/ray/generic/io/io.py
@@ -13,13 +13,13 @@
 
 """The module holds base class implementing required I/O over Ray."""
 
+import asyncio
 import io
 import os
 import pandas
 
 from modin.core.io import BaseIO
-from ray.util.queue import Queue
-from ray import get
+import ray
 
 
 class RayIO(BaseIO):
@@ -118,9 +118,23 @@ class RayIO(BaseIO):
         if not cls._to_csv_check_support(kwargs):
             return BaseIO.to_csv(qc, **kwargs)
 
-        # The partition id will be added to the queue, for which the moment
-        # of writing to the file has come
-        queue = Queue(maxsize=1)
+        @ray.remote(num_cpus=0)
+        class SignalActor:
+            def __init__(self, event_count):
+                self.events = [asyncio.Event() for _ in range(event_count)]
+
+            def send(self, event_idx):
+                self.events[event_idx].set()
+
+            async def wait(self, event_idx, should_wait=True):
+                if should_wait:
+                    await self.events[event_idx].wait()
+
+            def is_set(self, event_idx):
+                return self.events[event_idx].is_set()
+
+        signal_count = len(qc._modin_frame._partitions)
+        signals = SignalActor.remote(signal_count + 1)
 
         def func(df, **kw):
             """
@@ -134,61 +148,52 @@ class RayIO(BaseIO):
                 Arguments to pass to ``pandas.to_csv(**kw)`` plus an extra argument
                 `partition_idx` serving as chunk index to maintain rows order.
             """
-            try:
-                new_kwargs = kwargs.copy()
-                if kw["partition_idx"] != 0:
-                    # we need to create a new file only for first recording
-                    # all the rest should be recorded in appending mode
-                    if "w" in new_kwargs["mode"]:
-                        new_kwargs["mode"] = new_kwargs["mode"].replace("w", "a")
-                    # It is enough to write the header for the first partition
-                    new_kwargs["header"] = False
+            idx = kw["partition_idx"]
+            _kwargs = kwargs.copy()
+            if idx != 0:
+                # we need to create a new file only for first recording
+                # all the rest should be recorded in appending mode
+                if "w" in _kwargs["mode"]:
+                    _kwargs["mode"] = _kwargs["mode"].replace("w", "a")
+                # It is enough to write the header for the first partition
+                _kwargs["header"] = False
 
-                # for parallelization purposes, each partition is written to an intermediate buffer
-                path_or_buf = new_kwargs["path_or_buf"]
-                is_binary = "b" in new_kwargs["mode"]
-                if is_binary:
-                    new_kwargs["path_or_buf"] = io.BytesIO()
-                else:
-                    new_kwargs["path_or_buf"] = io.StringIO()
-                df.to_csv(**new_kwargs)
-                content = new_kwargs["path_or_buf"].getvalue()
-                new_kwargs["path_or_buf"].close()
+            # for parallelization purposes, each partition is written to an intermediate buffer
+            path_or_buf = _kwargs["path_or_buf"]
+            is_binary = "b" in _kwargs["mode"]
+            if is_binary:
+                _kwargs["path_or_buf"] = io.BytesIO()
+            else:
+                _kwargs["path_or_buf"] = io.StringIO()
+            df.to_csv(**_kwargs)
+            content = _kwargs["path_or_buf"].getvalue()
+            _kwargs["path_or_buf"].close()
 
-                # each process waits for its turn to write to a file;
-                # in case of violation of the order of receiving messages from the queue,
-                # the message is placed back
-                while True:
-                    get_value = queue.get(block=True)
-                    if get_value == kw["partition_idx"]:
-                        break
-                    queue.put(get_value)
+            # each process waits for its turn to write to a file
+            ray.get(signals.wait.remote(idx))
 
-                # preparing to write data from the buffer to a file
-                with pandas.io.common.get_handle(
-                    path_or_buf,
-                    # in case when using URL in implicit text mode
-                    # pandas try to open `path_or_buf` in binary mode
-                    new_kwargs["mode"] if is_binary else new_kwargs["mode"] + "t",
-                    encoding=new_kwargs["encoding"],
-                    errors=new_kwargs["errors"],
-                    compression=new_kwargs["compression"],
-                    storage_options=new_kwargs["storage_options"],
-                    is_text=False,
-                ) as handles:
-                    handles.handle.write(content)
+            # preparing to write data from the buffer to a file
+            with pandas.io.common.get_handle(
+                path_or_buf,
+                # in case when using URL in implicit text mode
+                # pandas try to open `path_or_buf` in binary mode
+                _kwargs["mode"] if is_binary else _kwargs["mode"] + "t",
+                encoding=_kwargs["encoding"],
+                errors=_kwargs["errors"],
+                compression=_kwargs["compression"],
+                storage_options=_kwargs["storage_options"],
+                is_text=False,
+            ) as handles:
+                handles.handle.write(content)
 
-                # signal that the next process can start writing to the file
-                queue.put(get_value + 1)
-
-            except Exception as e:
-                queue.shutdown(force=True)
-                raise e
-
+            # signal that the next process can start writing to the file
+            ray.get(signals.send.remote(idx + 1))
             # used for synchronization purposes
             return pandas.DataFrame()
 
-        result = qc._modin_frame._partition_mgr_cls.map_axis_partitions(
+        # signaling that the partition with id==0 can be written to the file
+        ray.get(signals.send.remote(0))
+        _ = qc._modin_frame._partition_mgr_cls.map_axis_partitions(
             axis=1,
             partitions=qc._modin_frame._partitions,
             map_func=func,
@@ -197,8 +202,6 @@ class RayIO(BaseIO):
             enumerate_partitions=True,
             max_retries=0,
         )
-        # signaling that the partition with id==0 can be written to the file
-        queue.put(0)
         # pending completion
         get([partition.oid for partition in result.flatten()])
 

--- a/modin/core/execution/ray/generic/io/io.py
+++ b/modin/core/execution/ray/generic/io/io.py
@@ -188,8 +188,6 @@ class RayIO(BaseIO):
             # used for synchronization purposes
             return pandas.DataFrame()
 
-        # signaling that the partition with id==0 can be written to the file
-        queue.put(0)
         result = qc._modin_frame._partition_mgr_cls.map_axis_partitions(
             axis=1,
             partitions=qc._modin_frame._partitions,
@@ -199,7 +197,8 @@ class RayIO(BaseIO):
             enumerate_partitions=True,
             max_retries=0,
         )
-
+        # signaling that the partition with id==0 can be written to the file
+        queue.put(0)
         # pending completion
         get([partition.oid for partition in result.flatten()])
 

--- a/modin/core/execution/ray/generic/io/io.py
+++ b/modin/core/execution/ray/generic/io/io.py
@@ -276,4 +276,4 @@ class RayIO(BaseIO):
             lengths=None,
             enumerate_partitions=True,
         )
-        get([partition.oid for partition in result.flatten()])
+        ray.get([part.oid for row in result for part in row])

--- a/modin/core/execution/ray/generic/io/io.py
+++ b/modin/core/execution/ray/generic/io/io.py
@@ -134,50 +134,56 @@ class RayIO(BaseIO):
                 Arguments to pass to ``pandas.to_csv(**kw)`` plus an extra argument
                 `partition_idx` serving as chunk index to maintain rows order.
             """
-            if kw["partition_idx"] != 0:
-                # we need to create a new file only for first recording
-                # all the rest should be recorded in appending mode
-                if "w" in kwargs["mode"]:
-                    kwargs["mode"] = kwargs["mode"].replace("w", "a")
-                # It is enough to write the header for the first partition
-                kwargs["header"] = False
+            try:
+                new_kwargs = kwargs.copy()
+                if kw["partition_idx"] != 0:
+                    # we need to create a new file only for first recording
+                    # all the rest should be recorded in appending mode
+                    if "w" in new_kwargs["mode"]:
+                        new_kwargs["mode"] = new_kwargs["mode"].replace("w", "a")
+                    # It is enough to write the header for the first partition
+                    new_kwargs["header"] = False
 
-            # for parallelization purposes, each partition is written to an intermediate buffer
-            path_or_buf = kwargs["path_or_buf"]
-            is_binary = "b" in kwargs["mode"]
-            if is_binary:
-                kwargs["path_or_buf"] = io.BytesIO()
-            else:
-                kwargs["path_or_buf"] = io.StringIO()
-            df.to_csv(**kwargs)
-            content = kwargs["path_or_buf"].getvalue()
-            kwargs["path_or_buf"].close()
+                # for parallelization purposes, each partition is written to an intermediate buffer
+                path_or_buf = new_kwargs["path_or_buf"]
+                is_binary = "b" in new_kwargs["mode"]
+                if is_binary:
+                    new_kwargs["path_or_buf"] = io.BytesIO()
+                else:
+                    new_kwargs["path_or_buf"] = io.StringIO()
+                df.to_csv(**new_kwargs)
+                content = new_kwargs["path_or_buf"].getvalue()
+                new_kwargs["path_or_buf"].close()
 
-            # each process waits for its turn to write to a file;
-            # in case of violation of the order of receiving messages from the queue,
-            # the message is placed back
-            while True:
-                get_value = queue.get(block=True)
-                if get_value == kw["partition_idx"]:
-                    break
-                queue.put(get_value)
+                # each process waits for its turn to write to a file;
+                # in case of violation of the order of receiving messages from the queue,
+                # the message is placed back
+                while True:
+                    get_value = queue.get(block=True)
+                    if get_value == kw["partition_idx"]:
+                        break
+                    queue.put(get_value)
 
-            # preparing to write data from the buffer to a file
-            with pandas.io.common.get_handle(
-                path_or_buf,
-                # in case when using URL in implicit text mode
-                # pandas try to open `path_or_buf` in binary mode
-                kwargs["mode"] if is_binary else kwargs["mode"] + "t",
-                encoding=kwargs["encoding"],
-                errors=kwargs["errors"],
-                compression=kwargs["compression"],
-                storage_options=kwargs["storage_options"],
-                is_text=False,
-            ) as handles:
-                handles.handle.write(content)
+                # preparing to write data from the buffer to a file
+                with pandas.io.common.get_handle(
+                    path_or_buf,
+                    # in case when using URL in implicit text mode
+                    # pandas try to open `path_or_buf` in binary mode
+                    new_kwargs["mode"] if is_binary else new_kwargs["mode"] + "t",
+                    encoding=new_kwargs["encoding"],
+                    errors=new_kwargs["errors"],
+                    compression=new_kwargs["compression"],
+                    storage_options=new_kwargs["storage_options"],
+                    is_text=False,
+                ) as handles:
+                    handles.handle.write(content)
 
-            # signal that the next process can start writing to the file
-            queue.put(get_value + 1)
+                # signal that the next process can start writing to the file
+                queue.put(get_value + 1)
+
+            except Exception as e:
+                queue.shutdown(force=True)
+                raise e
 
             # used for synchronization purposes
             return pandas.DataFrame()

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -155,12 +155,16 @@ def eval_to_file(modin_obj, pandas_obj, fn, extension, **fn_kwargs):
         # parameter `max_retries=0` is set for `to_csv` function on Ray engine,
         # in order to increase the stability of tests, we repeat the call of
         # the entire function manually
+        last_exception = None
         for _ in range(3):
             try:
                 getattr(modin_obj, fn)(unique_filename_modin, **fn_kwargs)
-            except EXCEPTIONS:
+            except EXCEPTIONS as exc:
+                last_exception = exc
                 continue
             break
+        else:
+            raise last_exception
 
         getattr(pandas_obj, fn)(unique_filename_pandas, **fn_kwargs)
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -152,10 +152,15 @@ def eval_to_file(modin_obj, pandas_obj, fn, extension, **fn_kwargs):
     unique_filename_pandas = get_unique_filename(extension=extension)
 
     try:
-        try:
-            getattr(modin_obj, fn)(unique_filename_modin, **fn_kwargs)
-        except EXCEPTIONS:
-            getattr(modin_obj, fn)(unique_filename_modin, **fn_kwargs)
+        # parameter `max_retries=0` is set for `to_csv` function on Ray engine,
+        # in order to increase the stability of tests, we repeat the call of
+        # the entire function manually
+        for _ in range(3):
+            try:
+                getattr(modin_obj, fn)(unique_filename_modin, **fn_kwargs)
+            except EXCEPTIONS:
+                continue
+            break
 
         getattr(pandas_obj, fn)(unique_filename_pandas, **fn_kwargs)
 


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
If an exception occurs in one of the tasks, we must complete the rest, which are waiting for messages from `Queue` (communication channel). When using `get` function, this is done automatically.

Another reason for the hang could be the implementation of communication between tasks using one queue. Situations could arise when the same task put and took a message from the queue many times in a row, preventing other tasks from taking the message. To avoid this situation, I propose to use its own communication channel for each task (a separate events).

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin`
- [ ] passes `black --check modin`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3551 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

**Performance**:

Version| Master| PR
-|-|-
Pandas| 40,5 sec| 40,5 sec
Modin - 4 cores| 12,4 sec| 12,7 sec
Modin - 8 cores| 7,0 sec| 7,1 sec
Modin - 16 cores| 4,6 sec| 4,5 sec


<details><summary>Benchmark</summary>

```python
from time import time
import os
import numpy as np
import modin.pandas as pd
#import pandas as pd

df = pd.DataFrame(np.random.randint(10**6, size=(375 * 10**4, 32)))

filename = "test_to_csv.csv"
for i in range(5):
    start = time()
    df.to_csv(filename)
    print(f"TO_CSV TIME: {time()-start}")
    os.remove(filename)
```

</details>