### PR TITLE
FIX-#3527: Fix parquet partitioning issue causing negative row length partitions

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -10,6 +10,7 @@ Key Features and Updates
   * FIX-#3615: Relax some deps in development env (#4365)
   * FIX-#4370: Fix broken docstring links (#4375)
   * FIX-#4392: Align Modin XGBoost with xgb>=1.6 (#4393)
+  * FIX-#3527: Fix parquet partitioning issue causing negative row length partitions (#4368)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
 * Benchmarking enhancements
@@ -42,3 +43,4 @@ Contributors
 @alexander3774
 @amyskov
 @wangxiaoying
+@jeffreykennethli

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -192,12 +192,24 @@ class PandasDataframe(object):
                     sum(row_lengths), len(self._index_cache)
                 ),
             )
+            ErrorMessage.catch_bugs_and_request_email(
+                any(val < 0 for val in row_lengths),
+                "Row lengths cannot be negative: {}".format(
+                    row_lengths
+                ),
+            )
         self._row_lengths_cache = row_lengths
         if column_widths is not None and len(self.columns) > 0:
             ErrorMessage.catch_bugs_and_request_email(
                 sum(column_widths) != len(self._columns_cache),
                 "Column widths: {} != {}".format(
                     sum(column_widths), len(self._columns_cache)
+                ),
+            )
+            ErrorMessage.catch_bugs_and_request_email(
+                any(val < 0 for val in column_widths),
+                "Column widths cannot be negative: {}".format(
+                    column_widths
                 ),
             )
         self._column_widths_cache = column_widths

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -194,9 +194,7 @@ class PandasDataframe(object):
             )
             ErrorMessage.catch_bugs_and_request_email(
                 any(val < 0 for val in row_lengths),
-                "Row lengths cannot be negative: {}".format(
-                    row_lengths
-                ),
+                "Row lengths cannot be negative: {}".format(row_lengths),
             )
         self._row_lengths_cache = row_lengths
         if column_widths is not None and len(self.columns) > 0:
@@ -208,9 +206,7 @@ class PandasDataframe(object):
             )
             ErrorMessage.catch_bugs_and_request_email(
                 any(val < 0 for val in column_widths),
-                "Column widths cannot be negative: {}".format(
-                    column_widths
-                ),
+                "Column widths cannot be negative: {}".format(column_widths),
             )
         self._column_widths_cache = column_widths
         self._dtypes = dtypes

--- a/modin/core/io/column_stores/column_store_dispatcher.py
+++ b/modin/core/io/column_stores/column_store_dispatcher.py
@@ -134,8 +134,8 @@ class ColumnStoreDispatcher(FileDispatcher):
         else:
             row_lengths = [
                 index_chunksize
-                if i != num_partitions - 1
-                else index_len - (index_chunksize * (num_partitions - 1))
+                if i * index_chunksize < index_len
+                else max(0, index_len - (index_chunksize * i))
                 for i in range(num_partitions)
             ]
         return index, row_lengths

--- a/modin/core/io/column_stores/column_store_dispatcher.py
+++ b/modin/core/io/column_stores/column_store_dispatcher.py
@@ -134,7 +134,7 @@ class ColumnStoreDispatcher(FileDispatcher):
         else:
             row_lengths = [
                 index_chunksize
-                if i * index_chunksize < index_len
+                if (i + 1) * index_chunksize < index_len
                 else max(0, index_len - (index_chunksize * i))
                 for i in range(num_partitions)
             ]

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1289,12 +1289,13 @@ class TestParquet:
     def test_read_parquet_indexing_by_column(self, make_parquet_file):
         # Test indexing into a column of modin with various parquet file row lengths.
         # Specifically, tests for https://github.com/modin-project/modin/issues/3527
-        # which fails when min_chunk_size (32) < nrows <= min_chunk_size * (num_partitions - 1)
+        # which fails when min_partition_size < nrows < min_partition_size * (num_partitions - 1)
+        from modin.config.envvars import MinPartitionSize
 
+        nrows = (
+            MinPartitionSize.get() + 1
+        )  # Use the minimal guaranteed failing value for nrows.
         unique_filename = get_unique_filename(extension="parquet")
