### PR TITLE
REFACTOR-#4322: Move is_reduce_fn outside of groupby_agg.

### DIFF
--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -39,7 +39,7 @@ Key Features and Updates
   * REFACTOR-#3900: add flake8-no-implicit-concat plugin and refactor flake8 error codes (#3901)
   * REFACTOR-#4093: Refactor base to be smaller (#4220)
   * REFACTOR-#4047: Rename `cluster` directory to `cloud` in examples (#4212)
-  * REFACTOR-#4323: Move is_reduce_fn outside of groupby_agg (#4323)
+  * REFACTOR-#4322: Move is_reduce_fn outside of groupby_agg (#4323)
 * Pandas API implementations and improvements
   * FEAT-#979: Enable reading from SQL server (#4279)
 * OmniSci enhancements

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -39,6 +39,7 @@ Key Features and Updates
   * REFACTOR-#3900: add flake8-no-implicit-concat plugin and refactor flake8 error codes (#3901)
   * REFACTOR-#4093: Refactor base to be smaller (#4220)
   * REFACTOR-#4047: Rename `cluster` directory to `cloud` in examples (#4212)
+  * REFACTOR-#4323: Move is_reduce_fn outside of groupby_agg (#4323)
 * Pandas API implementations and improvements
   * FEAT-#979: Enable reading from SQL server (#4279)
 * OmniSci enhancements

--- a/modin/core/dataframe/algebra/__init__.py
+++ b/modin/core/dataframe/algebra/__init__.py
@@ -19,10 +19,7 @@ from .tree_reduce import TreeReduce
 from .reduce import Reduce
 from .fold import Fold
 from .binary import Binary
-from .groupby import (
-    GroupByReduce,
-    groupby_reduce_functions,
-)
+from .groupby import GroupByReduce, groupby_reduce_functions, is_reduce_function
 
 __all__ = [
     "Operator",
@@ -33,4 +30,5 @@ __all__ = [
     "Binary",
     "GroupByReduce",
     "groupby_reduce_functions",
+    "is_reduce_function",
 ]

--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -541,4 +541,4 @@ def is_reduce_function(fn):
     bool
         Whether all functions defined by `fn` are reductions.
     """
-    return _is_reduce_function_with_depth(fn, 0)
+    return _is_reduce_function_with_depth(fn, depth=0)

--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -13,6 +13,7 @@
 
 """Module houses builder class for GroupByReduce operator."""
 
+from collections.abc import Container
 import pandas
 
 from .tree_reduce import TreeReduce
@@ -484,3 +485,60 @@ groupby_reduce_functions = {
     "size": ("size", "sum"),
     "sum": ("sum", "sum"),
 }
+
+
+def _is_reduce_function_with_depth(fn, depth: int = 0):
+    """
+    Check whether all functions defined by `fn` are groupby reductions.
+
+    If true, all functions defined by `fn` can be implemented with TreeReduce.
+    This is a recursive helper function for is_reduce_function.
+
+    Parameters
+    ----------
+    fn : Any
+        Function to test.
+    depth : int, default: 0
+        How many nested containers we are within for this check.
+            - if it's 0, then we're outside of any container, and `fn` could be
+              either function name or container of function names/renamers.
+            - if it's 1, then we're inside container of function
+              names/renamers.`fn` must be either function name or renamer.
+              renamer is some container which length == 2, where the first
+              element is the new column name and the second is the function
+              name.
+
+    Returns
+    -------
+    bool
+        Whether all functions defined by `fn` are reductions.
+    """
+    if not isinstance(fn, str) and isinstance(fn, Container):
+        assert depth == 0 or (
+            depth > 0 and len(fn) == 2
+        ), f"Got the renamer with incorrect length, expected 2 got {len(fn)}."
+        return (
+            all(is_reduce_function(f, depth + 1) for f in fn)
+            if depth == 0
+            else is_reduce_function(fn[1], depth + 1)
+        )
+    return isinstance(fn, str) and fn in groupby_reduce_functions
+
+
+def is_reduce_function(fn):
+    """
+    Check whether all functions defined by `fn` are groupby reductions.
+
+    If true, all functions defined by `fn` can be implemented with TreeReduce.
+
+    Parameters
+    ----------
+    fn : Any
+        Function to test.
+
+    Returns
+    -------
+    bool
+        Whether all functions defined by `fn` are reductions.
+    """
+    return _is_reduce_function_with_depth(fn, 0)

--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -518,9 +518,9 @@ def _is_reduce_function_with_depth(fn, depth: int = 0):
             depth > 0 and len(fn) == 2
         ), f"Got the renamer with incorrect length, expected 2 got {len(fn)}."
         return (
-            all(is_reduce_function(f, depth + 1) for f in fn)
+            all(_is_reduce_function_with_depth(f, depth + 1) for f in fn)
             if depth == 0
-            else is_reduce_function(fn[1], depth + 1)
+            else _is_reduce_function_with_depth(fn[1], depth + 1)
         )
     return isinstance(fn, str) and fn in groupby_reduce_functions
 


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

Move `is_reduce_fn` outside of the pandas query compiler's `groupby_agg`.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4322 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
