### PR TITLE
REFACTOR-#3900: add flake8-no-implicit-concat plugin and refactor flake8 error codes

### DIFF
--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -31,7 +31,7 @@ jobs:
       # install dependencies required for notebooks execution
       - run: pip install -r examples/tutorial/jupyter/execution/pandas_on_ray/requirements.txt
       # install test dependencies
-      - run: pip install pytest pytest-cov black flake8 flake8-print
+      - run: pip install pytest pytest-cov black flake8 flake8-print flake8-no-implicit-concat
       - run: pip list
       - run: black --check --diff examples/tutorial/jupyter/execution/pandas_on_ray/test/test_notebooks.py
       - run: flake8 --enable=T examples/tutorial/jupyter/execution/pandas_on_ray/test/test_notebooks.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,7 @@ jobs:
           python-version: "3.8.x"
           architecture: "x64"
       - run: pip install flake8 flake8-print flake8-no-implicit-concat
-      - run: flake8 --enable=T modin/ asv_bench/benchmarks scripts/doc_checker.py
+      - run: flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py
 
   test-api:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
         with:
           python-version: "3.8.x"
           architecture: "x64"
-      - run: pip install flake8 flake8-print
+      - run: pip install flake8 flake8-print flake8-no-implicit-concat
       - run: flake8 --enable=T modin/ asv_bench/benchmarks scripts/doc_checker.py
 
   test-api:

