### PR TITLE
FIX-#3774: Fix omnisci import

### DIFF
--- a/docs/developer/troubleshooting.rst
+++ b/docs/developer/troubleshooting.rst
@@ -111,10 +111,10 @@ differntly. Example of such behaviour is shown below.
   try :
       with open(test_filename, "w") as f:
           f.write(data)
-      
+
       pandas_df = pandas.read_csv(test_filename, **kwargs)
       pd_df = pd.read_csv(test_filename, **kwargs)
-      
+
       print(pandas_df)
       print(pd_df)
   finally:
@@ -194,5 +194,25 @@ funcion for example) as it is shown in the example below:
   pd_df = pd.read_csv(filename, dtype=data_dtype, index_col=None)
   pd_df = pd_df.set_index(index_col_name)
   pd_df.index.name = None
+
+Error when using OmniSci engine: ``CommandLine Error: Option 'enable-vfe' registered more than once!``
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+This can happen when you set the following config values prior Modin import:
+
+.. code-block:: python
+
+  import modin.config as cfg
+  cfg.Engine.put("Native")  # 'omniscidbe'/'dbe' would be imported with dlopen flags first time
+  cfg.StorageFormat.put("Omnisci")
+  cfg.IsExperimental.put(True)
+  import modin.pandas as pd  # Error
+  CommandLine Error: Option 'enable-vfe' registered more than once!
+  LLVM ERROR: inconsistency in registered CommandLine options
+  Aborted (core dumped)
+
+**Solution**
+
+Please use the guide that is specified in :doc:`Omnisci </developer/using_omnisci>` usage section.
 
 .. _issue: https://github.com/modin-project/modin/issues

--- a/docs/developer/troubleshooting.rst
+++ b/docs/developer/troubleshooting.rst
@@ -195,25 +195,25 @@ funcion for example) as it is shown in the example below:
   pd_df = pd_df.set_index(index_col_name)
   pd_df.index.name = None
 
-Error when using OmniSci engine: ``LLVM ERROR: inconsistency in registered CommandLine options``
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Error when using OmniSci engine along with ``pyarrow.gandiva``: ``LLVM ERROR: inconsistency in registered CommandLine options``
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
-This can happen when you set the following config values prior Modin import:
+This can happen when you use OmniSci engine along with ``pyarrow.gandiva``:
 
 .. code-block:: python
 
   import modin.config as cfg
-  cfg.Engine.put("Native")  # 'omniscidbe'/'dbe' would be imported with dlopen flags first time
+  cfg.Engine.put("Native")  # 'omniscidbe'/'dbe' would be imported with dlopen flags
   cfg.StorageFormat.put("Omnisci")
   cfg.IsExperimental.put(True)
-  import modin.pandas as pd  # Error
+  import modin.pandas as pd
+  import pyarrow.gandiva as gandiva  # Error
   CommandLine Error: Option 'enable-vfe' registered more than once!
   LLVM ERROR: inconsistency in registered CommandLine options
   Aborted (core dumped)
 
 **Solution**
 
-Do not set ``Engine`` to ``Native`` prior Modin import in your code. However, if you want to be explicit
-as to the engine used, you can specify it using ``MODIN_ENGINE`` environment variable.
+Do not use OmniSci engine along with ``pyarrow.gandiva``.
 
 .. _issue: https://github.com/modin-project/modin/issues

--- a/docs/developer/troubleshooting.rst
+++ b/docs/developer/troubleshooting.rst
@@ -195,8 +195,8 @@ funcion for example) as it is shown in the example below:
   pd_df = pd_df.set_index(index_col_name)
   pd_df.index.name = None
 
-Error when using OmniSci engine: ``CommandLine Error: Option 'enable-vfe' registered more than once!``
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+Error when using OmniSci engine: ``LLVM ERROR: inconsistency in registered CommandLine options``
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
 This can happen when you set the following config values prior Modin import:
 
@@ -213,6 +213,7 @@ This can happen when you set the following config values prior Modin import:
 
 **Solution**
 
-Please use the guide that is specified in :doc:`Omnisci </developer/using_omnisci>` usage section.
+Do not set ``Engine`` to ``Native`` prior Modin import in your code. However, if you want to be explicit
+as to the engine used, you can specify it using ``MODIN_ENGINE`` environment variable.
 
 .. _issue: https://github.com/modin-project/modin/issues

--- a/docs/developer/using_omnisci.rst
+++ b/docs/developer/using_omnisci.rst
@@ -21,4 +21,8 @@ or use it in your code:
 Since OmniSci is run through its native engine Modin itself sets ``MODIN_ENGINE=Native``
 and you might not specify it explicitly.
 
