### PR TITLE
FIX-#4058: Allow pickling empty dataframes and series.

### DIFF
--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -4,7 +4,7 @@ Key Features and Updates
 ------------------------
 
 * Stability and Bugfixes
-  *
+  * Allow pickling empty dataframes and series (5fc9565)
 * Performance enhancements
   *
 * Benchmarking enhancements

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -4,7 +4,7 @@ Key Features and Updates
 ------------------------
 
 * Stability and Bugfixes
-  * Allow pickling empty dataframes and series (5fc9565)
+  * FIX-#4058: Allow pickling empty dataframes and series (#4095)
 * Performance enhancements
   *
 * Benchmarking enhancements

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -91,6 +91,7 @@ _DEFAULT_BEHAVIOUR = {
     "_inflate_light",
     "_inflate_full",
     "__reduce__",
+    "__reduce_ex__",
 } | _ATTRS_NO_LOOKUP
 
 

--- a/modin/pandas/test/dataframe/test_pickle.py
+++ b/modin/pandas/test/dataframe/test_pickle.py
@@ -39,6 +39,9 @@ def persistent(request):
     PersistentPickle.put(old)
 
 
+@pytest.mark.parametrize(
+    "modin_df", [pytest.param(modin_df), pytest.param(pd.DataFrame(), id="empty_df")]
+)
 def test_dataframe_pickle(modin_df, persistent):
     other = pickle.loads(pickle.dumps(modin_df))
     df_equals(modin_df, other)


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/developer/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Allow pickling empty dataframes and series.

<!-- Please give a short brief about these changes. -->

We need to implement [`__reduce_ex__`](https://docs.python.org/3/library/pickle.html#object.__reduce_ex__) for `Series` and `Dataframe` for `pickle` to pickle them with their own `__reduce__` methods instead of defaulting to pandas for `__reduce_ex__`.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4058
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
