### PR TITLE
FIX-#3962: Change docs copyright statement to 'Modin Developers.'

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,7 +48,7 @@ configs_file_path = os.path.abspath(
 export_config_help(configs_file_path)
 
 project = "Modin"
-copyright = "2018-2022, Modin"
+copyright = "2018-2022, Modin Developers."
 author = "Modin contributors"
 
 # The short X.Y version


### PR DESCRIPTION
Signed-off-by: jeffreykennethli <jkli@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?
Change the docs copyright statement to match the statement in our [NOTICE](https://github.com/modin-project/modin/blob/master/NOTICE) file.

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3962? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
