### PR TITLE
FIX-#3695: use 'ray.get' to pending completion for 'to_csv' and 'to_parquet'

### DIFF
--- a/modin/core/execution/ray/generic/io/io.py
+++ b/modin/core/execution/ray/generic/io/io.py
@@ -19,7 +19,7 @@ import pandas
 
 from modin.core.io import BaseIO
 from ray.util.queue import Queue
-from ray import wait
+from ray import get
 
 
 class RayIO(BaseIO):
@@ -195,9 +195,7 @@ class RayIO(BaseIO):
         )
 
         # pending completion
-        for rows in result:
-            for partition in rows:
-                wait([partition.oid])
+        get([partition.oid for partition in result.flatten()])
 
     @staticmethod
     def _to_parquet_check_support(kwargs):
@@ -270,4 +268,4 @@ class RayIO(BaseIO):
             lengths=None,
             enumerate_partitions=True,
         )
-        wait([part.oid for row in result for part in row])
+        get([partition.oid for partition in result.flatten()])


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3695 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
