### PR TITLE
REFACTOR-#4223: use '@abc.abstractmethod' decorator in abstract classes

### DIFF
--- a/modin/core/dataframe/base/partitioning/axis_partition.py
+++ b/modin/core/dataframe/base/partitioning/axis_partition.py
@@ -13,7 +13,7 @@
 
 """Base class of an axis partition for a Modin Dataframe."""
 
-from abc import ABC
+from abc import ABC, abstractmethod
 
 
 class BaseDataframeAxisPartition(ABC):  # pragma: no cover
@@ -23,6 +23,11 @@ class BaseDataframeAxisPartition(ABC):  # pragma: no cover
     This class is intended to simplify the way that operations are performed.
     """
 
+    # Child classes must have these in order to correctly subclass.
+    instance_type = None
+    partition_type = None
+
+    @abstractmethod
     def apply(
         self,
         func,
@@ -68,6 +73,7 @@ class BaseDataframeAxisPartition(ABC):  # pragma: no cover
         """
         pass
 
+    @abstractmethod
     def shuffle(self, func, lengths, **kwargs):
         """
         Shuffle the order of the data in this axis partition based on the `lengths`.
@@ -87,10 +93,6 @@ class BaseDataframeAxisPartition(ABC):  # pragma: no cover
             A list of `BaseDataframePartition` objects split by `lengths`.
         """
         pass
-
-    # Child classes must have these in order to correctly subclass.
-    instance_type = None
-    partition_type = None
 
     def _wrap_partitions(self, partitions):
         """

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -13,7 +13,7 @@
 
 """The module defines base interface for a partition of a Modin DataFrame."""
 
-from abc import ABC
+from abc import ABC, abstractmethod
 from copy import copy
 
 import pandas
@@ -33,6 +33,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
     _length_cache = None
     _width_cache = None
 
+    @abstractmethod
     def get(self):
         """
         Get the object wrapped by this partition.
@@ -50,6 +51,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         """
         pass
 
+    @abstractmethod
     def apply(self, func, *args, **kwargs):
         """
         Apply a function to the object wrapped by this partition.
@@ -76,6 +78,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         """
         pass
 
+    @abstractmethod
     def add_to_apply_calls(self, func, *args, **kwargs):
         """
         Add a function to the call queue.
@@ -101,10 +104,12 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         """
         pass
 
+    @abstractmethod
     def drain_call_queue(self):
         """Execute all operations stored in the call queue on the object wrapped by this partition."""
         pass
 
+    @abstractmethod
     def wait(self):
         """Wait for completion of computations on the object wrapped by the partition."""
         pass
@@ -199,6 +204,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         return new_obj
 
     @classmethod
+    @abstractmethod
     def put(cls, obj):
         """
         Put an object into a store and wrap it with partition object.
@@ -216,6 +222,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         pass
 
     @classmethod
+    @abstractmethod
     def preprocess_func(cls, func):
         """
         Preprocess a function before an `apply` call.

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -112,8 +112,6 @@ class PandasDataframePartitionManager(ABC):
         """
         return cls._partition_class.preprocess_func(map_func)
 
-    # END Abstract Methods
-
     @classmethod
     def column_partitions(cls, partitions, full_axis=True):
         """

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -17,7 +17,7 @@ Module contains class ``BaseQueryCompiler``.
 ``BaseQueryCompiler`` is a parent abstract class for any other query compiler class.
 """
 
