### PR TITLE
REFACTOR-#3820: remove extra 'FactoryDispatcher' import statement

### DIFF
--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -303,8 +303,6 @@ def to_pickle_distributed(
         this argument with a non-fsspec URL. See the fsspec and backend storage
         implementation docs for the set of allowed keys and values.
     """
-    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
-
     obj = self
     Engine.subscribe(_update_engine)
     if isinstance(self, DataFrame):


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Remove second `FactoryDispatcher` import. The first is placed in  https://github.com/modin-project/modin/blob/195b66856b937af9e30c7baddcca7780478a55d2/modin/experimental/pandas/io.py#L27

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3820 <!-- issue must be created for each patch -->
- [x] tests ~added~ and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
