### PR TITLE
FEAT-#4342: Support `from_dataframe` for pandas storage format

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -483,6 +483,7 @@ jobs:
       - run: python -m pytest modin/experimental/pandas/test/test_io_exp.py
       - run: pip install "dfsql>=0.4.2" "pyparsing<=2.4.7" && pytest modin/experimental/sql/test/test_sql.py
       - run: pytest modin/test/exchange/dataframe_protocol/test_general.py
+      - run: pytest modin/test/exchange/dataframe_protocol/pandas/test_protocol.py
       - uses: codecov/codecov-action@v2
 
   test-experimental:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -184,6 +184,7 @@ jobs:
       - run: python -m pytest modin/pandas/test/test_io.py
       - run: python -m pytest modin/experimental/pandas/test/test_io_exp.py
       - run: pytest modin/test/exchange/dataframe_protocol/test_general.py
+      - run: pytest modin/test/exchange/dataframe_protocol/pandas/test_protocol.py
       - uses: codecov/codecov-action@v2
 
   test-windows:

--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -24,8 +24,8 @@ Key Features and Updates
   * FIX-#4303: Fix the syntax error in reading from postgres (#4304)
   * FIX-#4308: Add proper error handling in df.set_index (#4309)
   * FIX-#4056: Allow an empty parse_date list in `read_csv_glob` (#4074)
-  * FIX-#4312: Fix constructing categorical frame with duplicate column names (#4313).  
-  * FIX-#4314: Allow passing a series of dtypes to astype (#4318)  
+  * FIX-#4312: Fix constructing categorical frame with duplicate column names (#4313).
+  * FIX-#4314: Allow passing a series of dtypes to astype (#4318)
 * Performance enhancements
   * FIX-#4138, FIX-#4009: remove redundant sorting in the internal '.mask()' flow (#4140)
   * FIX-#4183: Stop shallow copies from creating global shared state. (#4184)
@@ -54,6 +54,8 @@ Key Features and Updates
 * Developer API enhancements
   * FEAT-#4245: Define base interface for dataframe exchange protocol (#4246)
   * FEAT-#4244: Implement dataframe exchange protocol for OmnisciOnNative execution (#4269)
+  * FEAT-#4144: Implement dataframe exchange protocol for pandas storage format (#4150)
+  * FEAT-#4342: Support `from_dataframe`` for pandas storage format (#4343)
 * Update testing suite
   * TEST-#3628: Report coverage data for `test-internals` CI job (#4198)
   * TEST-#3938: Test tutorial notebooks in CI (#4145)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2859,3 +2859,36 @@ class PandasDataframe(object):
         return PandasProtocolDataframe(
             self, nan_as_null=nan_as_null, allow_copy=allow_copy
         )
+
+    @classmethod
+    def from_dataframe(cls, df: "ProtocolDataframe") -> "PandasDataframe":
+        """
+        Convert a DataFrame implementing the dataframe exchange protocol to a Core Modin Dataframe.
+
+        See more about the protocol in https://data-apis.org/dataframe-protocol/latest/index.html.
+
+        Parameters
+        ----------
+        df : ProtocolDataframe
+            The DataFrame object supporting the dataframe exchange protocol.
+
+        Returns
+        -------
+        PandasDataframe
+            A new Core Modin Dataframe object.
+        """
+        if isinstance(df, cls):
+            return df
+
+        if not hasattr(df, "__dataframe__"):
+            raise ValueError(
+                "`df` does not support DataFrame exchange protocol, i.e. `__dataframe__` method"
+            )
+
+        from modin.core.dataframe.pandas.exchange.dataframe_protocol.from_dataframe import (
+            from_dataframe_to_pandas,
+        )
+
+        ErrorMessage.default_to_pandas(message="`from_dataframe`")
+        pandas_df = from_dataframe_to_pandas(df)
+        return cls.from_pandas(pandas_df)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2877,7 +2877,7 @@ class PandasDataframe(object):
         PandasDataframe
             A new Core Modin Dataframe object.
         """
-        if isinstance(df, cls):
+        if type(df) == cls:
             return df
 
         if not hasattr(df, "__dataframe__"):

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -274,9 +274,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     @classmethod
     def from_dataframe(cls, df, data_cls):
-        raise NotImplementedError(
-            "The selected execution does not implement the DataFrame exchange protocol yet."
-        )
+        return cls(data_cls.from_dataframe(df))
 
     # END Dataframe exchange protocol
 

--- a/modin/test/exchange/dataframe_protocol/pandas/__init__.py
+++ b/modin/test/exchange/dataframe_protocol/pandas/__init__.py
@@ -1,0 +1,12 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.

--- a/modin/test/exchange/dataframe_protocol/pandas/test_protocol.py
+++ b/modin/test/exchange/dataframe_protocol/pandas/test_protocol.py
@@ -1,0 +1,41 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Dataframe exchange protocol tests that are specific for pandas storage format implementation."""
+
+import modin.pandas as pd
+from modin.pandas.utils import from_dataframe
+from modin.pandas.test.utils import df_equals, test_data
+from modin.test.test_utils import warns_that_defaulting_to_pandas
+
+
+def test_simple_import():
+    modin_df_producer = pd.DataFrame(test_data["int_data"])
+    # Our configuration in pytest.ini requires that we explicitly catch all
+    # instances of defaulting to pandas, this one raises a warning on `.from_dataframe`
+    with warns_that_defaulting_to_pandas():
+        modin_df_consumer = from_dataframe(modin_df_producer)
+
+    # TODO: the following assertions verify that `from_dataframe` doesn't return
+    # the same object untouched due to optimization branching, it actually should
+    # do so but the logic is not implemented yet, so the assertions are passing
+    # for now. It's required to replace the producer's type with a different one
+    # to consumer when we have some other implementation of the protocol as the
+    # assertions may start failing shortly.
+    assert modin_df_producer is not modin_df_consumer
+    assert (
+        modin_df_producer._query_compiler._modin_frame
+        is not modin_df_consumer._query_compiler._modin_frame
+    )
+
+    df_equals(modin_df_producer, modin_df_consumer)


### PR DESCRIPTION
Signed-off-by: Igoshev, Yaroslav <yaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4342  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
