### PR TITLE
FIX-#4071: Fix DataFrame and Series equals() for None values.

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -88,11 +88,15 @@ class Binary(Operator):
                         )
                     )
                 else:
+                    new_index = kwargs.pop("new_index", None)
+                    new_columns = kwargs.pop("new_columns", None)
                     return query_compiler.__constructor__(
                         query_compiler._modin_frame.binary_op(
                             lambda x, y: func(x, y, *args, **kwargs),
                             other._modin_frame,
                             join_type=join_type,
+                            new_index=new_index,
+                            new_columns=new_columns,
                         )
                     )
             else:

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2478,9 +2478,9 @@ class PandasDataframe(object):
         join_type : str, default: "outer"
             Type of join to apply.
         new_index : pandas.Index, optional
-            New index of the frame resulting from the binary operation
-        new_columns: pandas.Index, optional
-            New columns of the frame reuslting from the binary operation
+            New index of the frame resulting from the binary operation.
+        new_columns : pandas.Index, optional
+            New columns of the frame reuslting from the binary operation.
 
         Returns
         -------

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -37,7 +37,7 @@ from pandas.core.dtypes.common import is_scalar
 import pandas.core.resample
 import pandas
 import numpy as np
-from typing import List, Hashable
+from typing import List, Hashable, Optional
 
 
 def _get_axis(axis):
@@ -482,6 +482,41 @@ class BaseQueryCompiler(abc.ABC):
     @doc_utils.doc_binary_method(operation="equality comparison", sign="==")
     def eq(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.eq)(self, other=other, **kwargs)
+
+    def equals(
+        self,
+        other,
+        new_index: Optional[pandas.Index] = None,
+        new_columns: Optional[pandas.Index] = None,
+    ):
+        """
+        Test whether two objects contain the same elements.
+
+        If axes are not equal, perform frames alignment first. Note that
+        because frame alignment includes filling in empty values with NaN,
+        the query compiler for DataFrame([[1], [np.NaN]]) is equal to the query
+        compiler for DataFrame([[1]]]). In that case, the latter dataframe's
+        partition is expanded to DataFrame([[1], [np.NaN]]]).
+
+        Parameters
+        ----------
+        other : BaseQueryCompiler
+            The other compiler to be compared with the first.
+        new_index : pandas.Index, optional
+            New index of the frame resulting from the binary operation.
+        new_columns : pandas.Index, optional
+            New columns of the frame reuslting from the binary operation.
+
+        Returns
+        -------
+        BaseQueryCompiler
+            Result where each.
+        """
+        return BinaryDefault.register(
+            lambda x, y: pandas.DataFrame(
+                pandas.DataFrame.equals(x, y), index=new_index, columns=new_columns
+            )
+        )(self, other=other)
 
     @doc_utils.doc_binary_method(operation="integer division", sign="//")
     def floordiv(self, other, **kwargs):  # noqa: PR02

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -501,7 +501,7 @@ class BaseQueryCompiler(abc.ABC):
         Parameters
         ----------
         other : BaseQueryCompiler
-            The other compiler to be compared with the first.
+            The other compiler to be compared with this one.
         new_index : pandas.Index, optional
             New index of the frame resulting from the binary operation.
         new_columns : pandas.Index, optional
@@ -510,7 +510,9 @@ class BaseQueryCompiler(abc.ABC):
         Returns
         -------
         BaseQueryCompiler
-            Result where each.
+            Result where each partition has a single element telling whether
+            the two objects are pandas.DataFrame.equals() in their
+            corresponding partitions.
         """
         return BinaryDefault.register(
             lambda x, y: pandas.DataFrame(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -368,6 +368,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
     combine = Binary.register(pandas.DataFrame.combine)
     combine_first = Binary.register(pandas.DataFrame.combine_first)
     eq = Binary.register(pandas.DataFrame.eq)
+    equals = Binary.register(
+        lambda x, y: pandas.DataFrame([[pandas.DataFrame.equals(x, y)]])
+    )
     floordiv = Binary.register(pandas.DataFrame.floordiv)
     ge = Binary.register(pandas.DataFrame.ge)
     gt = Binary.register(pandas.DataFrame.gt)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -423,6 +423,7 @@ class BasePandasDataset(object):
             "__ror__",
             "__xor__",
             "__rxor__",
+            "equals",
         ]
         if op in exclude_list:
             kwargs.pop("axis")
@@ -1415,6 +1416,19 @@ class BasePandasDataset(object):
         if ignore_index:
             exploded = exploded.reset_index(drop=True)
         return exploded
+
+    def equals(self, other, axis=None):
+        return (
+            self._binary_op(
+                "equals",
+                other,
+                new_index=pandas.Index([0]),
+                new_columns=pandas.Index([0]),
+                axis=axis,
+            )
+            .all()
+            .all()
+        )
 
     def ewm(
         self,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -784,12 +784,13 @@ class DataFrame(BasePandasDataset):
         Test whether two objects contain the same elements.
         """
         if isinstance(other, pandas.DataFrame):
-            # Copy into a Modin DataFrame to simplify logic below
             other = DataFrame(other)
+        if not (isinstance(other, type(self))):
+            return False
         return (
             self.index.equals(other.index)
             and self.columns.equals(other.columns)
-            and self.eq(other).all().all()
+            and super(DataFrame, self).equals(other)
         )
 
     def _update_var_dicts_in_kwargs(self, expr, kwargs):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -951,11 +951,12 @@ class Series(BasePandasDataset):
         """
         Test whether two objects contain the same elements.
         """
