### PR TITLE
DOCS-#4077: Add release notes template to docs folder

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,4 @@ if you have questions about contributing.
 - [ ] Resolves #? <!-- issue must be created for each patch -->
 - [ ] tests added and passing
 - [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
-- [ ] added (PR Numer: PR title) and github username to release notes for next major release
+- [ ] added (PR Number: PR title) and github username to release notes for next major release

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,4 @@ if you have questions about contributing.
 - [ ] Resolves #? <!-- issue must be created for each patch -->
 - [ ] tests added and passing
 - [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
-- [ ] added PR title and github handle to release notes for next major release
+- [ ] added (PR Numer: PR title) and github username to release notes for next major release

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,3 +15,4 @@ if you have questions about contributing.
 - [ ] Resolves #? <!-- issue must be created for each patch -->
 - [ ] tests added and passing
 - [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
+- [ ] added PR title and github handle to release notes for next major release

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,4 @@ if you have questions about contributing.
 - [ ] Resolves #? <!-- issue must be created for each patch -->
 - [ ] tests added and passing
 - [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
-- [ ] added (PR Number: PR title) and github username to release notes for next major release
+- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -22,7 +22,7 @@ Key Features and Updates
 * Update testing suite
   *
 * Documentation improvements
-  *
+  * DOCS-#4077: Add release notes template to docs folder (#4078)
 * Dependencies
   *
 

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -1,0 +1,31 @@
+Modin 0.14.0
+
+Key Features and Updates
+------------------------
+
+* Stability and Bugfixes
+  *
+* Performance enhancements
+  *
+* Benchmarking enhancements
+  *
+* Refactor Codebase
+  *
+* Pandas API implementations and improvements
+  *
+* OmniSci enhancements
+  *
+* XGBoost enhancements
+  *
+* Developer API enhancements
+  *
+* Update testing suite
+  *
+* Documentation improvements
+  *
+* Dependencies
+  *
+
+Contributors
+------------
+

--- a/docs/release_notes/release_notes-template.rst
+++ b/docs/release_notes/release_notes-template.rst
@@ -1,0 +1,31 @@
+Modin X.X.X
+
+Key Features and Updates
+------------------------
+
+* Stability and Bugfixes
+  *
+* Performance enhancements
+  *
+* Benchmarking enhancements
+  *
+* Refactor Codebase
+  *
+* Pandas API implementations and improvements
+  *
+* OmniSci enhancements
+  *
+* XGBoost enhancements
+  *
+* Developer API enhancements
+  *
+* Update testing suite
+  *
+* Documentation improvements
+  *
+* Dependencies
+  *
+
+Contributors
+------------
+


### PR DESCRIPTION
Resovles #4077

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/developer/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4077 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
