### PR TITLE
FIX-#3706: Deflake TestHdf.test_HDFStore.

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1622,7 +1622,9 @@ class TestHdf:
 
             modin_store.close()
             pandas_store.close()
-            assert assert_files_eq(unique_filename_modin, unique_filename_pandas)
+            modin_df = pandas.read_hdf(unique_filename_modin, key="foo", mode="r")
+            pandas_df = pandas.read_hdf(unique_filename_pandas, key="foo", mode="r")
+            df_equals(modin_df, pandas_df)
             assert isinstance(modin_store, pd.HDFStore)
 
             handle, hdf_file = tempfile.mkstemp(suffix=".hdf5", prefix="test_read")


### PR DESCRIPTION
The HDF files that Modin and Pandas write sometimes have different bytes.
Instead of checking that they are exactly equal, check that they contain
the same dataframes.

I ran:

```
pytest modin/pandas/test/test_io.py -k test_HDFStore --count 100
```

locally and got 4 failures for 100 attempts. After this commit, I got no
failures.

Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3706 
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
