### PR TITLE
Novichkovg/get arrow table support added

### DIFF
--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition_manager.py
@@ -263,7 +263,6 @@ class OmnisciOnNativeDataframePartitionManager(PandasDataframePartitionManager):
             at = pyarrow.Table.from_batches([rb])
         assert at is not None
 
-
         res = np.empty((1, 1), dtype=np.dtype(object))
         # workaround for https://github.com/modin-project/modin/issues/1851
         if DoUseCalcite.get():

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition_manager.py
@@ -255,6 +255,15 @@ class OmnisciOnNativeDataframePartitionManager(PandasDataframePartitionManager):
         assert rb is not None
         at = pyarrow.Table.from_batches([rb])
 
+        if hasattr(curs, 'getArrowTable'):
+            at = curs.getArrowTable()
+        else:
+            rb = curs.getArrowRecordBatch()
+            assert rb is not None
+            at = pyarrow.Table.from_batches([rb])
+        assert at is not None
+
+
         res = np.empty((1, 1), dtype=np.dtype(object))
         # workaround for https://github.com/modin-project/modin/issues/1851
         if DoUseCalcite.get():


### PR DESCRIPTION
Signed-off-by: Gleb Novichkov <gleb.novichkov@intel.com>

Added support for `getArrowTable()` function of DBEngine.  If present, this function is invoked; otherwise it falls back on `getArrowRecordBatch()`.
