### PR TITLE
REFACTOR-#3642: Move PyArrow storage format usage from main feature to experimental ones

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,7 @@ jobs:
           python scripts/doc_checker.py modin/experimental/pandas/io.py \
             modin/experimental/pandas/numpy_wrap.py modin/experimental/pandas/__init__.py
       - run: python scripts/doc_checker.py modin/core/storage_formats/base
-      - run: python scripts/doc_checker.py modin/core/storage_formats/pyarrow
+      - run: python scripts/doc_checker.py modin/experimental/core/storage_formats/pyarrow
       - run: python scripts/doc_checker.py modin/core/storage_formats/pandas
       - run: |
           python scripts/doc_checker.py \

--- a/docs/development/architecture.rst
+++ b/docs/development/architecture.rst
@@ -173,7 +173,7 @@ Data Ingress
    partitions and vice versa for data egress (e.g. ``to_csv``) operation.
    Improved performance is achieved by reading/writing in partitions in parallel.
 
-Data ingress starts with a function in the pandas API layer (e.g. ``read_csv``). Then the user's 
+Data ingress starts with a function in the pandas API layer (e.g. ``read_csv``). Then the user's
 query is passed to the :doc:`Factory Dispatcher </flow/modin/core/execution/dispatching>`,
 which defines a factory specific for the execution. The factory for execution contains an IO class
 (e.g. ``PandasOnRayIO``) whose responsibility is to perform a parallel read/write from/to a file.
@@ -252,7 +252,7 @@ following figure illustrates this concept.
    :align: center
 
 Currently, the main in-memory format of each partition is a `pandas DataFrame`_ (:doc:`pandas storage format </flow/modin/core/storage_formats/pandas/index>`).
-:doc:`Omnisci </flow/modin/experimental/core/storage_formats/omnisci/index>`, :doc:`PyArrow </flow/modin/core/storage_formats/pyarrow/index>`
+:doc:`Omnisci </flow/modin/experimental/core/storage_formats/omnisci/index>`, :doc:`PyArrow </flow/modin/experimental/core/storage_formats/pyarrow/index>`
 and cuDF are also supported as experimental in-memory formats in Modin.
 
 
@@ -316,8 +316,7 @@ details. The documentation covers most modules, with more docs being added every
    │   │   └─── :doc:`storage_formats </flow/modin/core/storage_formats/index>`
    │   │       ├─── :doc:`base </flow/modin/core/storage_formats/base/query_compiler>`
    │   │       ├───cudf
-   │   │       ├─── :doc:`pandas </flow/modin/core/storage_formats/pandas/index>`
-   │   │       └─── :doc:`pyarrow </flow/modin/core/storage_formats/pyarrow/index>`
+   │   │       └─── :doc:`pandas </flow/modin/core/storage_formats/pandas/index>`
    │   ├───distributed
    │   │   ├───dataframe
    │   │   │   └─── :doc:`pandas </flow/modin/distributed/dataframe/pandas>`
@@ -333,7 +332,8 @@ details. The documentation covers most modules, with more docs being added every
    │   │   │   │           ├─── :doc:`pandas_on_ray </flow/modin/experimental/core/execution/ray/implementations/pandas_on_ray/index>`
    │   │   │   │           └─── :doc:`pyarrow_on_ray </flow/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray>`
    │   │   │   └─── :doc:`storage_formats </flow/modin/experimental/core/storage_formats/index>`
-   │   │   │       └─── :doc:`omnisci </flow/modin/experimental/core/storage_formats/omnisci/index>`
+   |   │   │       ├─── :doc:`omnisci </flow/modin/experimental/core/storage_formats/omnisci/index>`
+   │   │   │       └─── :doc:`pyarrow </flow/modin/experimental/core/storage_formats/pyarrow/index>`
    │   │   ├─── :doc:`pandas </flow/modin/experimental/pandas>`
    │   │   ├─── :doc:`sklearn </flow/modin/experimental/sklearn>`
    │   │   ├───spreadsheet

--- a/docs/flow/modin/core/storage_formats/index.rst
+++ b/docs/flow/modin/core/storage_formats/index.rst
@@ -9,7 +9,7 @@ The base storage format in Modin is pandas. In that format, Modin Dataframe oper
 partitions that hold ``pandas.DataFrame`` objects. Pandas is the most natural storage format
 since high-level DataFrame objects mirror its API, however, Modin's storage formats are not
 limited to the objects that conform to pandas API. There are formats that are able to store
-``pyarrow.Table`` (:doc:`pyarrow storage format <pyarrow/index>`) or even instances of 
+``pyarrow.Table`` (:doc:`pyarrow storage format </flow/modin/experimental/core/storage_formats/pyarrow/index>`) or even instances of
 SQL-like databases (:doc:`OmniSci storage format </flow/modin/experimental/core/storage_formats/omnisci/index>`)
 inside Modin Dataframe's partitions.
 
