### PR TITLE
DOCS-#3782: Add `using_pandas_on_python.rst` doc

### DIFF
--- a/docs/developer/architecture.rst
+++ b/docs/developer/architecture.rst
@@ -200,7 +200,7 @@ documentation page on :doc:`contributing </developer/contributing>`.
     - Uses the `Dask Futures`_ execution framework.
     - The storage format is `pandas` and the in-memory partition type is a pandas DataFrame.
     - For more information on the execution path, see the :doc:`pandas on Dask </flow/modin/core/execution/dask/implementations/pandas_on_dask/index>` page.
-- pandas on Python
+- :doc:`pandas on Python </developer/using_pandas_on_python>`
     - Uses native python execution - mainly used for for debugging.
     - The storage format is `pandas` and the in-memory partition type is a pandas DataFrame.
     - For more information on the execution path, see the :doc:`pandas on Python </flow/modin/core/execution/python/implementations/pandas_on_python/index>` page.

--- a/docs/developer/architecture.rst
+++ b/docs/developer/architecture.rst
@@ -201,7 +201,7 @@ documentation page on :doc:`contributing </developer/contributing>`.
     - The storage format is `pandas` and the in-memory partition type is a pandas DataFrame.
     - For more information on the execution path, see the :doc:`pandas on Dask </flow/modin/core/execution/dask/implementations/pandas_on_dask/index>` page.
 - :doc:`pandas on Python </developer/using_pandas_on_python>`
-    - Uses native python execution - mainly used for for debugging.
+    - Uses native python execution - mainly used for debugging.
     - The storage format is `pandas` and the in-memory partition type is a pandas DataFrame.
     - For more information on the execution path, see the :doc:`pandas on Python </flow/modin/core/execution/python/implementations/pandas_on_python/index>` page.
 - :doc:`OmniSci on Native </developer/using_omnisci>` (experimental)

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -12,6 +12,7 @@ Developer
     using_omnisci
     using_pyarrow_on_ray
     using_sql_on_ray
+    using_pandas_on_python
     troubleshooting
 
 .. meta::

--- a/docs/developer/index.rst
+++ b/docs/developer/index.rst
@@ -9,10 +9,10 @@ Developer
     partition_api
     using_pandas_on_ray
     using_pandas_on_dask
+    using_pandas_on_python
     using_omnisci
     using_pyarrow_on_ray
     using_sql_on_ray
-    using_pandas_on_python
     troubleshooting
 
 .. meta::

--- a/docs/developer/using_pandas_on_python.rst
+++ b/docs/developer/using_pandas_on_python.rst
@@ -3,11 +3,11 @@ pandas on Python
 
 This section describes usage related documents for the pandas on Python component of Modin.
 
-Modin uses pandas as a primary memory format of the underlying partitions and optimizes queries
-ingested from the API layer in a specific way to this format. Thus, there is no need to care of choosing it
-but you can explicitly specify it anyway as shown below.
+Modin uses pandas as the primary memory format of the underlying partitions and optimizes queries
+from the API layer in a specific way to this format. Since it is a default, you do not need to specify
+the pandas memory format, but we show how to explicitly set it below.
 
-One of the execution engines that Modin uses is Python. This engine is sequential and it's used for the debug purposes.
+One of the execution engines that Modin uses is Python. This engine is sequential and used for the debugging.
 To enable the pandas on Python execution you should set the following environment variables:
 
 .. code-block:: bash

--- a/docs/developer/using_pandas_on_python.rst
+++ b/docs/developer/using_pandas_on_python.rst
@@ -7,7 +7,7 @@ Modin uses pandas as the primary memory format of the underlying partitions and 
 from the API layer in a specific way to this format. Since it is a default, you do not need to specify
 the pandas memory format, but we show how to explicitly set it below.
 
-One of the execution engines that Modin uses is Python. This engine is sequential and used for the debugging.
+One of the execution engines that Modin uses is Python. This engine is sequential and used for debugging.
 To enable the pandas on Python execution you should set the following environment variables:
 
 .. code-block:: bash

--- a/docs/developer/using_pandas_on_python.rst
+++ b/docs/developer/using_pandas_on_python.rst
@@ -8,7 +8,7 @@ ingested from the API layer in a specific way to this format. Thus, there is no 
 but you can explicitly specify it anyway as shown below.
 
 One of the execution engines that Modin uses is Python. This engine is sequential and it's used for the debug purposes.
-To enable this engine you should set the following environment variables:
+To enable the pandas on Python execution you should set the following environment variables:
 
 .. code-block:: bash
 

--- a/docs/developer/using_pandas_on_python.rst
+++ b/docs/developer/using_pandas_on_python.rst
@@ -1,0 +1,37 @@
+pandas on Python
+================
+
+This section describes usage related documents for the pandas on Python component of Modin.
+
+Modin uses pandas as a primary memory format of the underlying partitions and optimizes queries
+ingested from the API layer in a specific way to this format. Thus, there is no need to care of choosing it
+but you can explicitly specify it anyway as shown below.
+
+One of the execution engines that Modin uses is Python. This engine is sequential and it's used for the debug purposes.
+To enable this engine you should set the following environment variables:
+
+.. code-block:: bash
+
+   export MODIN_ENGINE=python
+   export MODIN_STORAGE_FORMAT=pandas
+
+or turn a debug mode on:
+
+.. code-block:: bash
+
+   export MODIN_DEBUG=True
+   export MODIN_STORAGE_FORMAT=pandas
+
+or do the same in source code:
+
+.. code-block:: python
+
+   import modin.config as cfg
+   cfg.Engine.put('python')
+   cfg.StorageFormat.put('pandas')
+
+.. code-block:: python
+
+   import modin.config as cfg
+   cfg.IsDebug.put(True)
+   cfg.StorageFormat.put('pandas')

--- a/docs/flow/modin/core/execution/python/implementations/pandas_on_python/index.rst
+++ b/docs/flow/modin/core/execution/python/implementations/pandas_on_python/index.rst
@@ -7,7 +7,7 @@ Queries that perform data transformation, data ingress or data egress using the 
 pass through the Modin components detailed below.
 
 `pandas on Python` execution is sequential and it's used for the debug purposes. To enable `pandas on Python` execution,
-please refer to the usage section in :doc:`pandas on Python </UsingPandasonPython/index>`.
+please refer to the usage section in :doc:`pandas on Python </developer/using_pandas_on_python>`.
 
 Data Transformation
 '''''''''''''''''''


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
PR adds `using_pandas_on_python.rst` doc

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3782  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

Actual doc build is here: https://modin--3809.org.readthedocs.build/en/3809/developer/using_pandas_on_python.html