### PR TITLE
Implement "modin.pandas.show_versions()" and "python -m modin --versions"

### DIFF
--- a/modin/__main__.py
+++ b/modin/__main__.py
@@ -1,0 +1,39 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Command-line interface piece, called when user issues "python -m modin --foo"."""
+
+import argparse
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        "python -m modin",
+        description="Drop-in pandas replacement; refer to https://modin.readthedocs.io/ for details.",
+    )
+    parser.add_argument(
+        "--versions",
+        action="store_true",
+        default=False,
+        help="Show versions of all known components",
+    )
+
+    args = parser.parse_args()
+    if args.versions:
+        from modin.utils import show_versions
+
+        show_versions()
+
+
+if __name__ == "__main__":
+    main()

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -21,6 +21,7 @@ from packaging import version
 import secrets
 
 from .pubsub import Parameter, _TYPE_PARAMS, ExactStr, ValueSource
+from modin.utils import MIN_RAY_VERSION, MIN_DASK_VERSION
 
 
 class EnvironmentVariable(Parameter, type=str, abstract=True):
@@ -89,9 +90,9 @@ class Engine(EnvironmentVariable, type=str):
         except ImportError:
             pass
         else:
-            if version.parse(ray.__version__) < version.parse("1.4.0"):
+            if version.parse(ray.__version__) < MIN_RAY_VERSION:
                 raise ImportError(
-                    "Please `pip install modin[ray]` to install compatible Ray version."
+                    "Please `pip install modin[ray]` to install compatible Ray version (>={MIN_RAY_VERSION})."
                 )
             return "Ray"
         try:
@@ -101,11 +102,12 @@ class Engine(EnvironmentVariable, type=str):
         except ImportError:
             pass
         else:
-            if version.parse(dask.__version__) < version.parse(
-                "2.22.0"
-            ) or version.parse(distributed.__version__) < version.parse("2.22.0"):
+            if (
+                version.parse(dask.__version__) < MIN_DASK_VERSION
+                or version.parse(distributed.__version__) < MIN_DASK_VERSION
+            ):
                 raise ImportError(
-                    "Please `pip install modin[dask]` to install compatible Dask version."
+                    "Please `pip install modin[dask]` to install compatible Dask version (>={MIN_DASK_VERSION})."
                 )
             return "Dask"
         try:

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -21,7 +21,6 @@ from packaging import version
 import secrets
 
 from .pubsub import Parameter, _TYPE_PARAMS, ExactStr, ValueSource
-from modin.utils import MIN_RAY_VERSION, MIN_DASK_VERSION
 
 
 class EnvironmentVariable(Parameter, type=str, abstract=True):
@@ -82,6 +81,8 @@ class Engine(EnvironmentVariable, type=str):
         -------
         str
         """
