### PR TITLE
FEAT-#3724: Converting self.resample_args for Resampler into a dict

### DIFF
--- a/modin/core/dataframe/algebra/default2pandas/resample.py
+++ b/modin/core/dataframe/algebra/default2pandas/resample.py
@@ -40,11 +40,11 @@ class Resampler:
             to resampled time-series data.
         """
 
-        def fn(df, resample_args, *args, **kwargs):
+        def fn(df, resample_kwargs, *args, **kwargs):
             """Resample time-series data of the passed frame and apply specified aggregation."""
             if squeeze_self:
                 df = df.squeeze(axis=1)
-            resampler = df.resample(*resample_args)
+            resampler = df.resample(**resample_kwargs)
 
             if type(func) == property:
                 return func.fget(resampler)

--- a/modin/core/storage_formats/base/doc_utils.py
+++ b/modin/core/storage_formats/base/doc_utils.py
@@ -310,7 +310,7 @@ doc_resample = partial(
 
     Parameters
     ----------
-    resample_args : list
+    resample_kwargs : dict
         Resample parameters as expected by ``modin.pandas.DataFrame.resample`` signature.
     {extra_params}
     Returns

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3164,9 +3164,9 @@ class BaseQueryCompiler(abc.ABC):
         output="function names",
         refer_to="agg",
     )
-    def resample_agg_df(self, resample_args, func, *args, **kwargs):
+    def resample_agg_df(self, resample_kwargs, func, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.aggregate)(
-            self, resample_args, func, *args, **kwargs
+            self, resample_kwargs, func, *args, **kwargs
         )
 
     @doc_utils.add_deprecation_warning(replacement_method="resample_agg_df")
@@ -3176,10 +3176,10 @@ class BaseQueryCompiler(abc.ABC):
         output="function names",
         refer_to="agg",
     )
-    def resample_agg_ser(self, resample_args, func, *args, **kwargs):
+    def resample_agg_ser(self, resample_kwargs, func, *args, **kwargs):
         return ResampleDefault.register(
             pandas.core.resample.Resampler.aggregate, squeeze_self=True
-        )(self, resample_args, func, *args, **kwargs)
+        )(self, resample_kwargs, func, *args, **kwargs)
 
     @doc_utils.add_deprecation_warning(replacement_method="resample_agg_df")
     @doc_utils.doc_resample_agg(
@@ -3188,9 +3188,9 @@ class BaseQueryCompiler(abc.ABC):
         output="function names",
         refer_to="apply",
     )
-    def resample_app_df(self, resample_args, func, *args, **kwargs):
+    def resample_app_df(self, resample_kwargs, func, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.apply)(
-            self, resample_args, func, *args, **kwargs
+            self, resample_kwargs, func, *args, **kwargs
         )
 
     @doc_utils.add_deprecation_warning(replacement_method="resample_agg_df")
@@ -3200,12 +3200,12 @@ class BaseQueryCompiler(abc.ABC):
         output="function names",
         refer_to="apply",
     )
-    def resample_app_ser(self, resample_args, func, *args, **kwargs):
+    def resample_app_ser(self, resample_kwargs, func, *args, **kwargs):
         return ResampleDefault.register(
             pandas.core.resample.Resampler.apply, squeeze_self=True
-        )(self, resample_args, func, *args, **kwargs)
+        )(self, resample_kwargs, func, *args, **kwargs)
 
-    def resample_asfreq(self, resample_args, fill_value):
+    def resample_asfreq(self, resample_kwargs, fill_value):
         """
         Resample time-series data and get the values at the new frequency.
 
@@ -3214,7 +3214,7 @@ class BaseQueryCompiler(abc.ABC):
 
         Parameters
         ----------
-        resample_args : list
+        resample_kwargs : dict
             Resample parameters as expected by ``modin.pandas.DataFrame.resample`` signature.
         fill_value : scalar
 
