### PR TITLE
DOCS-#3873: fix 'more than one target found for cross-reference DataFrame' warning

### DIFF
--- a/docs/flow/modin/experimental/pandas.rst
+++ b/docs/flow/modin/experimental/pandas.rst
@@ -12,5 +12,4 @@ Experimental API Reference
 .. autofunction:: read_sql
 .. autofunction:: read_csv_glob
 .. autofunction:: read_pickle_distributed
-.. autoclass:: DataFrame
-   :members: to_pickle_distributed
+.. automethod:: modin.experimental.pandas.DataFrame.to_pickle_distributed


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3873 <!-- issue must be created for each patch -->
- [x] tests ~added~ and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
