### PR TITLE
FIX-#3896: Change Series.values to default to to_numpy().

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -543,11 +543,7 @@ class Series(BasePandasDataset):
         """
         Return Series as ndarray or ndarray-like depending on the dtype.
         """
-
-        def values(df):
-            return df.values
-
-        return self._default_to_pandas(values)
+        return self.to_numpy()
 
     def add(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -543,7 +543,11 @@ class Series(BasePandasDataset):
         """
         Return Series as ndarray or ndarray-like depending on the dtype.
         """
-        return super(Series, self).to_numpy().flatten()
+
+        def values(df):
+            return df.values
+
+        return self._default_to_pandas(values)
 
     def add(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3204,6 +3204,21 @@ def test_to_period():
 )
 def test_to_numpy(data):
     modin_series, pandas_series = create_test_series(data)
+    assert_array_equal(modin_series.to_numpy(), pandas_series.to_numpy())
+
+
+@pytest.mark.parametrize(
+    "data",
+    test_data_values + test_data_large_categorical_series_values,
+    ids=test_data_keys + test_data_large_categorical_series_keys,
+)
+def test_series_values(data):
+    modin_series, pandas_series = create_test_series(data)
+    assert_array_equal(modin_series.values, pandas_series.values)
+
+
+def test_series_empty_values():
+    modin_series = pandas_series = pd.Series([])
     assert_array_equal(modin_series.values, pandas_series.values)
 
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3218,7 +3218,7 @@ def test_series_values(data):
 
 
 def test_series_empty_values():
-    modin_series = pandas_series = pd.Series([])
+    modin_series, pandas_series = pd.Series(), pandas.Series()
     assert_array_equal(modin_series.values, pandas_series.values)
 
 


### PR DESCRIPTION
Signed-off-by: jeffreykennethli <jkli@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/CONTRIBUTING.html
if you have questions about contributing.
-->

## What do these changes do?

Modify Series.values to default to Series.to_numpy(), which conveniently handles the empty dataframe/series case from #3896.

In [pandas/base.py](https://github.com/modin-project/modin/blob/master/modin/pandas/base.py#L3075-L3087), notice that if an attr is callable and self.empty, we default to pandas like in [Series.to_numpy()](https://github.com/modin-project/modin/blob/master/modin/pandas/series.py#L1863-L1877) which would fix our empty Series case from #3896. 

Because to_numpy() and .values are supposed to have identical behavior (see [pandas.Series.values](https://pandas.pydata.org/docs/reference/api/pandas.Series.values.html) and [this PR](https://github.com/pandas-dev/pandas/pull/23623)), we can safely make Series.values call Series.to_numpy().

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/contributing.html)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3896 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
