### PR TITLE
FIX-#3915: Add pandas==1.4.0rc0 release candidate to conda env

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,7 +153,7 @@ jobs:
           conda list
       - run: sudo apt update && sudo apt install -y libhdf5-dev
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - name: Api tests
         run: python -m pytest modin/pandas/test/test_api.py
       - name: Executions Api tests
@@ -187,7 +187,7 @@ jobs:
           conda info
           conda list
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - name: Headers tests
         run: python -m pytest modin/test/test_headers.py
 
@@ -207,7 +207,7 @@ jobs:
           python-version: "3.7.x"
           architecture: "x64"
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - name: Clean install and run
         run: |
           python -m pip install -e .[all]
@@ -230,7 +230,7 @@ jobs:
           python-version: "3.7.x"
           architecture: "x64"
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - name: Clean install and run
         run: |
           python -m pip install -e .[all]
@@ -266,7 +266,7 @@ jobs:
           conda info
           conda list
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - name: Internals tests
         run: python -m pytest modin/core/execution/dispatching/factories/test/test_dispatcher.py modin/experimental/cloud/test/test_cloud.py
       - run: python -m pytest modin/config/test
@@ -315,7 +315,7 @@ jobs:
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - run: pytest modin/experimental/xgboost/test/test_default.py --execution=${{ matrix.execution }}
       - run: python -m pytest -n 2 modin/test/storage_formats/base/test_internals.py --execution=${{ matrix.execution }}
       - run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py --execution=${{ matrix.execution }}
@@ -380,7 +380,7 @@ jobs:
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - run: pytest modin/test/storage_formats/omnisci/test_internals.py
       - run: MODIN_BENCHMARK_MODE=True pytest modin/pandas/test/internals/test_benchmark_mode.py
       - run: pytest modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
@@ -428,7 +428,7 @@ jobs:
           # yet appeared in the release versions;
           pip install git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - name: Running benchmarks
         run: |
           # ASV correctly creates environments for testing only from the branch
@@ -503,7 +503,7 @@ jobs:
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - run: MODIN_BENCHMARK_MODE=True pytest modin/pandas/test/internals/test_benchmark_mode.py
       - run: pytest -n 2 modin/experimental/xgboost/test/test_default.py
       - run: pytest -n 2 modin/experimental/xgboost/test/test_xgboost.py
@@ -576,7 +576,7 @@ jobs:
           conda info
           conda list
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - run: python -m pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
       - run: python -m pytest -n 2 modin/pandas/test/test_series.py
       - run: python -m pytest modin/pandas/test/test_io.py --verbose
@@ -624,7 +624,7 @@ jobs:
           conda info
           conda list
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - run: python -m pytest --simulate-cloud=normal modin/pandas/test/test_io.py --verbose
       - run: python -m pytest --simulate-cloud=normal modin/pandas/test/dataframe/test_default.py::test_kurt_kurtosis --verbose
       - # When running without parameters, some of the tests fail
@@ -695,7 +695,7 @@ jobs:
           conda info
           conda list
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - run: python -m pytest ${{matrix.test-task}}
         if: matrix.test-task != 'modin/pandas/test/test_io.py'
       - timeout-minutes: 30
@@ -740,7 +740,7 @@ jobs:
           conda list
       - run: sudo apt update && sudo apt install -y libhdf5-dev
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - run: python -m pytest modin/pandas/test/test_io.py::TestCsv --verbose
 
   test-spreadsheet:
@@ -779,5 +779,5 @@ jobs:
           conda info
           conda list
       - name: Install pandas release candidate
-        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
+        run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
       - run: python -m pytest modin/experimental/spreadsheet/test/test_general.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7.x"
+          python-version: "3.8.x"
           architecture: "x64"
       - run: pip install black
       - run: black --check --diff modin/ asv_bench/benchmarks scripts/doc_checker.py
@@ -43,7 +43,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7.x"
+          python-version: "3.8.x"
           architecture: "x64"
       - run: pip install pytest pytest-cov pydocstyle numpydoc==1.1.0 xgboost
       - run: pytest scripts/test
