### PR TITLE
FIX-#4158: Do not print OmniSci logs to stdout by default

### DIFF
--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -9,6 +9,7 @@ Key Features and Updates
   * FIX-#4105: Fix names of pandas options to avoid `OptionError` (#4109)
   * FIX-#3417: Fix read_csv with skiprows and header parameters (#3419)
   * FIX-#4142: Fix OmniSci enabling (#4146)
+  * FIX-#4158: Do not pring OmniSci logs to stdout by default (#4159)
 * Performance enhancements
   *
 * Benchmarking enhancements
@@ -34,4 +35,9 @@ Key Features and Updates
 
 Contributors
 ------------
-@prutskov, @amyskov, @paulovn, @anmyachev, @YarShev
+@prutskov
+@amyskov
+@paulovn
+@anmyachev
+@YarShev
+@dchigarev

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -10,7 +10,7 @@ Key Features and Updates
   * FIX-#3417: Fix read_csv with skiprows and header parameters (#3419)
   * FIX-#4142: Fix OmniSci enabling (#4146)
   * FIX-#4162: Use `skipif` instead of `skip` for compatibility with pytest 7.0 (#4163)
-  * FIX-#4158: Do not pring OmniSci logs to stdout by default (#4159)
+  * FIX-#4158: Do not print OmniSci logs to stdout by default (#4159)
 * Performance enhancements
   *
 * Benchmarking enhancements

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -384,6 +384,7 @@ class OmnisciLaunchParameters(EnvironmentVariable, type=dict):
         "enable_lazy_fetch": 0,
         "null_div_by_zero": 1,
         "enable_watchdog": 0,
+        "enable_thrift_logs": 0,
     }
 
     @classmethod


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Explicitly passes `--enable_thrift_logs=0` parameter to the OmniSci server to omit thrift logs.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4158 <!-- issue must be created for each patch -->
- [x] tests <s>added and</s> passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