-        return (
-            self.name == other.name
-            and self.index.equals(other.index)
-            and self.eq(other).all()
-        )
+        if isinstance(other, pandas.Series):
+            other = Series(other)
+        if not (isinstance(other, type(self))):
+            return False
+        new_self, new_other = self._prepare_inter_op(other)
+        return super(Series, new_self).equals(new_other, axis=0)
 
     def explode(self, ignore_index: bool = False):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -72,7 +72,7 @@ def test_math_functions(other, axis, op):
 
 @pytest.mark.parametrize(
     "other",
-    [lambda df: df[: -(2 ** 4)], lambda df: df[df.columns[0]].reset_index(drop=True)],
+    [lambda df: df[: -(2**4)], lambda df: df[df.columns[0]].reset_index(drop=True)],
     ids=["check_missing_value", "check_different_index"],
 )
 @pytest.mark.parametrize("fill_value", [None, 3.0])

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -15,6 +15,7 @@ import pytest
 import pandas
 import matplotlib
 import modin.pandas as pd
+import numpy as np
 
 from modin.pandas.test.utils import (
     df_equals,
@@ -173,6 +174,7 @@ def test_multi_level_comparison(data, op):
         pytest.param({}, {}, True, id="two_empty_dataframes"),
         pytest.param([[1]], [[0]], False, id="single_unequal_values"),
         pytest.param([[None]], [[None]], True, id="single_none_values"),
+        pytest.param([[np.NaN]], [[np.NaN]], True, id="single_nan_values"),
         pytest.param({1: [10]}, {1.0: [10]}, True, id="different_column_types"),
         pytest.param({1: [10]}, {2: [10]}, False, id="different_columns"),
         pytest.param(

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1695,26 +1695,63 @@ def test_eq(data):
     inter_df_math_helper(modin_series, pandas_series, "eq")
 
 
-def test_equals():
-    series_data = [2.9, 3, 3, 3]
-    modin_df1 = pd.Series(series_data)
-    modin_df2 = pd.Series(series_data)
+@pytest.mark.parametrize(
+    "series1_data,series2_data,expected_pandas_equals",
+    [
+        pytest.param([1], [0], False, id="single_unequal_values"),
+        pytest.param([None], [None], True, id="single_none_values"),
+        pytest.param(
+            pandas.Series(1, name="series1"),
+            pandas.Series(1, name="series2"),
+            True,
+            id="different_names",
+        ),
+        pytest.param(
+            pandas.Series([1], index=[1]),
+            pandas.Series([1], index=[1.0]),
+            True,
+            id="different_index_types",
+        ),
+        pytest.param(
+            pandas.Series([1], index=[1]),
+            pandas.Series([1], index=[2]),
+            False,
+            id="different_index_values",
+        ),
+        pytest.param([1], [1.0], False, id="different_value_types"),
+        pytest.param(
+            [1, 2],
+            [1, 2],
+            True,
+            id="equal_series_of_length_two",
+        ),
+        pytest.param(
+            [1, 2],
+            [1, 3],
+            False,
+            id="unequal_series_of_length_two",
+        ),
+        pytest.param(
+            [[1, 2]],
+            [[1]],
+            False,
+            id="different_lengths",
+        ),
+    ],
+)
+def test_equals(series1_data, series2_data, expected_pandas_equals):
+    modin_series1, pandas_df1 = create_test_series(series1_data)
+    modin_series2, pandas_df2 = create_test_series(series2_data)
 
-    assert modin_df1.equals(modin_df2)
-    assert modin_df1.equals(pd.Series(modin_df1))
-    df_equals(modin_df1, modin_df2)
-    df_equals(modin_df1, pd.Series(modin_df1))
+    pandas_equals = pandas_df1.equals(pandas_df2)
+    assert pandas_equals == expected_pandas_equals, (
+        f"Test expected pandas to say the series were"
+        f"{'' if expected_pandas_equals else ' not'} equal, but they were"
+        f"{' not' if expected_pandas_equals else ''} equal."
+    )
 
-    series_data = [2, 3, 5, 1]
-    modin_df3 = pd.Series(series_data, index=list("abcd"))
-
-    assert not modin_df1.equals(modin_df3)
-
-    with pytest.raises(AssertionError):
-        df_equals(modin_df3, modin_df1)
-
-    with pytest.raises(AssertionError):
-        df_equals(modin_df3, modin_df2)
+    assert modin_series1.equals(modin_series2) == pandas_equals
+    assert modin_series1.equals(pandas_df2) == pandas_equals
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
@@ -3490,7 +3527,7 @@ def test_value_counts(sort, normalize, bins, dropna, ascending):
     )
 
     # from issue #2365
-    arr = np.random.rand(2**6)
+    arr = np.random.rand(2 ** 6)
     arr[::10] = np.nan
     eval_general(
         *create_test_series(arr),

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3527,7 +3527,7 @@ def test_value_counts(sort, normalize, bins, dropna, ascending):
     )
 
     # from issue #2365
-    arr = np.random.rand(2 ** 6)
+    arr = np.random.rand(2**6)
     arr[::10] = np.nan
     eval_general(
         *create_test_series(arr),


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Currently, we implement DataFrame.equals() by calling DataFrame.eq() on both
input frames, then checking that every element of the result is True. However, pandas does not define `equals` equivalently. `pandas.eq` does not consider `None` to be equal to `None`, while `pandas.equals` does:

```python
import pandas
assert pandas.DataFrame([[None]]).equals(pandas.DataFrame([[None]]))
assert not pandas.DataFrame([[None]]).eq(pandas.DataFrame([[None]])).any().any()
```

It's hard to tell what exactly `equals` means for pandas, so I reimplemented it as a binary operation that transforms a pair of dataframes to dataframes with a single element telling whether the two dataframes are `equals`, followed by a check that every element of the result is true.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4071 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
