### PR TITLE
DOCS-#3795: Expand `using_pandas_on_dask.rst` doc

### DIFF
--- a/docs/developer/using_pandas_on_dask.rst
+++ b/docs/developer/using_pandas_on_dask.rst
@@ -1,8 +1,23 @@
 pandas on Dask
 ==============
 
-The Dask engine and documentation could use your help! Consider opening a
-`pull request`_ or an issue_ to contribute or ask clarifying questions.
+This section describes usage related documents for the pandas on Dask component of Modin.
 
-.. _pull request: https://github.com/modin-project/modin/pulls
-.. _issue: https://github.com/modin-project/modin/issues
+Modin uses pandas as a primary memory format of the underlying partitions and optimizes queries
+ingested from the API layer in a specific way to this format. Thus, there is no need to care of choosing it
+but you can explicitly specify it anyway as shown below.
+
+One of the execution engines that Modin uses is Dask. To enable this engine you should set the following environment variables:
+
+.. code-block:: bash
+
+   export MODIN_ENGINE=dask
+   export MODIN_STORAGE_FORMAT=pandas
+
+or turn them on in source code:
+
+.. code-block:: python
+
+   import modin.config as cfg
+   cfg.Engine.put('dask')
+   cfg.StorageFormat.put('pandas')


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
PR expands `using_pandas_on_dask.rst` doc

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3795  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
