### PR TITLE
DOCS-#3850: Elaborate on modin.core.dataframe.base and .pandas

### DIFF
--- a/docs/flow/modin/core/dataframe/base/index.rst
+++ b/docs/flow/modin/core/dataframe/base/index.rst
@@ -1,15 +1,15 @@
 Purpose
 =======
 
-``BaseDataframe`` serves the purpose of describing and defining the internal dataframe algebra.
+``BaseDataframe`` serves the purpose of describing and defining the :doc:`Core Dataframe Algebra </flow/modin/core/dataframe/algebra>`.
 
-It is the core construction element which serves as the client for :doc:`Modin query compiler</flow/modin/core/storage_formats/base/query_compiler>` and which implementations are actually executing the queries from the compiler by invoking functions over partition(s).
+It is the core construction element which serves as the client for :doc:`Modin Query Compiler</flow/modin/core/storage_formats/base/query_compiler>` and which implementations are actually executing the queries from the compiler by invoking functions over partition(s).
 
 To execute the queries, a typical implementation also itroduces partitions and
 partition manager, interfaces for which we might consider standardising in the future.
 For now they're totally implementation-specific.
 
-Base dataframe and axis partitions are the interfaces that must be implemented by any backend that wants to be plugged in Modin.
+Base dataframe and axis partitions are the interfaces that must be implemented by any :doc:`execution backend</flow/modin/core/execution/dispatching>` that wants to be plugged in Modin.
 These classes are mostly abstract, however very simple and generic enough methods like
 :py:meth:`~modin.core.dataframe.base.partitioning.BaseDataframeAxisPartition.force_materialization` can be implemented at the base level because for now we do not expect them to differ in any implementation.
 

--- a/docs/flow/modin/core/dataframe/base/index.rst
+++ b/docs/flow/modin/core/dataframe/base/index.rst
@@ -1,12 +1,13 @@
 Purpose
 =======
+
 ``BaseDataframe`` serves the purpose of describing and defining the internal dataframe algebra.
 
-It is the core construction element which serves as a middle layer between high-level pandas-imitating API
-and lower-level query compiler. ``BaseDataframe`` is the interface which implementations actually translate the dataframe algebra calls to queries to the underlying compiler.
+It is the core construction element which serves as the client for :doc:`Modin query compiler</flow/modin/core/storage_formats/base/query_compiler>` and which implementations are actually executing the queries from the compiler by invoking functions over partition(s).
 
-The purpose of such translation is to reduce the vast amount of public pandas API to something smaller but sufficient.
-Query compiler level could reduce the API even further depending on the implementation.
+To execute the queries, a typical implementation also itroduces partitions and
+partition manager, interfaces for which we might consider standardising in the future.
+For now they're totally implementation-specific.
 
 Base dataframe and axis partitions are the interfaces that must be implemented by any backend that wants to be plugged in Modin.
 These classes are mostly abstract, however very simple and generic enough methods like

--- a/docs/flow/modin/core/dataframe/base/index.rst
+++ b/docs/flow/modin/core/dataframe/base/index.rst
@@ -1,3 +1,17 @@
+Purpose
+=======
+``BaseDataframe`` serves the purpose of describing and defining the internal dataframe algebra.
+
+It is the core construction element which serves as a middle layer between high-level pandas-imitating API
+and lower-level query compiler. ``BaseDataframe`` is the interface which implementations actually translate the dataframe algebra calls to queries to the underlying compiler.
+
+The purpose of such translation is to reduce the vast amount of public pandas API to something smaller but sufficient.
+Query compiler level could reduce the API even further depending on the implementation.
+
+Base dataframe and axis partitions are the interfaces that must be implemented by any backend that wants to be plugged in Modin.
+These classes are mostly abstract, however very simple and generic enough methods like
+:py:meth:`~modin.core.dataframe.base.partitioning.BaseDataframeAxisPartition.force_materialization` can be implemented at the base level because for now we do not expect them to differ in any implementation.
+
 Modin BaseDataframe Interface
 =============================
 

--- a/docs/flow/modin/core/dataframe/base/partitioning/axis_partition.rst
+++ b/docs/flow/modin/core/dataframe/base/partitioning/axis_partition.rst
@@ -4,6 +4,10 @@ BaseDataframeAxisPartition
 The class is base for any axis partition class and serves as the last level on which
 operations that were conveyed from the partition manager are being performed on an entire column or row.
 
+**Note**: ``modin.core.dataframe.base`` intentionally does not describe any particular partition interface,
+as it is the partition manager responsibility (if said partition manager is implemented), i.e. it is
+too low-level to be present on the base, abstract level.
+
 The class provides an API that has to be overridden by the child classes in order to manipulate
 on a list of block partitions (making up column or row partition) they store.
 

