### PR TITLE
FIX-#3818: Ignore files from /private/tmp/ray/ when detecting file leaks

### DIFF
--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -1105,9 +1105,9 @@ def check_file_leaks(func):
                     # modin reading any data (and this is what we care about).
                     if item[0].startswith("/proc/"):
                         continue
-                    # Ignore files in /private/tmp/ray/session/ (ray session logs)
-                    # because Ray intends to keep these logs open even after work
-                    # has been done.
+                    # Ignore files in /private/tmp/ray/ (ray session logs)
+                    # because Ray intends to keep these logs open even after
+                    # work has been done.
                     if item[0].startswith("/private/tmp/ray/"):
                         continue
                     leaks.append(item)

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import re
 import pytest
 import numpy as np
 import math
@@ -1105,10 +1106,10 @@ def check_file_leaks(func):
                     # modin reading any data (and this is what we care about).
                     if item[0].startswith("/proc/"):
                         continue
-                    # Ignore files in /private/tmp/ray/ (ray session logs)
+                    # Ignore files in /tmp/ray/session_*/logs (ray session logs)
                     # because Ray intends to keep these logs open even after
                     # work has been done.
-                    if item[0].startswith("/private/tmp/ray/"):
+                    if re.search(r"/tmp/ray/session_.*/logs", item[0]):
                         continue
                     leaks.append(item)
 

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -1101,10 +1101,17 @@ def check_file_leaks(func):
                 try:
                     fstart.remove(item)
                 except ValueError:
-                    # ignore files in /proc/, as they have nothing to do with
-                    # modin reading any data (and this is what we care about)
-                    if not item[0].startswith("/proc/"):
-                        leaks.append(item)
+                    # Ignore files in /proc/, as they have nothing to do with
+                    # modin reading any data (and this is what we care about).
+                    if item[0].startswith("/proc/"):
+                        continue
+                    # Ignore files in /private/tmp/ray/session/ (ray session logs)
+                    # because Ray intends to keep these logs open even after work
+                    # has been done.
+                    if item[0].startswith("/private/tmp/ray/"):
+                        continue
+                    leaks.append(item)
+
             assert (
                 not leaks
             ), f"Unexpected open handles left for: {', '.join(item[0] for item in leaks)}"


### PR DESCRIPTION
Signed-off-by: jeffreykennethli <jkli@ponder.io>

## What do these changes do?

[test_io.p::TestExcel](https://github.com/modin-project/modin/blob/7c847581f8ce8b61307690c87884775eba8d034b/modin/pandas/test/test_io.py#L1482) open file handle checks currently catches our [check_file_leaks decorator](https://github.com/modin-project/modin/blob/7c847581f8ce8b61307690c87884775eba8d034b/modin/pandas/test/utils.py#L1083) check due to Ray session driver logs that are still open after read_excel(). check_file_leaks compares open files before and after a test case, therefore only the first instance where a Ray session is initiated will catch check_file_leaks.

The session logs still being open is the [intended Ray behavior](https://github.com/modin-project/modin/issues/3818#issuecomment-989332461), so our tests should ignore these open files in check_file_leaks. This change adds this exception to check_file_leaks.

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3818? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
