### PR TITLE
TEST-#3672: do fair 'join' at OmniSci's join bench

### DIFF
--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -62,7 +62,7 @@ class TimeJoin:
             # https://github.com/modin-project/modin/issues/3442
             # Generating a new object for every index to avoid shared index objects:
             self.df1.index = pandas.RangeIndex(1, len(self.df1) + 1)
-            self.df2.index = pandas.RangeIndex(1, len(self.df1) + 1)
+            self.df2.index = pandas.RangeIndex(1, len(self.df2) + 1)
         else:
             # Intersection rate indicates how many common join-keys `self.df1`
             # and `self.df2` have in terms of percentage.

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -59,7 +59,7 @@ class TimeJoin:
             # OmniSci backend performs join on the internal meta-column called 'rowid'.
             # There is a bug in the engine that makes such joins fail. To avoid joining
             # on the meta-column we explicitly specify a non-default index to join on.
-            # https://github.com/modin-project/modin/issues/3442
+            # https://github.com/modin-project/modin/issues/3740
             # Generating a new object for every index to avoid shared index objects:
             self.df1.index = pandas.RangeIndex(1, len(self.df1) + 1)
             self.df2.index = pandas.RangeIndex(1, len(self.df2) + 1)

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -59,10 +59,12 @@ class TimeJoin:
             # There is a bug in the engine that makes such joins fail. To avoid joining
             # on the meta-column we explicitly specify a non-default index to join on.
             # https://github.com/modin-project/modin/issues/3442
-            common_index = np.arange(1, len(self.df1) + 1)
-            self.df1.index = common_index
-            self.df2.index = common_index
+            # Generating a new object for every index to avoid shared index objects:
+            self.df1.index = np.arange(1, len(self.df1) + 1)
+            self.df2.index = np.arange(1, len(self.df2) + 1)
         else:
+            # Intersection rate indicates how many common join-keys `self.df1`
+            # and `self.df2` have in terms of percentage.
             indices_intersection_rate = 0.5
 
             frame_length = len(self.df1)

--- a/asv_bench/benchmarks/omnisci/benchmarks.py
+++ b/asv_bench/benchmarks/omnisci/benchmarks.py
@@ -30,6 +30,7 @@ from ..utils import (
 )
 from ..utils.common import random_state
 import numpy as np
+import pandas
 
 
 class TimeJoin:
@@ -60,8 +61,8 @@ class TimeJoin:
             # on the meta-column we explicitly specify a non-default index to join on.
             # https://github.com/modin-project/modin/issues/3442
             # Generating a new object for every index to avoid shared index objects:
-            self.df1.index = np.arange(1, len(self.df1) + 1)
-            self.df2.index = np.arange(1, len(self.df2) + 1)
+            self.df1.index = pandas.RangeIndex(1, len(self.df1) + 1)
+            self.df2.index = pandas.RangeIndex(1, len(self.df1) + 1)
         else:
             # Intersection rate indicates how many common join-keys `self.df1`
             # and `self.df2` have in terms of percentage.

--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -309,6 +309,7 @@ def generate_dataframe(
     groupby_ncols: Optional[int] = None,
     count_groups: Optional[int] = None,
     gen_unique_key: bool = False,
+    cache_prefix: str = None,
 ) -> Union[pd.DataFrame, pandas.DataFrame]:
     """
     Generate DataFrame with caching.
@@ -341,6 +342,8 @@ def generate_dataframe(
         Count of groups in groupby columns.
     gen_unique_key : bool, default: False
         Generate `col1` column where all elements are unique.
+    cache_prefix : str, optional
+        Prefix to add to the cache key of the requested frame.
 
     Returns
     -------
@@ -368,6 +371,9 @@ def generate_dataframe(
         count_groups,
         gen_unique_key,
     )
+
+    if cache_prefix is not None:
+        cache_key = (cache_prefix, *cache_key)
 
     if cache_key in dataframes_cache:
         return dataframes_cache[cache_key]


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3672 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
