### PR TITLE
FIX-#3648: Pin minimal s3fs which is not aiobotocore-broken

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   - pathlib
   - scipy
   - pip
-  - s3fs>=0.4.2
+  - s3fs>=2021.8
   - feather-format
   - lxml
   - openpyxl

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -11,7 +11,7 @@ Jinja2
 pathlib
 tables
 scipy
-s3fs>=0.4.2
+s3fs>=2021.8
 pytest
 pytest-benchmark
 coverage<5.0

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -14,7 +14,7 @@ dependencies:
   - coverage<5.0
   - pygithub==1.53
   - pyomniscidbe<=5.7.1 # modin-project/modin#3574
-  - s3fs>=0.4.2
+  - s3fs>=2021.8
   - psutil
   - openpyxl
   - xlrd

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -10,7 +10,7 @@ dependencies:
   - pathlib
   - scipy
   - pip
-  - s3fs>=0.4.2
+  - s3fs>=2021.8
   - feather-format
   - lxml
   - openpyxl


### PR DESCRIPTION
Ref: https://github.com/dask/s3fs/issues/514

Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3648
- [ ] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