+.. note::
+   If you encounter ``CommandLine Error: Option 'enable-vfe' registered more than once!`` error when using OmniSci,
+   please refer to the respective section in :doc:`Troubleshooting </developer/troubleshooting>` page to avoid the issue.
+
 .. _OmnisciDB: https://www.omnisci.com/platform/omniscidb

--- a/docs/developer/using_omnisci.rst
+++ b/docs/developer/using_omnisci.rst
@@ -22,7 +22,7 @@ Since OmniSci is run through its native engine Modin itself sets ``MODIN_ENGINE=
 and you might not specify it explicitly.
 
 .. note::
-   If you encounter ``CommandLine Error: Option 'enable-vfe' registered more than once!`` error when using OmniSci,
+   If you encounter ``LLVM ERROR: inconsistency in registered CommandLine options`` error when using OmniSci,
    please refer to the respective section in :doc:`Troubleshooting </developer/troubleshooting>` page to avoid the issue.
 
 .. _OmnisciDB: https://www.omnisci.com/platform/omniscidb

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -108,30 +108,12 @@ class Engine(EnvironmentVariable, type=str):
                     "Please `pip install modin[dask]` to install compatible Dask version."
                 )
             return "Dask"
-
-        # We use subprocess to identify whether 'omniscidbe'/'dbe' is installed by the following reasons:
-        # 1) We have to import 'omniscidbe'/'dbe' with specifying dlopen flags.
-        # 2) If we perform 1st clause, we have to import 'omniscidbe'/'dbe' after Modin itself is imported,
-        # i.e. the following code snippet won't work:
-        # ... import modin.config as cfg
-        # ... cfg.Engine.put("Native")  # 'omniscidbe'/'dbe' would be imported with dlopen flags first time
-        # ... cfg.StorageFormat.put("Omnisci")
-        # ... cfg.IsExperimental.put(True)
-        # ... import modin.pandas as pd  # Error
-        # ... CommandLine Error: Option 'enable-vfe' registered more than once!
-        # ... LLVM ERROR: inconsistency in registered CommandLine options
-        # ... Aborted (core dumped)
-        import subprocess
-
-        omniscidbe_info = subprocess.run(
-            ["pip", "show", "omniscidbe"], capture_output=True, text=True
-        )
-        if omniscidbe_info.stderr:
-            dbe_info = subprocess.run(
-                ["pip", "show", "dbe"], capture_output=True, text=True
+        try:
+            from modin.experimental.core.execution.native.implementations.omnisci_on_native.utils import (  # noqa
+                PyDbEngine,
             )
-            if not dbe_info.stderr:
-                return "Native"
+        except ImportError:
+            pass
         else:
             return "Native"
         raise ImportError(

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -108,14 +108,29 @@ class Engine(EnvironmentVariable, type=str):
                     "Please `pip install modin[dask]` to install compatible Dask version."
                 )
             return "Dask"
-        try:
-            from omniscidbe import PyDbEngine  # noqa
-        except ModuleNotFoundError:
-            try:
-                from dbe import PyDbEngine  # noqa
-            except ImportError:
-                pass
-            else:
+
+        # We use subprocess to identify whether 'omniscidbe'/'dbe' is installed by the following reasons:
+        # 1) We have to import 'omniscidbe'/'dbe' with specifying dlopen flags.
+        # 2) If we perform 1st clause, we have to import 'omniscidbe'/'dbe' after Modin itself is imported,
+        # i.e. the following code snippet won't work:
+        # ... import modin.config as cfg
+        # ... cfg.Engine.put("Native")  # 'omniscidbe'/'dbe' would be imported with dlopen flags first time
+        # ... cfg.StorageFormat.put("Omnisci")
+        # ... cfg.IsExperimental.put(True)
+        # ... import modin.pandas as pd  # Error
+        # ... CommandLine Error: Option 'enable-vfe' registered more than once!
+        # ... LLVM ERROR: inconsistency in registered CommandLine options
+        # ... Aborted (core dumped)
+        import subprocess
+
+        omniscidbe_info = subprocess.run(
+            ["pip", "show", "omniscidbe"], capture_output=True, text=True
+        )
+        if omniscidbe_info.stderr:
+            dbe_info = subprocess.run(
+                ["pip", "show", "dbe"], capture_output=True, text=True
+            )
+            if not dbe_info.stderr:
                 return "Native"
         else:
             return "Native"

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -109,6 +109,8 @@ class Engine(EnvironmentVariable, type=str):
                 )
             return "Dask"
         try:
