### PR TITLE
TEST-#3729: Delete the failed attempt to retry setup-miniconda.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,12 +155,6 @@ jobs:
           python-version: 3.7
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          # Miniconda setup sometimes fails because of an HTTP error. Retry
-          # it once if it fails. TODO(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # Get rid of this once setup-miniconda can be configured to retry
-          # setup on HTTP errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info
@@ -188,12 +182,6 @@ jobs:
           python-version: 3.7
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info
@@ -261,12 +249,6 @@ jobs:
           python-version: 3.7
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info
@@ -306,12 +288,6 @@ jobs:
           python-version: 3.7
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info
@@ -369,12 +345,6 @@ jobs:
           environment-file: requirements/env_omnisci.yml
           python-version: 3.7
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info
@@ -415,12 +385,6 @@ jobs:
         with:
           auto-activate-base: true
           activate-environment: ""
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: ASV installation
         run: |
           # FIXME: use the tag or release version of ASV as soon as it appears;
@@ -488,12 +452,6 @@ jobs:
           python-version: ${{matrix.python-version}}
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info
@@ -561,12 +519,6 @@ jobs:
           python-version: 3.7
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info
@@ -607,12 +559,6 @@ jobs:
           python-version: 3.7
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info
@@ -676,12 +622,6 @@ jobs:
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
           auto-update-conda: true # this enable `use-only-tar-bz2` feature on Windows
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info
@@ -718,12 +658,6 @@ jobs:
           python-version: ${{matrix.python-version}}
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info
@@ -756,12 +690,6 @@ jobs:
           python-version: ${{matrix.python-version}}
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-          # Miniconda setup sometimes fails because of an http error. retry
-          # it once if it fails. todo(https://github.com/conda-incubator/setup-miniconda/issues/129):
-          # get rid of this once setup-miniconda can be configured to retry
-          # setup on http errors.
-          max_attempts: 2
-          retry_on: error
       - name: Conda environment
         run: |
           conda info


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/developer/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Delete the failed attempt from #3760 to retry setup-miniconda. The new arguments don't do anything as explained [here](https://github.com/modin-project/modin/issues/3729#issuecomment-1017777466).

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Addresses #3729 but does not fix it
- [x] tests added and passing
- [x] module layout described at `docs/developer/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
