### PR TITLE
FEAT-#3875: Optimize append time for omnisci engine

### DIFF
--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/dataframe/dataframe.py
@@ -1689,9 +1689,7 @@ class OmnisciOnNativeDataframe(PandasDataframe):
             )
         elif isinstance(self._op, TransformNode):
             return (
-                not self._uses_rowid
-                and self._op.is_simple_select()
-                and self._op.input[0]._can_execute_arrow()
+                self._op.is_simple_select() and self._op.input[0]._can_execute_arrow()
             )
         elif isinstance(self._op, UnionNode):
             return all(frame._can_execute_arrow() for frame in self._op.input)
@@ -1737,13 +1735,16 @@ class OmnisciOnNativeDataframe(PandasDataframe):
             The resulting table.
         """
         table = self._execute_arrow()
-        schema = table.schema
 
         new_fields = []
         new_columns = []
 
         for col, expr in exprs.items():
-            field = schema.field(f"F_{expr.column}")
+            if expr.column == "__rowid__" and "F___rowid__" not in table.schema.names:
+                arr = pyarrow.array(np.arange(0, table.num_rows))
+                table = table.append_column("F___rowid__", arr)
+
+            field = table.schema.field(f"F_{expr.column}")
             if col != expr.column:
                 field = field.with_name(f"F_{col}")
             new_fields.append(field)

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
@@ -2026,16 +2026,9 @@ class TestConstructor:
 
 
 class TestArrowExecution:
-    data1 = {
-        "a": [1, 2, 3],
-        "b": [3, 4, 5],
-        "c": [6, 7, 8],
-    }
-    data2 = {
-        "a": [1, 2, 3],
-        "d": [3, 4, 5],
-        "e": [6, 7, 8],
-    }
+    data1 = {"a": [1, 2, 3], "b": [3, 4, 5], "c": [6, 7, 8]}
+    data2 = {"a": [1, 2, 3], "d": [3, 4, 5], "e": [6, 7, 8]}
+    data3 = {"a": [4, 5, 6], "b": [6, 7, 8], "c": [9, 10, 11]}
 
     def test_drop_rename_concat(self):
         def drop_rename_concat(df1, df2, lib, **kwargs):
@@ -2057,6 +2050,15 @@ class TestArrowExecution:
             return df + 1
 
         run_and_compare(apply, data={}, force_arrow_execute=True)
+
+    def test_append(self):
+        def apply(df1, df2, **kwargs):
+            tmp = df1.append(df2)
+            return tmp
+
+        run_and_compare(
+            apply, data=self.data1, data2=self.data3, force_arrow_execute=True
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Optimize `append` with `ignore_index=True` by bypassing omnisci engine and doing all operations with arrow table.
<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3875 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
