### PR TITLE
FIX-#4257: Fix Categorical() for scalar categories

### DIFF
--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -15,7 +15,7 @@ Key Features and Updates
   * FIX-#4234: Upgrade pandas to 1.4.1 (#4235)
   * FIX-#4057: Allow reading an empty parquet file (#4075)  
   * FIX-#3884: Fix read_excel() dropping empty rows (#4161)
-  * FIX-#4257: Fix Categorical() with for scalar categories (#4258) 
+  * FIX-#4257: Fix Categorical() for scalar categories (#4258) 
 * Performance enhancements
   * FIX-#4138, FIX-#4009: remove redundant sorting in the internal '.mask()' flow (#4140)
 * Benchmarking enhancements

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -15,6 +15,7 @@ Key Features and Updates
   * FIX-#4234: Upgrade pandas to 1.4.1 (#4235)
   * FIX-#4057: Allow reading an empty parquet file (#4075)  
   * FIX-#3884: Fix read_excel() dropping empty rows (#4161)
+  * FIX-#4257: Fix Categorical() with for scalar categories (#4258) 
 * Performance enhancements
   * FIX-#4138, FIX-#4009: remove redundant sorting in the internal '.mask()' flow (#4140)
 * Benchmarking enhancements

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -128,7 +128,8 @@ def find_common_type_cat(types):
                 categories = np.sort(categories)
             else:
                 # Cannot use np.sort() on array with ndim == 0
-                categories = [categories.item()]
+                # tolist() is called on scalar value and returns an int
+                categories = [categories.tolist()]
             return pandas.CategoricalDtype(
                 categories,
                 ordered=True,

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -128,8 +128,7 @@ def find_common_type_cat(types):
                 categories = np.sort(categories)
             else:
                 # Cannot use np.sort() on array with ndim == 0
-                # tolist() is called on scalar value and returns an int
-                categories = [categories.tolist()]
+                categories = [categories.item()]
             return pandas.CategoricalDtype(
                 categories,
                 ordered=True,

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -128,6 +128,7 @@ def find_common_type_cat(types):
                 categories = np.sort(categories)
             else:
                 # Cannot use np.sort() on array with ndim == 0
+                # tolist() is called on scalar value and returns an int
                 categories = [categories.tolist()]
             return pandas.CategoricalDtype(
                 categories,

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -123,8 +123,14 @@ def find_common_type_cat(types):
     """
     if all(isinstance(t, pandas.CategoricalDtype) for t in types):
         if all(t.ordered for t in types):
+            categories = np.unique([c for t in types for c in t.categories])[0]
+            if categories.ndim != 0:
+                categories = np.sort(categories)
+            else:
+                # Cannot use np.sort() on array with ndim == 0
+                categories = [categories.tolist()]
             return pandas.CategoricalDtype(
-                np.sort(np.unique([c for t in types for c in t.categories])[0]),
+                categories,
                 ordered=True,
             )
         return union_categoricals(

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2132,11 +2132,11 @@ def test_iloc_assigning_scalar_none_to_string_series():
 
 
 def test_categorical_dataframe_ordering():
-    data = {'a': [1, 2, 3], 'b': [4, 5, 6]}
+    data = {"a": [1, 2, 3], "b": [4, 5, 6]}
     mdf = pd.DataFrame(data)
     pdf = pandas.DataFrame(data)
-    mdf['a'] = pd.Categorical(mdf['a'], ordered=True)
-    pdf['a'] = pandas.Categorical(pdf['a'], ordered=True)
+    mdf["a"] = pd.Categorical(mdf["a"], ordered=True)
+    pdf["a"] = pandas.Categorical(pdf["a"], ordered=True)
     df_equals(mdf, pdf)
 
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2131,7 +2131,7 @@ def test_iloc_assigning_scalar_none_to_string_series():
     df_equals(modin_series, pandas_series)
 
 
-def test_categorical_dataframe_ordering():
+def test_set_ordered_categorical_column():
     data = {"a": [1, 2, 3], "b": [4, 5, 6]}
     mdf = pd.DataFrame(data)
     pdf = pandas.DataFrame(data)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2131,6 +2131,15 @@ def test_iloc_assigning_scalar_none_to_string_series():
     df_equals(modin_series, pandas_series)
 
 
+def test_categorical_dataframe_ordering():
+    data = {'a': [1, 2, 3], 'b': [4, 5, 6]}
+    mdf = pd.DataFrame(data)
+    pdf = pandas.DataFrame(data)
+    mdf['a'] = pd.Categorical(mdf['a'], ordered=True)
+    pdf['a'] = pandas.Categorical(pdf['a'], ordered=True)
+    df_equals(mdf, pdf)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_lt(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
Signed-off-by: Naren Krishna <naren@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Fixed the issue in #4257. `np.sort()` cannot be called on 0-dimensional arrays, so create a special case. 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
