### PR TITLE
DOCS-#3584: Make flake8 and black directories match CI.

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -133,14 +133,14 @@ that you run the following from the project root:
 
 .. code-block:: bash
 
-  black modin/
+  black modin/ asv_bench/benchmarks scripts/doc_checker.py
 
 We also use flake8_ to check linting errors. Running the following from the project root
 will ensure that it passes the lint checks on Github Actions:
 
 .. code-block:: bash
 
-  flake8 .
+  flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py
 
 We test that this has been run on our `Github Actions`_ test suite. If you do this and find
 that the tests are still failing, try updating your version of black and flake8.


### PR DESCRIPTION

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

The Continuous Integration (CI) for Modin runs flake8 and black on some directories that are not in the commands [here](https://github.com/modin-project/modin/blob/master/docs/contributing.rst#code-formatting-and-lint).

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin`
- [x] passes `black --check modin`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3584
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