@@ -3224,37 +3224,37 @@ class BaseQueryCompiler(abc.ABC):
             New QueryCompiler containing values at the specified frequency.
         """
         return ResampleDefault.register(pandas.core.resample.Resampler.asfreq)(
-            self, resample_args, fill_value
+            self, resample_kwargs, fill_value
         )
 
     # FIXME: `resample_backfill` is an alias for `resample_bfill`, one of these method
     # should be removed (Modin issue #3107).
     @doc_utils.doc_resample_fillna(method="back-fill", refer_to="backfill")
-    def resample_backfill(self, resample_args, limit):
+    def resample_backfill(self, resample_kwargs, limit):
         return ResampleDefault.register(pandas.core.resample.Resampler.backfill)(
-            self, resample_args, limit
+            self, resample_kwargs, limit
         )
 
     @doc_utils.doc_resample_fillna(method="back-fill", refer_to="bfill")
-    def resample_bfill(self, resample_args, limit):
+    def resample_bfill(self, resample_kwargs, limit):
         return ResampleDefault.register(pandas.core.resample.Resampler.bfill)(
-            self, resample_args, limit
+            self, resample_kwargs, limit
         )
 
     @doc_utils.doc_resample_reduction(
         result="number of non-NA values", refer_to="count", compatibility_params=False
     )
-    def resample_count(self, resample_args):
+    def resample_count(self, resample_kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.count)(
-            self, resample_args
+            self, resample_kwargs
         )
 
     # FIXME: `resample_ffill` is an alias for `resample_pad`, one of these method
     # should be removed (Modin issue #3107).
     @doc_utils.doc_resample_fillna(method="forward-fill", refer_to="ffill")
-    def resample_ffill(self, resample_args, limit):
+    def resample_ffill(self, resample_kwargs, limit):
         return ResampleDefault.register(pandas.core.resample.Resampler.ffill)(
-            self, resample_args, limit
+            self, resample_kwargs, limit
         )
 
     # FIXME: we should combine all resample fillna methods into `resample_fillna`
@@ -3262,23 +3262,23 @@ class BaseQueryCompiler(abc.ABC):
     @doc_utils.doc_resample_fillna(
         method="specified", refer_to="fillna", params="method : str"
     )
-    def resample_fillna(self, resample_args, method, limit):
+    def resample_fillna(self, resample_kwargs, method, limit):
         return ResampleDefault.register(pandas.core.resample.Resampler.fillna)(
-            self, resample_args, method, limit
+            self, resample_kwargs, method, limit
         )
 
     @doc_utils.doc_resample_reduction(
         result="first element", refer_to="first", params="_method : str"
     )
-    def resample_first(self, resample_args, _method, *args, **kwargs):
+    def resample_first(self, resample_kwargs, _method, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.first)(
-            self, resample_args, _method, *args, **kwargs
+            self, resample_kwargs, _method, *args, **kwargs
         )
 
     # FIXME: This function takes Modin DataFrame via `obj` parameter,
     # we should avoid leaking of the high-level objects to the query compiler level.
     # (Modin issue #3106)
-    def resample_get_group(self, resample_args, name, obj):
+    def resample_get_group(self, resample_kwargs, name, obj):
         """
         Resample time-series data and get the specified group.
 
@@ -3287,7 +3287,7 @@ class BaseQueryCompiler(abc.ABC):
 
         Parameters
         ----------
-        resample_args : list
+        resample_kwargs : dict
             Resample parameters as expected by ``modin.pandas.DataFrame.resample`` signature.
         name : object
         obj : modin.pandas.DataFrame, optional
