### PR TITLE
TEST-#1628: Test some methods of categorical dataframes and series.

### DIFF
--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -37,6 +37,7 @@ from modin.pandas.test.utils import (
     test_data,
     test_data_diff_dtype,
     modin_df_almost_equals_pandas,
+    test_data_large_categorical_dataframe,
 )
 from modin.config import NPartitions
 
@@ -94,7 +95,11 @@ def test_to_timestamp():
         df.to_period().to_timestamp()
 
 
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize(
+    "data",
+    test_data_values + [test_data_large_categorical_dataframe],
+    ids=test_data_keys + ["categorical_ints"],
+)
 def test_to_numpy(data):
     modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
     assert_array_equal(modin_df.values, pandas_df.values)

--- a/modin/pandas/test/dataframe/test_reduction.py
+++ b/modin/pandas/test/dataframe/test_reduction.py
@@ -34,6 +34,7 @@ from modin.pandas.test.utils import (
     generate_multiindex,
     test_data_diff_dtype,
     df_equals_with_non_stable_indices,
+    test_data_large_categorical_dataframe,
 )
 from modin.config import NPartitions
 
@@ -94,7 +95,9 @@ def test_all_any_level(data, axis, level, method):
 
 
 @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
-@pytest.mark.parametrize("data", [test_data["float_nan_data"]])
+@pytest.mark.parametrize(
+    "data", [test_data["float_nan_data"], test_data_large_categorical_dataframe]
+)
 def test_count(data, axis):
     eval_general(
         *create_test_dfs(data),

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -68,6 +68,8 @@ from .utils import (
     generate_multiindex,
     test_data_diff_dtype,
     df_equals_with_non_stable_indices,
+    test_data_large_categorical_series_keys,
+    test_data_large_categorical_series_values,
 )
 from modin.config import NPartitions
 
@@ -1229,7 +1231,11 @@ def test_corr(data):
     df_equals(modin_result, pandas_result)
 
 
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize(
+    "data",
+    test_data_values + test_data_large_categorical_series_values,
+    ids=test_data_keys + test_data_large_categorical_series_keys,
+)
 def test_count(data):
     modin_series, pandas_series = create_test_series(data)
     df_equals(modin_series.count(), pandas_series.count())
@@ -3181,7 +3187,11 @@ def test_to_period():
         series.to_period()
 
 
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize(
+    "data",
+    test_data_values + test_data_large_categorical_series_values,
+    ids=test_data_keys + test_data_large_categorical_series_keys,
+)
 def test_to_numpy(data):
     modin_series, pandas_series = create_test_series(data)
     assert_array_equal(modin_series.values, pandas_series.values)

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -21,6 +21,7 @@ from pandas.testing import (
     assert_index_equal,
     assert_extension_array_equal,
 )
+from modin.config.envvars import NPartitions
 import modin.pandas as pd
 from modin.utils import to_pandas, try_cast_to_pandas
 from modin.config import TestDatasetSize, TrackFileLeaks
@@ -202,6 +203,16 @@ test_data_categorical = {
 
 test_data_categorical_values = list(test_data_categorical.values())
 test_data_categorical_keys = list(test_data_categorical.keys())
+
+# Fully fill all of the partitions used in tests.
+test_data_large_categorical_dataframe = {
+    i: pandas.Categorical(np.arange(NPartitions.get() * 32))
+    for i in range(NPartitions.get() * 32)
+}
+test_data_large_categorical_series_values = [
+    pandas.Categorical(np.arange(NPartitions.get() * 32))
+]
+test_data_large_categorical_series_keys = ["categorical_series"]
 
 numeric_dfs = [
     "empty_data",


### PR DESCRIPTION
In #1628, some functions didn't work on Series with category dtype. Test some
other functions that Categorical natively supports.

Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

In #1628, some functions didn't work on Series with category dtype. Test some
other functions that Categorical natively supports.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1628 
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
