### PR TITLE
DOCS-#3712: Clarify GitHub release naming

### DIFF
--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -99,7 +99,7 @@ to test that the wheels were uploaded correctly.
 
 ### Github
 
-After all is said and done and pushed to PyPI, open Github Releases page and create a new release. It should be enough to just specify "release from tag" and point it to newly created `X.Y.Z` tag without filling any extra information - Github should pull that from your tag annotations.
+After all is said and done and pushed to PyPI, open Github Releases page and create a new release. It should be enough to just specify "release from tag" and point it to newly created `X.Y.Z` tag plus fill the release title - it should read `Modin X.Y.Z` - Github should pull everything else including release text from your tag annotations.
 
 ### Conda-forge
 

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -50,6 +50,7 @@ Push the commit, make a PR _against `release-X.Y.Z`_ branch and, when it's merge
         git tag -as X.Y.Z
 
   * Look for [other releases](https://github.com/modin-project/modin/releases) on examples of how to compose the release documentation
+    * Start with a `Modin X.Y.Z` line followed by an empty line
     * Always try to make a one-line summary
     * The annotation should contain features and changes compared to previous release
     * You can link to merge commits, but try to "explain" what a PR does instead of blindly copying its title
@@ -99,7 +100,7 @@ to test that the wheels were uploaded correctly.
 
 ### Github
 
-After all is said and done and pushed to PyPI, open Github Releases page and create a new release. It should be enough to just specify "release from tag" and point it to newly created `X.Y.Z` tag plus fill the release title - it should read `Modin X.Y.Z` - Github should pull everything else including release text from your tag annotations.
+After all is said and done and pushed to PyPI, open Github Releases page and create a new release. It should be enough to just specify "release from tag" and point it to newly created `X.Y.Z` tag (ensure the release title reads `Modin X.Y.Z`) - Github should pull everything including release text from your tag annotations.
 
 ### Conda-forge
 


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Clarify the GitHub release naming - it should read `Modin X.Y.Z`, not just `X.Y.Z` as GitHub fills it from tag initially.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3712
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
