### PR TITLE
DOCS-#4168: Fix rendering the examples on troubleshooting page

### DIFF
--- a/docs/getting_started/troubleshooting.rst
+++ b/docs/getting_started/troubleshooting.rst
@@ -175,17 +175,18 @@ in conjunction with python multiprocessing because that can lead to undefined be
 One of such examples is shown below:
 
 .. code-block:: python
+
   import modin.pandas as pd
-  
+
   # Ray engine is used by default
   df = pandas.DataFrame([1, 2, 3])
-  
+
   def f(arg):
     return df + arg
 
   if __name__ == '__main__':
     from multiprocessing import Pool
-    
+
     with Pool(5) as p:
         print(p.map(f, [1]))
 
@@ -209,9 +210,9 @@ This can happen when you use OmniSci engine along with ``pyarrow.gandiva``:
   cfg.IsExperimental.put(True)
   import modin.pandas as pd
   import pyarrow.gandiva as gandiva  # Error
-  CommandLine Error: Option 'enable-vfe' registered more than once!
-  LLVM ERROR: inconsistency in registered CommandLine options
-  Aborted (core dumped)
+  # CommandLine Error: Option 'enable-vfe' registered more than once!
+  # LLVM ERROR: inconsistency in registered CommandLine options
+  # Aborted (core dumped)
 
 **Solution**
 

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -30,7 +30,7 @@ Key Features and Updates
 * Documentation improvements
   * DOCS-#4077: Add release notes template to docs folder (#4078)
   * DOCS-#4082: Add pdf/epub/htmlzip formats for doc builds (#4083)
-  * DOCS-#4168: Fix rendering the example on troubleshooting page (#4169)
+  * DOCS-#4168: Fix rendering the examples on troubleshooting page (#4169)
 * Dependencies
   * FIX-#4113, FIX-#4116, FIX-#4115: Apply new `black` formatting, fix pydocstyle check and readthedocs build (#4114)
   * TEST-#3227: Use codecov github action instead of bash form in GA workflows (#3226)

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -30,6 +30,7 @@ Key Features and Updates
 * Documentation improvements
   * DOCS-#4077: Add release notes template to docs folder (#4078)
   * DOCS-#4082: Add pdf/epub/htmlzip formats for doc builds (#4083)
+  * DOCS-#4168: Fix rendering the example on troubleshooting page (#4169)
 * Dependencies
   * FIX-#4113, FIX-#4116, FIX-#4115: Apply new `black` formatting, fix pydocstyle check and readthedocs build (#4114)
   * TEST-#3227: Use codecov github action instead of bash form in GA workflows (#3226)


### PR DESCRIPTION
Signed-off-by: Igoshev, Yaroslav <yaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4168  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
