### PR TITLE
FIX-#3860: Fix single row Series assignment.

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -532,7 +532,9 @@ class _LocationIndexerBase(object):
             for i, lookup in enumerate([row_lookup, col_lookup])
         ]
 
-        if (
+        if col_lookup_len == 1 and row_lookup_len == 1:
+            axis = None
+        elif (
             row_lookup_len == len(self.qc.index)
             and col_lookup_len == 1
             and isinstance(self.df, DataFrame)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1605,6 +1605,12 @@ def test___setitem__(data):
     pandas_df[1:5] = 10
     df_equals(modin_df, pandas_df)
 
+    modin_single_item_series = pd.Series(99)
+    pandas_single_item_series = pandas.Series(99)
+    modin_single_item_series[:1] = pd.Series(100)
+    pandas_single_item_series[:1] = pandas.Series(100)
+    df_equals(modin_single_item_series, pandas_single_item_series)
+
 
 def test___setitem__partitions_aligning():
     # from issue #2390

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1605,6 +1605,8 @@ def test___setitem__(data):
     pandas_df[1:5] = 10
     df_equals(modin_df, pandas_df)
 
+    # Test assigning a single item in a Series for issue
+    # https://github.com/modin-project/modin/issues/3860
     modin_single_item_series = pd.Series(99)
     pandas_single_item_series = pandas.Series(99)
     modin_single_item_series[:1] = pd.Series(100)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Fix https://github.com/modin-project/modin/issues/3860 by setting the correct `axis` argument to the query compiler's `setitem` method. In the case where a single row and column are to be replaced, we are assigning both an entire row and an entire column, so `axis` should be `None` instead of `1`, so we don't transpose the new value [here](https://github.com/modin-project/modin/blob/d8963a691958d34627e503c7a437adade4935aa8/modin/core/storage_formats/pandas/query_compiler.py#L2230).

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3860
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
