### PR TITLE
FIX-#3219: delegate 'apply' result type inference to backend

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -2119,7 +2119,13 @@ class BaseQueryCompiler(abc.ABC):
               corresponding row/column.
         """
         return DataFrameDefault.register(pandas.DataFrame.apply)(
-            self, func=func, axis=axis, *args, **kwargs
+            self,
+            func=func,
+            axis=axis,
+            raw=raw,
+            result_type=result_type,
+            *args,
+            **kwargs,
         )
 
     def explode(self, column):

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -2089,7 +2089,7 @@ class BaseQueryCompiler(abc.ABC):
             Target axis to apply the function along.
             0 is for index, 1 is for columns.
         raw : bool, default: False
-            Whether to pass a high-level DataFrame object (False) or a raw representation
+            Whether to pass a high-level Series object (False) or a raw representation
             of the data (True).
         result_type : {"expand", "reduce", "broadcast", None}, default: None
             Determines how to treat list-like return type of the `func` (works only if
@@ -2111,9 +2111,9 @@ class BaseQueryCompiler(abc.ABC):
             the following rules:
 
             - Index of the specified axis contains: the names of the passed functions if multiple
-              functions were passed, otherwise: indices of the `func` result if "expand" strategy
-              was used, indices of the original frame if "broadcast" strategy was used, a single
-              label "__reduced__" if "reduce" strategy was used.
+              functions are passed, otherwise: indices of the `func` result if "expand" strategy
+              is used, indices of the original frame if "broadcast" strategy is used, a single
+              label "__reduced__" if "reduce" strategy is used.
             - Labels of the opposite axis are preserved.
             - Each element is the result of execution of `func` against
               corresponding row/column.

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2344,47 +2344,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
         # convert it to pandas
         args = try_cast_to_pandas(args)
         kwargs = try_cast_to_pandas(kwargs)
-        if isinstance(func, str):
-            return self._apply_text_func_elementwise(func, axis, *args, **kwargs)
-        elif callable(func):
-            return self._callable_func(func, axis, *args, **kwargs)
-        elif isinstance(func, dict):
+        if isinstance(func, dict):
             return self._dict_func(func, axis, *args, **kwargs)
         elif is_list_like(func):
             return self._list_like_func(func, axis, *args, **kwargs)
         else:
-            pass
-
-    # FIXME: `_apply_text_func_elementwise` duplicates most of the logic of `_callable_func`,
-    # these methods should be combined.
-    def _apply_text_func_elementwise(self, func, axis, *args, **kwargs):
-        """
-        Apply passed string function to each row/column.
-
-        Parameters
-        ----------
-        func : str
-            Function name to apply.
-        axis : {0, 1}
-            Target axis to apply function along. 0 means apply to columns,
-            1 means apply to rows.
-        *args : args
-            Arguments to pass to the specified function.
-        **kwargs : kwargs
-            Arguments to pass to the specified function.
-
-        Returns
-        -------
-        PandasQueryCompiler
-            New QueryCompiler containing the results of passed function
-            for each row/column.
-        """
-        assert isinstance(func, str)
-        kwargs["axis"] = axis
-        new_modin_frame = self._modin_frame.apply_full_axis(
-            axis, lambda df: df.apply(func, *args, **kwargs)
-        )
-        return self.__constructor__(new_modin_frame)
+            return self._callable_func(func, axis, *args, **kwargs)
 
     def _dict_func(self, func, axis, *args, **kwargs):
         """
@@ -2413,7 +2378,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
         def dict_apply_builder(df, func_dict={}):
             # Sometimes `apply` can return a `Series`, but we require that internally
             # all objects are `DataFrame`s.