-        from modin.config import NPartitions
-
-        nrows = (NPartitions.get() - 1) * 32 - 1
         make_parquet_file(filename=unique_filename, nrows=nrows)
 
         parquet_df = pd.read_parquet(unique_filename)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -19,6 +19,7 @@ import pandas._libs.lib as lib
 from pandas.core.dtypes.common import is_list_like
 from pathlib import Path
 from collections import OrderedDict
+from modin.config.envvars import MinPartitionSize
 from modin.db_conn import (
     ModinDatabaseConnection,
     UnsupportedDatabaseException,
@@ -1287,10 +1288,9 @@ class TestParquet:
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
     )
     def test_read_parquet_indexing_by_column(self, make_parquet_file):
-        # Test indexing into a column of modin with various parquet file row lengths.
+        # Test indexing into a column of Modin with various parquet file row lengths.
         # Specifically, tests for https://github.com/modin-project/modin/issues/3527
         # which fails when min_partition_size < nrows < min_partition_size * (num_partitions - 1)
-        from modin.config.envvars import MinPartitionSize
 
         nrows = (
             MinPartitionSize.get() + 1

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1282,6 +1282,20 @@ class TestParquet:
             columns=columns,
         )
 
+    @pytest.mark.parametrize("nrows", [32, 64, 128, 256, 512, 1024, 2048, 4096])
+    @pytest.mark.xfail(
+        condition="config.getoption('--simulate-cloud').lower() != 'off'",
+        reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
+    )
+    def test_read_parquet_indexing_by_column(self, make_parquet_file, nrows):
+        # Test indexing into a column of modin with various parquet file row lengths.
+        unique_filename = get_unique_filename(extension="parquet")
+        make_parquet_file(filename=unique_filename, nrows=nrows)
+
+        parquet_df = pd.read_parquet(unique_filename)
+        for col in parquet_df.columns:
+            parquet_df[col]
+
     @pytest.mark.parametrize("columns", [None, ["col1"]])
     @pytest.mark.xfail(
         condition="config.getoption('--simulate-cloud').lower() != 'off'",

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1282,7 +1282,7 @@ class TestParquet:
             columns=columns,
         )
 
-    @pytest.mark.parametrize("nrows", [32, 64, 128, 256, 512, 1024, 2048, 4096])
+    @pytest.mark.parametrize("nrows", [40, 80, 160, 320, 640, 1280, 2560, 5120])
     @pytest.mark.xfail(
         condition="config.getoption('--simulate-cloud').lower() != 'off'",
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
In #3527 , we found that partitions from `read_parquet` would have negative `_length_cache`, giving a `ValueError: lengths cannot be negative` when trying to materialize results, such as when indexing into a DataFrame by column name. `_length_cache` is set when the DataFrame is initialized and partitioned. For parquet files, this is in the [column_store_dispatcher](https://github.com/modin-project/modin/blob/master/modin/core/io/column_stores/column_store_dispatcher.py).

The previous logic would partition the row lengths with a minimum chunk size (32 rows). For DataFrames with less than 32 total rows, it would partition the rows:

`[32, 0, 0, .... , 0]` for each of the N partitions.

For DataFrames with more than `num_partitions * min_chunk_size` rows i.e. `index_len >= min_chunk_size * num_partitions`, it would be partitioned evenly
`[index_len / num_partitions, index_len / num_partitions, ...]`.

For DataFrames where `min_chunk_size < index_len < min_chunk_size * num_partitions`, it would partition it like
`[32, 32, 32, ... index_len - (index_chunksize * (num_partitions - 1)]` and the `index_len - (index_chunksize * (num_partitions - 1)` expression would be negative. This ensured the sum of the row lengths of all partitions would be equal to `index_len` but the negative row lengths is wrong.

It should be partitioned like
`[32, 32, 32, 0, 0, ...]` where the first `m` rows are `min_chunk_size` until the partitions have more cumulative rows than `index_len`, and be 0 for every partition after.

This is the change this PR is introducing, as well as adding a error checking statement in the DataFrame constructor to check that no partitions have negative row length or column width, and a unit test that checks for indexing into all columns of a parquet file with various row lengths. I think there is room to write a more appropriate unit test, as this one minimally tests this broken behavior.

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #3527 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
