### PR TITLE
FIX-#4017: Fix OmniSci engine enabling for IO functions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -354,8 +354,6 @@ jobs:
       run:
         shell: bash -l {0}
     env:
-      MODIN_EXPERIMENTAL: "True"
-      MODIN_ENGINE: "native"
       MODIN_STORAGE_FORMAT: "omnisci"
     name: Test OmniSci storage format, Python 3.7
     steps:

--- a/modin/core/execution/dispatching/factories/dispatcher.py
+++ b/modin/core/execution/dispatching/factories/dispatcher.py
@@ -20,6 +20,7 @@ Dispatcher routes the work to execution-specific functions.
 from modin.config import Engine, StorageFormat, IsExperimental
 from modin.core.execution.dispatching.factories import factories
 from modin.utils import get_current_execution, _inherit_docstrings
+from modin.pandas import _update_engine
 
 
 class FactoryNotFoundError(AttributeError):
@@ -294,5 +295,6 @@ class FactoryDispatcher(object):
         return cls.__factory._to_parquet(*args, **kwargs)
 
 
+Engine.subscribe(_update_engine)
 Engine.subscribe(FactoryDispatcher._update_factory)
 StorageFormat.subscribe(FactoryDispatcher._update_factory)

--- a/modin/core/execution/dispatching/factories/dispatcher.py
+++ b/modin/core/execution/dispatching/factories/dispatcher.py
@@ -20,7 +20,6 @@ Dispatcher routes the work to execution-specific functions.
 from modin.config import Engine, StorageFormat, IsExperimental
 from modin.core.execution.dispatching.factories import factories
 from modin.utils import get_current_execution, _inherit_docstrings
-from modin.pandas import _update_engine
 
 
 class FactoryNotFoundError(AttributeError):
@@ -295,6 +294,5 @@ class FactoryDispatcher(object):
         return cls.__factory._to_parquet(*args, **kwargs)
 
 
-Engine.subscribe(_update_engine)
 Engine.subscribe(FactoryDispatcher._update_factory)
 StorageFormat.subscribe(FactoryDispatcher._update_factory)

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
@@ -18,13 +18,11 @@ import pyarrow
 import pytest
 import re
 
-from modin.config import IsExperimental, Engine, StorageFormat
+from modin.config import StorageFormat
 from modin.pandas.test.utils import io_ops_bad_exc, default_to_pandas_ignore_string
 from .utils import eval_io, ForceOmnisciImport, set_execution_mode, run_and_compare
 from pandas.core.dtypes.common import is_list_like
 
-IsExperimental.put(True)
-Engine.put("native")
 StorageFormat.put("omnisci")
 
 import modin.pandas as pd

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -53,6 +53,7 @@ def _read(**kwargs):
     -------
     modin.pandas.DataFrame
     """
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     squeeze = kwargs.pop("squeeze", False)
@@ -208,6 +209,7 @@ def read_parquet(
     use_nullable_dtypes: bool = False,
     **kwargs,
 ):
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(
@@ -244,6 +246,7 @@ def read_json(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_json(**kwargs))
@@ -268,6 +271,7 @@ def read_gbq(
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_gbq(**kwargs))
@@ -293,6 +297,7 @@ def read_html(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_html(**kwargs))
@@ -303,6 +308,7 @@ def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_clipboard(**kwargs))
@@ -339,6 +345,7 @@ def read_excel(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     intermediate = FactoryDispatcher.read_excel(**kwargs)
@@ -368,6 +375,7 @@ def read_hdf(
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_hdf(**kwargs))
@@ -382,6 +390,7 @@ def read_feather(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_feather(**kwargs))
@@ -404,6 +413,7 @@ def read_stata(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_stata(**kwargs))
@@ -420,6 +430,7 @@ def read_sas(
 ):  # pragma: no cover
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_sas(**kwargs))
@@ -433,6 +444,7 @@ def read_pickle(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_pickle(**kwargs))
@@ -451,6 +463,7 @@ def read_sql(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     if kwargs.get("chunksize") is not None:
@@ -470,6 +483,7 @@ def read_fwf(
     infer_nrows=100,
     **kwds,
 ):
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
     from pandas.io.parsers.base_parser import parser_defaults
 
@@ -501,6 +515,7 @@ def read_sql_table(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_sql_table(**kwargs))
@@ -519,6 +534,7 @@ def read_sql_query(
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(query_compiler=FactoryDispatcher.read_sql_query(**kwargs))
@@ -530,6 +546,7 @@ def read_spss(
     usecols: Union[Sequence[str], type(None)] = None,
     convert_categoricals: bool = True,
 ):
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(
@@ -545,6 +562,7 @@ def to_pickle(
     protocol: int = pickle.HIGHEST_PROTOCOL,
     storage_options: StorageOptions = None,
 ):
+    Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     if isinstance(obj, DataFrame):

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -55,7 +55,6 @@ def _read(**kwargs):
     """
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     squeeze = kwargs.pop("squeeze", False)
     pd_obj = FactoryDispatcher.read_csv(**kwargs)
     # This happens when `read_csv` returns a TextFileReader object for iterating through
