### PR TITLE
FIX-#4004: Added wrapper Index for get local values from methods

### DIFF
--- a/modin/experimental/cloud/rpyc_proxy.py
+++ b/modin/experimental/cloud/rpyc_proxy.py
@@ -709,3 +709,23 @@ def make_series_wrapper(Series):
     inherited from normal Series but wrapping all access to remote end transparently.
     """
     return _deliveringWrapper(Series, ["apply"], target_name="Series")
+
+
+def make_index_wrapper(Index):
+
+    conn = get_connection()
+
+    class IndexOverrides:
+        @property
+        def dtype(self):
+            return conn.obtain(self.__remote_end__.dtype)
+
+    DeliveringIndex = _deliveringWrapper(
+        Index,
+        [
+            "equals",
+        ],
+        IndexOverrides,
+        "Index",
+    )
+    return DeliveringIndex


### PR DESCRIPTION
Signed-off-by: aleksandr.lozovskii <aleksandr.lozovskii@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [X] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [X] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [X] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [X] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #4004?
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->


The problem arose due to the fact that two `Index` were being compared, one of which was `pandas.Index`, and the second was a proxy object. This fix adds a wrapper for `panda.Index` so that methods return local values.

The fix fixed a bug with infinite recursion: `RecursionError: maximum recursion depth exceeded while calling a Python object`, but in the same tests the error `AttributeError: type object 'ndarray' has no attribute '__iter__'` appeared, which was encountered earlier in `cloud`.