### PR TITLE
FIX-#3945: bump omnisci version to 5.10.1

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2679,11 +2679,11 @@ class PandasDataframe(object):
             res = arrow_type.to_pandas_dtype()
         # Conversion to pandas is not implemented for some arrow types,
         # perform manual conversion for them:
-        except NotImplementedError as e:
+        except NotImplementedError:
             if pyarrow.types.is_time(arrow_type):
                 res = np.dtype(datetime.time)
             else:
-                raise e
+                raise
 
         if not isinstance(res, (np.dtype, str)):
             return np.dtype(res)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -20,6 +20,7 @@ for pandas storage format.
 from collections import OrderedDict
 import numpy as np
 import pandas
+import datetime
 from pandas.core.indexes.api import ensure_index, Index, RangeIndex
 from pandas.core.dtypes.common import is_numeric_dtype, is_list_like
 from typing import List, Hashable, Optional, Callable, Union, Dict
@@ -2672,7 +2673,16 @@ class PandasDataframe(object):
         object
             Any dtype compatible with pandas.
         """
-        res = arrow_type.to_pandas_dtype()
+        import pyarrow
+
+        try:
+            res = arrow_type.to_pandas_dtype()
+        except NotImplementedError as e:
+            if pyarrow.types.is_time(arrow_type):
+                res = np.dtype(datetime.time)
+            else:
+                raise e
+
         if not isinstance(res, (np.dtype, str)):
             return np.dtype(res)
         return res

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2677,6 +2677,8 @@ class PandasDataframe(object):
 
         try:
             res = arrow_type.to_pandas_dtype()
+        # Conversion to pandas is not implemented for some arrow types,
+        # perform manual conversion for them:
         except NotImplementedError as e:
             if pyarrow.types.is_time(arrow_type):
                 res = np.dtype(datetime.time)

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition_manager.py
@@ -191,14 +191,26 @@ class OmnisciOnNativeDataframePartitionManager(PandasDataframePartitionManager):
             else:
                 obj = at
 
+        def is_supported_object_type(dtype):
+            """Check whether the passed pyarrow `dtype` is supported by OmniSci."""
+            if (
+                pyarrow.types.is_string(dtype)
+                or pyarrow.types.is_time(dtype)
+                or pyarrow.types.is_dictionary(dtype)
+            ):
+                return True
+            try:
+                pandas_dtype = dtype.to_pandas_dtype()
+                return pandas_dtype != np.dtype("O")
+            except NotImplementedError:
+                return False
+
         return (
             obj,
             [
                 field.name
                 for field in obj.schema
-                if not isinstance(field.type, pyarrow.DictionaryType)
-                and field.type.to_pandas_dtype() == np.dtype("O")
-                and field.type != "string"
+                if not is_supported_object_type(field.type)
             ],
         )
 

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition_manager.py
@@ -191,7 +191,7 @@ class OmnisciOnNativeDataframePartitionManager(PandasDataframePartitionManager):
             else:
                 obj = at
 
-        def is_supported_object_type(dtype):
+        def is_supported_dtype(dtype):
             """Check whether the passed pyarrow `dtype` is supported by OmniSci."""
             if (
                 pyarrow.types.is_string(dtype)
@@ -207,11 +207,7 @@ class OmnisciOnNativeDataframePartitionManager(PandasDataframePartitionManager):
 
         return (
             obj,
-            [
-                field.name
-                for field in obj.schema
-                if not is_supported_object_type(field.type)
-            ],
+            [field.name for field in obj.schema if not is_supported_dtype(field.type)],
         )
 
     @classmethod

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/utils.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/utils.py
@@ -123,15 +123,16 @@ def align_datetime_dtypes(*dfs):
         else:
             return datetime.time(value)
 
+    time_cols_list = list(time_cols)
     casted_dfs = []
     for df in dfs:
         # OmniSci has difficulties with casting to certain dtypes (i.e. datetime64),
         # so casting it to pandas
         pandas_df = try_cast_to_pandas(df)
-        if len(datetime_cols):
+        if datetime_cols:
             pandas_df = pandas_df.astype(datetime_cols)
-        if len(time_cols):
-            pandas_df[list(time_cols)] = pandas_df[list(time_cols)].applymap(
+        if time_cols:
+            pandas_df[time_cols_list] = pandas_df[time_cols_list].applymap(
                 convert_to_time
             )
         casted_dfs.append(pandas_df)

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/utils.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/utils.py
@@ -126,7 +126,9 @@ def align_datetime_dtypes(*dfs):
         if len(datetime_cols):
             pandas_df = pandas_df.astype(datetime_cols)
         if len(time_cols):
-            pandas_df = pandas_df[time_cols].applymap(convert_to_time)
+            pandas_df[list(time_cols)] = pandas_df[list(time_cols)].applymap(
+                convert_to_time
+            )
         casted_dfs.append(pandas_df)
 
     return casted_dfs

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pandas==1.3.5
-  - pyarrow==6.*
+  - pyarrow=6
   - numpy>=1.16.5
   - fsspec
   - pip
@@ -12,7 +12,7 @@ dependencies:
   - pytest-xdist>=2.1.0
   - coverage<5.0
   - pygithub==1.53
-  - pyomniscidbe==5.10.0
+  - pyomniscidbe==5.10.1
   - s3fs>=2021.8
   - psutil
   - openpyxl

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pandas==1.3.5
-  - pyarrow==5.0.0
+  - pyarrow==6.*
   - numpy>=1.16.5
   - fsspec
   - pip
@@ -12,7 +12,7 @@ dependencies:
   - pytest-xdist>=2.1.0
   - coverage<5.0
   - pygithub==1.53
-  - pyomniscidbe<=5.8
+  - pyomniscidbe==5.10.0
   - s3fs>=2021.8
   - psutil
   - openpyxl


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
This PR bumps OmniSci version to 5.10.1 and PyArrow to 6.* as well (as this is the minimum supported version by OmniSci now).

### Changes in PyArrow 6.0 to align with
Arrow introduced an implicit `time32` values parsing when reading from CSV ([ARROW-11243](https://issues.apache.org/jira/browse/ARROW-11243)), this brought 2 problems for us:
1. We can't easily disable the automatic inference (the same problems as in #3485), that's why we just ignore the differences in dtypes between Modin on OmniSci and pandas in IO-tests (added another exception in [`align_datetime_dtypes`](https://github.com/dchigarev/modin/blob/3738915bdb43fe6308857da8021331ff1ed5644e/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/utils.py#L76) - preprocessor function before asserting equality in IO tests).
2. Pyarrow can't convert `pyarrow.Time32Type` to pandas-supported dtype (`.cast_to_pandas_dtype()` raises a `NotImplementedError`). Added manual conversion of the arrow time type to the python's `datetime.time` at [`PandasDataframe._arrow_type_to_dtype`](https://github.com/dchigarev/modin/blob/3738915bdb43fe6308857da8021331ff1ed5644e/modin/core/dataframe/pandas/dataframe/dataframe.py#L2367). `datetime.time` is the actual type that is stored in a frame when arrow table is converted to pandas:
```python
>>> at = pyarrow.Table.from_pydict({"a": [10, 20]}, schema=pyarrow.schema({"a": pyarrow.time32("s")}))
>>> at.to_pandas()
          a
0  00:00:10
1  00:00:20
>>> at.to_pandas().dtypes
a    object
dtype: object
>>> at.to_pandas().iloc[0, 0]
datetime.time(0, 0, 10)
```

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3945 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
