### PR TITLE
REFACTOR-#3881: remove unused '_read_parquet_columns' function

### DIFF
--- a/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -42,45 +42,6 @@ from modin.config import NPartitions
 import ray
 
 
-# Ray functions are not detected by codecov (thus pragma: no cover)
-@ray.remote
-def _read_parquet_columns(path, columns, num_splits, kwargs):  # pragma: no cover
-    """
-    Read columns from Parquet file into a ``pandas.DataFrame`` using Ray task.
-
-    Parameters
-    ----------
-    path : str or List[str]
-        The path of the Parquet file.
-    columns : List[str]
-        The list of column names to read.
-    num_splits : int
-        The number of partitions to split the column into.
-    kwargs : dict
-        Keyward arguments to pass into ``pyarrow.parquet.read`` function.
-
-    Returns
-    -------
-    list
-        A list containing the splitted ``pandas.DataFrame``-s and the Index as the last
-        element.
-
-    Notes
-    -----
-    ``pyarrow.parquet.read`` is used internally as the parse function.
-    """
-    import pyarrow.parquet as pq
-
-    df = (
-        pq.ParquetDataset(path, **kwargs)
-        .read(columns=columns, use_pandas_metadata=True)
-        .to_pandas()
-    )
-    df = df[columns]
-    # Append the length of the index here to build it externally
-    return _split_result_for_readers(0, num_splits, df) + [len(df.index)]
-
-
 class ExperimentalPandasOnRayIO(PandasOnRayIO):
     """
     Class for handling experimental IO functionality with pandas storage format and Ray engine.
@@ -102,7 +63,6 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
         (RayTask, PandasPickleExperimentalParser, PickleExperimentalDispatcher),
         build_args,
     )._read
-    read_parquet_remote_task = _read_parquet_columns
 
     @classmethod
     def read_sql(


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3881 <!-- issue must be created for each patch -->
- [x] tests ~added~ and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
