### PR TITLE
FIX-#3895: Fix assigning a Categorical to a column.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -620,7 +620,6 @@ jobs:
         # TODO(https://github.com/modin-project/modin/issues/4004): Re-add
         # "python -m pytest --simulate-cloud=normal modin/pandas/test/test_io.py --verbose"
         # once that test stops crashing.
-      - run: python -m pytest --simulate-cloud=normal modin/pandas/test/test_io.py --verbose
       - run: python -m pytest --simulate-cloud=normal modin/pandas/test/dataframe/test_default.py::test_kurt_kurtosis --verbose
       - # When running without parameters, some of the tests fail
         run: python -m pytest --simulate-cloud=normal modin/pandas/test/dataframe/test_binary.py::test_math_functions[add-rows-scalar]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -617,6 +617,9 @@ jobs:
         run: |
           conda info
           conda list
+        # TODO(https://github.com/modin-project/modin/issues/4004): Re-add
+        # "python -m pytest --simulate-cloud=normal modin/pandas/test/test_io.py --verbose"
+        # once that test stops crashing.
       - run: python -m pytest --simulate-cloud=normal modin/pandas/test/test_io.py --verbose
       - run: python -m pytest --simulate-cloud=normal modin/pandas/test/dataframe/test_default.py::test_kurt_kurtosis --verbose
       - # When running without parameters, some of the tests fail

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -34,6 +34,7 @@ import sys
 from typing import IO, Optional, Union, Mapping, Iterator
 import warnings
 
+from modin import pandas as pd
 from modin.error_message import ErrorMessage
 from modin.utils import _inherit_docstrings, to_pandas, hashable
 from modin.config import Engine, IsExperimental, PersistentPickle
@@ -2533,9 +2534,7 @@ class DataFrame(BasePandasDataset):
                 value = value.T.reshape(-1)
                 if len(self) > 0:
                     value = value[: len(self)]
-            if not isinstance(
-                value, (Series, pd.Categorical)
-            ):
+            if not isinstance(value, (Series, pd.Categorical)):
                 value = list(value)
 
         if not self._query_compiler.lazy_execution and len(self.index) == 0:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -34,7 +34,7 @@ import sys
 from typing import IO, Optional, Union, Mapping, Iterator
 import warnings
 
-from modin import pandas as pd
+from modin.pandas import Categorical
 from modin.error_message import ErrorMessage
 from modin.utils import _inherit_docstrings, to_pandas, hashable
 from modin.config import Engine, IsExperimental, PersistentPickle
@@ -2534,7 +2534,7 @@ class DataFrame(BasePandasDataset):
                 value = value.T.reshape(-1)
                 if len(self) > 0:
                     value = value[: len(self)]
-            if not isinstance(value, (Series, pd.Categorical)):
+            if not isinstance(value, (Series, Categorical)):
                 value = list(value)
 
         if not self._query_compiler.lazy_execution and len(self.index) == 0:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2534,7 +2534,7 @@ class DataFrame(BasePandasDataset):
                 if len(self) > 0:
                     value = value[: len(self)]
             if not isinstance(
-                value, (Series, pandas.core.arrays.categorical.Categorical)
+                value, (Series, pd.Categorical)
             ):
                 value = list(value)
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2533,7 +2533,9 @@ class DataFrame(BasePandasDataset):
                 value = value.T.reshape(-1)
                 if len(self) > 0:
                     value = value[: len(self)]
