### PR TITLE
FIX-#4060: Fix _to_pandas() dtypes for empty frames.

### DIFF
--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -4,7 +4,7 @@ Key Features and Updates
 ------------------------
 
 * Stability and Bugfixes
-  * Fix to_pandas() dtypes for empty dataframes and series (8312829)
+  * Fix to_pandas() dtypes for empty dataframes and series (4108)
 * Performance enhancements
   *
 * Benchmarking enhancements

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -4,7 +4,7 @@ Key Features and Updates
 ------------------------
 
 * Stability and Bugfixes
-  *
+  * Fix to_pandas() dtypes for empty dataframes and series (0d7c273)
 * Performance enhancements
   *
 * Benchmarking enhancements

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -4,7 +4,7 @@ Key Features and Updates
 ------------------------
 
 * Stability and Bugfixes
-  * Fix to_pandas() dtypes for empty dataframes and series (0d7c273)
+  * Fix to_pandas() dtypes for empty dataframes and series (8312829)
 * Performance enhancements
   *
 * Benchmarking enhancements

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2698,7 +2698,9 @@ class PandasDataframe(object):
         """
         df = self._partition_mgr_cls.to_pandas(self._partitions)
         if df.empty:
-            df = pandas.DataFrame(columns=self.columns, index=self.index)
+            df = pandas.DataFrame(columns=self.columns, index=self.index).astype(
+                self.dtypes
+            )
         else:
             for axis in [0, 1]:
                 ErrorMessage.catch_bugs_and_request_email(

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -19,6 +19,7 @@ import numpy as np
 from numpy.testing import assert_array_equal
 from modin.utils import get_current_execution, to_pandas
 from modin.test.test_utils import warns_that_defaulting_to_pandas
+from pandas.testing import assert_frame_equal, assert_series_equal
 
 from .utils import (
     test_data_values,
@@ -765,3 +766,15 @@ def test_empty_dataframe():
 def test_empty_series():
     s = pd.Series([])
     pd.to_numeric(s)
+
+
+def test_to_pandas_empty_series():
+    pandas_series = pandas.Series([], dtype="bool")
+    modin_series = pd.Series(pandas_series)
+    assert_series_equal(pandas_series, modin_series._to_pandas(), check_dtype=True)
+
+
+def test_to_pandas_empty_dataframe():
+    pandas_df = pandas.DataFrame([[]], dtype="bool")
+    modin_df = pd.DataFrame(pandas_df)
+    assert_frame_equal(pandas_df, modin_df._to_pandas(), check_dtype=True)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -19,7 +19,6 @@ import matplotlib
 import modin.pandas as pd
 from numpy.testing import assert_array_equal
 from pandas.core.base import SpecificationError
-from modin.utils import get_current_execution
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 import sys
 
@@ -514,13 +513,7 @@ def test___repr__(name, dt_index, data):
         )
         pandas_series.index = modin_series.index = index
 
-    if get_current_execution() == "BaseOnPython" and data == "empty":
-        # TODO: Remove this when default `dtype` of empty Series will be `object` in pandas (see #3142).
-        assert modin_series.dtype == np.object
-        assert pandas_series.dtype == np.float64
-        df_equals(modin_series.index, pandas_series.index)
-    else:
-        assert repr(modin_series) == repr(pandas_series)
+    assert repr(modin_series) == repr(pandas_series)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
@@ -1558,12 +1551,7 @@ def test_dropna_inplace(data):
 
 def test_dtype_empty():
     modin_series, pandas_series = pd.Series(), pandas.Series()
-    if get_current_execution() == "BaseOnPython":
-        # TODO: Remove this when default `dtype` of empty Series will be `object` in pandas (see #3142).
-        assert modin_series.dtype == np.object
-        assert pandas_series.dtype == np.float64
-    else:
-        assert modin_series.dtype == pandas_series.dtype
+    assert modin_series.dtype == pandas_series.dtype
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/developer/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/developer/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4060 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