--- a/docs/flow/modin/core/dataframe/pandas/dataframe.rst
+++ b/docs/flow/modin/core/dataframe/pandas/dataframe.rst
@@ -1,7 +1,10 @@
 PandasDataframe
 """""""""""""""
 
-The class is base for any frame class of ``pandas`` storage format and serves as the intermediate level
+``PandasDataframe`` should be a direct descendant of ``BaseDataframe`` which is being factored right now. Its purpose is to implement the abstract interfaces for usage with all ``pandas``-based :doc:`storage formats<flow/modin/core/storage_formats/index.html>`.
+``PandasDataframe`` could be inherited and augmented further by any specific implementation which needs it to take special care of some behaviour or to improve performance for certain execution engine.
+
+The class serves as the intermediate level
 between ``pandas`` query compiler and conforming partition manager. All queries formed
 at the query compiler layer are ingested by this class and then conveyed jointly with the stored partitions
 into the partition manager for processing. Direct partitions manipulation by this class is prohibited except

--- a/docs/flow/modin/core/dataframe/pandas/dataframe.rst
+++ b/docs/flow/modin/core/dataframe/pandas/dataframe.rst
@@ -1,8 +1,8 @@
 PandasDataframe
 """""""""""""""
 
-``PandasDataframe`` should be a direct descendant of ``BaseDataframe`` which is being factored right now. Its purpose is to implement the abstract interfaces for usage with all ``pandas``-based :doc:`storage formats<flow/modin/core/storage_formats/index.html>`.
-``PandasDataframe`` could be inherited and augmented further by any specific implementation which needs it to take special care of some behaviour or to improve performance for certain execution engine.
+:py:class:`~modin.core.dataframe.pandas.dataframe.dataframe.PandasDataframe` should be a direct descendant of ``BaseDataframe`` which is being factored right now. Its purpose is to implement the abstract interfaces for usage with all ``pandas``-based :doc:`storage formats<flow/modin/core/storage_formats/index.html>`.
+:py:class:`~modin.core.dataframe.pandas.dataframe.dataframe.PandasDataframe` could be inherited and augmented further by any specific implementation which needs it to take special care of some behavior or to improve performance for certain execution engine.
 
 The class serves as the intermediate level
 between ``pandas`` query compiler and conforming partition manager. All queries formed

--- a/docs/flow/modin/core/dataframe/pandas/index.rst
+++ b/docs/flow/modin/core/dataframe/pandas/index.rst
@@ -1,6 +1,12 @@
 Modin PandasDataframe Objects
 =============================
 
+``modin.core.dataframe.pandas`` is the package which houses common implementations
+of different Modin internal classes used by most `pandas`-based :doc:`storage formats</flow/modin/core/storage_formats>`.
+
+It also double-serves as the full example of how to implement Modin backend pieces (sans the :doc:`execution part</flow/modin/core/execution/dispatching>` which is absent here),
+as it implements everything a backend needs to be fully conformant to Modin expectations.
+
 * :doc:`PandasDataframe <dataframe>` is the class conforming to Dataframe Algebra.
 * :doc:`PandasDataframePartition <partitioning/partition>` implements ``Partition`` interface holding ``pandas.DataFrame``.
 * :doc:`PandasDataframeAxisPartition <partitioning/axis_partition>` is a joined group of ``PandasDataframePartition``-s along some axis (either rows or labels)

--- a/docs/flow/modin/core/dataframe/pandas/index.rst
+++ b/docs/flow/modin/core/dataframe/pandas/index.rst
@@ -4,8 +4,8 @@ Modin PandasDataframe Objects
 ``modin.core.dataframe.pandas`` is the package which houses common implementations
 of different Modin internal classes used by most `pandas`-based :doc:`storage formats</flow/modin/core/storage_formats>`.
 
-It also double-serves as the full example of how to implement Modin backend pieces (sans the :doc:`execution part</flow/modin/core/execution/dispatching>` which is absent here),
-as it implements everything a backend needs to be fully conformant to Modin expectations.
+It also double-serves as the full example of how to implement Modin execution backend pieces (sans the :doc:`execution part</flow/modin/core/execution/dispatching>` which is absent here),
+as it implements everything an execution backend needs to be fully conformant to Modin expectations.
 
 * :doc:`PandasDataframe <dataframe>` is the class conforming to Dataframe Algebra.
 * :doc:`PandasDataframePartition <partitioning/partition>` implements ``Partition`` interface holding ``pandas.DataFrame``.

--- a/docs/flow/modin/core/dataframe/pandas/partitioning/axis_partition.rst
+++ b/docs/flow/modin/core/dataframe/pandas/partitioning/axis_partition.rst
@@ -1,6 +1,9 @@
 PandasDataframeAxisPartition
 """"""""""""""""""""""""""""
 
+The class implements abstract interface methods from :py:class:`~modin.core.dataframe.base.partitioning.axis_partition.BaseDataframeAxisPartition`
+giving the means for a sibling :doc:`partition manager<partition_manager>` to actually work with the axis-wide partitions.
+
 The class is base for any axis partition class of ``pandas`` storage format.
 
 Subclasses must implement ``list_of_blocks`` which represents data wrapped by the :py:class:`~modin.core.dataframe.pandas.partitioning.partition.PandasDataframePartition`


### PR DESCRIPTION
Signed-off-by: Vasilij Litvinov <vasilij.n.litvinov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
This expands the documentation sections about `modin.core.dataframe.base` and `modin.core.dataframe.pandas`.
They're mostly fine to my taste, but need a little of high-level sauce.

Do note that these changes introduce a `BaseDataframe` object which is _not_ actually in the code - it's going to be added by #3717, but that section felt too empty and meaningless without at least mentioning the interface class.
@RehanSD I think this should be the point where you would probably be inserting the documentation after #3717 is merged.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3850
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

Preview: https://modin--3851.org.readthedocs.build/en/3851/developer/architecture.html

Any readability improvements are welcome!