+            # We import ``PyDbEngine`` from this module since correct import of ``PyDbEngine`` itself
+            # from Omnisci is located in it with all the necessary options for dlopen.
             from modin.experimental.core.execution.native.implementations.omnisci_on_native.utils import (  # noqa
                 PyDbEngine,
             )

--- a/modin/core/storage_formats/pyarrow/query_compiler.py
+++ b/modin/core/storage_formats/pyarrow/query_compiler.py
@@ -26,7 +26,6 @@ from pandas.core.computation.scope import Scope
 from pandas.core.computation.ops import UnaryOp, BinOp, Term, MathCall, Constant
 
 import pyarrow as pa
-import pyarrow.gandiva as gandiva
 
 
 class FakeSeries:
@@ -221,6 +220,11 @@ class PyarrowQueryCompiler(PandasQueryCompiler):
             expr = gen_table_expr(table, query)
             if not can_be_condition(expr):
                 raise ValueError("Root operation should be a filter.")
+
+            # We use this import here because of https://github.com/modin-project/modin/issues/3849,
+            # after the issue is fixed we should put the import at the top of this file
+            import pyarrow.gandiva as gandiva
+
             builder = gandiva.TreeExprBuilder()
             root = build_node(table, expr.terms, builder)
             cond = builder.make_condition(root)

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/omnisci_worker.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/omnisci_worker.py
@@ -14,23 +14,12 @@
 """Module provides ``OmnisciServer`` class."""
 
 import uuid
-import sys
 import os
 
 import pyarrow as pa
 import numpy as np
 
-if sys.platform == "linux":
-    prev = sys.getdlopenflags()
-    sys.setdlopenflags(1 | 256)  # RTLD_LAZY+RTLD_GLOBAL
-
-try:
-    from omniscidbe import PyDbEngine
-except ModuleNotFoundError:  # fallback for older omniscidbe4py package naming
-    from dbe import PyDbEngine
-
-if sys.platform == "linux":
-    sys.setdlopenflags(prev)
+from .utils import PyDbEngine
 
 from modin.config import OmnisciFragmentSize, OmnisciLaunchParameters
 

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/utils.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/utils.py
@@ -1,0 +1,29 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Utilities for OmniSci on Native execution."""
+
+import sys
+
+
+if sys.platform == "linux":
+    prev = sys.getdlopenflags()
+    sys.setdlopenflags(1 | 256)  # RTLD_LAZY+RTLD_GLOBAL
+
+try:
+    from omniscidbe import PyDbEngine  # noqa
+except ModuleNotFoundError:  # fallback for older omniscidbe4py package naming
+    from dbe import PyDbEngine  # noqa
+
+if sys.platform == "linux":
+    sys.setdlopenflags(prev)

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/utils.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/utils.py
@@ -13,17 +13,18 @@
 
 """Utilities for OmniSci on Native execution."""
 
+import os
 import sys
 
 
 if sys.platform == "linux":
     prev = sys.getdlopenflags()
-    sys.setdlopenflags(1 | 256)  # RTLD_LAZY+RTLD_GLOBAL
+    sys.setdlopenflags(os.RTLD_LAZY | os.RTLD_GLOBAL)
 
 try:
     from omniscidbe import PyDbEngine  # noqa
 except ModuleNotFoundError:  # fallback for older omniscidbe4py package naming
     from dbe import PyDbEngine  # noqa
-
-if sys.platform == "linux":
-    sys.setdlopenflags(prev)
+finally:
+    if sys.platform == "linux":
+        sys.setdlopenflags(prev)

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ per-file-ignores =
     stress_tests/kaggle/*:E402
     modin/experimental/pandas/__init__.py:E402
     modin/_version.py:T001
-    modin/experimental/core/execution/native/implementations/omnisci_on_native/omnisci_worker.py:E402
     modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py:E402
 
 [coverage:run]


### PR DESCRIPTION
Signed-off-by: Igoshev, Yaroslav <yaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

There is an interesting thing with omnisci import. We have to import it with dlopen flags. Wherein, if we perform this, we have to import omnisci after Modin itself is imported, i.e. the following code snippet won't work:

```python
import modin.config as cfg
cfg.Engine.put("Native")  # 'omniscidbe'/'dbe' would be imported with dlopen flags first time
cfg.StorageFormat.put("Omnisci")
cfg.IsExperimental.put(True)
import modin.pandas as pd  # Error
CommandLine Error: Option 'enable-vfe' registered more than once!
LLVM ERROR: inconsistency in registered CommandLine options
Aborted (core dumped)
```

The error is apparently arisen since there are other libraries which use LLVM and may register an option in the same address space.

This PR adds using subprocess to check whether omnisci is installed in order to return corresponding value from `Engine.get_default()`.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3774 <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
