### PR TITLE
FIX-#4162: Use `skipif` instead of `skip` for compatibility with pytest 7.0

### DIFF
--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -9,7 +9,7 @@ Key Features and Updates
   * FIX-#4105: Fix names of pandas options to avoid `OptionError` (#4109)
   * FIX-#3417: Fix read_csv with skiprows and header parameters (#3419)
   * FIX-#4142: Fix OmniSci enabling (#4146)
-  * FIX-#4162: FIX-#4162: Use `skipif` instead of `skip` for compatibility with pytest 7.0 (#4163)
+  * FIX-#4162: Use `skipif` instead of `skip` for compatibility with pytest 7.0 (#4163)
 * Performance enhancements
   *
 * Benchmarking enhancements
@@ -29,7 +29,6 @@ Key Features and Updates
 * Documentation improvements
   * DOCS-#4077: Add release notes template to docs folder (#4078)
   * DOCS-#4082: Add pdf/epub/htmlzip formats for doc builds (#4083)
-  * DOCS-#4079: Fix link to PandasDataframe in docs (#4108)
 * Dependencies
   * FIX-#4113, FIX-#4116, FIX-#4115: Apply new `black` formatting, fix pydocstyle check and readthedocs build (#4114)
   * TEST-#3227: Use codecov github action instead of bash form in GA workflows (#3226)

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -9,6 +9,7 @@ Key Features and Updates
   * FIX-#4105: Fix names of pandas options to avoid `OptionError` (#4109)
   * FIX-#3417: Fix read_csv with skiprows and header parameters (#3419)
   * FIX-#4142: Fix OmniSci enabling (#4146)
+  * FIX-#4162: FIX-#4162: Use `skipif` instead of `skip` for compatibility with pytest 7.0 (#4163)
 * Performance enhancements
   *
 * Benchmarking enhancements
@@ -28,10 +29,11 @@ Key Features and Updates
 * Documentation improvements
   * DOCS-#4077: Add release notes template to docs folder (#4078)
   * DOCS-#4082: Add pdf/epub/htmlzip formats for doc builds (#4083)
+  * DOCS-#4079: Fix link to PandasDataframe in docs (#4108)
 * Dependencies
   * FIX-#4113, FIX-#4116, FIX-#4115: Apply new `black` formatting, fix pydocstyle check and readthedocs build (#4114)
   * TEST-#3227: Use codecov github action instead of bash form in GA workflows (#3226)
 
 Contributors
 ------------
-@prutskov, @amyskov, @paulovn, @anmyachev, @YarShev
+@prutskov, @amyskov, @paulovn, @anmyachev, @YarShev, @RehanSD, @devin-petersohn

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -619,7 +619,7 @@ class TestCsv:
             "utf8",
             pytest.param(
                 "unicode_escape",
-                marks=pytest.mark.skip(
+                marks=pytest.mark.skipif(
                     condition=sys.version_info < (3, 9),
                     reason="https://bugs.python.org/issue45461",
                 ),


### PR DESCRIPTION


Signed-off-by: Rehan Durrani <rehan@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4162 ? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
