### PR TITLE
DOCS-#4176: Update OmniSci usage section

### DIFF
--- a/docs/development/using_omnisci.rst
+++ b/docs/development/using_omnisci.rst
@@ -18,8 +18,15 @@ or use it in your code:
    import modin.config as cfg
    cfg.StorageFormat.put('omnisci')
 
-Since OmniSci is run through its native engine Modin itself sets ``MODIN_ENGINE=Native``
-and you might not specify it explicitly.
+Since OmniSci is run through its native engine, Modin automatically sets ``MODIN_ENGINE=Native`` and you might not specify it explicitly.
+If for some reasons ``Native`` engine is explicitly set using modin.config or environment variable, make sure you also tell modin that
+``Experimental`` mode is turned on (``export MODIN_EXPERIMENTAL=true`` or ``cfg.IsExperimental.put(True)``) otherwise following error occurs:
+
+.. code-block:: bash
+
+   FactoryNotFoundError: Omnisci on Native is only accessible through the experimental API.
+   Run `import modin.experimental.pandas as pd` to use Omnisci on Native.
+
 
 .. note::
    If you encounter ``LLVM ERROR: inconsistency in registered CommandLine options`` error when using OmniSci,


### PR DESCRIPTION
Signed-off-by: izamyati <igor.zamyatin@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Give some details about using engine settings in case of Omnisci

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4176 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
