### PR TITLE
FIX-#4327: Update min pin for xgboost version

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -25,9 +25,10 @@ Key Features and Updates
 * Documentation improvements
   *
 * Dependencies
-  *
+  * FIX-#4327: Update min pin for xgboost version (#4328)
 
 Contributors
 ------------
 @YarShev
 @Garra1980
+@prutskov

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -38,7 +38,7 @@ dependencies:
   - pymssql
   - psycopg2
   - pip:
-      - xgboost>=1.3
+      - xgboost>=1.5.0
       - modin-spreadsheet>=0.1.1
       - tqdm
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -29,7 +29,7 @@ cloudpickle
 rpyc==4.1.5
 scikit-learn
 git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
-xgboost>=1.3
+xgboost>=1.5.0
 tqdm
 modin-spreadsheet>=0.1.1
 pymssql

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -31,7 +31,7 @@ dependencies:
   - cloudpickle
   - boto3
   - pip:
-      - xgboost>=1.3
+      - xgboost>=1.5.0
       - modin-spreadsheet>=0.1.1
       - tqdm
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

PR updates min pin for xgboost, because Modin uses behavior of xgboost which started from 1.5.0.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4327  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
