### PR TITLE
FIX-#3899: Add pyright config.

### DIFF
--- a/contributing/contributing.md
+++ b/contributing/contributing.md
@@ -80,12 +80,13 @@ you should reopen your terminal to find "(base)" next to your prompt: ![](conda_
 
 1. (Optional) We recommend a few workflow settings:
 
-    1. If you use Visual Studio Code, auto-format with [black](https://black.readthedocs.io/en/stable/) every time you save changes:
-        1. Install [Microsoft's Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python)
-        1. Open your VSCode settings, in `Code -> Preferences -> Settings`.
-        1. Search for "python formatting provider" and select "black" from the dropdown menu.
-        1. Again in settings, search for "format on save" and enable the "Editor: Format on Save" option.
+    1. If you use Visual Studio Code, auto-format with [black](https://black.readthedocs.io/en/stable/) every time you save changes and type check with [pyright](https://github.com/microsoft/pyright):
+        1. Install [Microsoft's Python extension](https://marketplace.visualstudio.com/items?itemName=ms-python.python) which also installs Pylance (which runs Pyright under the hood).
+        2. Open your VSCode settings, in `Code -> Preferences -> Settings`.
+        3. Search for "type checking" and select "off" which enables the smallest set of type rules.
+        4. Search for "python formatting provider" and select "black" from the dropdown menu.
+        5. Again in settings, search for "format on save" and enable the "Editor: Format on Save" option.
     2. Add a pre-commit hook:
         1. In your modin repository, copy [this pre-commit file](pre-commit) to `.git/hooks/pre-commit`
-        1. Every time you try to commit, git will run flake8 and abort the commit if it fails. This lets you make sure your commits passes flake8 before you push to GitHub.
-        1. To bypass the pre-commit hook (e.g. if you don't want to create a pull request, or you already know your code will pass the tests), commit with the flag `--no-verify`.
+        2. Every time you try to commit, git will run flake8 and abort the commit if it fails. This lets you make sure your commits passes flake8 before you push to GitHub.
+        3. To bypass the pre-commit hook (e.g. if you don't want to create a pull request, or you already know your code will pass the tests), commit with the flag `--no-verify`.

--- a/contributing/pre-commit
+++ b/contributing/pre-commit
@@ -10,5 +10,7 @@ set -e
 printf "running flake8. This script will preempt the commit if flake8 fails.\n"
 flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py
 printf "flake8 passed!\n"
-
+printf "running pyright. This script will preempt the commit if pyright fails.\n"
+pyright
+printf "pyright passed!\n"
 printf "pre-commit hook finished!\n"

--- a/modin/experimental/cloud/meta_magic.py
+++ b/modin/experimental/cloud/meta_magic.py
@@ -153,7 +153,7 @@ def make_wrapped_class(local_cls: type, rpyc_wrapper_name: str):
         def __new__(cls, *a, **kw):
             if cls is result and cls.__real_cls__ is not result:
                 return cls.__real_cls__(*a, **kw)
-            return super().__new__(cls)
+            return super(__class__).__new__(cls)
 
         __class__.__new__ = __new__
 

--- a/modin/experimental/xgboost/xgboost.py
+++ b/modin/experimental/xgboost/xgboost.py
@@ -284,7 +284,7 @@ class DMatrix:
             self.feature_weights = feature_weights
 
 
-class Booster(xgb.Booster):
+class ModinBooster(xgb.Booster):
     """
     A Modin Booster of XGBoost.
 
@@ -302,7 +302,9 @@ class Booster(xgb.Booster):
     """
 
     def __init__(self, params=None, cache=(), model_file=None):  # noqa: MD01
-        super(Booster, self).__init__(params=params, cache=cache, model_file=model_file)
+        super(ModinBooster, self).__init__(
+            params=params, cache=cache, model_file=model_file
+        )
 
     def predict(
         self,
@@ -426,4 +428,4 @@ def train(
         evals_result.update(result["history"])
 
     LOGGER.info("Training finished")
-    return Booster(model_file=result["booster"])
+    return ModinBooster(model_file=result["booster"])

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -27,7 +27,7 @@ import pathlib
 import re
 from collections import OrderedDict
 from pandas._typing import CompressionOptions, StorageOptions
-from typing import Union, IO, AnyStr, Sequence, Dict, List, Optional, Any
+from typing import Type, Union, IO, AnyStr, Sequence, Dict, List, Optional, Any
 
 from modin.error_message import ErrorMessage
 from .dataframe import DataFrame
@@ -545,7 +545,7 @@ def read_sql_query(
 @_inherit_docstrings(pandas.read_spss)
 def read_spss(
     path: Union[str, pathlib.Path],
-    usecols: Union[Sequence[str], type(None)] = None,
+    usecols: Union[Sequence[str], Type[None]] = None,
     convert_categoricals: bool = True,
 ):
     Engine.subscribe(_update_engine)

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,17 +1,13 @@
 {
-    "include": [
-      "modin",
-    ],
-    
-    "exclude": [
-      "**/node_modules",
-      "**/__pycache__",
-    ],
-  
-    "ignore": [
-    ],
-
-    "reportUnknownParameterType": true,
-  
-    "pythonVersion": "3.8",
-  }
+  "include": [
+    "modin",
+    "asv_bench/benchmarks",
+    "scripts/doc_checker.py",
+  ],
+  "exclude": [
+    "**/node_modules",
+    "**/__pycache__",
+  ],
+  "ignore": [],
+  "typeCheckingMode": "off",
+}

--- a/pyrightconfig.json
+++ b/pyrightconfig.json
@@ -1,0 +1,17 @@
+{
+    "include": [
+      "modin",
+    ],
+    
+    "exclude": [
+      "**/node_modules",
+      "**/__pycache__",
+    ],
+  
+    "ignore": [
+    ],
+
+    "reportUnknownParameterType": true,
+  
+    "pythonVersion": "3.8",
+  }


### PR DESCRIPTION
Signed-off-by: jeffreykennethli <jkli@ponder.io>

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Adds a [pyrightconfig.json file](https://github.com/microsoft/pyright/blob/main/docs/configuration.md) that specifies the pyright options we want to use for Modin. Pyright has three strictness levels: `off`, `basic`, and `strict`. We can start with `off` level and fix all the errors and warnings, then gradually move up.

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3899? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