--- a/contributing/contributing.md
+++ b/contributing/contributing.md
@@ -88,4 +88,5 @@ you should reopen your terminal to find "(base)" next to your prompt: ![](conda_
     2. Add a pre-commit hook:
         1. In your modin repository, copy [this pre-commit file](pre-commit) to `.git/hooks/pre-commit`
         1. Every time you try to commit, git will run flake8 and abort the commit if it fails. This lets you make sure your commits passes flake8 before you push to GitHub.
-        1. To bypass the pre-commit hook (e.g. if you don't want to create a pull request, or you already know your code will pass the tests), commit with the flag `--no-verify`.
+        1. To bypass the pre-commit hook (e.g. if you don't want to create a pull request, or you already know your code will pass the tests), commit with the flag `--no-verify`
+        1. We also recommend installing [flake8-no-implicit-concat](https://pypi.org/project/flake8-no-implicit-concat/) via `pip install flake8-no-implicit-concat` to avoid Python implicit string concatenation errors.

--- a/contributing/contributing.md
+++ b/contributing/contributing.md
@@ -88,5 +88,5 @@ you should reopen your terminal to find "(base)" next to your prompt: ![](conda_
     2. Add a pre-commit hook:
         1. In your modin repository, copy [this pre-commit file](pre-commit) to `.git/hooks/pre-commit`
         1. Every time you try to commit, git will run flake8 and abort the commit if it fails. This lets you make sure your commits passes flake8 before you push to GitHub.
-        1. To bypass the pre-commit hook (e.g. if you don't want to create a pull request, or you already know your code will pass the tests), commit with the flag `--no-verify`
+        1. To bypass the pre-commit hook (e.g. if you don't want to create a pull request, or you already know your code will pass the tests), commit with the flag `--no-verify`.
         1. We also recommend installing [flake8-no-implicit-concat](https://pypi.org/project/flake8-no-implicit-concat/) via `pip install flake8-no-implicit-concat` to avoid Python implicit string concatenation errors.

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -26,6 +26,7 @@ Key Features and Updates
   * REFACTOR-#3994: remove code duplication for `get_indices` function (#3995)
   * REFACTOR-#4213: Refactor `modin/examples/tutorial/` directory (#4214)
   * REFACTOR-#4206: add assert check into `__init__` method of `PandasOnDaskDataframePartition` class (#4207)
+  * REFACTOR-#3900: add flake8-no-implicit-concat plugin and refactor flake8 error codes (#3901)
 * Pandas API implementations and improvements
   *
 * OmniSci enhancements
@@ -65,3 +66,4 @@ Contributors
 @Garra1980
 @mvashishtha
 @naren-ponder
+@jeffreykennethli

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -28,7 +28,7 @@ warnings.filterwarnings("ignore", message="Large object of size")
 warnings.filterwarnings(
     "ignore",
     message="The pandas.datetime class is deprecated and will be removed from pandas in a future version. "
-    "Import from datetime module instead.",
+    + "Import from datetime module instead.",
 )
 
 

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -465,7 +465,7 @@ def _check_vars():
     if unknown:
         warnings.warn(
             f"Found unknown environment variable{'s' if len(unknown) > 1 else ''},"
-            f" please check {'their' if len(unknown) > 1 else 'its'} spelling: "
+            + f" please check {'their' if len(unknown) > 1 else 'its'} spelling: "
             + ", ".join(sorted(unknown))
         )
 

--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -319,8 +319,8 @@ class GroupByReduce(TreeReduce):
                 operation="df.groupby(categorical_by, sort=False)",
                 message=(
                     "the groupby keys will be sorted anyway, although the 'sort=False' was passed. "
-                    "See the following issue for more details: "
-                    "https://github.com/modin-project/modin/issues/3571"
+                    + "See the following issue for more details: "
+                    + "https://github.com/modin-project/modin/issues/3571"
                 ),
             )
             groupby_kwargs = groupby_kwargs.copy()

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -310,8 +310,8 @@ class PandasDataframe(object):
         new_len = len(new_labels)
         if old_len != new_len:
             raise ValueError(
-                "Length mismatch: Expected axis has %d elements, "
-                "new values have %d elements" % (old_len, new_len)
+                f"Length mismatch: Expected axis has {old_len} elements, "
+                + "new values have {new_len} elements"
             )
         return new_labels
 

--- a/modin/core/execution/dispatching/factories/dispatcher.py
+++ b/modin/core/execution/dispatching/factories/dispatcher.py
@@ -131,7 +131,7 @@ class FactoryDispatcher(object):
             if factory_name == "ExperimentalOmnisciOnRayFactory":
                 msg = (
                     "OmniSci storage format no longer needs Ray engine; "
-                    "please specify MODIN_ENGINE='native'"
+                    + "please specify MODIN_ENGINE='native'"
                 )
                 raise FactoryNotFoundError(msg)
             if not IsExperimental.get():
@@ -139,13 +139,13 @@ class FactoryDispatcher(object):
                 if hasattr(factories, "Experimental" + factory_name):
                     msg = (
                         "{0} on {1} is only accessible through the experimental API.\nRun "
-                        "`import modin.experimental.pandas as pd` to use {0} on {1}."
+                        + "`import modin.experimental.pandas as pd` to use {0} on {1}."
                     )
                 else:
                     msg = (
                         "Cannot find a factory for partition '{}' and execution engine '{}'. "
-                        "Potential reason might be incorrect environment variable value for "
-                        f"{StorageFormat.varname} or {Engine.varname}"
+                        + "Potential reason might be incorrect environment variable value for "
+                        + f"{StorageFormat.varname} or {Engine.varname}"
                     )
                 raise FactoryNotFoundError(
                     msg.format(StorageFormat.get(), Engine.get())

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -156,9 +156,9 @@ def initialize_ray(
                         if system_memory / (virtual_memory / 2) < 0.99:
                             warnings.warn(
                                 f"The size of /dev/shm is too small ({system_memory} bytes). The required size "
-                                f"at least half of RAM ({virtual_memory // 2} bytes). Please, delete files in /dev/shm or "
-                                "increase size of /dev/shm with --shm-size in Docker. Also, you can set "
-                                "the required memory size for each Ray worker in bytes to MODIN_MEMORY environment variable."
+                                + f"at least half of RAM ({virtual_memory // 2} bytes). Please, delete files in /dev/shm or "
+                                + "increase size of /dev/shm with --shm-size in Docker. Also, you can set "
+                                + "the required memory size for each Ray worker in bytes to MODIN_MEMORY environment variable."
                             )
                     finally:
                         os.close(shm_fd)

--- a/modin/core/io/column_stores/hdf_dispatcher.py
+++ b/modin/core/io/column_stores/hdf_dispatcher.py
@@ -71,7 +71,7 @@ class HDFDispatcher(ColumnStoreDispatcher):  # pragma: no cover
         if cls._validate_hdf_format(path_or_buf=path_or_buf) is None:
             ErrorMessage.default_to_pandas(
                 "File format seems to be `fixed`. For better distribution consider "
-                "saving the file in `table` format. df.to_hdf(format=`table`)."
+                + "saving the file in `table` format. df.to_hdf(format=`table`)."
             )
             return cls.single_worker_read(path_or_buf, **kwargs)
 

--- a/modin/core/io/sql/sql_dispatcher.py
+++ b/modin/core/io/sql/sql_dispatcher.py
@@ -57,11 +57,10 @@ class SQLDispatcher(FileDispatcher):
         if not (is_modin_db_connection or isinstance(con, str)):
             warnings.warn(
                 "To use parallel implementation of `read_sql`, pass either "
-                "the SQL connection string or a ModinDatabaseConnection "
-                "with the arguments required to make a connection, instead "
-                "of {}. For documentation of ModinDatabaseConnection, see https://modin.readthedocs.io/en/latest/supported_apis/io_supported.html#connecting-to-a-database-for-read-sql".format(
-                    type(con)
-                )
+                + "the SQL connection string or a ModinDatabaseConnection "
+                + "with the arguments required to make a connection, instead "
+                + f"of {type(con)}. For documentation of ModinDatabaseConnection, see "
+                + "https://modin.readthedocs.io/en/latest/supported_apis/io_supported.html#connecting-to-a-database-for-read-sql"
             )
             return cls.single_worker_read(sql, con=con, index_col=index_col, **kwargs)
         row_cnt_query = "SELECT COUNT(*) FROM ({}) as foo".format(sql)

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -61,7 +61,7 @@ class CSVGlobDispatcher(CSVDispatcher):
             if "*" not in filepath_or_buffer and not is_folder:
                 warnings.warn(
                     "Shell-style wildcard '*' must be in the filename pattern in order to read multiple "
-                    f"files at once. Did you forget it? Passed filename: '{filepath_or_buffer}'"
+                    + f"files at once. Did you forget it? Passed filename: '{filepath_or_buffer}'"
                 )
             if not cls.file_exists(filepath_or_buffer):
                 return cls.single_worker_read(filepath_or_buffer, **kwargs)

--- a/modin/core/io/text/excel_dispatcher.py
+++ b/modin/core/io/text/excel_dispatcher.py
@@ -50,8 +50,8 @@ class ExcelDispatcher(TextFileDispatcher):
         ):
             warnings.warn(
                 "Modin only implements parallel `read_excel` with `openpyxl` engine, "
-                'please specify `engine=None` or `engine="openpyxl"` to '
-                "use Modin's parallel implementation."
+                + 'please specify `engine=None` or `engine="openpyxl"` to '
+                + "use Modin's parallel implementation."
             )
             return cls.single_worker_read(io, **kwargs)
         if sys.version_info < (3, 7):
@@ -68,13 +68,13 @@ class ExcelDispatcher(TextFileDispatcher):
         if sheet_name is None or isinstance(sheet_name, list):
             warnings.warn(
                 "`read_excel` functionality is only implemented for a single sheet at a "
-                "time. Multiple sheet reading coming soon!"
+                + "time. Multiple sheet reading coming soon!"
             )
             return cls.single_worker_read(io, **kwargs)
 
         warnings.warn(
             "Parallel `read_excel` is a new feature! Please email "
-            "bug_reports@modin.org if you run into any problems."
+            + "bug_reports@modin.org if you run into any problems."
         )
 
         # NOTE: ExcelReader() in read-only mode does not close file handle by itself

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -662,7 +662,7 @@ class TextFileDispatcher(FileDispatcher):
         if not skiprows_supported:
             ErrorMessage.single_warning(
                 "Values of `header` and `skiprows` parameters have intersections. "
-                "This case is unsupported by Modin, so pandas implementation will be used"
+                + "This case is unsupported by Modin, so pandas implementation will be used"
             )
             return False
 

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -73,8 +73,8 @@ class TextFileDispatcher(FileDispatcher):
             if cls.file_exists(buffer_filepath):
                 warnings.warn(
                     "For performance reasons, the filepath will be "
-                    "used in place of the file handle passed in "
-                    "to load the data"
+                    + "used in place of the file handle passed in "
+                    + "to load the data"
                 )
                 return cls.get_path(buffer_filepath)
         return filepath_or_buffer
@@ -673,7 +673,7 @@ class TextFileDispatcher(FileDispatcher):
     def _validate_usecols_arg(cls, usecols):
         msg = (
             "'usecols' must either be list-like of all strings, all unicode, "
-            "all integers or a callable."
+            + "all integers or a callable."
         )
         if usecols is not None:
             if callable(usecols):

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -233,8 +233,8 @@ class PandasParser(object):
             ErrorMessage.missmatch_with_pandas(
                 operation="read_*",
                 message="Data types of partitions are different! "
-                "Please refer to the troubleshooting section of the Modin documentation "
-                "to fix this issue",
+                + "Please refer to the troubleshooting section of the Modin documentation "
+                + "to fix this issue",
             )
 
             # concat all elements of `partitions_dtypes` and find common dtype

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -572,7 +572,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                         if len(last_col_name) not in (1, self.columns.nlevels):
                             raise ValueError(
                                 "col_fill=None is incompatible "
-                                f"with incomplete column name {last_col_name}"
+                                + f"with incomplete column name {last_col_name}"
                             )
                         col_fill = last_col_name[0]
                     columns_list = new_modin_frame.columns.tolist()

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -24,9 +24,9 @@ class ErrorMessage(object):
         if message == "":
             message = "This functionality is not yet available in Modin."
         raise NotImplementedError(
-            "{}\n"
-            "To request implementation, send an email to "
-            "feature_requests@modin.org".format(message)
+            f"{message}\n"
+            + "To request implementation, send an email to "
+            + "feature_requests@modin.org"
         )
 
     @classmethod
@@ -41,13 +41,13 @@ class ErrorMessage(object):
     @classmethod
     def default_to_pandas(cls, message=""):
         if message != "":
-            message = "{} defaulting to pandas implementation.".format(message)
+            message = f"{message} defaulting to pandas implementation."
         else:
             message = "Defaulting to pandas implementation."
 
         if not cls.printed_request_implementation:
             message = (
-                "{}\n".format(message)
+                f"{message}\n"
                 + "To request implementation, send an email to "
                 + "feature_requests@modin.org."
             )
@@ -59,15 +59,15 @@ class ErrorMessage(object):
         if failure_condition:
             raise Exception(
                 "Internal Error. "
-                "Please email bug_reports@modin.org with the traceback and command that"
-                " caused this error.\n{}".format(extra_log)
+                + "Please email bug_reports@modin.org with the traceback and command that"
+                + f" caused this error.\n{extra_log}"
             )
 
     @classmethod
     def non_verified_udf(cls):
         warnings.warn(
             "User-defined function verification is still under development in Modin. "
-            "The function provided is not verified."
+            + "The function provided is not verified."
         )
 
     @classmethod
@@ -79,7 +79,7 @@ class ErrorMessage(object):
     @classmethod
     def not_initialized(cls, engine, code):
         warnings.warn(
-            "{} execution environment not yet initialized. Initializing...\n"
-            "To remove this warning, run the following python code before doing dataframe operations:\n"
-            "{}".format(engine, code)
+            f"{engine} execution environment not yet initialized. Initializing...\n"
+            + "To remove this warning, run the following python code before doing dataframe operations:\n"
+            + f"{code}"
         )

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/dataframe/dataframe.py
@@ -480,8 +480,8 @@ class OmnisciOnNativeDataframe(PandasDataframe):
         if not isinstance(by_frame._op, allowed_nodes):
             raise NotImplementedError(
                 "OmniSci doesn't allow complex expression to be a group key. "
-                f"The only allowed frame nodes are: {tuple(o.__name__ for o in allowed_nodes)}, "
-                f"met '{type(by_frame._op).__name__}'."
+                + f"The only allowed frame nodes are: {tuple(o.__name__ for o in allowed_nodes)}, "
+                + f"met '{type(by_frame._op).__name__}'."
             )
 
         col_to_delete_template = "__delete_me_{name}"
@@ -2322,7 +2322,7 @@ class OmnisciOnNativeDataframe(PandasDataframe):
         if len(unsupported_cols) > 0:
             ErrorMessage.single_warning(
                 f"Frame contain columns with unsupported data-types: {unsupported_cols}. "
-                "All operations with this frame will be default to pandas!"
+                + "All operations with this frame will be default to pandas!"
             )
 
         return cls(
@@ -2407,7 +2407,7 @@ class OmnisciOnNativeDataframe(PandasDataframe):
         if len(unsupported_cols) > 0:
             ErrorMessage.single_warning(
                 f"Frame contain columns with unsupported data-types: {unsupported_cols}. "
-                "All operations with this frame will be default to pandas!"
+                + "All operations with this frame will be default to pandas!"
             )
 
         return cls(

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/df_algebra.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/df_algebra.py
@@ -443,8 +443,8 @@ class MaskNode(DFAlgNode):
         """
         return (
             f"{prefix}MaskNode:\n"
-            f"{prefix}  row_labels: {self.row_labels}\n"
-            f"{prefix}  row_positions: {self.row_positions}\n"
+            + f"{prefix}  row_labels: {self.row_labels}\n"
+            + f"{prefix}  row_positions: {self.row_positions}\n"
             + self._prints_input(prefix + "  ")
         )
 
@@ -507,9 +507,9 @@ class GroupbyAggNode(DFAlgNode):
         """
         return (
             f"{prefix}AggNode:\n"
-            f"{prefix}  by: {self.by}\n"
-            f"{prefix}  aggs: {self.agg_exprs}\n"
-            f"{prefix}  groupby_opts: {self.groupby_opts}\n"
+            + f"{prefix}  by: {self.by}\n"
+            + f"{prefix}  aggs: {self.agg_exprs}\n"
+            + f"{prefix}  groupby_opts: {self.groupby_opts}\n"
             + self._prints_input(prefix + "  ")
         )
 
@@ -703,7 +703,7 @@ class JoinNode(DFAlgNode):
             exprs_str += f"{prefix}    {k}: {v}\n"
         return (
             f"{prefix}JoinNode:\n"
-            f"{prefix}  Fields:\n"
+            + f"{prefix}  Fields:\n"
             + exprs_str
             + f"{prefix}  How: {self.how}\n"
             + f"{prefix}  Condition: {self.condition}\n"
@@ -815,9 +815,9 @@ class SortNode(DFAlgNode):
         """
         return (
             f"{prefix}SortNode:\n"
-            f"{prefix}  Columns: {self.columns}\n"
-            f"{prefix}  Ascending: {self.ascending}\n"
-            f"{prefix}  NULLs position: {self.na_position}\n"
+            + f"{prefix}  Columns: {self.columns}\n"
+            + f"{prefix}  Ascending: {self.ascending}\n"
+            + f"{prefix}  NULLs position: {self.na_position}\n"
             + self._prints_input(prefix + "  ")
         )
 
@@ -872,7 +872,7 @@ class FilterNode(DFAlgNode):
         """
         return (
             f"{prefix}FilterNode:\n"
-            f"{prefix}  Condition: {self.condition}\n"
+            + f"{prefix}  Condition: {self.condition}\n"
             + self._prints_input(prefix + "  ")
         )
 

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/io/io.py
@@ -431,7 +431,7 @@ class OmnisciOnNativeIO(BaseIO, TextFileDispatcher):
             return (
                 False,
                 "read_csv with 'arrow' engine doesn't support explicit compression parameter, compression"
-                " must be inferred automatically (supported compression types are gzip and bz2)",
+                + " must be inferred automatically (supported compression types are gzip and bz2)",
             )
 
         if isinstance(filepath_or_buffer, str):
@@ -472,14 +472,14 @@ class OmnisciOnNativeIO(BaseIO, TextFileDispatcher):
             return (
                 False,
                 "read_csv with 'arrow' engine supports only bool and "
-                "flattened lists 'parse_dates' parameter",
+                + "flattened lists 'parse_dates' parameter",
             )
         if names and names != lib.no_default:
             if header not in [None, 0, "infer"]:
                 return (
                     False,
                     "read_csv with 'arrow' engine and provided 'names' parameter supports only 0, None and "
-                    "'infer' header values",
+                    + "'infer' header values",
                 )
             if isinstance(parse_dates, list) and not set(parse_dates).issubset(names):
                 raise ValueError("Missing column provided to 'parse_dates'")
@@ -502,14 +502,14 @@ class OmnisciOnNativeIO(BaseIO, TextFileDispatcher):
                 return (
                     False,
                     "read_csv with 'arrow' engine doesn't support names parameter, which length doesn't match "
-                    "with actual number of columns",
+                    + "with actual number of columns",
                 )
         else:
             if header not in [0, "infer"]:
                 return (
                     False,
                     "read_csv with 'arrow' engine without 'names' parameter provided supports only 0 and 'infer' "
-                    "header values",
+                    + "header values",
                 )
             if isinstance(parse_dates, list):
                 empty_pandas_df = pandas.read_csv(
@@ -576,13 +576,13 @@ class OmnisciOnNativeIO(BaseIO, TextFileDispatcher):
         if delim_whitespace and (delimiter is not lib.no_default):
             raise ValueError(
                 "Specified a delimiter with both sep and "
-                "delim_whitespace=True; you can only specify one."
+                + "delim_whitespace=True; you can only specify one."
             )
         if on_bad_lines is not None:
             if error_bad_lines is not None or warn_bad_lines is not None:
                 raise ValueError(
                     "Both on_bad_lines and error_bad_lines/warn_bad_lines are set. "
-                    "Please only set on_bad_lines."
+                    + "Please only set on_bad_lines."
                 )
 
         if on_bad_lines not in ["error", "warn", "skip", None]:

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
@@ -289,7 +289,7 @@ class TestCSV:
         if parse_dates_unsupported and engine == "arrow" and not names:
             pytest.skip(
                 "In these cases Modin raises `ArrowEngineException` while pandas "
-                "doesn't raise any exceptions that causes tests fails"
+                + "doesn't raise any exceptions that causes tests fails"
             )
         # In these cases Modin raises `ArrowEngineException` while pandas
         # raises `ValueError`, so skipping exception type checking
@@ -1162,8 +1162,8 @@ class TestAgg:
         ).isna().any(axis=None):
             pytest.xfail(
                 reason="'dropna' parameter is forcibly disabled in OmniSci's GroupBy"
-                "due to performance issues, you can track this problem at:"
-                "https://github.com/modin-project/modin/issues/2896"
+                + "due to performance issues, you can track this problem at:"
+                + "https://github.com/modin-project/modin/issues/2896"
             )
 
         # Custom comparator is required because pandas is inconsistent about

--- a/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/sql.py
+++ b/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/sql.py
@@ -49,7 +49,7 @@ def is_distributed(partition_column, lower_bound, upper_bound):
     else:
         raise InvalidArguments(
             "Invalid combination of partition_column, lower_bound, upper_bound."
-            "All these arguments should be passed (distributed) or none of them (standard pandas)."
+            + "All these arguments should be passed (distributed) or none of them (standard pandas)."
         )
 
 

--- a/modin/experimental/pandas/__init__.py
+++ b/modin/experimental/pandas/__init__.py
@@ -52,6 +52,6 @@ setattr(DataFrame, "to_pickle_distributed", to_pickle_distributed)  # noqa: F405
 
 warnings.warn(
     "Thank you for using the Modin Experimental pandas API."
-    "\nPlease note that some of these APIs deviate from pandas in order to "
-    "provide improved performance."
+    + "\nPlease note that some of these APIs deviate from pandas in order to "
+    + "provide improved performance."
 )

--- a/modin/experimental/pandas/numpy_wrap.py
+++ b/modin/experimental/pandas/numpy_wrap.py
@@ -91,7 +91,7 @@ else:
 
                 warnings.warn(
                     "Was not able to intercept all numpy imports. "
-                    "To intercept all of these please do 'import modin.experimental.pandas' as early as possible"
+                    + "To intercept all of these please do 'import modin.experimental.pandas' as early as possible"
                 )
                 self.__has_to_warn = False
 

--- a/modin/experimental/sql/__init__.py
+++ b/modin/experimental/sql/__init__.py
@@ -19,7 +19,7 @@ try:
 except ImportError:
     warnings.warn(
         "Modin experimental sql interface requires dfsql to be installed."
-        " Run `pip install modin[sql]` to install it."
+        + " Run `pip install modin[sql]` to install it."
     )
     raise
 

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -18,10 +18,8 @@ __pandas_version__ = "1.4.1"
 
 if pandas.__version__ != __pandas_version__:
     warnings.warn(
-        "The pandas version installed {} does not match the supported pandas version in"
-        " Modin {}. This may cause undesired side effects!".format(
-            pandas.__version__, __pandas_version__
-        )
+        f"The pandas version installed {pandas.__version__} does not match the supported pandas version in"
+        + f" Modin {__pandas_version__}. This may cause undesired side effects!"
     )
 
 with warnings.catch_warnings():

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -272,16 +272,14 @@ class BasePandasDataset(object):
             if axis == 0:
                 if len(other) != len(self._query_compiler.index):
                     raise ValueError(
-                        "Unable to coerce to Series, length must be {0}: "
-                        "given {1}".format(len(self._query_compiler.index), len(other))
+                        f"Unable to coerce to Series, length must be {len(self._query_compiler.index)}: "
+                        + f"given {len(other)}"
                     )
             else:
                 if len(other) != len(self._query_compiler.columns):
                     raise ValueError(
-                        "Unable to coerce to Series, length must be {0}: "
-                        "given {1}".format(
-                            len(self._query_compiler.columns), len(other)
-                        )
+                        f"Unable to coerce to Series, length must be {len(self._query_compiler.columns)}: "
+                        + f"given {len(other)}"
                     )
             if hasattr(other, "dtype"):
                 other_dtypes = [other.dtype] * len(other)
@@ -380,7 +378,7 @@ class BasePandasDataset(object):
             elif not callable(fn):
                 on_invalid(
                     f"One of the passed functions has an invalid type: {type(fn)}: {fn}, "
-                    "only callable or string is acceptable.",
+                    + "only callable or string is acceptable.",
                     TypeError,
                 )
 
@@ -917,7 +915,7 @@ class BasePandasDataset(object):
             ):
                 raise KeyError(
                     "Only a column name can be used for the key in"
-                    "a dtype mappings argument."
+                    + "a dtype mappings argument."
                 )
             col_dtypes = dtype
         else:
@@ -1396,7 +1394,7 @@ class BasePandasDataset(object):
         if isinstance(value, (list, tuple)):
             raise TypeError(
                 '"value" parameter must be a scalar or dict, but '
-                'you passed a "{0}"'.format(type(value).__name__)
+                + f'you passed a "{type(value).__name__}"'
             )
         if value is None and method is None:
             raise ValueError("must specify a fill method or value")
@@ -2016,7 +2014,7 @@ class BasePandasDataset(object):
             if non_mapper:
                 return self._set_axis_name(mapper, axis=axis, inplace=inplace)
             else:
-                raise ValueError("Use `.rename` to alter labels " "with a mapper.")
+                raise ValueError("Use `.rename` to alter labels with a mapper.")
         else:
             # Use new behavior.  Means that index and/or columns is specified
             result = self if inplace else self.copy(deep=copy)
@@ -2216,8 +2214,8 @@ class BasePandasDataset(object):
                 else:
                     raise ValueError(
                         "Strings can only be passed to "
-                        "weights when sampling from rows on "
-                        "a DataFrame"
+                        + "weights when sampling from rows on "
+                        + "a DataFrame"
                     )
             weights = pandas.Series(weights, dtype="float64")
 
@@ -2284,7 +2282,7 @@ class BasePandasDataset(object):
                 # random_state must be an int or a numpy RandomState object
                 raise ValueError(
                     "Please enter an `int` OR a "
-                    "np.random.RandomState for random_state"
+                    + "np.random.RandomState for random_state"
                 )
             # choose random numbers and then get corresponding labels from
             # chosen axis
@@ -2321,9 +2319,9 @@ class BasePandasDataset(object):
         if is_scalar(labels):
             warnings.warn(
                 'set_axis now takes "labels" as first argument, and '
-                '"axis" as named parameter. The old form, with "axis" as '
-                'first parameter and "labels" as second, is still supported '
-                "but will be deprecated in a future version of pandas.",
+                + '"axis" as named parameter. The old form, with "axis" as '
+                + 'first parameter and "labels" as second, is still supported '
+                + "but will be deprecated in a future version of pandas.",
                 FutureWarning,
                 stacklevel=2,
             )
@@ -3105,10 +3103,8 @@ class BasePandasDataset(object):
 
     def __nonzero__(self):
         raise ValueError(
-            "The truth value of a {0} is ambiguous. "
-            "Use a.empty, a.bool(), a.item(), a.any() or a.all().".format(
-                self.__class__.__name__
-            )
+            f"The truth value of a {self.__class__.__name__} is ambiguous. "
+            + "Use a.empty, a.bool(), a.item(), a.any() or a.all()."
         )
 
     __bool__ = __nonzero__

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -113,7 +113,7 @@ class DataFrame(BasePandasDataset):
             if index is not None and any(i not in data.index for i in index):
                 raise NotImplementedError(
                     "Passing non-existant columns or index values to constructor not"
-                    " yet implemented."
+                    + " yet implemented."
                 )
             if isinstance(data, Series):
                 # We set the column name if it is not in the provided Series
@@ -133,7 +133,7 @@ class DataFrame(BasePandasDataset):
                 if columns is not None and any(i not in data.columns for i in columns):
                     raise NotImplementedError(
                         "Passing non-existant columns or index values to constructor not"
-                        " yet implemented."
+                        + " yet implemented."
                     )
                 if index is None:
                     index = slice(None)
@@ -402,7 +402,7 @@ class DataFrame(BasePandasDataset):
             warnings.warn(
                 (
                     "The `squeeze` parameter is deprecated and "
-                    "will be removed in a future version."
+                    + "will be removed in a future version."
                 ),
                 FutureWarning,
                 stacklevel=2,
@@ -544,7 +544,7 @@ class DataFrame(BasePandasDataset):
         if sort is False:
             warnings.warn(
                 "Due to https://github.com/pandas-dev/pandas/issues/35092, "
-                "Pandas ignores sort=False; Modin correctly does not sort."
+                + "Pandas ignores sort=False; Modin correctly does not sort."
             )
         if isinstance(other, (Series, dict)):
             if isinstance(other, dict):
@@ -552,7 +552,7 @@ class DataFrame(BasePandasDataset):
             if other.name is None and not ignore_index:
                 raise TypeError(
                     "Can only append a Series if ignore_index=True"
-                    " or if the Series has a name"
+                    + " or if the Series has a name"
                 )
             if other.name is not None:
                 # other must have the same index name as self, otherwise
@@ -1134,8 +1134,8 @@ class DataFrame(BasePandasDataset):
                 except (TypeError, ValueError, IndexError):
                     raise ValueError(
                         "Cannot insert into a DataFrame with no defined index "
-                        "and a value that cannot be converted to a "
-                        "Series"
+                        + "and a value that cannot be converted to a "
+                        + "Series"
                     )
             new_index = value.index.copy()
             new_columns = self.columns.insert(loc, column)
@@ -2457,7 +2457,7 @@ class DataFrame(BasePandasDataset):
         elif isinstance(value, pandas.Series):
             warnings.warn(
                 "Modin doesn't allow columns to be created via a new attribute name - see "
-                "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
+                + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
                 UserWarning,
             )
         object.__setattr__(self, key, value)

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -372,8 +372,8 @@ def concat(
     if isinstance(objs, (pandas.Series, Series, DataFrame, str, pandas.DataFrame)):
         raise TypeError(
             "first argument must be an iterable of pandas "
-            "objects, you passed an object of type "
-            '"{name}"'.format(name=type(objs).__name__)
+            + "objects, you passed an object of type "
+            + f'"{type(objs).__name__}"'
         )
     axis = pandas.DataFrame()._get_axis_number(axis)
     if isinstance(objs, dict):
@@ -398,9 +398,9 @@ def concat(
     if type_check is not None:
         raise ValueError(
             'cannot concatenate object of type "{0}"; only '
-            "modin.pandas.Series "
-            "and modin.pandas.DataFrame objs are "
-            "valid",
+            + "modin.pandas.Series "
+            + "and modin.pandas.DataFrame objs are "
+            + "valid",
             type(type_check),
         )
     all_series = all(isinstance(obj, Series) for obj in list_of_objs)
@@ -548,8 +548,8 @@ def get_dummies(
     if sparse:
         raise NotImplementedError(
             "SparseDataFrame is not implemented. "
-            "To contribute to Modin, please visit "
-            "github.com/modin-project/modin."
+            + "To contribute to Modin, please visit "
+            + "github.com/modin-project/modin."
         )
     if not isinstance(data, DataFrame):
         ErrorMessage.default_to_pandas("`get_dummies` on non-DataFrame")

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -422,10 +422,10 @@ class DataFrameGroupBy(object):
                     operation="GroupBy.__getitem__",
                     message=(
                         "intersection of the selection and 'by' columns is not yet supported, "
-                        "to achieve the desired result rewrite the original code from:\n"
-                        "df.groupby('by_column')['by_column']\n"
-                        "to the:\n"
-                        "df.groupby(df['by_column'].copy())['by_column']"
+                        + "to achieve the desired result rewrite the original code from:\n"
+                        + "df.groupby('by_column')['by_column']\n"
+                        + "to the:\n"
+                        + "df.groupby(df['by_column'].copy())['by_column']"
                     ),
                 )
             cols_to_grab = internal_by.union(key)
@@ -442,7 +442,7 @@ class DataFrameGroupBy(object):
         ):
             raise NotImplementedError(
                 "Column lookups on GroupBy with arbitrary Series in by"
-                " is not yet supported."
+                + " is not yet supported."
             )
         return SeriesGroupBy(
             self._df[key],
@@ -513,11 +513,11 @@ class DataFrameGroupBy(object):
                     operation="GroupBy.aggregate(**dictionary_renaming_aggregation)",
                     message=(
                         "intersection of the columns to aggregate and 'by' is not yet supported when 'as_index=False', "
-                        "columns with group names of the intersection will not be presented in the result. "
-                        "To achieve the desired result rewrite the original code from:\n"
-                        "df.groupby('by_column', as_index=False).agg(agg_func=('by_column', agg_func))\n"
-                        "to the:\n"
-                        "df.groupby('by_column').agg(agg_func=('by_column', agg_func)).reset_index()"
+                        + "columns with group names of the intersection will not be presented in the result. "
+                        + "To achieve the desired result rewrite the original code from:\n"
+                        + "df.groupby('by_column', as_index=False).agg(agg_func=('by_column', agg_func))\n"
+                        + "to the:\n"
+                        + "df.groupby('by_column').agg(agg_func=('by_column', agg_func)).reset_index()"
                     ),
                 )
 

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -451,7 +451,7 @@ class _LocationIndexerBase(object):
             if not all(idx in item.index for idx in index_values):
                 raise ValueError(
                     "Must have equal len keys and value when setting with "
-                    "an iterable"
+                    + "an iterable"
                 )
             if hasattr(item, "columns"):
                 column_values = self.qc.columns[col_lookup]
@@ -459,7 +459,7 @@ class _LocationIndexerBase(object):
                     # TODO: think if it is needed to handle cases when columns have duplicate names
                     raise ValueError(
                         "Must have equal len keys and value when setting "
-                        "with an iterable"
+                        + "with an iterable"
                     )
                 item = item.reindex(index=index_values, columns=column_values)
             else:
@@ -473,8 +473,8 @@ class _LocationIndexerBase(object):
         except ValueError:
             from_shape = np.array(item).shape
             raise ValueError(
-                "could not broadcast input array from shape {from_shape} into shape "
-                "{to_shape}".format(from_shape=from_shape, to_shape=to_shape)
+                f"could not broadcast input array from shape {from_shape} into shape "
+                + f"{to_shape}"
             )
 
     def _write_items(self, row_lookup, col_lookup, item):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -132,7 +132,7 @@ class Series(BasePandasDataset):
                 if any(i not in data.index for i in index):
                     raise NotImplementedError(
                         "Passing non-existent columns or index values to constructor "
-                        "not yet implemented."
+                        + "not yet implemented."
                     )
                 query_compiler = data.loc[index]._query_compiler
         if query_compiler is None:
@@ -576,7 +576,7 @@ class Series(BasePandasDataset):
 
         bad_type_msg = (
             'cannot concatenate object of type "{}"; only pd.Series, '
-            "pd.DataFrame, and pd.Panel (deprecated) objs are valid"
+            + "pd.DataFrame, and pd.Panel (deprecated) objs are valid"
         )
         if isinstance(to_append, list):
             if not all(isinstance(o, BasePandasDataset) for o in to_append):
@@ -1024,7 +1024,7 @@ class Series(BasePandasDataset):
         if isinstance(value, BasePandasDataset) and not isinstance(value, Series):
             raise TypeError(
                 '"value" parameter must be a scalar, dict or Series, but '
-                'you passed a "{0}"'.format(type(value).__name__)
+                + f'you passed a "{type(value).__name__}"'
             )
         return super(Series, self)._fillna(
             squeeze_self=True,
@@ -1074,7 +1074,7 @@ class Series(BasePandasDataset):
             warnings.warn(
                 (
                     "The `squeeze` parameter is deprecated and "
-                    "will be removed in a future version."
+                    + "will be removed in a future version."
                 ),
                 FutureWarning,
                 stacklevel=2,
@@ -1540,7 +1540,7 @@ class Series(BasePandasDataset):
         if kwargs:
             raise TypeError(
                 "reindex() got an unexpected keyword "
-                'argument "{0}"'.format(list(kwargs.keys())[0])
+                + f'argument "{list(kwargs.keys())[0]}"'
             )
         return super(Series, self).reindex(
             index=index,

--- a/modin/pandas/test/dataframe/test_udf.py
+++ b/modin/pandas/test/dataframe/test_udf.py
@@ -116,9 +116,9 @@ def test_aggregate_error_checking():
 @pytest.mark.xfail(
     StorageFormat.get() == "Pandas",
     reason="DataFrame.apply(dict) raises an exception because of a bug in its"
-    "implementation for pandas storage format, this prevents us from catching the desired"
-    "exception. You can track this bug at:"
-    "https://github.com/modin-project/modin/issues/3221",
+    + "implementation for pandas storage format, this prevents us from catching the desired"
+    + "exception. You can track this bug at:"
+    + "https://github.com/modin-project/modin/issues/3221",
 )
 @pytest.mark.parametrize(
     "func",
@@ -129,9 +129,9 @@ def test_apply_key_error(func):
     if not (is_list_like(func) or callable(func) or isinstance(func, str)):
         pytest.xfail(
             reason="Because index materialization is expensive Modin first"
-            "checks the validity of the function itself and only then the engine level"
-            "checks the validity of the indices. Pandas order of such checks is reversed,"
-            "so we get different errors when both (function and index) are invalid."
+            + "checks the validity of the function itself and only then the engine level"
+            + "checks the validity of the indices. Pandas order of such checks is reversed,"
+            + "so we get different errors when both (function and index) are invalid."
         )
     eval_general(
         *create_test_dfs(test_data["int_data"]),

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1616,9 +1616,9 @@ def test_agg_exceptions(operation):
 
 @pytest.mark.skip(
     "Pandas raises a ValueError on empty dictionary aggregation since 1.2.0"
-    "It's unclear is that was made on purpose or it is a bug. That question"
-    "was asked in https://github.com/pandas-dev/pandas/issues/39609."
-    "So until the answer this test is disabled."
+    + "It's unclear is that was made on purpose or it is a bug. That question"
+    + "was asked in https://github.com/pandas-dev/pandas/issues/39609."
+    + "So until the answer this test is disabled."
 )
 @pytest.mark.parametrize(
     "kwargs",
@@ -1941,7 +1941,7 @@ def test_handle_as_index(
     ):
         pytest.skip(
             "The linked bug makes pandas raise an exception when 'by' is categorical: "
-            "https://github.com/pandas-dev/pandas/issues/36698"
+            + "https://github.com/pandas-dev/pandas/issues/36698"
         )
 
     df = pandas.DataFrame(test_groupby_data)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -90,6 +90,11 @@ DATASET_SIZE_DICT = {
     "Big": 20000,
 }
 
+print('foo' 'bar', 'baz')
+a = ["aaa",
+     "bbb"
+     "ccc"]
+
 # Number of rows in the test file
 NROWS = DATASET_SIZE_DICT.get(TestDatasetSize.get(), DATASET_SIZE_DICT["Small"])
 
@@ -257,7 +262,7 @@ class TestCsv:
 
     @pytest.mark.parametrize("usecols", [lambda col_name: col_name in ["a", "b", "e"]])
     def test_from_csv_with_callable_usecols(self, usecols):
-        fname = "modin/pandas/test/data/test_usecols.csv"
+        fname = "modin/pandas/test/data/test_usecols" ".csv"
         pandas_df = pandas.read_csv(fname, usecols=usecols)
         modin_df = pd.read_csv(fname, usecols=usecols)
         df_equals(modin_df, pandas_df)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -90,7 +90,6 @@ DATASET_SIZE_DICT = {
     "Big": 20000,
 }
 
-print('foo' 'bar', 'baz')
 a = ["aaa",
      "bbb"
      "ccc"]

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -90,8 +90,6 @@ DATASET_SIZE_DICT = {
     "Big": 20000,
 }
 
-a = ["aaa", "bbb" "ccc"]
-
 # Number of rows in the test file
 NROWS = DATASET_SIZE_DICT.get(TestDatasetSize.get(), DATASET_SIZE_DICT["Small"])
 
@@ -259,7 +257,7 @@ class TestCsv:
 
     @pytest.mark.parametrize("usecols", [lambda col_name: col_name in ["a", "b", "e"]])
     def test_from_csv_with_callable_usecols(self, usecols):
-        fname = "modin/pandas/test/data/test_usecols" ".csv"
+        fname = "modin/pandas/test/data/test_usecols.csv"
         pandas_df = pandas.read_csv(fname, usecols=usecols)
         modin_df = pd.read_csv(fname, usecols=usecols)
         df_equals(modin_df, pandas_df)
@@ -423,9 +421,9 @@ class TestCsv:
         unique_filename = get_unique_filename()
         str_initial_spaces = (
             "col1,col2,col3,col4\n"
-            "five,  six,  seven,  eight\n"
-            "    five,    six,    seven,    eight\n"
-            "five, six,  seven,   eight\n"
+            + "five,  six,  seven,  eight\n"
+            + "    five,    six,    seven,    eight\n"
+            + "five, six,  seven,   eight\n"
         )
 
         eval_io_from_str(str_initial_spaces, unique_filename, skipinitialspace=True)
@@ -1893,10 +1891,10 @@ class TestFwf:
     def test_fwf_file(self, make_fwf_file):
         fwf_data = (
             "id8141  360.242940  149.910199 11950.7\n"
-            "id1594  444.953632  166.985655 11788.4\n"
-            "id1849  364.136849  183.628767 11806.2\n"
-            "id1230  413.836124  184.375703 11916.8\n"
-            "id1948  502.953953  173.237159 12468.3\n"
+            + "id1594  444.953632  166.985655 11788.4\n"
+            + "id1849  364.136849  183.628767 11806.2\n"
+            + "id1230  413.836124  184.375703 11916.8\n"
+            + "id1948  502.953953  173.237159 12468.3\n"
         )
         unique_filename = make_fwf_file(fwf_data=fwf_data)
 
@@ -1947,11 +1945,11 @@ class TestFwf:
     def test_fwf_file_usecols(self, make_fwf_file, usecols):
         fwf_data = (
             "a       b           c          d\n"
-            "id8141  360.242940  149.910199 11950.7\n"
-            "id1594  444.953632  166.985655 11788.4\n"
-            "id1849  364.136849  183.628767 11806.2\n"
-            "id1230  413.836124  184.375703 11916.8\n"
-            "id1948  502.953953  173.237159 12468.3\n"
+            + "id8141  360.242940  149.910199 11950.7\n"
+            + "id1594  444.953632  166.985655 11788.4\n"
+            + "id1849  364.136849  183.628767 11806.2\n"
+            + "id1230  413.836124  184.375703 11916.8\n"
+            + "id1948  502.953953  173.237159 12468.3\n"
         )
         eval_io(
             fn_name="read_fwf",
@@ -2012,11 +2010,11 @@ class TestFwf:
     def test_fwf_file_index_col(self, make_fwf_file):
         fwf_data = (
             "a       b           c          d\n"
-            "id8141  360.242940  149.910199 11950.7\n"
-            "id1594  444.953632  166.985655 11788.4\n"
-            "id1849  364.136849  183.628767 11806.2\n"
-            "id1230  413.836124  184.375703 11916.8\n"
-            "id1948  502.953953  173.237159 12468.3\n"
+            + "id8141  360.242940  149.910199 11950.7\n"
+            + "id1594  444.953632  166.985655 11788.4\n"
+            + "id1849  364.136849  183.628767 11806.2\n"
+            + "id1230  413.836124  184.375703 11916.8\n"
+            + "id1948  502.953953  173.237159 12468.3\n"
         )
         eval_io(
             fn_name="read_fwf",

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -90,9 +90,7 @@ DATASET_SIZE_DICT = {
     "Big": 20000,
 }
 
-a = ["aaa",
-     "bbb"
-     "ccc"]
+a = ["aaa", "bbb" "ccc"]
 
 # Number of rows in the test file
 NROWS = DATASET_SIZE_DICT.get(TestDatasetSize.get(), DATASET_SIZE_DICT["Small"])

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -571,7 +571,7 @@ def import_optional_dependency(name, message):
     except ImportError:
         raise ImportError(
             f"Missing optional dependency '{name}'. {message} "
-            f"Use pip or conda to install {name}."
+            + f"Use pip or conda to install {name}."
         ) from None
 
 

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -580,9 +580,9 @@ def check_args(args: argparse.Namespace):
         abs_path = os.path.abspath(path)
         if not abs_path.startswith(MODIN_PATH):
             raise ValueError(
-                f"it is unsupported to use this script on files from another "
-                f"repository; script' repo '{MODIN_PATH}', "
-                f"input path '{abs_path}'"
+                "it is unsupported to use this script on files from another "
+                + f"repository; script' repo '{MODIN_PATH}', "
+                + f"input path '{abs_path}'"
             )
 
 

--- a/scripts/test/examples.py
+++ b/scripts/test/examples.py
@@ -34,7 +34,7 @@ def optional_square(number: int = 5) -> int:  # noqa
     -----
     The `optional_square` Modin function from modin/scripts/examples.py.
     """
-    return number**2
+    return number ** 2
 
 
 def optional_square_empty_parameters(number: int = 5) -> int:
@@ -42,7 +42,7 @@ def optional_square_empty_parameters(number: int = 5) -> int:
     Parameters
     ----------
     """
-    return number**2
+    return number ** 2
 
 
 def square_summary(number: int) -> int:  # noqa: PR01, GL08
@@ -56,4 +56,4 @@ def square_summary(number: int) -> int:  # noqa: PR01, GL08
     The function that will never be used in modin.pandas.DataFrame same as in
     pandas or NumPy.
     """
-    return number**2
+    return number ** 2

--- a/scripts/test/examples.py
+++ b/scripts/test/examples.py
@@ -15,6 +15,7 @@
 # noqa: MD02
 """Function examples for docstring testing."""
 
+
 class weakdict(dict):  # noqa: GL08
     __slots__ = ("__weakref__",)
 

--- a/scripts/test/examples.py
+++ b/scripts/test/examples.py
@@ -15,7 +15,6 @@
 # noqa: MD02
 """Function examples for docstring testing."""
 
-
 class weakdict(dict):  # noqa: GL08
     __slots__ = ("__weakref__",)
 
@@ -35,7 +34,7 @@ def optional_square(number: int = 5) -> int:  # noqa
     -----
     The `optional_square` Modin function from modin/scripts/examples.py.
     """
-    return number ** 2
+    return number**2
 
 
 def optional_square_empty_parameters(number: int = 5) -> int:
@@ -43,7 +42,7 @@ def optional_square_empty_parameters(number: int = 5) -> int:
     Parameters
     ----------
     """
-    return number ** 2
+    return number**2
 
 
 def square_summary(number: int) -> int:  # noqa: PR01, GL08
@@ -57,4 +56,4 @@ def square_summary(number: int) -> int:  # noqa: PR01, GL08
     The function that will never be used in modin.pandas.DataFrame same as in
     pandas or NumPy.
     """
-    return number ** 2
+    return number**2

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ filterwarnings =
 [flake8]
 max-line-length = 88
 ignore = E203, E266, E501, W503, F821
-select = B,C,E,F,W,T4,B9
+select = B,C,E,F,W,T4,B9,NIC
 per-file-ignores =
     modin/pandas/__init__.py:E402,F401
     stress_tests/kaggle/*:E402

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ filterwarnings =
 [flake8]
 max-line-length = 88
 ignore = E203, E266, E501, W503, F821
-select = B,C,E,F,W,T4,B9,NIC
+select = B,C,E,F,W,T,B9,NIC
 per-file-ignores =
     modin/pandas/__init__.py:E402,F401
     stress_tests/kaggle/*:E402


### PR DESCRIPTION
## What do these changes do?
To avoid errors like this one: https://codereviewdoctor.medium.com/5-of-666-python-repos-had-comma-typos-including-tensorflow-and-pytorch-sentry-and-v8-7bc3ad9a1bb7, add a recommendation to use flake8-no-implicit-concat in the contributing docs and add this plugin to the CI.

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3900? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
