### PR TITLE
implement multi-column assignment in '__setitem__' (draft)

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -323,7 +323,7 @@ class PandasDataframe(object):
         if old_len != new_len:
             raise ValueError(
                 f"Length mismatch: Expected axis has {old_len} elements, "
-                + "new values have {new_len} elements"
+                + f"new values have {new_len} elements"
             )
         return new_labels
 

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1215,11 +1215,6 @@ class PandasDataframePartitionManager(ABC):
                             row_position_counter : row_position_counter + row_offset,
                             col_position_counter : col_position_counter + col_offset,
                         ]
-                    elif isinstance(item_to_distribute, pandas.DataFrame):
-                        item = item_to_distribute.iloc[
-                            row_position_counter : row_position_counter + row_offset,
-                            col_position_counter : col_position_counter + col_offset,
-                        ]
                     else:
                         item = item_to_distribute
                     item = {"item": item}

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1210,8 +1210,13 @@ class PandasDataframePartitionManager(ABC):
                 )
 
                 if item_to_distribute is not no_default:
-                    if isinstance(item_to_distribute, np.ndarray):
+                    if isinstance(item_to_distribute, (np.ndarray, pandas.Series)):
                         item = item_to_distribute[
+                            row_position_counter : row_position_counter + row_offset,
+                            col_position_counter : col_position_counter + col_offset,
+                        ]
+                    elif isinstance(item_to_distribute, pandas.DataFrame):
+                        item = item_to_distribute.iloc[
                             row_position_counter : row_position_counter + row_offset,
                             col_position_counter : col_position_counter + col_offset,
                         ]

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1210,7 +1210,7 @@ class PandasDataframePartitionManager(ABC):
                 )
 
                 if item_to_distribute is not no_default:
