### PR TITLE
DOCS-#3617: Fix typos in `modin.core.io.text.csv_dispatcher`

### DIFF
--- a/modin/core/io/text/csv_dispatcher.py
+++ b/modin/core/io/text/csv_dispatcher.py
@@ -420,11 +420,11 @@ class CSVDispatcher(TextFileDispatcher):
         to `skiprows`=[1,2,3]. Now, to avoid this discrepancy, we need to assign
         the first partition to read data between header line and the first
         row for skipping by setting of `pre_reading` parameter, so setting
-        `pre_reading`=2. During data file partitiong, these lines will be assigned
+        `pre_reading`=2. During data file partitioning, these lines will be assigned
         for reading for the first partition, and then file position will be set at
         the beginning of rows that should be skipped by `skiprows_partitioning`.
         After skipping of these rows, the rest data will be divided between the
-        rest of partitions, see rows assignement below:
+        rest of partitions, see rows assignment below:
 
         0 - header line (skip during partitioning)
         1 - pre_reading (assign to read by the first partition)


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3617  <!-- issue must be created for each patch -->
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