-            return pandas.DataFrame(df.apply(func_dict, *args, **kwargs))
+            result = df.apply(func_dict, *args, **kwargs)
+            return (
+                result.to_frame("__reduced__")
+                if isinstance(result, pandas.Series)
+                else result
+            )
 
         func = {k: wrap_udf_function(v) if callable(v) else v for k, v in func.items()}
         return self.__constructor__(
@@ -2469,7 +2439,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
         Parameters
         ----------
-        func : callable
+        func : callable or str
             Function to apply.
         axis : {0, 1}
             Target axis to apply function along. 0 means apply to columns,
@@ -2485,7 +2455,18 @@ class PandasQueryCompiler(BaseQueryCompiler):
             New QueryCompiler containing the results of passed function
             for each row/column.
         """
-        func = wrap_udf_function(func)
+        if callable(func):
+            func = wrap_udf_function(func)
+
+        def applyier(df):
+            """Execute apply function against `df` held by partition."""
+            result = df.apply(func, *args, **kwargs)
+            return (
+                result.to_frame("__reduced__")
+                if isinstance(result, pandas.Series)
+                else result
+            )
+
         new_modin_frame = self._modin_frame.apply_full_axis(
             axis, lambda df: df.apply(func, axis=axis, *args, **kwargs)
         )

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -362,8 +362,6 @@ class DataFrame(BasePandasDataset):
         query_compiler = super(DataFrame, self).apply(
             func, axis=axis, raw=raw, result_type=result_type, args=args, **kwargs
         )
-        if not isinstance(query_compiler, type(self._query_compiler)):
-            return query_compiler
 
         if result_type == "reduce":
             output_type = Series

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -362,6 +362,9 @@ class DataFrame(BasePandasDataset):
         query_compiler = super(DataFrame, self).apply(
             func, axis=axis, raw=raw, result_type=result_type, args=args, **kwargs
         )
+        if not isinstance(query_compiler, type(self._query_compiler)):
+            # A scalar was returned
+            return query_compiler
 
         if result_type == "reduce":
             output_type = Series

--- a/modin/pandas/test/dataframe/test_udf.py
+++ b/modin/pandas/test/dataframe/test_udf.py
@@ -228,8 +228,7 @@ def test_apply_metadata():
 def test_apply_udf(data, func):
     eval_general(
         *create_test_dfs(data),
-        lambda df, *args, **kwargs: df.apply(*args, **kwargs),
-        func=func,
+        lambda df, *args, **kwargs: df.apply(func, *args, **kwargs),
         other=lambda df: df,
     )
 

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -295,6 +295,9 @@ agg_func = {
     "str": str,
     "sum mean": ["sum", "mean"],
     "sum df sum": ["sum", lambda df: df.sum()],
+    "axis-wise sum": lambda axis: (
+        axis.iloc[0] + axis.iloc[1] if isinstance(axis, pandas.Series) else axis + axis
+    ),
     "should raise TypeError": 1,
 }
 agg_func_keys = list(agg_func.keys())

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -295,8 +295,9 @@ agg_func = {
     "str": str,
     "sum mean": ["sum", "mean"],
     "sum df sum": ["sum", lambda df: df.sum()],
-    "axis-wise sum": lambda axis: (
-        axis.iloc[0] + axis.iloc[1] if isinstance(axis, pandas.Series) else axis + axis
+    # The case verify that returning a scalar that is based on a frame's data doesn't cause a problem
+    "sum of certain elements": lambda axis: (
+        axis.iloc[0] + axis.iloc[-1] if isinstance(axis, pandas.Series) else axis + axis
     ),
     "should raise TypeError": 1,
 }

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -314,13 +314,13 @@ agg_func_except_values = list(agg_func_except.values())
 numeric_agg_funcs = ["sum mean", "sum sum", "sum df sum"]
 
 udf_func = {
-    "return self": lambda df: lambda x, *args, **kwargs: type(x)(x.values),
-    "change index": lambda df: lambda x, *args, **kwargs: pandas.Series(
+    "return self": lambda x, *args, **kwargs: type(x)(x.values),
+    "change index": lambda x, *args, **kwargs: pandas.Series(
         x.values, index=np.arange(-1, len(x.index) - 1)
     ),
-    "return none": lambda df: lambda x, *args, **kwargs: None,
-    "return empty": lambda df: lambda x, *args, **kwargs: pandas.Series(),
-    "access self": lambda df: lambda x, other, *args, **kwargs: pandas.Series(
+    "return none": lambda x, *args, **kwargs: None,
+    "return empty": lambda x, *args, **kwargs: pandas.Series(),
+    "access self": lambda x, other, *args, **kwargs: pandas.Series(
         x.values, index=other.index
     ),
 }

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -295,7 +295,7 @@ agg_func = {
     "str": str,
     "sum mean": ["sum", "mean"],
     "sum df sum": ["sum", lambda df: df.sum()],
-    # The case verify that returning a scalar that is based on a frame's data doesn't cause a problem
+    # The case verifies that returning a scalar that is based on a frame's data doesn't cause a problem
     "sum of certain elements": lambda axis: (
         axis.iloc[0] + axis.iloc[-1] if isinstance(axis, pandas.Series) else axis + axis
     ),


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

At the issue discussion (#3219) it was decided to move the frame's type inference for the `.apply()` result to the QC level, since the result type strictly depends on the UDF's behavior, which is only known at the execution level. This PR updates the contract for the `query_compiler.apply()` method as well as its behavior to do the inferring.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3219 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
