### PR TITLE
TEST-#3852: add a test for OmniSci import

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -367,6 +367,7 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
+      - run: pytest modin/test/storage_formats/omnisci/test_internals.py
       - run: MODIN_BENCHMARK_MODE=True pytest modin/pandas/test/internals/test_benchmark_mode.py
       - run: pytest modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
       - run: pytest modin/pandas/test/test_io.py::TestCsv --verbose

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -114,6 +114,7 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
+      - run: pytest modin/test/storage_formats/omnisci/test_internals.py
       - run: pytest modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
       - run: pytest modin/pandas/test/test_io.py::TestCsv
       - run: |

--- a/modin/test/storage_formats/omnisci/test_internals.py
+++ b/modin/test/storage_formats/omnisci/test_internals.py
@@ -27,7 +27,7 @@ cfg.StorageFormat.put('Omnisci')
 cfg.IsExperimental.put(True)
 import modin.pandas as pd
 """,
-            id="config_first-import_second",
+            id="config_omnisci_first-import_modin_second",
         ),
         pytest.param(
             """
@@ -37,7 +37,7 @@ cfg.Engine.put('Native')
 cfg.StorageFormat.put('Omnisci')
 cfg.IsExperimental.put(True)
 """,
-            id="import_first-config_second",
+            id="import_modin_first-config_omnisci_second",
         ),
     ],
 )
@@ -46,7 +46,7 @@ def test_omnisci_import(import_strategy, has_other_engines):
     """
     Test import of OmniSci engine.
 
-    The import of PyDBEngine requires to set special open flags which makes it then
+    The import of PyDBEngine requires to set special dlopen flags which make it then
     incompatible to import some other libraries further (like ``pyarrow.gandiva``).
     This test verifies that it's not the case when a user naturally imports Modin
     with OmniSci engine.
@@ -54,12 +54,12 @@ def test_omnisci_import(import_strategy, has_other_engines):
     Parameters
     ----------
     import_strategy : str
-        There are several scenarios of how user can import Modin with OmniSci engine:
-        configure Modin first and then import ``modin.pandas`` or vice versa.
+        There are several scenarios of how a user can import Modin with OmniSci engine:
+        configure Modin first to use OmniSci engine and then import ``modin.pandas`` or vice versa.
         This parameters holds a python code, implementing one of these scenarious.
     has_other_engines : bool
         The problem with import may appear depending on whether other engines are
-        installed. This parameter indicates of whether to remove modules for
+        installed. This parameter indicates whether to remove modules for
         non-omnisci engines before the test.
 
     Notes
@@ -88,7 +88,7 @@ sys.modules['dask'] = None
         pytest.fail(str(res.stderr))
 
 