@@ -3298,7 +3298,7 @@ class BaseQueryCompiler(abc.ABC):
             New QueryCompiler containing the values from the specified group.
         """
         return ResampleDefault.register(pandas.core.resample.Resampler.get_group)(
-            self, resample_args, name, obj
+            self, resample_kwargs, name, obj
         )
 
     @doc_utils.doc_resample_fillna(
@@ -3319,7 +3319,7 @@ class BaseQueryCompiler(abc.ABC):
     )
     def resample_interpolate(
         self,
-        resample_args,
+        resample_kwargs,
         method,
         axis,
         limit,
@@ -3331,7 +3331,7 @@ class BaseQueryCompiler(abc.ABC):
     ):
         return ResampleDefault.register(pandas.core.resample.Resampler.interpolate)(
             self,
-            resample_args,
+            resample_kwargs,
             method,
             axis,
             limit,
@@ -3345,55 +3345,55 @@ class BaseQueryCompiler(abc.ABC):
     @doc_utils.doc_resample_reduction(
         result="last element", params="_method : str", refer_to="last"
     )
-    def resample_last(self, resample_args, _method, *args, **kwargs):
+    def resample_last(self, resample_kwargs, _method, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.last)(
-            self, resample_args, _method, *args, **kwargs
+            self, resample_kwargs, _method, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
         result="maximum value", params="_method : str", refer_to="max"
     )
-    def resample_max(self, resample_args, _method, *args, **kwargs):
+    def resample_max(self, resample_kwargs, _method, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.max)(
-            self, resample_args, _method, *args, **kwargs
+            self, resample_kwargs, _method, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
         result="mean value", params="_method : str", refer_to="mean"
     )
-    def resample_mean(self, resample_args, _method, *args, **kwargs):
+    def resample_mean(self, resample_kwargs, _method, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.mean)(
-            self, resample_args, _method, *args, **kwargs
+            self, resample_kwargs, _method, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
         result="median value", params="_method : str", refer_to="median"
     )
-    def resample_median(self, resample_args, _method, *args, **kwargs):
+    def resample_median(self, resample_kwargs, _method, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.median)(
-            self, resample_args, _method, *args, **kwargs
+            self, resample_kwargs, _method, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
         result="minimum value", params="_method : str", refer_to="min"
     )
-    def resample_min(self, resample_args, _method, *args, **kwargs):
+    def resample_min(self, resample_kwargs, _method, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.min)(
-            self, resample_args, _method, *args, **kwargs
+            self, resample_kwargs, _method, *args, **kwargs
         )
 
     @doc_utils.doc_resample_fillna(method="'nearest'", refer_to="nearest")
-    def resample_nearest(self, resample_args, limit):
+    def resample_nearest(self, resample_kwargs, limit):
         return ResampleDefault.register(pandas.core.resample.Resampler.nearest)(
-            self, resample_args, limit
+            self, resample_kwargs, limit
         )
 
     @doc_utils.doc_resample_reduction(
         result="number of unique values", params="_method : str", refer_to="nunique"
     )
-    def resample_nunique(self, resample_args, _method, *args, **kwargs):
+    def resample_nunique(self, resample_kwargs, _method, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.nunique)(
-            self, resample_args, _method, *args, **kwargs
+            self, resample_kwargs, _method, *args, **kwargs
         )
 
     # FIXME: Query Compiler shouldn't care about differences between Series and DataFrame
@@ -3404,9 +3404,9 @@ class BaseQueryCompiler(abc.ABC):
         output="labels of columns containing computed values",
         refer_to="ohlc",
     )
-    def resample_ohlc_df(self, resample_args, _method, *args, **kwargs):
+    def resample_ohlc_df(self, resample_kwargs, _method, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.ohlc)(
-            self, resample_args, _method, *args, **kwargs
+            self, resample_kwargs, _method, *args, **kwargs
         )
 
     @doc_utils.doc_resample_agg(
@@ -3415,22 +3415,22 @@ class BaseQueryCompiler(abc.ABC):
         output="labels of columns containing computed values",
         refer_to="ohlc",
     )
-    def resample_ohlc_ser(self, resample_args, _method, *args, **kwargs):
+    def resample_ohlc_ser(self, resample_kwargs, _method, *args, **kwargs):
         return ResampleDefault.register(
             pandas.core.resample.Resampler.ohlc, squeeze_self=True
-        )(self, resample_args, _method, *args, **kwargs)
+        )(self, resample_kwargs, _method, *args, **kwargs)
 
     @doc_utils.doc_resample_fillna(method="'pad'", refer_to="pad")
-    def resample_pad(self, resample_args, limit):
+    def resample_pad(self, resample_kwargs, limit):
         return ResampleDefault.register(pandas.core.resample.Resampler.pad)(
-            self, resample_args, limit
+            self, resample_kwargs, limit
         )
 
     # FIXME: This method require us to build high-level resampler object
     # which we shouldn't do at the query compiler. We need to move this at the front.
     # (Modin issue #3105)
     @doc_utils.add_refer_to("Resampler.pipe")
-    def resample_pipe(self, resample_args, func, *args, **kwargs):
+    def resample_pipe(self, resample_kwargs, func, *args, **kwargs):
         """
         Resample time-series data and apply aggregation on it.
 
