### PR TITLE
FIX-#3804: Make `df_equals` check dtypes

### DIFF
--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -478,7 +478,7 @@ def df_categories_equals(df1, df2):
         assert_extension_array_equal(
             df1[column].values,
             df2[column].values,
-            check_dtype=False,
+            check_dtype=True,
         )
 
 
@@ -559,7 +559,7 @@ def df_equals(df1, df2):
         assert_frame_equal(
             df1,
             df2,
-            check_dtype=False,
+            check_dtype=True,
             check_datetimelike_compat=True,
             check_index_type=False,
             check_column_type=False,
@@ -569,7 +569,7 @@ def df_equals(df1, df2):
     elif isinstance(df1, pandas.Index) and isinstance(df2, pandas.Index):
         assert_index_equal(df1, df2)
     elif isinstance(df1, pandas.Series) and isinstance(df2, pandas.Series):
-        assert_series_equal(df1, df2, check_dtype=False, check_series_type=False)
+        assert_series_equal(df1, df2, check_dtype=True, check_series_type=False)
     elif isinstance(df1, groupby_types) and isinstance(df2, groupby_types):
         for g1, g2 in zip(df1, df2):
             assert g1[0] == g2[0]


### PR DESCRIPTION
Signed-off-by: Rehan Durrani <rehan@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3804  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
