### PR TITLE
TEST-#3708: use 'latest' tag for 'rayproject/ray' base Ray image

### DIFF
--- a/ci/teamcity/Dockerfile.teamcity-ci
+++ b/ci/teamcity/Dockerfile.teamcity-ci
@@ -14,6 +14,8 @@ ADD modin.tar /modin
 ADD git-rev /modin/git-rev
 
 WORKDIR /modin
+RUN ls -l /
+RUN ls -l /home/
 
 # Make RUN commands use `bash --login`:
 SHELL ["/bin/bash", "--login", "-c"]

--- a/ci/teamcity/Dockerfile.teamcity-ci
+++ b/ci/teamcity/Dockerfile.teamcity-ci
@@ -31,6 +31,6 @@ RUN conda install curl PyGithub
 # activation is not always executed when "docker exec" is used
 # and then conda initialization overwrites PATH with its base
 # environment where python doesn't have any packages installed.
-RUN echo "conda activate modin" > ~/.bashrc
+RUN echo "conda activate modin" >> ~/.bashrc
 RUN echo "Make sure environment is activated"
 RUN conda list -n modin

--- a/ci/teamcity/Dockerfile.teamcity-ci
+++ b/ci/teamcity/Dockerfile.teamcity-ci
@@ -14,7 +14,7 @@ ADD modin.tar /modin
 ADD git-rev /modin/git-rev
 
 WORKDIR /modin
-RUN sudo chown -R $USER /modin
+RUN sudo chown -R ray /modin
 
 # Make RUN commands use `bash --login`:
 SHELL ["/bin/bash", "--login", "-c"]

--- a/ci/teamcity/Dockerfile.teamcity-ci
+++ b/ci/teamcity/Dockerfile.teamcity-ci
@@ -20,7 +20,7 @@ SHELL ["/bin/bash", "--login", "-c"]
 
 # Initialize conda in bash config files:
 RUN conda init bash
-ENV PATH /root/anaconda3/envs/modin/bin:$PATH
+ENV PATH /home/ray/anaconda3/envs/modin/bin:$PATH
 
 RUN conda config --set channel_priority strict
 RUN conda update python -y

--- a/ci/teamcity/Dockerfile.teamcity-ci
+++ b/ci/teamcity/Dockerfile.teamcity-ci
@@ -6,7 +6,7 @@
 #
 # docker build --build-arg ENVIRONMENT=environment-dev.yml -t modin-project/teamcity-ci:${BUILD_NUMBER} -f ci/teamcity/Dockerfile.teamcity-ci ci/teamcity
 
-FROM rayproject/ray:1.0.1
+FROM rayproject/ray:latest
 
 ARG ENVIRONMENT=environment-dev.yml
 

--- a/ci/teamcity/Dockerfile.teamcity-ci
+++ b/ci/teamcity/Dockerfile.teamcity-ci
@@ -19,6 +19,10 @@ RUN sudo chown -R ray /modin
 # Make RUN commands use `bash --login`:
 SHELL ["/bin/bash", "--login", "-c"]
 
+# Initialize conda in bash config files:
+RUN conda init bash
+ENV PATH /home/ray/anaconda3/envs/modin/bin:$PATH
+
 RUN conda config --set channel_priority strict
 RUN conda update python -y
 RUN conda env create -f ${ENVIRONMENT}
@@ -31,6 +35,6 @@ RUN conda install curl PyGithub
 # activation is not always executed when "docker exec" is used
 # and then conda initialization overwrites PATH with its base
 # environment where python doesn't have any packages installed.
-RUN echo "conda activate modin" >> ~/.bashrc
+RUN echo "conda activate modin" > ~/.bashrc
 RUN echo "Make sure environment is activated"
 RUN conda list -n modin

--- a/ci/teamcity/Dockerfile.teamcity-ci
+++ b/ci/teamcity/Dockerfile.teamcity-ci
@@ -18,10 +18,6 @@ WORKDIR /modin
 # Make RUN commands use `bash --login`:
 SHELL ["/bin/bash", "--login", "-c"]
 
-# Initialize conda in bash config files:
-RUN conda init bash
-ENV PATH /home/ray/anaconda3/envs/modin/bin:$PATH
-
 RUN conda config --set channel_priority strict
 RUN conda update python -y
 RUN conda env create -f ${ENVIRONMENT}

--- a/ci/teamcity/Dockerfile.teamcity-ci
+++ b/ci/teamcity/Dockerfile.teamcity-ci
@@ -14,8 +14,7 @@ ADD modin.tar /modin
 ADD git-rev /modin/git-rev
 
 WORKDIR /modin
-RUN ls -l /
-RUN ls -l /home/
+RUN sudo chown -R $USER /modin
 
 # Make RUN commands use `bash --login`:
 SHELL ["/bin/bash", "--login", "-c"]


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Updates the image in order not to use the outdated one.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3708 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
