### PR TITLE
DOCS-#4173: Mention strict channel priority in conda install section

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -124,6 +124,14 @@ or explicitly:
 
   conda install -c conda-forge modin-ray modin-dask modin-omnisci
 
+``conda`` may be rather slow, especially installing ``modin-all`` package so it's worth to run 
+
+.. code-block:: bash
+
+  conda config --set channel_priority strict
+
+prior the installation process
+
 Using Intel\ |reg| Distribution of Modin
 """"""""""""""""""""""""""""""""""""""""
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -124,13 +124,12 @@ or explicitly:
 
   conda install -c conda-forge modin-ray modin-dask modin-omnisci
 
-``conda`` may be rather slow, especially installing ``modin-all`` package so it's worth to run 
+``conda`` may be slow installing ``modin-omnisci`` and hence ``modin-all`` packages so it's worth trying to set ``channel_priority`` to ``strict`` prior the installation process:
 
 .. code-block:: bash
 
   conda config --set channel_priority strict
 
-prior the installation process
 
 Using Intel\ |reg| Distribution of Modin
 """"""""""""""""""""""""""""""""""""""""

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -33,6 +33,7 @@ Key Features and Updates
   * DOCS-#4168: Fix rendering the examples on troubleshooting page (#4169)
   * DOCS-#4151: Add info in troubleshooting page related to Dask engine usage (#4152)
   * DOCS-#4172: Refresh Intel Distribution of Modin paragraph (#4175)
+  * DOCS-#4173: Mention strict channel priority in conda install section (#4178)
 * Dependencies
   * FIX-#4113, FIX-#4116, FIX-#4115: Apply new `black` formatting, fix pydocstyle check and readthedocs build (#4114)
   * TEST-#3227: Use codecov github action instead of bash form in GA workflows (#3226)


### PR DESCRIPTION
Signed-off-by: izamyati <igor.zamyatin@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Conda is rather slow installing modin-all and some other packages. Using strict channel priority speeds up the process

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4173  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
