### PR TITLE
DOCS: Engines - capitlization consistency

### DIFF
--- a/docs/UsingPandasonDask/index.rst
+++ b/docs/UsingPandasonDask/index.rst
@@ -1,4 +1,4 @@
-Pandas on Dask
+pandas on Dask
 ==============
 
 The Dask engine and documentation could use your help! Consider opening a


### PR DESCRIPTION
Signed-off-by: Marcel <marcelc@nedbank.co.za>

pandas is written as both capitlized and smallcaps. Converting to
smallcaps where this is spotted in rst files.