### PR TITLE
DOCS-#4079: Fix link PandasDataframe in docs

### DIFF
--- a/docs/flow/modin/core/dataframe/base/dataframe.rst
+++ b/docs/flow/modin/core/dataframe/base/dataframe.rst
@@ -10,7 +10,7 @@ a significantly reduced set of operations that can be composed to form any panda
 
 The :py:class:`~modin.core.dataframe.pandas.dataframe.dataframe.PandasDataframe` is an example of a descendant of this class. It currently has implementations for some of the operators
 exposed in this class, and is currently being refactored to include implementations for all of the algebra operators. Please
-refer to the :doc:`PandasDataframe documentation <flow/modin/core/dataframe/pandas/dataframe>` for more information.
+refer to the :doc:`PandasDataframe documentation <flow/modin/core/dataframe/pandas/index>` for more information.
 
 The :py:class:`~modin.core.dataframe.base.dataframe.dataframe.ModinDataframe` is independent of implementation specific details such as partitioning, storage format, or execution engine.
 

--- a/docs/flow/modin/core/dataframe/base/dataframe.rst
+++ b/docs/flow/modin/core/dataframe/base/dataframe.rst
@@ -10,7 +10,7 @@ a significantly reduced set of operations that can be composed to form any panda
 
 The :py:class:`~modin.core.dataframe.pandas.dataframe.dataframe.PandasDataframe` is an example of a descendant of this class. It currently has implementations for some of the operators
 exposed in this class, and is currently being refactored to include implementations for all of the algebra operators. Please
-refer to the :doc:`PandasDataframe documentation<flow/modin/core/dataframe/pandas/dataframe>` for more information.
+refer to the :doc:`PandasDataframe documentation <flow/modin/core/dataframe/pandas/dataframe>` for more information.
 
 The :py:class:`~modin.core.dataframe.base.dataframe.dataframe.ModinDataframe` is independent of implementation specific details such as partitioning, storage format, or execution engine.
 

--- a/docs/flow/modin/core/dataframe/base/dataframe.rst
+++ b/docs/flow/modin/core/dataframe/base/dataframe.rst
@@ -10,7 +10,7 @@ a significantly reduced set of operations that can be composed to form any panda
 
 The :py:class:`~modin.core.dataframe.pandas.dataframe.dataframe.PandasDataframe` is an example of a descendant of this class. It currently has implementations for some of the operators
 exposed in this class, and is currently being refactored to include implementations for all of the algebra operators. Please
-refer to the :doc: `PandasDataframe documentation<flow/modin/core/dataframe/pandas/dataframe.rst>` for more information.
+refer to the :doc:`PandasDataframe documentation<flow/modin/core/dataframe/pandas/dataframe.rst>` for more information.
 
 The :py:class:`~modin.core.dataframe.base.dataframe.dataframe.ModinDataframe` is independent of implementation specific details such as partitioning, storage format, or execution engine.
 

--- a/docs/flow/modin/core/dataframe/base/dataframe.rst
+++ b/docs/flow/modin/core/dataframe/base/dataframe.rst
@@ -10,7 +10,7 @@ a significantly reduced set of operations that can be composed to form any panda
 
 The :py:class:`~modin.core.dataframe.pandas.dataframe.dataframe.PandasDataframe` is an example of a descendant of this class. It currently has implementations for some of the operators
 exposed in this class, and is currently being refactored to include implementations for all of the algebra operators. Please
-refer to the :doc:`PandasDataframe documentation<flow/modin/core/dataframe/pandas/dataframe.rst>` for more information.
+refer to the :doc:`PandasDataframe documentation<flow/modin/core/dataframe/pandas/dataframe>` for more information.
 
 The :py:class:`~modin.core.dataframe.base.dataframe.dataframe.ModinDataframe` is independent of implementation specific details such as partitioning, storage format, or execution engine.
 

--- a/docs/flow/modin/core/dataframe/base/dataframe.rst
+++ b/docs/flow/modin/core/dataframe/base/dataframe.rst
@@ -10,7 +10,7 @@ a significantly reduced set of operations that can be composed to form any panda
 
 The :py:class:`~modin.core.dataframe.pandas.dataframe.dataframe.PandasDataframe` is an example of a descendant of this class. It currently has implementations for some of the operators
 exposed in this class, and is currently being refactored to include implementations for all of the algebra operators. Please
-refer to the :doc:`PandasDataframe documentation <flow/modin/core/dataframe/pandas/index>` for more information.
+refer to the :doc:`PandasDataframe documentation </flow/modin/core/dataframe/pandas/dataframe>` for more information.
 
 The :py:class:`~modin.core.dataframe.base.dataframe.dataframe.ModinDataframe` is independent of implementation specific details such as partitioning, storage format, or execution engine.
 


### PR DESCRIPTION
Signed-off-by: Rehan Durrani <rehan@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/developer/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4079 ? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
