### PR TITLE
FIX-#3890: Fix the default to pandas in pd.DataFrame.sparse.from_spmatrix.

### DIFF
--- a/modin/pandas/accessor.py
+++ b/modin/pandas/accessor.py
@@ -24,6 +24,8 @@ CachedAccessor implements API of pandas.core.accessor.CachedAccessor
 import pandas
 from pandas.core.arrays.sparse.dtype import SparseDtype
 
+import modin.pandas as pd
+from modin.error_message import ErrorMessage
 from modin.utils import _inherit_docstrings
 
 
@@ -108,8 +110,9 @@ class SparseFrameAccessor(BaseSparseAccessor):
 
     @classmethod
     def from_spmatrix(cls, data, index=None, columns=None):
-        return cls._default_to_pandas(
-            pandas.DataFrame.sparse.from_spmatrix, data, index=index, columns=columns
+        ErrorMessage.default_to_pandas("`from_spmatrix`")
+        return pd.DataFrame(
+            pandas.DataFrame.sparse.from_spmatrix(data, index=index, columns=columns)
         )
 
     def to_dense(self):

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -24,6 +24,7 @@ from modin.utils import to_pandas
 from modin.pandas.utils import from_arrow
 import pyarrow as pa
 import os
+from scipy import sparse
 import sys
 import shutil
 import sqlalchemy as sa
@@ -2172,6 +2173,14 @@ class TestPickle:
 def test_from_arrow():
     _, pandas_df = create_test_dfs(TEST_DATA)
     modin_df = from_arrow(pa.Table.from_pandas(pandas_df))
+    df_equals(modin_df, pandas_df)
+
+
+def test_from_spmatrix():
+    data = sparse.eye(3)
+    with pytest.warns(UserWarning, match="defaulting to pandas.*"):
+        modin_df = pd.DataFrame.sparse.from_spmatrix(data)
+    pandas_df = pandas.DataFrame.sparse.from_spmatrix(data)
     df_equals(modin_df, pandas_df)
 
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -2176,6 +2176,10 @@ def test_from_arrow():
     df_equals(modin_df, pandas_df)
 
 
+@pytest.mark.xfail(
+    condition="config.getoption('--simulate-cloud').lower() != 'off'",
+    reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
+)
 def test_from_spmatrix():
     data = sparse.eye(3)
     with pytest.warns(UserWarning, match="defaulting to pandas.*"):

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -19,3 +19,4 @@ dependencies:
   - openpyxl
   - xlrd
   - sqlalchemy
+  - scipy


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Fix the default to pandas in pd.DataFrame.sparse.from_spmatrix by not trying to use an instance method.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3890 
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
