### PR TITLE
FIX-#4383: Remove `pathlib` from deps

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -26,6 +26,7 @@ Key Features and Updates
   *
 * Dependencies
   * FIX-#4327: Update min pin for xgboost version (#4328)
+  * FIX-#4383: Remove `pathlib` from deps (#4384)
 
 Contributors
 ------------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -10,7 +10,6 @@ dependencies:
   - fsspec
   - xarray
   - Jinja2
-  - pathlib
   - scipy
   - pip
   - s3fs>=2021.8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,6 @@ psutil==5.6.6
 fsspec
 xarray
 Jinja2
-pathlib
 tables
 scipy
 s3fs>=2021.8

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -7,7 +7,6 @@ dependencies:
   - fsspec
   - xarray
   - Jinja2
-  - pathlib
   - scipy
   - pip
   - s3fs>=2021.8


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
PR removes explicit dependency `pathlib` from all deps because `pathlib` is a part of python standard lib starting from py3.4.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4383  <!-- issue must be created for each patch -->
- [x] tests ~added~ and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