@@ -211,7 +210,6 @@ def read_parquet(
 ):
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(
         query_compiler=FactoryDispatcher.read_parquet(
             path=path,
@@ -248,7 +246,6 @@ def read_json(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_json(**kwargs))
 
 
@@ -273,7 +270,6 @@ def read_gbq(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_gbq(**kwargs))
 
 
@@ -299,7 +295,6 @@ def read_html(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_html(**kwargs))
 
 
@@ -310,7 +305,6 @@ def read_clipboard(sep=r"\s+", **kwargs):  # pragma: no cover
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_clipboard(**kwargs))
 
 
@@ -347,7 +341,6 @@ def read_excel(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     intermediate = FactoryDispatcher.read_excel(**kwargs)
     if isinstance(intermediate, (OrderedDict, dict)):
         parsed = type(intermediate)()
@@ -377,7 +370,6 @@ def read_hdf(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_hdf(**kwargs))
 
 
@@ -392,7 +384,6 @@ def read_feather(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_feather(**kwargs))
 
 
@@ -415,7 +406,6 @@ def read_stata(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_stata(**kwargs))
 
 
@@ -432,7 +422,6 @@ def read_sas(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_sas(**kwargs))
 
 
@@ -446,7 +435,6 @@ def read_pickle(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_pickle(**kwargs))
 
 
@@ -465,7 +453,6 @@ def read_sql(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     if kwargs.get("chunksize") is not None:
         ErrorMessage.default_to_pandas("Parameters provided [chunksize]")
         df_gen = pandas.read_sql(**kwargs)
@@ -486,7 +473,6 @@ def read_fwf(
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
     from pandas.io.parsers.base_parser import parser_defaults
 
-    Engine.subscribe(_update_engine)
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwds", {}))
     target_kwargs = parser_defaults.copy()
@@ -517,7 +503,6 @@ def read_sql_table(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_sql_table(**kwargs))
 
 
@@ -536,7 +521,6 @@ def read_sql_query(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(query_compiler=FactoryDispatcher.read_sql_query(**kwargs))
 
 
@@ -548,7 +532,6 @@ def read_spss(
 ):
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     return DataFrame(
         query_compiler=FactoryDispatcher.read_spss(path, usecols, convert_categoricals)
     )
@@ -564,7 +547,6 @@ def to_pickle(
 ):
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    Engine.subscribe(_update_engine)
     if isinstance(obj, DataFrame):
         obj = obj._query_compiler
     return FactoryDispatcher.to_pickle(


### PR DESCRIPTION
Signed-off-by: Alexander Myskov <alexander.myskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/developer/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The problem is that when `FactoryDispatcher` is imported, command `Engine.subscribe(FactoryDispatcher._update_factory)` is executed before `Engine` config correction in `Engine.subscribe(_update_engine)`, that leads to incorrect factory search. To fix it we need to update `Engine` before `FactoryDispatcher` import.

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #4017  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
