### PR TITLE
DOCS-#3960: Fix links to the contributing page.

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,7 @@ if you have questions about contributing.
 
 <!-- Please give a short brief about these changes. -->
 
-- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html)
+- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
 - [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
 - [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
 - [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 <!--
 Thank you for your contribution!
-Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
+Please review the contributing docs: https://modin.readthedocs.io/en/latest/developer/contributing.html
 if you have questions about contributing.
 -->
 
@@ -8,7 +8,7 @@ if you have questions about contributing.
 
 <!-- Please give a short brief about these changes. -->
 
-- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
+- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html)
 - [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
 - [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
 - [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Fix links to the contributing page in the pull request template.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3960 
- [N/A] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
