### PR TITLE
FIX-#3505: Throw custom errors for some missing packages.

### DIFF
--- a/modin/core/io/column_stores/feather_dispatcher.py
+++ b/modin/core/io/column_stores/feather_dispatcher.py
@@ -16,6 +16,7 @@
 from modin.core.io.column_stores.column_store_dispatcher import (
     ColumnStoreDispatcher,
 )
+from modin.utils import import_optional_dependency
 
 
 class FeatherDispatcher(ColumnStoreDispatcher):
@@ -54,6 +55,9 @@ class FeatherDispatcher(ColumnStoreDispatcher):
         """
         path = cls.get_path(path)
         if columns is None:
+            import_optional_dependency(
+                "pyarrow", "pyarrow is required to read feather files."
+            )
             from pyarrow.feather import read_feather
 
             df = read_feather(path)

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -19,6 +19,7 @@ from modin.core.io.column_stores.column_store_dispatcher import (
     ColumnStoreDispatcher,
 )
 from modin.error_message import ErrorMessage
+from modin.utils import import_optional_dependency
 
 
 class ParquetDispatcher(ColumnStoreDispatcher):
@@ -55,6 +56,10 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         ParquetFile API is used. Please refer to the documentation here
         https://arrow.apache.org/docs/python/parquet.html
         """
+        import_optional_dependency(
+            "pyarrow",
+            "pyarrow is required to read parquet files.",
+        )
         from pyarrow.parquet import ParquetDataset
         from modin.pandas.io import PQ_INDEX_REGEX
 

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -22,6 +22,7 @@ import fsspec
 import os
 import re
 from modin.config import StorageFormat
+from modin.utils import import_optional_dependency
 import numpy as np
 
 S3_ADDRESS_REGEX = re.compile("[sS]3://(.*?)/(.*)")
@@ -245,7 +246,9 @@ class FileDispatcher:
             if match is not None:
                 if file_path[0] == "S":
                     file_path = "{}{}".format("s", file_path[1:])
-                import s3fs as S3FS
+                S3FS = import_optional_dependency(
+                    "s3fs", "Module s3fs is required to read S3FS files."
+                )
                 from botocore.exceptions import NoCredentialsError
 
                 s3fs = S3FS.S3FileSystem(anon=False)

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -28,6 +28,7 @@ from modin.config import NPartitions
 from modin.core.io.file_dispatcher import OpenFile
 from modin.core.io.file_dispatcher import S3_ADDRESS_REGEX
 from modin.core.io.text.csv_dispatcher import CSVDispatcher
+from modin.utils import import_optional_dependency
 
 
 class CSVGlobDispatcher(CSVDispatcher):
@@ -287,7 +288,9 @@ class CSVGlobDispatcher(CSVDispatcher):
             if match is not None:
                 if file_path[0] == "S":
                     file_path = "{}{}".format("s", file_path[1:])
-                import s3fs as S3FS
+                S3FS = import_optional_dependency(
+                    "s3fs", "Module s3fs is required to read S3FS files."
+                )
                 from botocore.exceptions import NoCredentialsError
 
                 s3fs = S3FS.S3FileSystem(anon=False)
@@ -320,7 +323,9 @@ class CSVGlobDispatcher(CSVDispatcher):
             if file_path[0] == "S":
                 file_path = "{}{}".format("s", file_path[1:])
 
-            import s3fs as S3FS
+            S3FS = import_optional_dependency(
+                "s3fs", "Module s3fs is required to read S3FS files."
+            )
             from botocore.exceptions import NoCredentialsError
 
             def get_file_path(fs_handle) -> List[str]:

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -13,6 +13,7 @@
 
 """Collection of general utility functions, mostly for internal use."""
 
+import importlib
 import types
 import re
 
@@ -535,3 +536,28 @@ def instancer(_class):
         Instance of `_class`.
     """
     return _class()
+
+
+def import_optional_dependency(name, message):
+    """
+    Import an optional dependecy.
+
+    Parameters
+    ----------
+    name : str
+        The module name.
+    extra : str
+        Additional text to include in the ImportError message.
+
+    Returns
+    -------
+    module : ModuleType
+        The imported module.
+    """
+    try:
+        return importlib.import_module(name)
+    except ImportError:
+        raise ImportError(
+            f"Missing optional dependency '{name}'. {message} "
+            f"Use pip or conda to install {name}."
+        ) from None

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -546,7 +546,7 @@ def import_optional_dependency(name, message):
     ----------
     name : str
         The module name.
-    extra : str
+    message : str
         Additional text to include in the ImportError message.
 
     Returns


### PR DESCRIPTION
Make Modin throw custom errors when the optional s3fs and parquet modules are
missing, as Pandas would.

I tested this manually by uninstalling pyarrow and running `read_parquet` and
`read_feather`. I copied some of the common implementation from
[pandas.compat._optional.import_optional_dependency](https://github.com/pandas-dev/pandas/blob/a0660b2e3a0fbe872ff9a587af40d3633777107f/pandas/compat/_optional.py#L64).

Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

Make Modin throw custom errors when the optional s3fs and parquet modules are
missing, as Pandas would.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3652 
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
