### PR TITLE
TEST-#4153: Fix condition of running lint-commit and set of CI triggers

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -1,0 +1,21 @@
+name: ci-required
+on: pull_request
+jobs:
+  lint-commit:
+    name: lint (commit)
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: "12.x"
+      - run: npm install --save-dev @commitlint/{config-conventional,cli} commitlint-plugin-jira-rules commitlint-config-jira
+      - name: Add dependencies for commitlint action
+        run: echo "NODE_PATH=$GITHUB_WORKSPACE/node_modules" >> $GITHUB_ENV
+      - run: git remote add upstream https://github.com/modin-project/modin.git
+      - run: git fetch upstream
+      - run: npx commitlint --from upstream/master --to $(git log upstream/master..HEAD --pretty=format:"%h" | tail -1) --verbose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
         run: python -m pytest modin/test/test_headers.py
 
   test-clean-install-ubuntu:
-    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -196,7 +196,7 @@ jobs:
           MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3]))"
 
   test-clean-install-windows:
-    needs: [ lint-commit, lint-flake8, lint-black, test-api, test-headers ]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: windows-latest
     defaults:
       run:
@@ -217,7 +217,7 @@ jobs:
           MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3]))"
 
   test-internals:
-    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -250,7 +250,7 @@ jobs:
       - run: python -m pytest asv_bench/test/test_utils.py
 
   test-defaults:
-    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -300,7 +300,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-omnisci:
-    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -332,7 +332,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-asv-benchmarks:
-    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -393,7 +393,7 @@ jobs:
         if: failure()
 
   test-all:
-    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -454,7 +454,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-experimental:
-    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -485,7 +485,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-cloud:
-    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -519,7 +519,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-windows:
-    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: windows-latest
     defaults:
       run:
@@ -574,7 +574,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-pyarrow:
-    needs: [lint-commit, lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -605,7 +605,7 @@ jobs:
       - run: python -m pytest modin/pandas/test/test_io.py::TestCsv --verbose
 
   test-spreadsheet:
-    needs: [ lint-commit, lint-flake8, lint-black, test-api, test-headers ]
+    needs: [lint-flake8, lint-black, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,5 @@
-name: ci
-on:
-  pull_request:
-    paths:
-      - modin/**
-      - .github/**
+name: ci-required
+on: pull_request
 jobs:
   lint-commit:
     name: lint (commit)
@@ -24,6 +20,13 @@ jobs:
       - run: git fetch upstream
       - run: npx commitlint --from upstream/master --to $(git log upstream/master..HEAD --pretty=format:"%h" | tail -1) --verbose
 
+name: ci
+on:
+  pull_request:
+    paths-ignore:
+      - "**.rst"
+      - "**.md"
+jobs:
   lint-black:
     name: lint (black)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,17 @@
 name: ci
 on:
   pull_request:
-    paths-ignore:
-      - "**.rst"
-      - "**.md"
+    paths:
+      - .github/**
+      - asv_bench/**
+      - modin/**
+      - requirements/**
+      - scripts/**
+      - environment-dev.yml
+      - requirements-dev.txt
+      - setup.cfg
+      - setup.py
+      - versioneer.py
 jobs:
   lint-black:
     name: lint (black)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,3 @@
-name: ci-required
-on: pull_request
-jobs:
-  lint-commit:
-    name: lint (commit)
-    runs-on: ubuntu-latest
-    env:
-      GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: actions/setup-node@v1
-        with:
-          node-version: "12.x"
-      - run: npm install --save-dev @commitlint/{config-conventional,cli} commitlint-plugin-jira-rules commitlint-config-jira
-      - name: Add dependencies for commitlint action
-        run: echo "NODE_PATH=$GITHUB_WORKSPACE/node_modules" >> $GITHUB_ENV
-      - run: git remote add upstream https://github.com/modin-project/modin.git
-      - run: git fetch upstream
-      - run: npx commitlint --from upstream/master --to $(git log upstream/master..HEAD --pretty=format:"%h" | tail -1) --verbose
-
 name: ci
 on:
   pull_request:

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -26,7 +26,7 @@ Key Features and Updates
 * Developer API enhancements
   *
 * Update testing suite
-  *
+  * TEST-#4153: Fix condition of running lint-commit and set of CI triggers (#4156)
 * Documentation improvements
   * DOCS-#4077: Add release notes template to docs folder (#4078)
   * DOCS-#4082: Add pdf/epub/htmlzip formats for doc builds (#4083)


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

1. PR add `lint-commit` check as separate workflow `ci-required` to be run in each PR.
2. The list of triggers-paths in workflow `ci` is expanded to list described here https://github.com/modin-project/modin/pull/4092#issuecomment-1026210166
3. As `lint-commit` became a separate workflow it was removed from dependencies of jobs in `ci` workflow.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4153  <!-- issue must be created for each patch -->
- [x] tests ~~added~~ and passing
- [x] ~~module layout described at `docs/development/architecture.rst` is up-to-date~~ <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
