### PR TITLE
FEAT-#3887: added Dask diagnostics dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import versioneer
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-dask_deps = ["dask>=2.22.0", "distributed>=2.22.0"]
+dask_deps = ["dask[diagnostics]>=2.22.0", "distributed>=2.22.0"]
 ray_deps = ["ray[default]>=1.4.0", "pyarrow>=1.0"]
 remote_deps = ["rpyc==4.1.5", "cloudpickle", "boto3"]
 spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]


### PR DESCRIPTION
Signed-off-by: Andrew Li <orcahmlee@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Ray and Dask both have diagnostic dashboard. It's useful for debugging when the user submit a job. However, when the user run `pip install modin[dask]`, it wouldn't install the Dask diagnostic dependences. It would be convenience if install the diagnostic tools at same time.


<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3887
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
