### PR TITLE
DOCS-#4082: Add `pdf`/`epub`/`htmlzip` formats for doc builds

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -15,6 +15,8 @@ build:
 sphinx:
    configuration: docs/conf.py
 
+formats: all
+
 python:
    install:
    - requirements: docs/requirements-doc.txt

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -29,4 +29,4 @@ Key Features and Updates
 
 Contributors
 ------------
-
+@prutskov

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -23,6 +23,7 @@ Key Features and Updates
   *
 * Documentation improvements
   * DOCS-#4077: Add release notes template to docs folder (#4078)
+  * DOCS-#4082: Add pdf/epub/htmlzip formats for doc builds (#4083)
 * Dependencies
   *
 


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/developer/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

PR adds missed after #4073 formats of doc builds 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4082  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
