### PR TITLE
FIX-#3576: limit OmniSci version to <=5.7.1

### DIFF
--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -13,7 +13,7 @@ dependencies:
   - pytest-xdist>=2.1.0
   - coverage<5.0
   - pygithub==1.53
-  - pyomniscidbe
+  - pyomniscidbe<=5.7.1 # modin-project/modin#3574
   - s3fs>=0.4.2
   - psutil
   - openpyxl


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3576 <!-- issue must be created for each patch -->
- [x] tests <s>added and</s> passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
