### PR TITLE
FIX-#3744: Align default value of REDIS_PASSWORD with Ray

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -18,7 +18,6 @@ import sys
 from textwrap import dedent
 import warnings
 from packaging import version
-import secrets
 
 from .pubsub import Parameter, _TYPE_PARAMS, ExactStr, ValueSource
 
@@ -154,7 +153,6 @@ class RayRedisPassword(EnvironmentVariable, type=ExactStr):
     """What password to use for connecting to Redis."""
 
     varname = "MODIN_REDIS_PASSWORD"
-    default = secrets.token_hex(32)
 
 
 class CpuCount(EnvironmentVariable, type=int):

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -154,6 +154,19 @@ class RayRedisPassword(EnvironmentVariable, type=ExactStr):
 
     varname = "MODIN_REDIS_PASSWORD"
 
+    @classmethod
+    def _get_default(cls):
+        """
+        Get default value of the config.
+
+        Returns
+        -------
+        int
+        """
+        from ray import ray_constants
+
+        return ray_constants.REDIS_DEFAULT_PASSWORD
+
 
 class CpuCount(EnvironmentVariable, type=int):
     """How many CPU cores to use during initialization of the Modin engine."""

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -18,6 +18,7 @@ import sys
 from textwrap import dedent
 import warnings
 from packaging import version
+import secrets
 
 from .pubsub import Parameter, _TYPE_PARAMS, ExactStr, ValueSource
 
@@ -153,19 +154,7 @@ class RayRedisPassword(EnvironmentVariable, type=ExactStr):
     """What password to use for connecting to Redis."""
 
     varname = "MODIN_REDIS_PASSWORD"
-
-    @classmethod
-    def _get_default(cls):
-        """
-        Get default value of the config.
-
-        Returns
-        -------
-        str
-        """
-        from ray import ray_constants
-
-        return ray_constants.REDIS_DEFAULT_PASSWORD
+    default = secrets.token_hex(32)
 
 
 class CpuCount(EnvironmentVariable, type=int):

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -161,7 +161,7 @@ class RayRedisPassword(EnvironmentVariable, type=ExactStr):
 
         Returns
         -------
-        int
+        str
         """
         from ray import ray_constants
 

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -20,7 +20,6 @@ import warnings
 import asyncio
 
 import ray
-from ray import ray_constants
 
 from modin.config import (
     StorageFormat,
@@ -117,7 +116,7 @@ def initialize_ray(
         redis_address = override_redis_address or RayRedisAddress.get()
         redis_password = (
             (
-                ray_constants.REDIS_DEFAULT_PASSWORD
+                ray.ray_constants.REDIS_DEFAULT_PASSWORD
                 if cluster
                 else RayRedisPassword.get()
             )

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -20,7 +20,6 @@ import warnings
 import asyncio
 
 import ray
-from ray import ray_constants
 
 from modin.config import (
     StorageFormat,
@@ -122,7 +121,7 @@ def initialize_ray(
                 address=redis_address or "auto",
                 include_dashboard=False,
                 ignore_reinit_error=True,
-                _redis_password=redis_password or ray_constants.REDIS_DEFAULT_PASSWORD,
+                _redis_password=redis_password,
             )
         else:
             from modin.error_message import ErrorMessage

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -121,7 +121,7 @@ def initialize_ray(
                 if cluster
                 else RayRedisPassword.get()
             )
-            if override_redis_address is None
+            if override_redis_password is None
             and RayRedisPassword.get_value_source() == ValueSource.DEFAULT
             else override_redis_password or RayRedisPassword.get()
         )

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -20,6 +20,7 @@ import warnings
 import asyncio
 
 import ray
+from ray import ray_constants
 
 from modin.config import (
     StorageFormat,
@@ -121,7 +122,7 @@ def initialize_ray(
                 address=redis_address or "auto",
                 include_dashboard=False,
                 ignore_reinit_error=True,
-                _redis_password=redis_password,
+                _redis_password=redis_password or ray_constants.REDIS_DEFAULT_PASSWORD,
             )
         else:
             from modin.error_message import ErrorMessage


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

PR changes default Redis password to bo aligned with Ray default. This makes possible to not provide redis password in case using of default Ray cluster.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3744  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