@@ -26,7 +26,6 @@ Query Compiler
 
     base/query_compiler
     pandas/index
-    pyarrow/index
 
 Modin supports several execution backends (storage format + execution engine). Calling any
 DataFrame API function will end up in some execution-specific method. The query compiler is
@@ -65,6 +64,7 @@ interprets a one-column query compiler as Series or DataFrame depending on the o
 
 High-level module overview
 ''''''''''''''''''''''''''
+
 This module houses submodules of all of the stable storage formats:
 
 ..
@@ -73,6 +73,5 @@ This module houses submodules of all of the stable storage formats:
 - :doc:`Base module <base/query_compiler>` contains an abstract query compiler class which defines common API.
 - :doc:`Pandas module <pandas/index>` contains query compiler and text parsers for pandas storage format.
 - cuDF module contains query compiler and text parsers for cuDF storage format.
-- :doc:`Pyarrow module <pyarrow/index>` contains query compiler and text parsers for Pyarrow storage format.
 
 You can find more in the :doc:`experimental section </flow/modin/experimental/core/storage_formats/index>`.

--- a/docs/flow/modin/experimental/core/storage_formats/index.rst
+++ b/docs/flow/modin/experimental/core/storage_formats/index.rst
@@ -7,9 +7,11 @@ Experimental storage formats
 and provides a limited set of functionality:
 
 * :doc:`omnisci <omnisci/index>`
+* :doc:`pyarrow <pyarrow/index>`
 
 
 .. toctree::
     :hidden:
 
     omnisci/index
+    pyarrow/index

