### PR TITLE
FEAT-#3554: Add support for `set_index` with different input types

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1955,24 +1955,17 @@ class DataFrame(BasePandasDataset):
             isinstance(col, (pandas.Index, Series, np.ndarray, list, Iterator))
             for col in keys
         ):
-            # The current implementation cannot mix a list column labels and list like
-            # objects.
-            if not all(
-                isinstance(col, (pandas.Index, Series, np.ndarray, list, Iterator))
-                for col in keys
-            ):
-                return self._default_to_pandas(
-                    "set_index",
-                    keys,
-                    drop=drop,
-                    append=append,
-                    inplace=inplace,
-                    verify_integrity=verify_integrity,
-                )
             if inplace:
                 frame = self
             else:
                 frame = self.copy()
+            if not all(
+                isinstance(col, (pandas.Index, Series, np.ndarray, list, Iterator))
+                for col in keys
+            ):
+                if drop:
+                    keys = [frame.pop(k) if not is_list_like(k) else k for k in keys]
+                keys = [k._to_pandas() if isinstance(k, Series) else k for k in keys]
             # These are single-threaded objects, so we might as well let pandas do the
             # calculation so that it matches.
             frame.index = (

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -267,6 +267,16 @@ def test_indexing_duplicate_axis(data):
     )
 
 
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_set_index(data):
+    modin_df = pd.DataFrame(data)
+    pandas_df = pandas.DataFrame(data)
+    
+    modin_result = modin_df.set_index([modin_df.index, modin_df.columns[0]])
+    pandas_result = pandas_df.set_index([pandas_df.index, pandas_df.columns[0]])
+    df_equals(modin_result, pandas_result)
+
+
 @pytest.mark.gpu
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_keys(data):

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -271,7 +271,7 @@ def test_indexing_duplicate_axis(data):
 def test_set_index(data):
     modin_df = pd.DataFrame(data)
     pandas_df = pandas.DataFrame(data)
-    
+
     modin_result = modin_df.set_index([modin_df.index, modin_df.columns[0]])
     pandas_result = pandas_df.set_index([pandas_df.index, pandas_df.columns[0]])
     df_equals(modin_result, pandas_result)


### PR DESCRIPTION
Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3554 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