-                    if isinstance(item_to_distribute, (np.ndarray, pandas.Series)):
+                    if isinstance(item_to_distribute, np.ndarray):
                         item = item_to_distribute[
                             row_position_counter : row_position_counter + row_offset,
                             col_position_counter : col_position_counter + col_offset,

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1198,6 +1198,7 @@ class PandasDataframePartitionManager(ABC):
         for row_idx, row_values in enumerate(row_partitions_list):
             row_blk_idx, row_internal_idx = row_values
             col_position_counter = 0
+            row_offset = 0
             for col_idx, col_values in enumerate(col_partitions_list):
                 col_blk_idx, col_internal_idx = col_values
                 remote_part = partition_copy[row_blk_idx, col_blk_idx]

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3062,13 +3062,13 @@ class BaseQueryCompiler(abc.ABC):
 
         Parameters
         ----------
-        row_numeric_index : list of ints
-            Row positions to write value.
-        col_numeric_index : list of ints
-            Column positions to write value.
-        broadcasted_items : 2D-array
+        row_numeric_index : list, np.ndarray, slice(None), pandas.RangeIndex
+            Row numeric positions to write value.
+        col_numeric_index : list, np.ndarray, slice(None), pandas.RangeIndex
+            Column numeric positions to write value.
+        broadcasted_items : 2D-array or scalar
             Values to write. Have to be same size as defined by `row_numeric_index`
-            and `col_numeric_index`.
+            and `col_numeric_index` except scalar case.
 
         Returns
         -------

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3062,9 +3062,9 @@ class BaseQueryCompiler(abc.ABC):
 
         Parameters
         ----------
-        row_numeric_index : list of ints or slice
+        row_numeric_index : list of ints
             Row positions to write value.
-        col_numeric_index : list of ints or slice
+        col_numeric_index : list of ints
             Column positions to write value.
         broadcasted_items : 2D-array
             Values to write. Have to be same size as defined by `row_numeric_index`

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3062,9 +3062,9 @@ class BaseQueryCompiler(abc.ABC):
 
         Parameters
         ----------
-        row_numeric_index : list of ints
+        row_numeric_index : list of ints or slice
             Row positions to write value.
-        col_numeric_index : list of ints
+        col_numeric_index : list of ints or slice
             Column positions to write value.
         broadcasted_items : 2D-array
             Values to write. Have to be same size as defined by `row_numeric_index`
@@ -3079,9 +3079,7 @@ class BaseQueryCompiler(abc.ABC):
         def write_items(df, broadcasted_items):
             if isinstance(df.iloc[row_numeric_index, col_numeric_index], pandas.Series):
                 broadcasted_items = broadcasted_items.squeeze()
-            df.iloc[
-                list(row_numeric_index), list(col_numeric_index)
-            ] = broadcasted_items
+            df.iloc[row_numeric_index, col_numeric_index] = broadcasted_items
             return df
 
         return DataFrameDefault.register(write_items)(

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -36,7 +36,7 @@ import warnings
 
 from modin.pandas import Categorical
 from modin.error_message import ErrorMessage
-from modin.utils import _inherit_docstrings, to_pandas, hashable, try_cast_to_pandas
+from modin.utils import _inherit_docstrings, to_pandas, hashable
 from modin.config import Engine, IsExperimental, PersistentPickle
 from .utils import (
     from_pandas,
@@ -2536,36 +2536,7 @@ class DataFrame(BasePandasDataset):
             return
 
         if isinstance(key, list) and is_list_like(value):
-            if not isinstance(
-                value,
-                (
-                    np.ndarray,
-                    pandas.Index,
-                    pandas.Series,
-                    pandas.DataFrame,
-                    Series,
-                    DataFrame,
-                ),
-            ):
-                # Converting to numpy to be able to access `.shape` property
-                value = np.array(value)
-
-            if len(key) != value.shape[0 if value.ndim == 1 else 1]:
-                raise ValueError("Columns must be same length as key")
-
-            if isinstance(value, (Series, DataFrame)):
-                ErrorMessage.default_to_pandas("Multi-column `__setitem__`")
-                value = try_cast_to_pandas(value)
-
-            if value.ndim != 2:
-                value = np.broadcast_to(value, shape=(len(self), len(key)))
-
-            res = self._query_compiler.write_items(
-                row_numeric_index=slice(None),
-                col_numeric_index=self.columns.get_indexer_for(key),
-                broadcasted_items=value,
-            )
-            self._update_inplace(res)
+            self.loc[slice(None), key] = value
             return
 
         if not hashable(key):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -36,7 +36,7 @@ import warnings
 
 from modin.pandas import Categorical
 from modin.error_message import ErrorMessage
-from modin.utils import _inherit_docstrings, to_pandas, hashable
+from modin.utils import _inherit_docstrings, to_pandas, hashable, try_cast_to_pandas
 from modin.config import Engine, IsExperimental, PersistentPickle
 from .utils import (
     from_pandas,

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -376,14 +376,8 @@ class _LocationIndexerBase(object):
             self.df._create_or_update_from_compiler(new_qc, inplace=True)
         # Assignment to both axes.
         else:
-            if isinstance(row_lookup, slice):
-                new_row_len = len(self.df.index[row_lookup])
-            else:
-                new_row_len = len(row_lookup)
-            if isinstance(col_lookup, slice):
-                new_col_len = len(self.df.columns[col_lookup])
-            else:
-                new_col_len = len(col_lookup)
+            new_row_len = len(row_lookup)
+            new_col_len = len(col_lookup)
             to_shape = new_row_len, new_col_len
             if not is_scalar(item):
                 item = self._broadcast_item(row_lookup, col_lookup, item, to_shape)

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -701,35 +701,6 @@ class _LocIndexer(_LocationIndexerBase):
         if isinstance(row_loc, slice) and row_loc == slice(None):
             # fast path for columns case
             if hashable(col_loc) and col_loc not in self.qc.columns:
-                if isinstance(item, Series) and len(self.qc.columns) == 0:
-                    self.df._update_inplace(item._query_compiler.copy())
-                    # Now that the data is appended, we need to update the column name for
-                    # that column to `key`, otherwise the name could be incorrect. Drop the
-                    # last column name from the list (the appended item's name and append
-                    # the new name.
-                    self.df.columns = self.df.columns[:-1].append(
-                        pandas.Index([col_loc])
-                    )
-                    self.qc = self.df._query_compiler
-                    return
-                elif (
-                    isinstance(item, (pandas.DataFrame, DataFrame))
-                    and item.shape[1] != 1
-                ):
-                    raise ValueError(
-                        "Wrong number of items passed %i, placement implies 1"
-                        % item.shape[1]
-                    )
-                elif isinstance(item, np.ndarray) and len(item.shape) > 1:
-                    if item.shape[1] == 1:
-                        # Transform into columnar table and take first column
-                        item = item.copy().T[0]
-                    else:
-                        raise ValueError(
-                            "Wrong number of items passed %i, placement implies 1"
-                            % item.shape[1]
-                        )
-
                 # Do new column assignment after error checks and possible item modifications
                 # inplace operation
                 self.df.insert(loc=len(self.qc.columns), column=col_loc, value=item)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1784,10 +1784,15 @@ def test_setitem_unhashable_key():
     modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
     count_rows = modin_df.shape[0]
     value = [[1, 2]] * count_rows
-    key = ["test_col1", "test_col2"]
+    # Failed with columns that doesn't exist
+    key = ["col1", "col2"]
     # TODO: add no warning check
     modin_df[key], pandas_df[key] = value, value
     df_equals(modin_df, pandas_df)
+    # This should also work
+    # df_value = pandas.DataFrame(value)
+    # modin_df[key], pandas_df[key] = df_value, df_value
+    # df_equals(modin_df, pandas_df)
 
 
 def test___setitem__single_item_in_series():

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1779,6 +1779,17 @@ def test___setitem__unhashable_list():
     df_equals(modin_df, pandas_df)
 
 
+def test_setitem_unhashable_key():
+    data = test_data["float_nan_data"]
+    modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
+    count_rows = modin_df.shape[0]
+    value = [[1, 2]] * count_rows
+    key = ["test_col1", "test_col2"]
+    # TODO: add no warning check
+    modin_df[key], pandas_df[key] = value, value
+    df_equals(modin_df, pandas_df)
+
+
 def test___setitem__single_item_in_series():
     # Test assigning a single item in a Series for issue
     # https://github.com/modin-project/modin/issues/3860


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

* In addition to implementing efficient handling of the case when multiple columns are added at once, this PR also does some refactoring. Its main idea is that we can reuse the code of `loc` function for `__setitem__` function, thus reducing the complexity of the code that performs the indexing.
* Main change: the case when key is hashable or when it is of list type now handled in `loc` function. All optimizations that were in `__setitem__` function are now also moved to.
* An interesting and discussed point is the handling of the situation when several rows / columns are added at once. This flow of execution corresponds to `axis==None` (when `axis in {0, 1}` `qc.setitem` function is executed). The following functions are executed on the path: `compute_lookup`, `broadcast_item`, `write_items`. They are written with one fundamental limitation - adding objects is only possible if the corresponding labels (that used in `key`) are already present in the object. To get around this limitation, I have to do an explicit reindexing, which adds rows/columns with NaN values. In addition to the fact that we can do this operation directly in `write_items` (I think so) much more efficient than it is now, it also leads to problems with changing columns dtype, which most likely does not correspond to the behavior of pandas.
* 

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4325 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
