### PR TITLE
FIX-#3574: use floor for float to int cast.

### DIFF
--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/expr.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/expr.py
@@ -219,6 +219,11 @@ class BaseExpr(abc.ABC):
         BaseExpr
             The cast expression.
         """
+        # From float to int cast we expect truncate behavior but CAST
+        # operation would give us round behavior.
+        if is_float_dtype(self._dtype) and is_integer_dtype(res_type):
+            return self.floor()
+
         new_expr = OpExpr("CAST", [self], res_type)
         return new_expr
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
With OmniSci 5.8.0 we have to use FLOOR instead of CAST for float to int conversion to ensure truncate semantics.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3574 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
