### PR TITLE
FIX-#3741: Added delivery of the data argument to df

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -549,6 +549,7 @@ jobs:
           conda info
           conda list
       - run: python -m pytest --simulate-cloud=normal modin/pandas/test/test_io.py --verbose
+      - run: python -m pytest --simulate-cloud=normal modin/pandas/test/dataframe/test_default.py::test_kurt_kurtosis --verbose
       - # When running without parameters, some of the tests fail
         run: python -m pytest --simulate-cloud=normal modin/pandas/test/dataframe/test_binary.py::test_math_functions[add-rows-scalar]
       - run: |

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -428,9 +428,13 @@ def make_proxy_cls(
 
         def __init__(self, *a, __remote_end__=None, **kw):
             if __remote_end__ is None:
-                if hasattr(self, "_preprocess_init_args"):
-                    a, kw = self._preprocess_init_args(*a, **kw)
-            if __remote_end__ is None:
+                try:
+                    preprocess = object.__getattribute__(self, "_preprocess_init_args")
+                except AttributeError:
+                    pass
+                else:
+                    a, kw = preprocess(*a, **kw)
+
                 __remote_end__ = remote_cls(*a, **kw)
             while True:
                 # unwrap the object if it's a wrapper

--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -428,6 +428,9 @@ def make_proxy_cls(
 
         def __init__(self, *a, __remote_end__=None, **kw):
             if __remote_end__ is None:
+                if hasattr(self, "_preprocess_init_args"):
+                    a, kw = self._preprocess_init_args(*a, **kw)
+            if __remote_end__ is None:
                 __remote_end__ = remote_cls(*a, **kw)
             while True:
                 # unwrap the object if it's a wrapper
@@ -622,6 +625,27 @@ def make_dataframe_wrapper(DataFrame):
     ObtainingItems = _deliveringWrapper(Series, mixin=ObtainingItems)
 
     class DataFrameOverrides(_prepare_loc_mixin()):
+        @classmethod
+        def _preprocess_init_args(
+            cls,
+            data=None,
+            index=None,
+            columns=None,
+            dtype=None,
+            copy=None,
+            query_compiler=None,
+        ):
+
+            (data,) = conn.deliver((data,), {})[0]
+            return (), dict(
+                data=data,
+                index=index,
+                columns=columns,
+                dtype=dtype,
+                copy=copy,
+                query_compiler=query_compiler,
+            )
+
         @property
         def dtypes(self):
             remote_dtypes = self.__remote_end__.dtypes


### PR DESCRIPTION
Signed-off-by: aleksandr.lozovskii <aleksandr.lozovskii@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [X] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [X] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [X] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [X] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [X] Resolves [#3741](https://github.com/modin-project/modin/issues/3741)
- [X] tests added and passing
- [X] module layout described at `docs/developer/architecture.rst` is up-to-date 

The problem was that in the `cloud` mode modin was created a proxy `DataFrame`, where the element type was not `float64`, as intended, but a proxy object. To solve this problem for `DataFrame`, we will pass the data parameter from the local side to the remote side.