### PR TITLE
FIX-#4177: Support read_feather from pathlike objects.

### DIFF
--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -11,6 +11,7 @@ Key Features and Updates
   * FIX-#4142: Fix OmniSci enabling (#4146)
   * FIX-#4162: Use `skipif` instead of `skip` for compatibility with pytest 7.0 (#4163)
   * FIX-#4158: Do not print OmniSci logs to stdout by default (#4159)
+  * FIX-#4177: Support read_feather from pathlike objects (#4177)
 * Performance enhancements
   *
 * Benchmarking enhancements
@@ -49,3 +50,4 @@ Contributors
 @devin-petersohn
 @dchigarev
 @Garra1980
+@mvashishtha

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -194,9 +194,9 @@ class FileDispatcher:
 
         Parameters
         ----------
-        file_path : str
-            String that represents the path to the file (paths to S3 buckets
-            are also acceptable).
+        file_path : str, os.PathLike[str] object or file-like object
+            The file, or a path to the file. Paths to S3 buckets are also
+            acceptable.
 
         Returns
         -------
@@ -208,7 +208,7 @@ class FileDispatcher:
         if `file_path` is an S3 bucket, parameter will be returned as is, otherwise
         absolute path will be returned.
         """
-        if S3_ADDRESS_REGEX.search(file_path):
+        if isinstance(file_path, str) and S3_ADDRESS_REGEX.search(file_path):
             return file_path
         else:
             return os.path.abspath(file_path)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -17,6 +17,7 @@ import pandas
 from pandas.errors import ParserWarning
 import pandas._libs.lib as lib
 from pandas.core.dtypes.common import is_list_like
+from pathlib import Path
 from collections import OrderedDict
 from modin.db_conn import ModinDatabaseConnection, UnsupportedDatabaseException
 from modin.config import TestDatasetSize, Engine, StorageFormat, IsExperimental
@@ -2127,6 +2128,12 @@ class TestFeather:
             fn_name="read_feather",
             path="s3://modin-datasets/testing/test_data.feather",
             storage_options=storage_options,
+        )
+
+    def test_read_feather_path_object(self, make_feather_file):
+        eval_io(
+            fn_name="read_feather",
+            path=Path(make_feather_file()),
         )
 
     @pytest.mark.xfail(


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Support `read_feather` from pathlike objects.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4177 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
