### PR TITLE
FIX-#4115: Unpin `pip` in readthedocs deps list

### DIFF
--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -35,6 +35,7 @@ Key Features and Updates
 * Dependencies
   * FIX-#4113, FIX-#4116, FIX-#4115: Apply new `black` formatting, fix pydocstyle check and readthedocs build (#4114)
   * TEST-#3227: Use codecov github action instead of bash form in GA workflows (#3226)
+  * FIX-#4115: Unpin `pip` in readthedocs deps list (#4170)
 
 Contributors
 ------------

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -13,7 +13,3 @@ git+https://github.com/modin-project/modin.git@master#egg=modin[all]
 sphinxcontrib_plantuml
 sphinx-issues
 xgboost
-# FIXME: readthedocs builds are failing when using a newer pip version.
-# This temporal workaround should be removed after original issue resolved:
-# https://github.com/readthedocs/readthedocs.org/issues/8864
-pip==21.3.1


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <alexey.prutskov@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

PR removes temporary workaround for building our docs.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [ ] ~~passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`~~
- [ ] ~~passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`~~
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4115  <!-- issue must be created for each patch -->
- [x] tests ~~added~~ and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] ~~added (Issue Number: PR title (PR Number)) and github username to release notes for next major release~~ <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) --> () (too minor change to be highlighted in the notes)