-def test_compatibility_omnisci_with_pyarrow_gandiva():
+def test_omnisci_compatibility_with_pyarrow_gandiva():
     """
     Test that PyDbEngine and pyarrow.gandiva packages are still incompatible.
 
@@ -116,4 +116,4 @@ import pyarrow.gandiva
         error_msg = res.stderr.decode("utf-8")
         assert (
             error_msg.find("LLVM ERROR") != -1
-        ), f"Expected to fail because LLVM error, but failed because of:\n{error_msg}"
+        ), f"Expected to fail because of LLVM error, but failed because of:\n{error_msg}"

--- a/modin/test/storage_formats/omnisci/test_internals.py
+++ b/modin/test/storage_formats/omnisci/test_internals.py
@@ -86,3 +86,34 @@ sys.modules['dask'] = None
 
     if res.returncode != 0:
         pytest.fail(str(res.stderr))
+
+
+def test_compatibility_omnisci_with_pyarrow_gandiva():
+    """
+    Test that PyDbEngine and pyarrow.gandiva packages are still incompatible.
+
+    At the moment of writing this test PyDbEngine (5.8.0) and pyarrow.gandiva (3.0.0) are incompatible.
+    If this test appears to fail, it means that these packages are now compatible, if it's so,
+    change the failing assert statement and this doc-string accordingly.
+    """
+    res = subprocess.run(
+        [
+            sys.executable,
+            "-c",
+            """
+from modin.experimental.core.execution.native.implementations.omnisci_on_native.utils import PyDbEngine
+import pyarrow.gandiva
+""",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    assert (
+        res.returncode != 0
+    ), "PyDbEngine and pyarrow.gandiva are now compatible! Please check the test's doc-string for further instructions."
+
+    if res.returncode != 0:
+        error_msg = res.stderr.decode("utf-8")
+        assert (
+            error_msg.find("LLVM ERROR") != -1
+        ), f"Expected to fail because LLVM error, but failed because of:\n{error_msg}"

--- a/modin/test/storage_formats/omnisci/test_internals.py
+++ b/modin/test/storage_formats/omnisci/test_internals.py
@@ -1,0 +1,88 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pytest
+import sys
+import subprocess
+
+
+@pytest.mark.parametrize(
+    "import_strategy",
+    [
+        pytest.param(
+            """
+import modin.config as cfg
+cfg.Engine.put('Native') # 'omniscidbe'/'dbe' would be imported with dlopen flags first time
+cfg.StorageFormat.put('Omnisci')
+cfg.IsExperimental.put(True)
+import modin.pandas as pd
+""",
+            id="config_first-import_second",
+        ),
+        pytest.param(
+            """
+import modin.pandas as pd
+import modin.config as cfg
+cfg.Engine.put('Native')
+cfg.StorageFormat.put('Omnisci')
+cfg.IsExperimental.put(True)
+""",
+            id="import_first-config_second",
+        ),
+    ],
+)
+@pytest.mark.parametrize("has_other_engines", [True, False])
+def test_omnisci_import(import_strategy, has_other_engines):
+    """
+    Test import of OmniSci engine.
+
+    The import of PyDBEngine requires to set special open flags which makes it then
+    incompatible to import some other libraries further (like ``pyarrow.gandiva``).
+    This test verifies that it's not the case when a user naturally imports Modin
+    with OmniSci engine.
+
+    Parameters
+    ----------
+    import_strategy : str
+        There are several scenarios of how user can import Modin with OmniSci engine:
+        configure Modin first and then import ``modin.pandas`` or vice versa.
+        This parameters holds a python code, implementing one of these scenarious.
+    has_other_engines : bool
+        The problem with import may appear depending on whether other engines are
+        installed. This parameter indicates of whether to remove modules for
+        non-omnisci engines before the test.
+
+    Notes
+    -----
+    The failed import flow may cause segfault, which causes to crash the pytest itself.
+    This makes us to run the test in a separate process and check its exit-code to
+    decide the success of the test.
+    """
+
+    remove_other_engines = """
+import sys
+sys.modules['ray'] = None
+sys.modules['dask'] = None
+"""
+
+    if not has_other_engines:
+        import_strategy = f"{remove_other_engines}\n{import_strategy}"
+
+    res = subprocess.run(
+        [sys.executable, "-c", import_strategy],
+        stderr=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+    )
+
+    if res.returncode != 0:
+        pytest.fail(str(res.stderr))

--- a/modin/test/storage_formats/omnisci/test_internals.py
+++ b/modin/test/storage_formats/omnisci/test_internals.py
@@ -53,11 +53,11 @@ def test_omnisci_import(import_strategy, has_other_engines):
 
     Parameters
     ----------
-    import_strategy : str,
+    import_strategy : str
         There are several scenarios of how a user can import Modin with OmniSci engine:
         configure Modin first to use OmniSci engine and then import ``modin.pandas`` or vice versa.
-        This parameters holds a python code, implementing one of these scenarious.
-    has_other_engines : bool,
+        This parameters holds a python code, implementing one of these scenarios.
+    has_other_engines : bool
         The problem with import may appear depending on whether other engines are
         installed. This parameter indicates whether to remove modules for
         non-omnisci engines before the test.
@@ -89,7 +89,7 @@ sys.modules['dask'] = None
 
 
 @pytest.mark.parametrize(
-    "import_strategy,expected_to_fail",
+    "import_strategy, expected_to_fail",
     [
         pytest.param(
             """
@@ -120,10 +120,10 @@ def test_omnisci_compatibility_with_pyarrow_gandiva(import_strategy, expected_to
 
     Parameters
     ----------
-    import_strategy : str,
+    import_strategy : str
         There are several scenarios of how a user can import PyDbEngine and pyarrow.gandiva.
-        This parameters holds a python code, implementing one of the scenarious.
-    expected_to_fail : bool,
+        This parameters holds a python code, implementing one of the scenarios.
+    expected_to_fail : bool
         Indicates the estimated compatibility status for the specified `import_strategy`.
         True - the strategy expected to fail, False - the strategy expected to pass.
         Note: we can't use built-in ``pytest.marks.xfail`` as we need to check that the


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Adds a test, verifying that the natural ways of importing Modin with OmniSci backend don't fail, and also a test, indicating the current status of compatibility of PyDbEngine and pyarrow.gandiva packages.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3852 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