+        from modin.utils import MIN_RAY_VERSION, MIN_DASK_VERSION
+
         if IsDebug.get():
             return "Python"
         try:

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -76,7 +76,6 @@ from pandas import (
     Grouper,
     array,
     Period,
-    show_versions,
     DateOffset,
     timedelta_range,
     infer_freq,
@@ -233,6 +232,7 @@ from .general import (
     wide_to_long,
 )
 from .plotting import Plotting as plotting
+from modin.utils import show_versions
 
 __all__ = [
     "DataFrame",

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -254,7 +254,7 @@ def warns_that_defaulting_to_pandas():
     return pytest.warns(UserWarning, match="defaulting to pandas")
 
 
-@pytest.mark.parametrize("as_json", [True, False, None])
+@pytest.mark.parametrize("as_json", [True, False])
 def test_show_versions(as_json, capsys):
     modin.utils.show_versions(as_json=as_json)
     versions = capsys.readouterr()

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -13,6 +13,7 @@
 
 import pytest
 import modin.utils
+import json
 
 from textwrap import dedent, indent
 
@@ -251,3 +252,14 @@ def warns_that_defaulting_to_pandas():
         defaulting to Pandas.
     """
     return pytest.warns(UserWarning, match="defaulting to pandas")
+
+
+@pytest.mark.parametrize("as_json", [True, False, None])
+def test_show_versions(as_json, capsys):
+    modin.utils.show_versions(as_json=as_json)
+    versions = capsys.readouterr()
+    assert modin.__version__ in versions
+
+    if as_json:
+        versions = json.loads(versions)
+        assert versions["modin dependencies"]["modin"] == modin.__version__

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -257,7 +257,7 @@ def warns_that_defaulting_to_pandas():
 @pytest.mark.parametrize("as_json", [True, False])
 def test_show_versions(as_json, capsys):
     modin.utils.show_versions(as_json=as_json)
-    versions = capsys.readouterr()
+    versions = capsys.readouterr().out
     assert modin.__version__ in versions
 
     if as_json:

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -578,7 +578,9 @@ def _get_modin_deps_info() -> dict[str, JSONSerializable]:
     """
     Returns Modin-specific dependencies information as a JSON serializable dictionary.
     """
-    result = {}
+    import modin  # delayed import so modin.__init__ is fully initialized
+
+    result = {"modin": modin.__version__}
 
     for pkg_name, pkg_version in [
         ("ray", MIN_RAY_VERSION),

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -33,6 +33,7 @@ from pandas.util._print_versions import _get_sys_info, _get_dependency_info
 from pandas._typing import JSONSerializable
 
 from modin.config import Engine, StorageFormat, IsExperimental
+from modin._version import get_versions
 
 MIN_RAY_VERSION = version.parse("1.4.0")
 MIN_DASK_VERSION = version.parse("2.22.0")
@@ -637,9 +638,10 @@ def show_versions(as_json: str | bool = False) -> None:
     Notes
     -----
     This is mostly a copy of pandas.show_versions() but adds separate listing
-    of Modin-specific dependencies
+    of Modin-specific dependencies.
     """
     sys_info = _get_sys_info()
+    sys_info["commit"] = get_versions()["full-revisionid"]
     modin_deps = _get_modin_deps_info()
     deps = _get_dependency_info()
 

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -25,9 +25,6 @@ from textwrap import dedent, indent
 from typing import Union
 from packaging import version
 
-MIN_RAY_VERSION = version.parse("1.4.0")
-MIN_DASK_VERSION = version.parse("2.22.0")
-
 import pandas
 import numpy as np
 
@@ -36,6 +33,9 @@ from pandas.util._print_versions import _get_sys_info, _get_dependency_info
 from pandas._typing import JSONSerializable
 
 from modin.config import Engine, StorageFormat, IsExperimental
+
+MIN_RAY_VERSION = version.parse("1.4.0")
+MIN_DASK_VERSION = version.parse("2.22.0")
 
 PANDAS_API_URL_TEMPLATE = f"https://pandas.pydata.org/pandas-docs/version/{pandas.__version__}/reference/api/{{}}.html"
 

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -576,7 +576,12 @@ def import_optional_dependency(name, message):
 
 def _get_modin_deps_info() -> dict[str, JSONSerializable]:
     """
-    Returns Modin-specific dependencies information as a JSON serializable dictionary.
+    Return Modin-specific dependencies information as a JSON serializable dictionary.
+
+    Returns
+    -------
+    dict[str, JSONSerializable]
+        The dictionary of Modin dependencies and their versions.
     """
     import modin  # delayed import so modin.__init__ is fully initialized
 
@@ -612,6 +617,8 @@ def _get_modin_deps_info() -> dict[str, JSONSerializable]:
     return result
 
 
+# Disable flake8 checks for print() in this file
+# flake8: noqa: T001
 def show_versions(as_json: str | bool = False) -> None:
     """
     Provide useful information, important for bug reports.
@@ -621,7 +628,7 @@ def show_versions(as_json: str | bool = False) -> None:
 
     Parameters
     ----------
-    as_json : str or bool, default False
+    as_json : str or bool, default: False
         * If False, outputs info in a human readable form to the console.
         * If str, it will be considered as a path to a file.
           Info will be written to that file in JSON format.

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -12,18 +12,29 @@
 # governing permissions and limitations under the License.
 
 """Collection of general utility functions, mostly for internal use."""
+from __future__ import annotations
 
 import importlib
 import types
 import re
+import sys
+import json
+import codecs
 
 from textwrap import dedent, indent
 from typing import Union
+from packaging import version
+
+MIN_RAY_VERSION = version.parse("1.4.0")
+MIN_DASK_VERSION = version.parse("2.22.0")
 
 import pandas
 import numpy as np
 
 from pandas.util._decorators import Appender
+from pandas.util._print_versions import _get_sys_info, _get_dependency_info
+from pandas._typing import JSONSerializable
+
 from modin.config import Engine, StorageFormat, IsExperimental
 
 PANDAS_API_URL_TEMPLATE = f"https://pandas.pydata.org/pandas-docs/version/{pandas.__version__}/reference/api/{{}}.html"
@@ -561,3 +572,94 @@ def import_optional_dependency(name, message):
             f"Missing optional dependency '{name}'. {message} "
             f"Use pip or conda to install {name}."
         ) from None
+
+
+def _get_modin_deps_info() -> dict[str, JSONSerializable]:
+    """
+    Returns Modin-specific dependencies information as a JSON serializable dictionary.
+    """
+    result = {}
+
+    for pkg_name, pkg_version in [
+        ("ray", MIN_RAY_VERSION),
+        ("dask", MIN_DASK_VERSION),
+        ("distributed", MIN_DASK_VERSION),
+    ]:
+        try:
+            pkg = importlib.import_module(pkg_name)
+        except ImportError:
+            result[pkg_name] = None
+        else:
+            result[pkg_name] = pkg.__version__ + (
+                f" (outdated; >={pkg_version} required)"
+                if version.parse(pkg.__version__) < pkg_version
+                else ""
+            )
+
+    try:
+        # We import ``PyDbEngine`` from this module since correct import of ``PyDbEngine`` itself
+        # from Omnisci is located in it with all the necessary options for dlopen.
+        from modin.experimental.core.execution.native.implementations.omnisci_on_native.utils import (  # noqa
+            PyDbEngine,
+        )
+
+        result["omniscidbe"] = "present"
+    except ImportError:
+        result["omniscidbe"] = None
+
+    return result
+
+
+def show_versions(as_json: str | bool = False) -> None:
+    """
+    Provide useful information, important for bug reports.
+
+    It comprises info about hosting operation system, pandas version,
+    and versions of other installed relative packages.
+
+    Parameters
+    ----------
+    as_json : str or bool, default False
+        * If False, outputs info in a human readable form to the console.
+        * If str, it will be considered as a path to a file.
+          Info will be written to that file in JSON format.
+        * If True, outputs info in JSON format to the console.
+
+    Notes
+    -----
+    This is mostly a copy of pandas.show_versions() but adds separate listing
+    of Modin-specific dependencies
+    """
+    sys_info = _get_sys_info()
+    modin_deps = _get_modin_deps_info()
+    deps = _get_dependency_info()
+
+    if as_json:
+        j = {
+            "system": sys_info,
+            "modin dependencies": modin_deps,
+            "pandas dependencies": deps,
+        }
+
+        if as_json is True:
+            sys.stdout.writelines(json.dumps(j, indent=2))
+        else:
+            assert isinstance(as_json, str)  # needed for mypy
+            with codecs.open(as_json, "wb", encoding="utf8") as f:
+                json.dump(j, f, indent=2)
+
+    else:
+        assert isinstance(sys_info["LOCALE"], dict)  # needed for mypy
+        language_code = sys_info["LOCALE"]["language-code"]
+        encoding = sys_info["LOCALE"]["encoding"]
+        sys_info["LOCALE"] = f"{language_code}.{encoding}"
+
+        maxlen = max(max(len(x) for x in d) for d in (deps, modin_deps))
+        print("\nINSTALLED VERSIONS")
+        print("------------------")
+        for k, v in sys_info.items():
+            print(f"{k:<{maxlen}}: {v}")
+        for name, d in (("Modin", modin_deps), ("pandas", deps)):
+            print(f"\n{name} dependencies\n{'-' * (len(name) + 13)}")
+            for k, v in d.items():
+                print(f"{k:<{maxlen}}: {v}")

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -649,7 +649,7 @@ def show_versions(as_json: str | bool = False) -> None:
         j = {
             "system": sys_info,
             "modin dependencies": modin_deps,
-            "pandas dependencies": deps,
+            "dependencies": deps,
         }
 
         if as_json is True:

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,8 @@ omit =
     modin/core/execution/ray/implementations/cudf_on_ray/*
     modin/core/execution/ray/implementations/cudf_on_ray/frame/*
     modin/core/execution/ray/implementations/cudf_on_ray/series/*
+    # Skip CLI part
+    modin/__main__.py
 parallel = True
 
 [coverage:report]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/developer/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
This is an augmentation for [pandas.show_versions()](https://pandas.pydata.org/pandas-docs/dev/reference/api/pandas.show_versions.html) plus an ability to call this from command line in an easy way.
<!-- Please give a short brief about these changes. -->

<details><summary>Example output</summary>

```
>python -m modin --versions

INSTALLED VERSIONS
------------------
commit           : 66e3805b8cabe977f40c05259cc3fcf7ead5687d
python           : 3.8.8.final.0
python-bits      : 64
OS               : Windows
OS-release       : 10
Version          : 10.0.19041
machine          : AMD64
processor        : Intel64 Family 6 Model 165 Stepping 2, GenuineIntel
byteorder        : little
LC_ALL           : None
LANG             : None
LOCALE           : Russian_Russia.1251

Modin dependencies
------------------
modin            : 0.12.0+80.gdd2c53f6
ray              : 1.6.0
dask             : 2021.10.0
distributed      : 2021.10.0
omniscidbe       : None

pandas dependencies
-------------------
pandas           : 1.3.5
numpy            : 1.21.3
pytz             : 2020.1
dateutil         : 2.8.1
pip              : 21.3.1
setuptools       : 52.0.0.post20210125
Cython           : None
pytest           : 6.2.5
hypothesis       : None
sphinx           : 3.5.3
blosc            : None
feather          : 0.4.1
xlsxwriter       : None
lxml.etree       : 4.6.3
html5lib         : None
pymysql          : None
psycopg2         : None
jinja2           : 2.11.3
IPython          : 7.29.0
pandas_datareader: None
bs4              : 4.9.3
bottleneck       : 1.3.2
fsspec           : 2022.01.0
fastparquet      : None
gcsfs            : None
matplotlib       : 3.2.2
numexpr          : 2.7.3
odfpy            : None
openpyxl         : 3.0.9
pandas_gbq       : 0.15.0
pyarrow          : 1.0.1
pyxlsb           : None
s3fs             : 2022.01.0
scipy            : 1.7.1
sqlalchemy       : 1.4.26
tables           : 3.6.1
tabulate         : None
xarray           : 0.19.0
xlrd             : 2.0.1
xlwt             : None
numba            : None
```
</details>

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3971
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