@@ -118,7 +118,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7.x"
+          python-version: "3.8.x"
           architecture: "x64"
       - run: pip install flake8 flake8-print
       - run: flake8 --enable=T modin/ asv_bench/benchmarks scripts/doc_checker.py
@@ -138,7 +138,7 @@ jobs:
         with:
           activate-environment: modin
           environment-file: environment-dev.yml
-          python-version: 3.7
+          python-version: 3.8
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
           # Miniconda setup sometimes fails because of an HTTP error. Retry
@@ -173,7 +173,7 @@ jobs:
         with:
           activate-environment: modin
           environment-file: environment-dev.yml
-          python-version: 3.7
+          python-version: 3.8
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
           # Miniconda setup sometimes fails because of an http error. retry
@@ -204,7 +204,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7.x"
+          python-version: "3.8.x"
           architecture: "x64"
       - name: Install pandas release candidate
         run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
@@ -227,7 +227,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-python@v2
         with:
-          python-version: "3.7.x"
+          python-version: "3.8.x"
           architecture: "x64"
       - name: Install pandas release candidate
         run: conda install -c conda-forge/label/pandas_rc pandas==1.4.0rc0
@@ -252,7 +252,7 @@ jobs:
         with:
           activate-environment: modin
           environment-file: environment-dev.yml
-          python-version: 3.7
+          python-version: 3.8
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
           # Miniconda setup sometimes fails because of an http error. retry
@@ -290,7 +290,7 @@ jobs:
     env:
       MODIN_MEMORY: 1000000000
       MODIN_TEST_DATASET_SIZE: "small"
-    name: Test ${{ matrix.execution }} execution, Python 3.7
+    name: Test ${{ matrix.execution }} execution, Python 3.8
     steps:
       - uses: actions/checkout@v2
         with:
@@ -299,7 +299,7 @@ jobs:
         with:
           activate-environment: modin
           environment-file: environment-dev.yml
-          python-version: 3.7
+          python-version: 3.8
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
           # Miniconda setup sometimes fails because of an http error. retry
@@ -355,7 +355,7 @@ jobs:
       MODIN_EXPERIMENTAL: "True"
       MODIN_ENGINE: "native"
       MODIN_STORAGE_FORMAT: "omnisci"
-    name: Test OmniSci storage format, Python 3.7
+    name: Test OmniSci storage format, Python 3.8
     steps:
       - uses: actions/checkout@v2
         with:
@@ -365,7 +365,7 @@ jobs:
         with:
           activate-environment: modin_on_omnisci
           environment-file: requirements/env_omnisci.yml
-          python-version: 3.7
+          python-version: 3.8
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
           # Miniconda setup sometimes fails because of an http error. retry
           # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
@@ -473,7 +473,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8"]
         engine: ["python", "ray", "dask"]
     env:
       MODIN_ENGINE: ${{matrix.engine}}
@@ -562,7 +562,7 @@ jobs:
         with:
           activate-environment: modin
           environment-file: environment-dev.yml
-          python-version: 3.7
+          python-version: 3.8
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
           # Miniconda setup sometimes fails because of an http error. retry
@@ -610,7 +610,7 @@ jobs:
         with:
           activate-environment: modin
           environment-file: environment-dev.yml
-          python-version: 3.7
+          python-version: 3.8
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
           # Miniconda setup sometimes fails because of an http error. retry
@@ -648,7 +648,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8"]
         engine: ["ray", "dask"]
         test-task:
           - modin/pandas/test/dataframe/test_binary.py
@@ -712,7 +712,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: ["3.7", "3.8"]
+        python-version: ["3.8"]
     env:
       MODIN_STORAGE_FORMAT: pyarrow
       MODIN_EXPERIMENTAL: "True"
@@ -751,7 +751,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8" ]
+        python-version: [ "3.8" ]
         engine: ["ray", "dask"]
     env:
       MODIN_EXPERIMENTAL: "True"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,8 @@ jobs:
           conda info
           conda list
       - run: sudo apt update && sudo apt install -y libhdf5-dev
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - name: Api tests
         run: python -m pytest modin/pandas/test/test_api.py
       - name: Executions Api tests
@@ -184,6 +186,8 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - name: Headers tests
         run: python -m pytest modin/test/test_headers.py
 
