### PR TITLE
FIX-#4026: Move code to raise error to appropriate place.

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -531,10 +531,11 @@ class PandasDataframe(object):
                     for i in range(len(self._partitions))
                 ]
             )
+            self._deferred_column = False
+        else:
             ErrorMessage.catch_bugs_and_request_email(
                 axis is not None and axis not in [0, 1]
             )
-            self._deferred_column = False
 
     @lazy_metadata_decorator(apply_axis=None)
     def mask(


### PR DESCRIPTION
Signed-off-by: Rehan Durrani <rehan@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/developer/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Moves the code that raises an error in `_propagate_index_objs` if an incorrect axis argument is provided out of the codepath for when the axis provided is the column axis, and into its own codepath.
<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