--- a/docs/flow/modin/experimental/core/storage_formats/pyarrow/index.rst
+++ b/docs/flow/modin/experimental/core/storage_formats/pyarrow/index.rst
@@ -15,6 +15,7 @@ visit :doc:`PyArrowOnRay execution </flow/modin/experimental/core/execution/ray/
 
 High-Level Module Overview
 ''''''''''''''''''''''''''
+
 This module houses submodules which are responsible for communication between
 the query compiler level and execution implementation level for PyArrow storage format:
 

--- a/docs/flow/modin/experimental/core/storage_formats/pyarrow/parsers.rst
+++ b/docs/flow/modin/experimental/core/storage_formats/pyarrow/parsers.rst
@@ -1,5 +1,6 @@
-PyArrow Parsers Module Description
-""""""""""""""""""""""""""""""""""
+Experimental PyArrow Parsers Module Description
+"""""""""""""""""""""""""""""""""""""""""""""""
+
 This module houses parser classes that are responsible for data parsing on the workers for the PyArrow storage format.
 Parsers for PyArrow storage formats follow an interface of :doc:`pandas format parsers </flow/modin/core/storage_formats/pandas/parsers>`:
 parser class of every file format implements ``parse`` method, which parses the specified part
@@ -9,6 +10,6 @@ The resulted PyArrow tables will be used as a partitions payload in the :py:clas
 Public API
 ''''''''''
 
-.. automodule:: modin.core.storage_formats.pyarrow.parsers
+.. automodule:: modin.experimental.core.storage_formats.pyarrow.parsers
     :members:
 

--- a/docs/flow/modin/experimental/core/storage_formats/pyarrow/query_compiler.rst
+++ b/docs/flow/modin/experimental/core/storage_formats/pyarrow/query_compiler.rst
@@ -1,19 +1,21 @@
 PyarrowQueryCompiler
 """"""""""""""""""""
-:py:class:`~modin.core.storage_formats.pyarrow.query_compiler.PyarrowQueryCompiler` is responsible for compiling efficient
+
+:py:class:`~modin.experimental.core.storage_formats.pyarrow.query_compiler.PyarrowQueryCompiler` is responsible for compiling efficient
 Dataframe algebra queries for the :doc:`PyarrowOnRayDataframe </flow/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray>`,
 the frames which are backed by ``pyarrow.Table`` objects.
 
-Each :py:class:`~modin.core.storage_formats.pyarrow.query_compiler.PyarrowQueryCompiler` contains an instance of
+Each :py:class:`~modin.experimental.core.storage_formats.pyarrow.query_compiler.PyarrowQueryCompiler` contains an instance of
 :py:class:`~modin.experimental.core.execution.ray.implementations.pyarrow_on_ray.dataframe.dataframe.PyarrowOnRayDataframe` which it queries to get the result.
 
 Public API
 ''''''''''
-:py:class:`~modin.core.storage_formats.pyarrow.query_compiler.PyarrowQueryCompiler` implements common query compilers API
+
+:py:class:`~modin.experimental.core.storage_formats.pyarrow.query_compiler.PyarrowQueryCompiler` implements common query compilers API
 defined by the :py:class:`~modin.core.storage_formats.base.query_compiler.BaseQueryCompiler`. Most functionalities
 are inherited from :py:class:`~modin.core.storage_formats.pandas.query_compiler.PandasQueryCompiler`, in the following
 section only overridden methods are presented.
 
-.. autoclass:: modin.core.storage_formats.pyarrow.query_compiler.PyarrowQueryCompiler
+.. autoclass:: modin.experimental.core.storage_formats.pyarrow.query_compiler.PyarrowQueryCompiler
   :members:
   :show-inheritance:

--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -17,7 +17,7 @@ Key Features and Updates
 * Benchmarking enhancements
   *
 * Refactor Codebase
-  *
+  * REFACTOR-#3642: Move PyArrow storage format usage from main feature to experimental ones (#4374)
 * Pandas API implementations and improvements
   *
 * OmniSci enhancements

--- a/modin/core/storage_formats/__init__.py
+++ b/modin/core/storage_formats/__init__.py
@@ -17,9 +17,3 @@ from .base import BaseQueryCompiler
 from .pandas import PandasQueryCompiler
 
 __all__ = ["BaseQueryCompiler", "PandasQueryCompiler"]
-try:
-    from .pyarrow import PyarrowQueryCompiler  # noqa: F401
-except ImportError:
-    pass
-else:
-    __all__.append("PyarrowQueryCompiler")

--- a/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/io/io.py
+++ b/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/io/io.py
@@ -13,7 +13,10 @@
 
 """Module for housing IO classes with PyArrow storage format and Ray engine."""
 
-from modin.core.storage_formats.pyarrow.query_compiler import PyarrowQueryCompiler
+from modin.experimental.core.storage_formats.pyarrow import (
+    PyarrowQueryCompiler,
+    PyarrowCSVParser,
+)
 from modin.core.execution.ray.generic.io import RayIO
 from modin.experimental.core.execution.ray.implementations.pyarrow_on_ray.dataframe.dataframe import (
     PyarrowOnRayDataframe,
@@ -21,7 +24,6 @@ from modin.experimental.core.execution.ray.implementations.pyarrow_on_ray.datafr
 from modin.experimental.core.execution.ray.implementations.pyarrow_on_ray.partitioning.partition import (
     PyarrowOnRayDataframePartition,
 )
-from modin.core.storage_formats.pyarrow.parsers import PyarrowCSVParser
 from modin.core.execution.ray.common import RayTask
 from modin.core.io import CSVDispatcher
 

--- a/modin/experimental/core/storage_formats/pyarrow/__init__.py
+++ b/modin/experimental/core/storage_formats/pyarrow/__init__.py
@@ -11,8 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-"""The module represents the query compiler level for the PyArrow storage format."""
+"""Experimental Modin functionality specific to PyArrow storage format."""
 
 from .query_compiler import PyarrowQueryCompiler
+from .parsers import PyarrowCSVParser
 
-__all__ = ["PyarrowQueryCompiler"]
+__all__ = ["PyarrowQueryCompiler", "PyarrowCSVParser"]

--- a/modin/experimental/core/storage_formats/pyarrow/parsers.py
+++ b/modin/experimental/core/storage_formats/pyarrow/parsers.py
@@ -13,9 +13,10 @@
 
 """Module houses Modin parser classes, that are used for data parsing on the workers."""
 
-from modin.core.storage_formats.pandas.utils import compute_chunksize
-from io import BytesIO
 import pandas
+from io import BytesIO
+
+from modin.core.storage_formats.pandas.utils import compute_chunksize
 
 
 class PyarrowCSVParser:

--- a/modin/experimental/core/storage_formats/pyarrow/query_compiler.py
+++ b/modin/experimental/core/storage_formats/pyarrow/query_compiler.py
@@ -18,14 +18,14 @@ Module contains ``PyarrowQueryCompiler`` class.
 queries for the ``PyarrowOnRayDataframe``.
 """
 
+import pandas
+import pyarrow as pa
+
 from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.utils import _inherit_docstrings
-import pandas
 from pandas.core.computation.expr import Expr
 from pandas.core.computation.scope import Scope
 from pandas.core.computation.ops import UnaryOp, BinOp, Term, MathCall, Constant
-
-import pyarrow as pa
 
 
 class FakeSeries:

--- a/modin/test/test_executions_api.py
+++ b/modin/test/test_executions_api.py
@@ -11,13 +11,14 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import pytest
+
 from modin.core.storage_formats import (
     BaseQueryCompiler,
     PandasQueryCompiler,
-    PyarrowQueryCompiler,
 )
+from modin.experimental.core.storage_formats.pyarrow import PyarrowQueryCompiler
 
-import pytest
 
 BASE_EXECUTION = BaseQueryCompiler
 EXECUTIONS = [PandasQueryCompiler, PyarrowQueryCompiler]


### PR DESCRIPTION
Signed-off-by: Igoshev, Yaroslav <Poolliver868@mail.ru>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3642  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