@@ -202,6 +206,8 @@ jobs:
         with:
           python-version: "3.7.x"
           architecture: "x64"
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - name: Clean install and run
         run: |
           python -m pip install -e .[all]
@@ -223,6 +229,8 @@ jobs:
         with:
           python-version: "3.7.x"
           architecture: "x64"
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - name: Clean install and run
         run: |
           python -m pip install -e .[all]
@@ -257,6 +265,8 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - name: Internals tests
         run: python -m pytest modin/core/execution/dispatching/factories/test/test_dispatcher.py modin/experimental/cloud/test/test_cloud.py
       - run: python -m pytest modin/config/test
@@ -304,6 +314,8 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - run: pytest modin/experimental/xgboost/test/test_default.py --execution=${{ matrix.execution }}
       - run: python -m pytest -n 2 modin/test/storage_formats/base/test_internals.py --execution=${{ matrix.execution }}
       - run: pytest -n 2 modin/pandas/test/dataframe/test_binary.py --execution=${{ matrix.execution }}
@@ -367,6 +379,8 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - run: pytest modin/test/storage_formats/omnisci/test_internals.py
       - run: MODIN_BENCHMARK_MODE=True pytest modin/pandas/test/internals/test_benchmark_mode.py
       - run: pytest modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
@@ -413,6 +427,8 @@ jobs:
           # The ability to build a conda environment by specifying yml file has not
           # yet appeared in the release versions;
           pip install git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - name: Running benchmarks
         run: |
           # ASV correctly creates environments for testing only from the branch
@@ -486,6 +502,8 @@ jobs:
           conda list
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - run: MODIN_BENCHMARK_MODE=True pytest modin/pandas/test/internals/test_benchmark_mode.py
       - run: pytest -n 2 modin/experimental/xgboost/test/test_default.py
       - run: pytest -n 2 modin/experimental/xgboost/test/test_xgboost.py
@@ -557,6 +575,8 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - run: python -m pytest -n 2 modin/pandas/test/dataframe/test_map_metadata.py
       - run: python -m pytest -n 2 modin/pandas/test/test_series.py
       - run: python -m pytest modin/pandas/test/test_io.py --verbose
@@ -603,6 +623,8 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - run: python -m pytest --simulate-cloud=normal modin/pandas/test/test_io.py --verbose
       - run: python -m pytest --simulate-cloud=normal modin/pandas/test/dataframe/test_default.py::test_kurt_kurtosis --verbose
       - # When running without parameters, some of the tests fail
@@ -672,6 +694,8 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - run: python -m pytest ${{matrix.test-task}}
         if: matrix.test-task != 'modin/pandas/test/test_io.py'
       - timeout-minutes: 30
@@ -715,6 +739,8 @@ jobs:
           conda info
           conda list
       - run: sudo apt update && sudo apt install -y libhdf5-dev
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - run: python -m pytest modin/pandas/test/test_io.py::TestCsv --verbose
 
   test-spreadsheet:
@@ -752,4 +778,6 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Install pandas release candidate
+        run: python -m pip install --upgrade --pre pandas==1.4.0rc0
       - run: python -m pytest modin/experimental/spreadsheet/test/test_general.py

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,6 +2,7 @@ name: modin
 channels:
   - conda-forge
 dependencies:
+  - pandas==1.3.5
   - numpy>=1.16.5
   - pyarrow>=1.0.0
   - libthrift<0.14.1  # ref: modin gh-2840
@@ -41,4 +42,4 @@ dependencies:
       - modin-spreadsheet>=0.1.1
       - tqdm
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
-      - --pre pandas==1.4.0rc0
+

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -2,7 +2,6 @@ name: modin
 channels:
   - conda-forge
 dependencies:
-  - pandas==1.3.5
   - numpy>=1.16.5
   - pyarrow>=1.0.0
   - libthrift<0.14.1  # ref: modin gh-2840
@@ -42,3 +41,4 @@ dependencies:
       - modin-spreadsheet>=0.1.1
       - tqdm
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
+      - --pre pandas==1.4.0rc0


### PR DESCRIPTION
Signed-off-by: jeffreykennethli <jkli@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Modifies pandas version to the pre-release version pandas==1.4.0rc0 to test compatibility.

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3915 ? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