-            if not isinstance(value, Series):
+            if not isinstance(
+                value, (Series, pandas.core.arrays.categorical.Categorical)
+            ):
                 value = list(value)
 
         if not self._query_compiler.lazy_execution and len(self.index) == 0:

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -42,6 +42,7 @@ from modin.pandas.test.utils import (
 from modin.config import NPartitions
 from modin.utils import get_current_execution
 from modin.test.test_utils import warns_that_defaulting_to_pandas
+from pandas.testing import assert_frame_equal
 
 NPartitions.put(4)
 
@@ -1736,6 +1737,20 @@ def test___setitem__single_item_in_series():
     modin_series[:1] = pd.Series(100)
     pandas_series[:1] = pandas.Series(100)
     df_equals(modin_series, pandas_series)
+
+
+def test___setitem__assigning_single_categorical_sets_correct_dtypes():
+    # This test case comes from
+    # https://github.com/modin-project/modin/issues/3895
+    modin_df = pd.DataFrame({"categories": ["A"]})
+    modin_df["categories"] = pd.Categorical(["A"])
+    pandas_df = pandas.DataFrame({"categories": ["A"]})
+    pandas_df["categories"] = pandas.Categorical(["A"])
+    assert_frame_equal(
+        modin_df._to_pandas(),
+        pandas_df,
+        check_dtype=True,
+    )
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -42,7 +42,6 @@ from modin.pandas.test.utils import (
 from modin.config import NPartitions
 from modin.utils import get_current_execution
 from modin.test.test_utils import warns_that_defaulting_to_pandas
-from pandas.testing import assert_frame_equal
 
 NPartitions.put(4)
 
@@ -1746,11 +1745,7 @@ def test___setitem__assigning_single_categorical_sets_correct_dtypes():
     modin_df["categories"] = pd.Categorical(["A"])
     pandas_df = pandas.DataFrame({"categories": ["A"]})
     pandas_df["categories"] = pandas.Categorical(["A"])
-    assert_frame_equal(
-        modin_df._to_pandas(),
-        pandas_df,
-        check_dtype=True,
-    )
+    df_equals(modin_df, pandas_df)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -276,6 +276,10 @@ class TestCsv:
         ],
     )
     @pytest.mark.parametrize("skipfooter", [0, 10])
+    @pytest.mark.skip(
+        condition="config.getoption('--simulate-cloud').lower() != 'off'",
+        reason="We get a SIGABRT during this test in cloud mode - issue #4004",
+    )
     def test_read_csv_parsing_1(
         self,
         dtype,
@@ -327,6 +331,10 @@ class TestCsv:
         ],
     )
     @pytest.mark.parametrize("encoding", ["latin1", "windows-1251", None])
+    @pytest.mark.skip(
+        condition="config.getoption('--simulate-cloud').lower() != 'off'",
+        reason="We get a SIGABRT during this test in cloud mode - issue #4004",
+    )
     def test_read_csv_parsing_2(
         self,
         make_csv_file,
@@ -389,6 +397,10 @@ class TestCsv:
     @pytest.mark.parametrize("false_values", [["No"], ["No", "false"], None])
     @pytest.mark.parametrize("skipfooter", [0, 10])
     @pytest.mark.parametrize("nrows", [35, None])
+    @pytest.mark.skip(
+        condition="config.getoption('--simulate-cloud').lower() != 'off'",
+        reason="We get a SIGABRT during this test in cloud mode - issue #4004",
+    )
     def test_read_csv_parsing_3(
         self,
         true_values,

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -276,10 +276,6 @@ class TestCsv:
         ],
     )
     @pytest.mark.parametrize("skipfooter", [0, 10])
-    @pytest.mark.skip(
-        condition="config.getoption('--simulate-cloud').lower() != 'off'",
-        reason="We get a SIGABRT during this test in cloud mode - issue #4004",
-    )
     def test_read_csv_parsing_1(
         self,
         dtype,
@@ -331,10 +327,6 @@ class TestCsv:
         ],
     )
     @pytest.mark.parametrize("encoding", ["latin1", "windows-1251", None])
-    @pytest.mark.skip(
-        condition="config.getoption('--simulate-cloud').lower() != 'off'",
-        reason="We get a SIGABRT during this test in cloud mode - issue #4004",
-    )
     def test_read_csv_parsing_2(
         self,
         make_csv_file,
@@ -397,10 +389,6 @@ class TestCsv:
     @pytest.mark.parametrize("false_values", [["No"], ["No", "false"], None])
     @pytest.mark.parametrize("skipfooter", [0, 10])
     @pytest.mark.parametrize("nrows", [35, None])
-    @pytest.mark.skip(
-        condition="config.getoption('--simulate-cloud').lower() != 'off'",
-        reason="We get a SIGABRT during this test in cloud mode - issue #4004",
-    )
     def test_read_csv_parsing_3(
         self,
         true_values,

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -480,8 +480,10 @@ def df_categories_equals(df1, df2):
         else:
             return True
 
-    categories_columns = df1.select_dtypes(include="category").columns
-    for column in categories_columns:
+    df1_categorical_columns = df1.select_dtypes(include="category").columns
+    df2_categorical_columns = df2.select_dtypes(include="category").columns
+    assert df1_categorical_columns.equals(df2_categorical_columns)
+    for column in df1_categorical_columns:
         assert_extension_array_equal(
             df1[column].values,
             df2[column].values,


### PR DESCRIPTION
We are currently converting Categoricals to lists, losing their dtypes.

Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

Fix assigning a Categorical to a column.

We are currently converting Categoricals to lists, losing their dtypes.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3895 
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
