### PR TITLE
FEAT-#3829: Add support of `storage_options` for `read_csv_glob`

### DIFF
--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -312,7 +312,12 @@ class PandasCSVGlobParser(PandasCSVParser):
         for fname, start, end in chunks:
             if start is not None and end is not None:
                 # pop "compression" from kwargs because bio is uncompressed
-                with OpenFile(fname, "rb", kwargs.pop("compression", "infer")) as bio:
+                with OpenFile(
+                    fname,
+                    "rb",
+                    kwargs.pop("compression", "infer"),
+                    **(kwargs.pop("storage_options", None) or {}),
+                ) as bio:
                     if kwargs.get("encoding", None) is not None:
                         header = b"" + bio.readline()
                     else:

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -309,12 +309,12 @@ class PandasCSVGlobParser(PandasCSVParser):
         index_col = kwargs.get("index_col", None)
 
         kwargs_bio = kwargs.copy()
+        # pop `compression` from kwargs_bio because `bio` below is uncompressed
         compression = kwargs_bio.pop("compression", "infer")
         storage_options = kwargs_bio.pop("storage_options", None) or {}
         pandas_dfs = []
         for fname, start, end in chunks:
             if start is not None and end is not None:
-                # pop "compression" from kwargs because bio is uncompressed
                 with OpenFile(fname, "rb", compression, **storage_options) as bio:
                     if kwargs_bio.get("encoding", None) is not None:
                         header = b"" + bio.readline()

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -16,6 +16,7 @@ import pandas
 import pytest
 import modin.experimental.pandas as pd
 from modin.config import Engine
+from modin.utils import get_current_execution
 from modin.pandas.test.utils import df_equals, teardown_test_files, test_data
 
 
@@ -137,8 +138,8 @@ def test_read_multiple_csv_s3():
 
 
 @pytest.mark.skipif(
-    Engine.get() != "Ray",
-    reason=f"{Engine.get()} engine doesn't have an experimental API.",
+    get_current_execution() != "ExperimentalPandasOnRay",
+    reason=f"Execution {get_current_execution()} isn't supported.",
 )
 @pytest.mark.parametrize(
     "storage_options",

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -144,7 +144,8 @@ def test_read_multiple_csv_s3_storage_opts(storage_options):
     path = "s3://modin-datasets/testing/multiple_csv/"
     modin_df = pd.read_csv_glob(path, storage_options=storage_options)
     pandas_df = pd.concat(
-        [pandas.read_csv(f"{path}test_data{i}.csv") for i in range(2)]
+        [pandas.read_csv(f"{path}test_data{i}.csv") for i in range(2)],
+        storage_options=storage_options,
     ).reset_index(drop=True)
 
     df_equals(modin_df, pandas_df)

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -136,6 +136,20 @@ def test_read_multiple_csv_s3():
     df_equals(modin_df, pandas_df)
 
 
+@pytest.mark.parametrize(
+    "storage_options",
+    [{"anon": False}, {"anon": True}, {"key": "123", "secret": "123"}, None],
+)
+def test_read_multiple_csv_s3_storage_opts(storage_options):
+    path = "s3://modin-datasets/testing/multiple_csv/"
+    modin_df = pd.read_csv_glob(path, storage_options=storage_options)
+    pandas_df = pd.concat(
+        [pandas.read_csv(f"{path}test_data{i}.csv") for i in range(2)]
+    ).reset_index(drop=True)
+
+    df_equals(modin_df, pandas_df)
+
+
 @pytest.mark.skipif(
     not Engine.get() == "Ray",
     reason=f"{Engine.get()} does not have experimental API",

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -136,6 +136,10 @@ def test_read_multiple_csv_s3():
     df_equals(modin_df, pandas_df)
 
 
+@pytest.mark.skipif(
+    Engine.get() != "Ray",
+    reason=f"{Engine.get()} engine doesn't have an experimental API.",
+)
 @pytest.mark.parametrize(
     "storage_options",
     [{"anon": False}, {"anon": True}, {"key": "123", "secret": "123"}, None],

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -142,10 +142,16 @@ def test_read_multiple_csv_s3():
 )
 def test_read_multiple_csv_s3_storage_opts(storage_options):
     path = "s3://modin-datasets/testing/multiple_csv/"
+    # Test the fact of handling of `storage_options`
     modin_df = pd.read_csv_glob(path, storage_options=storage_options)
     pandas_df = pd.concat(
-        [pandas.read_csv(f"{path}test_data{i}.csv") for i in range(2)],
-        storage_options=storage_options,
+        [
+            pandas.read_csv(
+                f"{path}test_data{i}.csv",
+                storage_options=storage_options,
+            )
+            for i in range(2)
+        ],
     ).reset_index(drop=True)
 
     df_equals(modin_df, pandas_df)


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

This PR add possibility to specify storage options for remote buckets for `read_csv_glob` function.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3829  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