@@ -3440,7 +3440,7 @@ class BaseQueryCompiler(abc.ABC):
 
         Parameters
         ----------
-        resample_args : list
+        resample_kwargs : dict
             Resample parameters as expected by ``modin.pandas.DataFrame.resample`` signature.
         func : callable(pandas.Resampler) -> object or tuple(callable, str)
         *args : iterable
@@ -3454,7 +3454,7 @@ class BaseQueryCompiler(abc.ABC):
             New QueryCompiler containing the result of passed function.
         """
         return ResampleDefault.register(pandas.core.resample.Resampler.pipe)(
-            self, resample_args, func, *args, **kwargs
+            self, resample_kwargs, func, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
@@ -3464,17 +3464,17 @@ class BaseQueryCompiler(abc.ABC):
         min_count : int""",
         refer_to="prod",
     )
-    def resample_prod(self, resample_args, _method, min_count, *args, **kwargs):
+    def resample_prod(self, resample_kwargs, _method, min_count, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.prod)(
-            self, resample_args, _method, min_count, *args, **kwargs
+            self, resample_kwargs, _method, min_count, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
         result="quantile", params="q : float", refer_to="quantile"
     )
-    def resample_quantile(self, resample_args, q, *args, **kwargs):
+    def resample_quantile(self, resample_kwargs, q, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.quantile)(
-            self, resample_args, q, *args, **kwargs
+            self, resample_kwargs, q, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
@@ -3482,25 +3482,25 @@ class BaseQueryCompiler(abc.ABC):
         params="ddof : int, default: 1",
         refer_to="sem",
     )
-    def resample_sem(self, resample_args, ddof=1, *args, **kwargs):
+    def resample_sem(self, resample_kwargs, ddof=1, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.sem)(
-            self, resample_args, ddof, *args, **kwargs
+            self, resample_kwargs, ddof, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
         result="number of elements in a group", refer_to="size"
     )
-    def resample_size(self, resample_args, *args, **kwargs):
+    def resample_size(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.size)(
-            self, resample_args, *args, **kwargs
+            self, resample_kwargs, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
         result="standart deviation", params="ddof : int", refer_to="std"
     )