-import abc
+from abc import ABC, abstractmethod
 
 from modin.core.dataframe.algebra.default2pandas import (
     DataFrameDefault,
@@ -89,7 +89,7 @@ def _set_axis(axis):
 # Currently actual arguments are placed in the methods docstrings, but since they're
 # not presented in the function's signature it makes linter to raise `PR02: unknown parameters`
 # warning. For now, they're silenced by using `noqa` (Modin issue #3108).
-class BaseQueryCompiler(abc.ABC):
+class BaseQueryCompiler(ABC):
     """
     Abstract class that handles the queries to Modin dataframes.
 
@@ -109,7 +109,7 @@ class BaseQueryCompiler(abc.ABC):
     for a list of requirements for subclassing this object.
     """
 
-    @abc.abstractmethod
+    @abstractmethod
     def default_to_pandas(self, pandas_op, *args, **kwargs):
         """
         Do fallback to pandas for the passed function.
@@ -265,12 +265,12 @@ class BaseQueryCompiler(abc.ABC):
     # END Abstract join and append helper functions
 
     # Data Management Methods
-    @abc.abstractmethod
+    @abstractmethod
     def free(self):
         """Trigger a cleanup of this object."""
         pass
 
-    @abc.abstractmethod
+    @abstractmethod
     def finalize(self):
         """Finalize constructing the dataframe calling all deferred functions which were used to build it."""
         pass
@@ -278,7 +278,7 @@ class BaseQueryCompiler(abc.ABC):
     # END Data Management Methods
 
     # To/From Pandas
-    @abc.abstractmethod
+    @abstractmethod
     def to_pandas(self):
         """
         Convert underlying query compilers data to ``pandas.DataFrame``.
@@ -291,7 +291,7 @@ class BaseQueryCompiler(abc.ABC):
         pass
 
     @classmethod
-    @abc.abstractmethod
+    @abstractmethod
     def from_pandas(cls, df, data_cls):
         """
         Build QueryCompiler from pandas DataFrame.
@@ -315,7 +315,7 @@ class BaseQueryCompiler(abc.ABC):
 
     # From Arrow
     @classmethod
-    @abc.abstractmethod
+    @abstractmethod
     def from_arrow(cls, at, data_cls):
         """
         Build QueryCompiler from Arrow Table.

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/calcite_algebra.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/calcite_algebra.py
@@ -18,7 +18,7 @@ Provided classes reflect relational algebra format used by
 OmniSci storage format.
 """
 
-import abc
+from abc import ABC
 from .expr import BaseExpr
 
 
@@ -106,7 +106,7 @@ class CalciteInputIdxExpr(BaseExpr):
         return f"(input_idx {self.input})"
 
 
-class CalciteBaseNode(abc.ABC):
+class CalciteBaseNode(ABC):
     """
     A base class for a Calcite computation sequence node.
 

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/df_algebra.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/df_algebra.py
@@ -13,9 +13,10 @@
 
 """Module provides classes for lazy DataFrame algebra operations."""
 
-import abc
-from .expr import InputRefExpr
+from abc import ABC, abstractmethod
 from collections import OrderedDict
+
+from .expr import InputRefExpr
 
 
 class TransformMapper:
@@ -149,7 +150,7 @@ class InputMapper:
         return ref
 
 
-class DFAlgNode(abc.ABC):
+class DFAlgNode(ABC):
     """
     A base class for dataframe algebra tree node.
 
@@ -161,7 +162,7 @@ class DFAlgNode(abc.ABC):
         Holds child nodes.
     """
 
-    @abc.abstractmethod
+    @abstractmethod
     def copy(self):
         """
         Make a shallow copy of the node.
@@ -219,6 +220,7 @@ class DFAlgNode(abc.ABC):
         self.walk_dfs(lambda a, b: a._append_frames(b), frames)
         return frames
 
+    @abstractmethod
     def _append_partitions(self, partitions):
         """
         Append all used by the node partitions to `partitions` list.
@@ -233,6 +235,7 @@ class DFAlgNode(abc.ABC):
         """
         pass
 
+    @abstractmethod
     def _append_frames(self, frames):
         """
         Append all used by the node frames to `frames` list.
@@ -283,7 +286,7 @@ class DFAlgNode(abc.ABC):
         """
         return self._prints(prefix)
 
-    @abc.abstractmethod
+    @abstractmethod
     def _prints(self, prefix):
         """
         Return a string representation of the tree.

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/expr.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/expr.py
@@ -13,7 +13,7 @@
 
 """Module provides classes for scalar expression trees."""
 
-import abc
+from abc import ABC, abstractmethod
 from pandas.core.dtypes.common import (
     is_list_like,
     get_dtype,
@@ -130,7 +130,7 @@ def is_logical_op(op):
     return op in _logical_ops
 
 
-class BaseExpr(abc.ABC):
+class BaseExpr(ABC):
     """
     An abstract base class for expression tree node.
 
@@ -501,7 +501,7 @@ class BaseExpr(abc.ABC):
         else:
             raise NotImplementedError(f"unsupported binary operation {op_name}")
 
-    @abc.abstractmethod
+    @abstractmethod
     def copy(self):
         """
         Make a shallow copy of the expression.


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4223 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
