### PR TITLE
FIX-#4330: Override the memory limit to start ray 1.11.0 on Macs.

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -12,6 +12,7 @@ Key Features and Updates
   * FIX-#4392: Align Modin XGBoost with xgb>=1.6 (#4393)
   * FIX-#4385: Get rid of `use-deprecated` option in `pip` (#4386)
   * FIX-#3527: Fix parquet partitioning issue causing negative row length partitions (#4368)
+  * FIX-#4330: Override the memory limit to start ray 1.11.0 on Macs (#4335)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
 * Benchmarking enhancements
@@ -45,3 +46,4 @@ Contributors
 @amyskov
 @wangxiaoying
 @jeffreykennethli
+@mvashishtha

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -171,8 +171,14 @@ def initialize_ray(
             else:
                 object_store_memory = int(object_store_memory)
 
-            mac_size_limit = ray.ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT
-            if sys.platform == "darwin" and object_store_memory > mac_size_limit:
+            mac_size_limit = getattr(
+                ray.ray_constants, "MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT", None
+            )
+            if (
+                sys.platform == "darwin"
+                and mac_size_limit is not None
+                and object_store_memory > mac_size_limit
+            ):
                 warnings.warn(
                     "On Macs, Ray's performance is known to degrade with "
                     + "object store size greater than "

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -186,7 +186,8 @@ def initialize_ray(
                     + "not allow setting an object store size greater than "
                     + "that. Modin is overriding that default limit because "
                     + "it would rather have a larger, slower object store "
-                    + "than spill to disk more often."
+                    + "than spill to disk more often. To override Modin's "
+                    + "behavior, you can initialize Ray yourself."
                 )
                 os.environ["RAY_ENABLE_MAC_LARGE_OBJECT_STORE"] = "1"
 

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -179,8 +179,8 @@ def initialize_ray(
                     + f"{mac_size_limit / 2 ** 30:.4} GiB. Ray by default does "
                     + "not allow setting an object store size greater than "
                     + "that. Modin is overriding that default limit because "
-                    + "because it would rather have a larger, slower object "
-                    + "store than spill to disk more often."
+                    + "it would rather have a larger, slower object store "
+                    + "than spill to disk more often."
                 )
                 os.environ["RAY_ENABLE_MAC_LARGE_OBJECT_STORE"] = "1"
 

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -171,6 +171,19 @@ def initialize_ray(
             else:
                 object_store_memory = int(object_store_memory)
 
+            mac_size_limit = ray.ray_constants.MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT
+            if sys.platform == "darwin" and object_store_memory > mac_size_limit:
+                warnings.warn(
+                    "On Macs, Ray's performance is known to degrade with "
+                    + "object store size greater than "
+                    + f"{mac_size_limit / 2 ** 30:.4} GiB. Ray by default does "
+                    + "not allow setting an object store size greater than "
+                    + "that. Modin is overriding that default limit because "
+                    + "because it would rather have a larger, slower object "
+                    + "store than spill to disk more often."
+                )
+                os.environ["RAY_ENABLE_MAC_LARGE_OBJECT_STORE"] = "1"
+
             ray_init_kwargs = {
                 "num_cpus": CpuCount.get(),
                 "num_gpus": GpuCount.get(),


### PR DESCRIPTION
## What do these changes do?

Override the memory limit to start ray 1.11.0 on Macs.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4330 
- [🚫 ] tests added and passing, but I did test manually with object store sizes 2147483648 and 2147483649
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
