### PR TITLE
FIX-#3736: Don't use a 2-d array to set a categorical column.

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -385,7 +385,34 @@ class _LocationIndexerBase(object):
             else:
                 new_col_len = len(col_lookup)
             to_shape = new_row_len, new_col_len
-            item = self._broadcast_item(row_lookup, col_lookup, item, to_shape)
+            # If we are asssigning to a single categorical column, we won't be
+            # able to set the column to a 2-d array due to a bug in Pandas.
+            # Until that bug is fixed, don't convert `item` to a 2-d array
+            # in that case.
+            # TODO(https://github.com/pandas-dev/pandas/issues/44703): Delete
+            # this special case once the pandas bug is fixed.
+            assigning_to_single_category_column = new_col_len == 1 and (
+                # Case 1: df = pd.DataFrame({"status": ["a", "b", "c"]},
+                #                           dtype="category")
+                # Then type(df.dtypes) is pandas.core.series.Series
+                (
+                    type(self.df.dtypes) == pandas.core.series.Series
+                    and self.df.dtypes[col_lookup][0].name == "category"
+                )
+                # Case 2: df = pd.Series( ["a", "b", "c"],  dtype="category")
+                # Then df.dtypes ==  CategoricalDtype(categories=['a', 'b', 'c'],
+                #                                     ordered=False)
+                # and type(df.dtypes) is pandas.core.dtypes.dtypes.CategoricalDtype.
+                # Case 3:  df = pd.Series([0, 1, 2], index=['a', 'b', 'c'])
+                # Then df.dtypes == dtype('int64') and type(df.dtypes) is
+                # numpy.dtype
+                or (
+                    hasattr(type(self.df.dtypes), "name")
+                    and self.df.dtypes.name == "category"
+                )
+            )
+            if not assigning_to_single_category_column:
+                item = self._broadcast_item(row_lookup, col_lookup, item, to_shape)
             self._write_items(row_lookup, col_lookup, item)
 
     def _broadcast_item(self, row_lookup, col_lookup, item, to_shape):

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -396,7 +396,7 @@ class _LocationIndexerBase(object):
                 #                           dtype="category")
                 # Then type(df.dtypes) is pandas.core.series.Series
                 (
-                    type(self.df.dtypes) == pandas.core.series.Series
+                    isinstance(self.df.dtypes, pandas.core.series.Series)
                     and self.df.dtypes[col_lookup][0].name == "category"
                 )
                 # Case 2: df = pd.Series( ["a", "b", "c"],  dtype="category")
@@ -407,8 +407,7 @@ class _LocationIndexerBase(object):
                 # Then df.dtypes == dtype('int64') and type(df.dtypes) is
                 # numpy.dtype
                 or (
-                    hasattr(type(self.df.dtypes), "name")
-                    and self.df.dtypes.name == "category"
+                    getattr(self.df.dtypes, "name", "") == "category"
                 )
             )
             if not assigning_to_single_category_column:

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -406,9 +406,7 @@ class _LocationIndexerBase(object):
                 # Case 3:  df = pd.Series([0, 1, 2], index=['a', 'b', 'c'])
                 # Then df.dtypes == dtype('int64') and type(df.dtypes) is
                 # numpy.dtype
-                or (
-                    getattr(self.df.dtypes, "name", "") == "category"
-                )
+                or (getattr(self.df.dtypes, "name", "") == "category")
             )
             if not assigning_to_single_category_column:
                 item = self._broadcast_item(row_lookup, col_lookup, item, to_shape)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -372,6 +372,15 @@ def test_loc(data):
         modin_df.loc["NO_EXIST"]
 
 
+# This tests the bug from https://github.com/modin-project/modin/issues/3736
+def test_loc_setting_single_categorical_column():
+    modin_df = pd.DataFrame({"status": ["a", "b", "c"]}, dtype="category")
+    pandas_df = pandas.DataFrame({"status": ["a", "b", "c"]}, dtype="category")
+    modin_df.loc[1:3, "status"] = "a"
+    pandas_df.loc[1:3, "status"] = "a"
+    df_equals(modin_df, pandas_df)
+
+
 def test_loc_multi_index():
     modin_df = pd.read_csv(
         "modin/pandas/test/data/blah.csv", header=[0, 1, 2, 3], index_col=0

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2105,6 +2105,15 @@ def test_loc(data):
     df_equals(modin_result, pandas_result)
 
 
+# This tests the bug from https://github.com/modin-project/modin/issues/3736
+def test_loc_setting_categorical_series():
+    modin_series = pd.Series(["a", "b", "c"], dtype="category")
+    pandas_series = pandas.Series(["a", "b", "c"], dtype="category")
+    modin_series.loc[1:3] = "a"
+    pandas_series.loc[1:3] = "a"
+    df_equals(modin_series, pandas_series)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_lt(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Work around https://github.com/pandas-dev/pandas/issues/44703 by not converting a categorical scalar to a 2-d array to set a categorical column.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3736 
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
