### PR TITLE
FIX-#3702: add proper check for none-slice at `df.__getitem__`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -955,7 +955,7 @@ class PandasDataframe(object):
         if isinstance(indices, slice) or (is_range_like(indices) and indices.step == 1):
             # Converting range-like indexer to slice
             indices = slice(indices.start, indices.stop, indices.step)
-            if is_full_grab_slice(indices):
+            if is_full_grab_slice(indices, sequence_len=len(self.axes[axis])):
                 return OrderedDict(
                     zip(
                         range(self._partitions.shape[axis]),

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -30,6 +30,7 @@ from modin.core.storage_formats.pandas.parsers import (
     find_common_type_cat as find_common_type,
 )
 from modin.pandas.indexing import is_range_like
+from modin.pandas.utils import is_full_grab_slice
 
 
 class PandasDataframe(object):
@@ -954,12 +955,7 @@ class PandasDataframe(object):
         if isinstance(indices, slice) or (is_range_like(indices) and indices.step == 1):
             # Converting range-like indexer to slice
             indices = slice(indices.start, indices.stop, indices.step)
-            # Detecting full-axis grab
-            if (
-                indices.start in (None, 0)
-                and indices.step in (None, 1)
-                and (indices.stop is None or indices.stop >= len(self.axes[axis]))
-            ):
+            if is_full_grab_slice(indices):
                 return OrderedDict(
                     zip(
                         range(self._partitions.shape[axis]),

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2997,7 +2997,11 @@ class BasePandasDataset(object):
         modin.pandas.BasePandasDataset
             Selected rows.
         """
-        if is_full_grab_slice(key):
+        if is_full_grab_slice(
+            key,
+            # Avoid triggering shape computation for lazy executions
+            sequence_len=(None if self._query_compiler.lazy_execution else len(self)),
+        ):
             return self.copy()
         return self.iloc[key]
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -45,6 +45,7 @@ from typing import Optional, Union, Sequence, Hashable
 import warnings
 import pickle as pkl
 
+from .utils import is_full_grab_slice
 from modin.utils import try_cast_to_pandas, _inherit_docstrings
 from modin.error_message import ErrorMessage
 from modin.pandas.utils import is_scalar
@@ -2996,7 +2997,7 @@ class BasePandasDataset(object):
         modin.pandas.BasePandasDataset
             Selected rows.
         """
-        if key.start is None and key.stop is None:
+        if is_full_grab_slice(key):
             return self.copy()
         return self.iloc[key]
 

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1437,6 +1437,7 @@ def test___getitem__(data):
         (-3, -1),
         (1, -1, 2),
         (-1, 1, -1),
+        (None, None, 2),
     ]
 
     # slice test

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -352,6 +352,7 @@ def test___getitem__(data):
     pandas_series = pandas.Series(list(range(1000)))
     df_equals(modin_series[:30], pandas_series[:30])
     df_equals(modin_series[modin_series > 500], pandas_series[pandas_series > 500])
+    df_equals(modin_series[::2], pandas_series[::2])
 
     # Test empty series
     df_equals(pd.Series([])[:30], pandas.Series([])[:30])

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -123,9 +123,10 @@ def is_full_grab_slice(slc, sequence_len=None):
         Slice object to check.
     sequence_len : int, optional
         Length of the sequence to index with the passed `slc`.
-        If not specified the function won't consider `slc` to
-        be a full-grab if its ``.stop`` attribute is equal or
-        greater than the sequence length.
+        If not specified the function won't be able to check whether
+        ``slc.stop`` is equal or greater than the sequence length to
+        consider `slc` to be a full-grab, and so, only slices with
+        ``.stop is None`` are considered to be a full-grab.
 
     Returns
     -------

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -132,6 +132,7 @@ def is_full_grab_slice(slc, sequence_len=None):
     -------
     bool
     """
+    assert isinstance(slc, slice), "slice object required"
     return (
         slc.start in (None, 0)
         and slc.step in (None, 1)

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -113,6 +113,33 @@ def is_scalar(obj):
     return not isinstance(obj, BasePandasDataset) and pandas_is_scalar(obj)
 
 
+def is_full_grab_slice(slc, sequence_len=None):
+    """
+    Check that the passes slice grabs the whole sequence.
+
+    Parameters
+    ----------
+    slc : slice
+        Slice object to check.
+    sequence_len : int, optional
+        Length of the sequence to index with the passed `slc`.
+        If not specified the function won't consider `slc` to
+        be a full-grab if its ``.stop`` attribute is equal or
+        greater than the sequence length.
+
+    Returns
+    -------
+    bool
+    """
+    return (
+        slc.start in (None, 0)
+        and slc.step in (None, 1)
+        and (
+            slc.stop is None or (sequence_len is not None and slc.stop >= sequence_len)
+        )
+    )
+
+
 def from_modin_frame_to_mi(df, sortorder=None, names=None):
     """
     Make a pandas.MultiIndex from a DataFrame.

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -115,7 +115,7 @@ def is_scalar(obj):
 
 def is_full_grab_slice(slc, sequence_len=None):
     """
-    Check that the passes slice grabs the whole sequence.
+    Check that the passed slice grabs the whole sequence.
 
     Parameters
     ----------


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Adds a unified check of whether a slice indexer grabs the whole sequence (`is_full_grab_slice`) and replaces an incorrect full-grab check at the `df.__getitem__` with the call of the new function.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3702 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
