### PR TITLE
FEAT-#3043: allow `pandas.DataFrame` to be passed into `merge` and `join` functions

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -448,7 +448,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         sort = kwargs.get("sort", False)
 
         if how in ["left", "inner"] and left_index is False and right_index is False:
-            right = right.to_pandas()
+            if not isinstance(right, pandas.DataFrame):
+                right = right.to_pandas()
 
             kwargs["sort"] = False
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -496,7 +496,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         sort = kwargs.get("sort", False)
 
         if how in ["left", "inner"]:
-            right = right.to_pandas()
+            if not isinstance(right, pandas.DataFrame):
+                right = right.to_pandas()
 
             def map_func(left, right=right, kwargs=kwargs):
                 return pandas.DataFrame.join(left, right, **kwargs)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1387,19 +1387,25 @@ class DataFrame(BasePandasDataset):
                 raise ValueError("Cannot merge a Series without a name")
             else:
                 right = right.to_frame()
-        if not isinstance(right, DataFrame):
+        if not isinstance(right, (DataFrame, pandas.DataFrame)):
             raise TypeError(
                 f"Can only merge Series or DataFrame objects, a {type(right)} was passed"
             )
 
         if left_index and right_index:
+            if not isinstance(right, DataFrame):
+                raise TypeError(
+                    f"Can only merge Series or DataFrame objects, a {type(right)} was passed"
+                )
             return self.join(
                 right, how=how, lsuffix=suffixes[0], rsuffix=suffixes[1], sort=sort
             )
 
         return self.__constructor__(
             query_compiler=self._query_compiler.merge(
-                right._query_compiler,
+                right._query_compiler
+                if not isinstance(right, pandas.DataFrame)
+                else right,
                 how=how,
                 on=on,
                 left_on=left_on,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1258,7 +1258,9 @@ class DataFrame(BasePandasDataset):
         if on is not None:
             return self.__constructor__(
                 query_compiler=self._query_compiler.join(
-                    other._query_compiler,
+                    other._query_compiler
+                    if not isinstance(other, pandas.DataFrame)
+                    else other,
                     on=on,
                     how=how,
                     lsuffix=lsuffix,
@@ -1266,6 +1268,8 @@ class DataFrame(BasePandasDataset):
                     sort=sort,
                 )
             )
+        if isinstance(other, pandas.DataFrame):
+            other = DataFrame(other)
         if isinstance(other, DataFrame):
             # Joining the empty DataFrames with either index or columns is
             # fast. It gives us proper error checking for the edge cases that

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -21,6 +21,7 @@ from modin.utils import get_current_execution, to_pandas
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 
 from .utils import (
+    test_data,
     test_data_values,
     test_data_keys,
     df_equals,
@@ -177,6 +178,21 @@ def test_merge():
 
     with pytest.raises(TypeError):
         pd.merge("Non-valid type", modin_df2)
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_merge_pandas(data):
+    modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
+    df_equals(modin_df.merge(pandas_df), modin_df.merge(modin_df))
+
+
+def test_join_pandas():
+    data = test_data["int_data"]
+    modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
+    df_equals(
+        modin_df.join(pandas_df, lsuffix="left", on="col3"),
+        modin_df.join(modin_df, lsuffix="left", on="col3"),
+    )
 
 
 def test_merge_ordered():


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3043 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
