### PR TITLE
FEAT-#4320: Add `connectorx` as an alternative engine for `read_sql`

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -10,7 +10,7 @@ Key Features and Updates
   * FIX-#3615: Relax some deps in development env (#4365)
   * FIX-#4370: Fix broken docstring links (#4375)
 * Performance enhancements
-  *
+  * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
 * Benchmarking enhancements
   *
 * Refactor Codebase
@@ -38,3 +38,4 @@ Contributors
 @prutskov
 @alexander3774
 @amyskov
+@wangxiaoying

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -42,3 +42,4 @@ dependencies:
       - tqdm
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
       - ray[default]>=1.4.0
+      - connectorx>=0.2.6a4

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -460,6 +460,14 @@ class TestReadFromPostgres(EnvironmentVariable, type=bool):
     default = False
 
 
+class ReadSqlEngine(EnvironmentVariable, type=str):
+    """Engine to run `read_sql`."""
+
+    varname = "MODIN_READ_SQL_ENGINE"
+    default = "Pandas"
+    choices = ("Pandas", "Connectorx")
+
+
 def _check_vars():
     """
     Check validity of environment variables.

--- a/modin/core/io/sql/sql_dispatcher.py
+++ b/modin/core/io/sql/sql_dispatcher.py
@@ -26,7 +26,7 @@ import warnings
 
 from modin.core.io.file_dispatcher import FileDispatcher
 from modin.db_conn import ModinDatabaseConnection
-from modin.config import NPartitions
+from modin.config import NPartitions, ReadSqlEngine
 
 
 class SQLDispatcher(FileDispatcher):
@@ -63,7 +63,13 @@ class SQLDispatcher(FileDispatcher):
                 + f"of {type(con)}. For documentation of ModinDatabaseConnection, see "
                 + "https://modin.readthedocs.io/en/latest/supported_apis/io_supported.html#connecting-to-a-database-for-read-sql"
             )
-            return cls.single_worker_read(sql, con=con, index_col=index_col, **kwargs)
+            return cls.single_worker_read(
+                sql,
+                con=con,
+                index_col=index_col,
+                read_sql_engine=ReadSqlEngine.get(),
+                **kwargs,
+            )
         row_count_query = con.row_count_query(sql)
         connection_for_pandas = con.get_connection()
         colum_names_query = con.column_names_query(sql)
@@ -87,6 +93,7 @@ class SQLDispatcher(FileDispatcher):
                 sql=query,
                 con=con,
                 index_col=index_col,
+                read_sql_engine=ReadSqlEngine.get(),
                 **kwargs,
             )
             partition_ids.append(

--- a/modin/db_conn.py
+++ b/modin/db_conn.py
@@ -104,6 +104,16 @@ class ModinDatabaseConnection:
 
         raise UnsupportedDatabaseException("Unsupported database library")
 
+    def get_string(self):
+        """
+        Get input connection string.
+
+        Returns
+        -------
+        str
+        """
+        return self.args[0]
+
     def column_names_query(self, query):
         """
         Get a query that gives the names of columns that `query` would produce.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -33,3 +33,4 @@ tqdm
 modin-spreadsheet>=0.1.1
 pymssql
 psycopg2
+connectorx>=0.2.6a4

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -34,3 +34,4 @@ dependencies:
       - modin-spreadsheet>=0.1.1
       - tqdm
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
+      - connectorx>=0.2.6a4


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Add connectorx as an alternative engine for `read_sql`. #4320

I tested locally by setting the env var `READ_SQL_ENGINE` to `connectorx` and it works fine. However, when I set the config by `ReadSqlEngine.put("connectorx")` (like [here](https://github.com/wangxiaoying/cx-modin/blob/main/tpch-modin.py#L29)), the result of `ReadSqlEngine` retrieved in the `PandasSQLParser` is `pandas`. It's very likely that I missed some setup of the config. Can you take a look?

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4320  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
