### PR TITLE
TEST-#3710: add groupby benchmarks with dict aggregation for omnisci

### DIFF
--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -459,10 +459,3 @@ class TimeGroupByMultiColumn(BaseTimeGroupBy):
                 {col: "mean" for col in self.non_groupby_columns}
             )
         )
-
-    def time_groupby_agg_nunique_dict(self, *args, **kwargs):
-        execute(
-            self.df.groupby(by=self.groupby_columns).agg(
-                {col: "nunique" for col in self.non_groupby_columns}
-            )
-        )

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -416,6 +416,9 @@ class BaseTimeGroupBy:
             groupby_ncols,
             count_groups=ngroups,
         )
+        # correct while we use 'col*' like name for non-groupby columns
+        # and 'groupby_col*' like name for groupby columns
+        self.non_groupby_columns = self.df.columns[:-groupby_ncols]
         trigger_import(self.df)
 
 
@@ -449,3 +452,17 @@ class TimeGroupByMultiColumn(BaseTimeGroupBy):
 
     def time_groupby_agg_nunique(self, *args, **kwargs):
         execute(self.df.groupby(by=self.groupby_columns).agg("nunique"))
+
+    def time_groupby_agg_mean_dict(self, *args, **kwargs):
+        execute(
+            self.df.groupby(by=self.groupby_columns).agg(
+                {col: "mean" for col in self.non_groupby_columns}
+            )
+        )
+
+    def time_groupby_agg_nunique_dict(self, *args, **kwargs):
+        execute(
+            self.df.groupby(by=self.groupby_columns).agg(
+                {col: "nunique" for col in self.non_groupby_columns}
+            )
+        )


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3710 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
