### PR TITLE
FIX-#3616: Remove setup.py platform-specific logic to make distribution pure Python

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -58,7 +58,7 @@ Push the commit, make a PR _against `release-X.Y.Z`_ branch and, when it's merge
   * Push the tag to master: `git push upstream X.Y.Z`
     * If you're re-pushing a tag (beware! you shouldn't be doing that, no, _really_!), you can remove remote tag and push a local one by `git push upstream :refs/tags/X.Y.Z`
 
-### Build wheels:
+### Build wheel:
 
 ```bash
 # Install/update tools
@@ -66,16 +66,11 @@ pip install --upgrade build twine
 # Fresh clone Modin
 git clone git@github.com:modin-project/modin.git
 cd modin
-# Build wheels. Wheels must be built per-distribution
-SETUP_PLAT_NAME=macos python3 setup.py sdist bdist_wheel --plat-name macosx_10_9_x86_64
-SETUP_PLAT_NAME=win32 python3 setup.py sdist bdist_wheel --plat-name win32
-SETUP_PLAT_NAME=win_amd64 python3 setup.py sdist bdist_wheel --plat-name win_amd64
-SETUP_PLAT_NAME=linux python3 setup.py sdist bdist_wheel --plat-name manylinux1_x86_64
-SETUP_PLAT_NAME=linux python3 setup.py sdist bdist_wheel --plat-name manylinux1_i686
+# Build a pure Python wheel.
+python3 setup.py sdist bdist_wheel
 ```
 
-You may see the wheels in the `dist` folder: `ls -l dist`. Make sure the version is correct,
-and make sure there are 5 distributions listed above with the `--plat-name` arguments.
+You may see the wheel in the `dist` folder: `ls -l dist`. Make sure the version is correct.
 Also make sure there is a `tar` file that contains the source.
 
 ### Upload wheels:

--- a/setup.py
+++ b/setup.py
@@ -1,41 +1,8 @@
 from setuptools import setup, find_packages
 import versioneer
-import os
-from setuptools.dist import Distribution
-
-try:
-    from wheel.bdist_wheel import bdist_wheel
-
-    HAS_WHEEL = True
-except ImportError:
-    HAS_WHEEL = False
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
-
-if HAS_WHEEL:
-
-    class ModinWheel(bdist_wheel):
-        def finalize_options(self):
-            bdist_wheel.finalize_options(self)
-            self.root_is_pure = False
-
-        def get_tag(self):
-            _, _, plat = bdist_wheel.get_tag(self)
-            py = "py3"
-            abi = "none"
-            return py, abi, plat
-
-
-class ModinDistribution(Distribution):
-    def __init__(self, *attrs):
-        Distribution.__init__(self, *attrs)
-        if HAS_WHEEL:
-            self.cmdclass["bdist_wheel"] = ModinWheel
-
-    def is_pure(self):
-        return False
-
 
 dask_deps = ["dask>=2.22.0", "distributed>=2.22.0"]
 ray_deps = ["ray[default]>=1.4.0", "pyarrow>=1.0"]
@@ -44,15 +11,10 @@ spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]
 sql_deps = ["dfsql>=0.4.2", "pyparsing<=2.4.7"]
 all_deps = dask_deps + ray_deps + remote_deps + spreadsheet_deps
 
-# dfsql does not support Windows yet
-if os.name != 'nt':
-    all_deps += sql_deps
-
 setup(
     name="modin",
     version=versioneer.get_version(),
     cmdclass=versioneer.get_cmdclass(),
-    distclass=ModinDistribution,
     description="Modin: Make your pandas code run faster by changing one line of code.",
     packages=find_packages(),
     include_package_data=True,


### PR DESCRIPTION
## What do these changes do?

Deletes platform-specific logic in setup.py so that the Python wheel file is [pure python](https://packaging.python.org/guides/distributing-packages-using-setuptools/#pure-python-wheels) so that all platforms can use the same wheel.

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3616?
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
