### PR TITLE
FIX-#3725: do not trigger computation of lazy 'dtypes' on transpose

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2295,10 +2295,13 @@ class PandasDataframe(object):
         new_partitions = self._partition_mgr_cls.lazy_map_partitions(
             self._partitions, lambda df: df.T
         ).T
-        new_dtypes = pandas.Series(
-            np.full(len(self.index), find_common_type(self.dtypes.values)),
-            index=self.index,
-        )
+        if self._dtypes is not None:
+            new_dtypes = pandas.Series(
+                np.full(len(self.index), find_common_type(self.dtypes.values)),
+                index=self.index,
+            )
+        else:
+            new_dtypes = None
         return self.__constructor__(
             new_partitions,
             self.columns,


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Adds conditioning on computing new 'dtypes' at transpose: if `._dtypes` is None (computation delayed) keep it None for the transposed frame as well. Transpose of a frame with delayed 'dtypes' is a part of reduction operations flow ([columnarization at `Series` constructor](https://github.com/modin-project/modin/blob/f2133da30ba40786fcd421396b92f29bd121083c/modin/pandas/series.py#L160)), so these changes should speed-up at least reduction operations.

<details><summary>ASV benchmarks</summary>

Launch command:
```
MODIN_CPUS=16 MODIN_TEST_DATASET_SIZE=Big asv continuous -b "^benchmarks.TimeArithmetic" --show-stderr --no-only-changed 698f3632 lazy_transpose
```

```
       before           after         ratio
     [698f3632]       [a869c096]
     <master>       <lazy_transpose>
         155±50ms          170±4ms     1.10  benchmarks.TimeArithmetic.time_apply([1000000, 10], 0)
        113±0.5ms          121±7ms     1.07  benchmarks.TimeArithmetic.time_median([1000000, 10], 1)
         51.6±5ms         54.6±4ms     1.06  benchmarks.TimeArithmetic.time_mean([1000000, 10], 1)
          175±4ms          183±5ms     1.05  benchmarks.TimeArithmetic.time_apply([5000, 5000], 1)
        3.29±0.1s       3.36±0.03s     1.02  benchmarks.TimeArithmetic.time_nunique([1000000, 10], 1)
        67.9±50ms         71±30ms     ~1.02  benchmarks.TimeArithmetic.time_mean([1000000, 10], 0)
          150±3ms          153±2ms     1.02  benchmarks.TimeArithmetic.time_median([5000, 5000], 1)
          124±1ms          125±1ms     1.01  benchmarks.TimeArithmetic.time_nunique([5000, 5000], 1)
       3.22±0.05s       3.24±0.04s     1.01  benchmarks.TimeArithmetic.time_apply([1000000, 10], 1)
          116±7ms          115±5ms     0.99  benchmarks.TimeArithmetic.time_sum([5000, 5000], 1)
          305±3ms        285±0.9ms     0.94  benchmarks.TimeArithmetic.time_median([1000000, 10], 0)
          151±7ms          140±9ms     0.92  benchmarks.TimeArithmetic.time_mean([5000, 5000], 1)
         53.0±4ms         48.2±2ms     0.91  benchmarks.TimeArithmetic.time_sum([1000000, 10], 1)
-         153±1ms          134±2ms     0.87  benchmarks.TimeArithmetic.time_nunique([1000000, 10], 0)
-         232±9ms          173±3ms     0.75  benchmarks.TimeArithmetic.time_mean([5000, 5000], 0)
-         267±9ms          199±7ms     0.74  benchmarks.TimeArithmetic.time_sum([5000, 5000], 0)
-         188±9ms          138±7ms     0.73  benchmarks.TimeArithmetic.time_median([5000, 5000], 0)
         151±40ms        95.4±30ms    ~0.63  benchmarks.TimeArithmetic.time_sum([1000000, 10], 0)
-        189±20ms          116±6ms     0.61  benchmarks.TimeArithmetic.time_nunique([5000, 5000], 0)
-         214±9ms         123±10ms     0.58  benchmarks.TimeArithmetic.time_apply([5000, 5000], 0)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.

```

</details>

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3725 <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
