### PR TITLE
FIX-#3533: Drop OmniSci table on partition deallocation.

### DIFF
--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition.py
@@ -16,6 +16,9 @@
 import pandas
 
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
+from ..omnisci_worker import (
+    OmnisciServer,
+)
 import pyarrow
 
 
@@ -62,6 +65,12 @@ class OmnisciOnNativeDataframePartition(PandasDataframePartition):
         self.arrow_table = arrow_table
         self._length_cache = length
         self._width_cache = width
+        self._server = OmnisciServer
+
+    def __del__(self):
+        """Deallocate OmniSci resources related to the partition."""
+        if self.frame_id is not None:
+            self._server.executeDDL(f"DROP TABLE {self.frame_id};")
 
     def to_pandas(self):
         """


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Execute `DROP TABLE` for imported partitions on their deallocation.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3533 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