-    def resample_std(self, resample_args, ddof, *args, **kwargs):
+    def resample_std(self, resample_kwargs, ddof, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.std)(
-            self, resample_args, ddof, *args, **kwargs
+            self, resample_kwargs, ddof, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
@@ -3510,12 +3510,12 @@ class BaseQueryCompiler(abc.ABC):
         min_count : int""",
         refer_to="sum",
     )
-    def resample_sum(self, resample_args, _method, min_count, *args, **kwargs):
+    def resample_sum(self, resample_kwargs, _method, min_count, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.sum)(
-            self, resample_args, _method, min_count, *args, **kwargs
+            self, resample_kwargs, _method, min_count, *args, **kwargs
         )
 
-    def resample_transform(self, resample_args, arg, *args, **kwargs):
+    def resample_transform(self, resample_kwargs, arg, *args, **kwargs):
         """
         Resample time-series data and apply aggregation on it.
 
@@ -3526,7 +3526,7 @@ class BaseQueryCompiler(abc.ABC):
 
         Parameters
         ----------
-        resample_args : list
+        resample_kwargs : dict
             Resample parameters as expected by ``modin.pandas.DataFrame.resample`` signature.
         arg : callable(pandas.DataFrame) -> pandas.Series
         *args : iterable
@@ -3540,15 +3540,15 @@ class BaseQueryCompiler(abc.ABC):
             New QueryCompiler containing the result of passed function.
         """
         return ResampleDefault.register(pandas.core.resample.Resampler.transform)(
-            self, resample_args, arg, *args, **kwargs
+            self, resample_kwargs, arg, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduction(
         result="variance", params="ddof : int", refer_to="var"
     )
-    def resample_var(self, resample_args, ddof, *args, **kwargs):
+    def resample_var(self, resample_kwargs, ddof, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.var)(
-            self, resample_args, ddof, *args, **kwargs
+            self, resample_kwargs, ddof, *args, **kwargs
         )
 
     # End of Resample methods

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -793,14 +793,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # END Reduction operations
 
     def _resample_func(
-        self, resample_args, func_name, new_columns=None, df_op=None, *args, **kwargs
+        self, resample_kwargs, func_name, new_columns=None, df_op=None, *args, **kwargs
     ):
         """
         Resample underlying time-series data and apply aggregation on it.
 
         Parameters
         ----------
-        resample_args : list
+        resample_kwargs : dict
             Resample parameters in the format of ``modin.pandas.DataFrame.resample`` signature.
         func_name : str
             Aggregation function name to apply on resampler object.
@@ -820,11 +820,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
             New QueryCompiler containing the result of resample aggregation.
         """
 
-        def map_func(df, resample_args=resample_args):
+        def map_func(df, resample_kwargs=resample_kwargs):
             """Resample time-series data of the passed frame and apply aggregation function on it."""
             if df_op is not None:
                 df = df_op(df)
-            resampled_val = df.resample(*resample_args)
+            resampled_val = df.resample(**resample_kwargs)
             op = getattr(pandas.core.resample.Resampler, func_name)
             if callable(op):
                 try:
@@ -832,7 +832,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     # all the time, so this will try to fast-path the code first.
                     val = op(resampled_val, *args, **kwargs)
                 except (ValueError):
-                    resampled_val = df.copy().resample(*resample_args)
+                    resampled_val = df.copy().resample(**resample_kwargs)
                     val = op(resampled_val, *args, **kwargs)
             else:
                 val = getattr(resampled_val, func_name)
@@ -847,12 +847,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
         )
         return self.__constructor__(new_modin_frame)
 
-    def resample_get_group(self, resample_args, name, obj):
-        return self._resample_func(resample_args, "get_group", name=name, obj=obj)
+    def resample_get_group(self, resample_kwargs, name, obj):
+        return self._resample_func(resample_kwargs, "get_group", name=name, obj=obj)
 
-    def resample_app_ser(self, resample_args, func, *args, **kwargs):
+    def resample_app_ser(self, resample_kwargs, func, *args, **kwargs):
         return self._resample_func(
-            resample_args,
+            resample_kwargs,
             "apply",
             df_op=lambda df: df.squeeze(axis=1),
             func=func,
@@ -860,12 +860,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
             **kwargs,
         )
 
-    def resample_app_df(self, resample_args, func, *args, **kwargs):
-        return self._resample_func(resample_args, "apply", func=func, *args, **kwargs)
+    def resample_app_df(self, resample_kwargs, func, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "apply", func=func, *args, **kwargs)
 
-    def resample_agg_ser(self, resample_args, func, *args, **kwargs):
+    def resample_agg_ser(self, resample_kwargs, func, *args, **kwargs):
         return self._resample_func(
-            resample_args,
+            resample_kwargs,
             "aggregate",
             df_op=lambda df: df.squeeze(axis=1),
             func=func,
@@ -873,41 +873,45 @@ class PandasQueryCompiler(BaseQueryCompiler):
             **kwargs,
         )
 
-    def resample_agg_df(self, resample_args, func, *args, **kwargs):
+    def resample_agg_df(self, resample_kwargs, func, *args, **kwargs):
         return self._resample_func(
-            resample_args, "aggregate", func=func, *args, **kwargs
+            resample_kwargs, "aggregate", func=func, *args, **kwargs
         )
 
-    def resample_transform(self, resample_args, arg, *args, **kwargs):
-        return self._resample_func(resample_args, "transform", arg=arg, *args, **kwargs)
+    def resample_transform(self, resample_kwargs, arg, *args, **kwargs):
+        return self._resample_func(
+            resample_kwargs, "transform", arg=arg, *args, **kwargs
+        )
 
-    def resample_pipe(self, resample_args, func, *args, **kwargs):
-        return self._resample_func(resample_args, "pipe", func=func, *args, **kwargs)
+    def resample_pipe(self, resample_kwargs, func, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "pipe", func=func, *args, **kwargs)
 
-    def resample_ffill(self, resample_args, limit):
-        return self._resample_func(resample_args, "ffill", limit=limit)
+    def resample_ffill(self, resample_kwargs, limit):
+        return self._resample_func(resample_kwargs, "ffill", limit=limit)
 
-    def resample_backfill(self, resample_args, limit):
-        return self._resample_func(resample_args, "backfill", limit=limit)
+    def resample_backfill(self, resample_kwargs, limit):
+        return self._resample_func(resample_kwargs, "backfill", limit=limit)
 
-    def resample_bfill(self, resample_args, limit):
-        return self._resample_func(resample_args, "bfill", limit=limit)
+    def resample_bfill(self, resample_kwargs, limit):
+        return self._resample_func(resample_kwargs, "bfill", limit=limit)
 
-    def resample_pad(self, resample_args, limit):
-        return self._resample_func(resample_args, "pad", limit=limit)
+    def resample_pad(self, resample_kwargs, limit):
+        return self._resample_func(resample_kwargs, "pad", limit=limit)
 
-    def resample_nearest(self, resample_args, limit):
-        return self._resample_func(resample_args, "nearest", limit=limit)
+    def resample_nearest(self, resample_kwargs, limit):
+        return self._resample_func(resample_kwargs, "nearest", limit=limit)
 
-    def resample_fillna(self, resample_args, method, limit):
-        return self._resample_func(resample_args, "fillna", method=method, limit=limit)
+    def resample_fillna(self, resample_kwargs, method, limit):
+        return self._resample_func(
+            resample_kwargs, "fillna", method=method, limit=limit
+        )
 
-    def resample_asfreq(self, resample_args, fill_value):
-        return self._resample_func(resample_args, "asfreq", fill_value=fill_value)
+    def resample_asfreq(self, resample_kwargs, fill_value):
+        return self._resample_func(resample_kwargs, "asfreq", fill_value=fill_value)
 
     def resample_interpolate(
         self,
-        resample_args,
+        resample_kwargs,
         method,
         axis,
         limit,
@@ -918,7 +922,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         **kwargs,
     ):
         return self._resample_func(
-            resample_args,
+            resample_kwargs,
             "interpolate",
             axis=axis,
             limit=limit,
@@ -929,47 +933,47 @@ class PandasQueryCompiler(BaseQueryCompiler):
             **kwargs,
         )
 
-    def resample_count(self, resample_args):
-        return self._resample_func(resample_args, "count")
+    def resample_count(self, resample_kwargs):
+        return self._resample_func(resample_kwargs, "count")
 
-    def resample_nunique(self, resample_args, _method, *args, **kwargs):
+    def resample_nunique(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
-            resample_args, "nunique", _method=_method, *args, **kwargs
+            resample_kwargs, "nunique", _method=_method, *args, **kwargs
         )
 
-    def resample_first(self, resample_args, _method, *args, **kwargs):
+    def resample_first(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
-            resample_args, "first", _method=_method, *args, **kwargs
+            resample_kwargs, "first", _method=_method, *args, **kwargs
         )
 
-    def resample_last(self, resample_args, _method, *args, **kwargs):
+    def resample_last(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
-            resample_args, "last", _method=_method, *args, **kwargs
+            resample_kwargs, "last", _method=_method, *args, **kwargs
         )
 
-    def resample_max(self, resample_args, _method, *args, **kwargs):
+    def resample_max(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
-            resample_args, "max", _method=_method, *args, **kwargs
+            resample_kwargs, "max", _method=_method, *args, **kwargs
         )
 
-    def resample_mean(self, resample_args, _method, *args, **kwargs):
+    def resample_mean(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
-            resample_args, "median", _method=_method, *args, **kwargs
+            resample_kwargs, "median", _method=_method, *args, **kwargs
         )
 
-    def resample_median(self, resample_args, _method, *args, **kwargs):
+    def resample_median(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
-            resample_args, "median", _method=_method, *args, **kwargs
+            resample_kwargs, "median", _method=_method, *args, **kwargs
         )
 
-    def resample_min(self, resample_args, _method, *args, **kwargs):
+    def resample_min(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
-            resample_args, "min", _method=_method, *args, **kwargs
+            resample_kwargs, "min", _method=_method, *args, **kwargs
         )
 
-    def resample_ohlc_ser(self, resample_args, _method, *args, **kwargs):
+    def resample_ohlc_ser(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
-            resample_args,
+            resample_kwargs,
             "ohlc",
             df_op=lambda df: df.squeeze(axis=1),
             _method=_method,
@@ -977,37 +981,47 @@ class PandasQueryCompiler(BaseQueryCompiler):
             **kwargs,
         )
 
-    def resample_ohlc_df(self, resample_args, _method, *args, **kwargs):
+    def resample_ohlc_df(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
-            resample_args, "ohlc", _method=_method, *args, **kwargs
+            resample_kwargs, "ohlc", _method=_method, *args, **kwargs
         )
 
-    def resample_prod(self, resample_args, _method, min_count, *args, **kwargs):
+    def resample_prod(self, resample_kwargs, _method, min_count, *args, **kwargs):
         return self._resample_func(
-            resample_args, "prod", _method=_method, min_count=min_count, *args, **kwargs
+            resample_kwargs,
+            "prod",
+            _method=_method,
+            min_count=min_count,
+            *args,
+            **kwargs,
         )
 
-    def resample_size(self, resample_args):
-        return self._resample_func(resample_args, "size", new_columns=["__reduced__"])
+    def resample_size(self, resample_kwargs):
+        return self._resample_func(resample_kwargs, "size", new_columns=["__reduced__"])
 
-    def resample_sem(self, resample_args, _method, *args, **kwargs):
+    def resample_sem(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
-            resample_args, "sem", _method=_method, *args, **kwargs
+            resample_kwargs, "sem", _method=_method, *args, **kwargs
         )
 
-    def resample_std(self, resample_args, ddof, *args, **kwargs):
-        return self._resample_func(resample_args, "std", ddof=ddof, *args, **kwargs)
+    def resample_std(self, resample_kwargs, ddof, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "std", ddof=ddof, *args, **kwargs)
 
-    def resample_sum(self, resample_args, _method, min_count, *args, **kwargs):
+    def resample_sum(self, resample_kwargs, _method, min_count, *args, **kwargs):
         return self._resample_func(
-            resample_args, "sum", _method=_method, min_count=min_count, *args, **kwargs
+            resample_kwargs,
+            "sum",
+            _method=_method,
+            min_count=min_count,
+            *args,
+            **kwargs,
         )
 
-    def resample_var(self, resample_args, ddof, *args, **kwargs):
-        return self._resample_func(resample_args, "var", ddof=ddof, *args, **kwargs)
+    def resample_var(self, resample_kwargs, ddof, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "var", ddof=ddof, *args, **kwargs)
 
-    def resample_quantile(self, resample_args, q, **kwargs):
-        return self._resample_func(resample_args, "quantile", q=q, **kwargs)
+    def resample_quantile(self, resample_kwargs, q, **kwargs):
+        return self._resample_func(resample_kwargs, "quantile", q=q, **kwargs)
 
     window_mean = Fold.register(
         lambda df, rolling_args, *args, **kwargs: pandas.DataFrame(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3111,21 +3111,21 @@ class Resampler(object):
         axis = self._dataframe._get_axis_number(axis)
         # FIXME: this should be converted into a dict to ensure simplicity
         # of handling resample parameters at the query compiler level.
-        self.resample_args = [
-            rule,
-            axis,
-            closed,
-            label,
-            convention,
-            kind,
-            loffset,
-            base,
-            on,
-            level,
-            origin,
-            offset,
-        ]
-        self.__groups = self.__get_groups(*self.resample_args)
+        self.resample_args = {
+            "rule": rule,
+            "axis": axis,
+            "closed": closed,
+            "label": label,
+            "convention": convention,
+            "kind": kind,
+            "loffset": loffset,
+            "base": base,
+            "on": on,
+            "level": level,
+            "origin": origin,
+            "offset": offset,
+        }
+        self.__groups = self.__get_groups(**self.resample_args)
 
     def __getitem__(self, key):
         """
@@ -3144,9 +3144,7 @@ class Resampler(object):
         """
 
         def _get_new_resampler(key):
-            subset = self._dataframe[key]
-            resampler = type(self)(subset, *self.resample_args)
-            return resampler
+            return Resampler(self._dataframe[key], **self.resample_args)
 
         from .series import Series
 
@@ -3201,17 +3199,17 @@ class Resampler(object):
     @property
     def groups(self):
         return self._query_compiler.default_to_pandas(
-            lambda df: pandas.DataFrame.resample(df, *self.resample_args).groups
+            lambda df: pandas.DataFrame.resample(df, **self.resample_args).groups
         )
 
     @property
     def indices(self):
         return self._query_compiler.default_to_pandas(
-            lambda df: pandas.DataFrame.resample(df, *self.resample_args).indices
+            lambda df: pandas.DataFrame.resample(df, **self.resample_args).indices
         )
 
     def get_group(self, name, obj=None):
-        if self.resample_args[1] == 0:
+        if self.resample_args["axis"] == 0:
             result = self.__groups.get_group(name)
         else:
             result = self.__groups.get_group(name).T
@@ -3446,7 +3444,7 @@ class Resampler(object):
             )
 
     def prod(self, _method="prod", min_count=0, *args, **kwargs):
-        if self.resample_args[1] == 0:
+        if self.resample_args["axis"] == 0:
             result = self.__groups.prod(min_count=min_count, *args, **kwargs)
         else:
             result = self.__groups.prod(min_count=min_count, *args, **kwargs).T
@@ -3477,7 +3475,7 @@ class Resampler(object):
         )
 
     def sum(self, _method="sum", min_count=0, *args, **kwargs):
-        if self.resample_args[1] == 0:
+        if self.resample_args["axis"] == 0:
             result = self.__groups.sum(min_count=min_count, *args, **kwargs)
         else:
             result = self.__groups.sum(min_count=min_count, *args, **kwargs).T

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3109,8 +3109,6 @@ class Resampler(object):
         self._dataframe = dataframe
         self._query_compiler = dataframe._query_compiler
         axis = self._dataframe._get_axis_number(axis)
-        # FIXME: this should be converted into a dict to ensure simplicity
-        # of handling resample parameters at the query compiler level.
         self.resample_kwargs = {
             "rule": rule,
             "axis": axis,


### PR DESCRIPTION
Signed-off-by: Maria Rubtsova <maria.rubtsova@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
self.resample_args for Resampler converted into a dict to ensure simplicity of handling resample parameters at the query compiler level.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3724 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
