### PR TITLE
FIX-#4385: Get rid of `use-deprecated` option in `pip`

### DIFF
--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -1,8 +1,5 @@
 name: push-to-master
-on:
-  push:
-    branches:
-      - master
+on: pull_request
 jobs:
   test-ray-master:
     runs-on: ubuntu-latest

--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -115,7 +115,7 @@ jobs:
           python-version: ${{matrix.python-version}}
           channel-priority: strict
           use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
-      - run: pip install -r requirements-dev.txt --use-deprecated=legacy-resolver
+      - run: pip install -r requirements-dev.txt
       # Use a ray master commit that includes the fix here: https://github.com/ray-project/ray/pull/16278
       # Can be changed after a Ray version > 1.4 is released.
       - run: pip install https://s3-us-west-2.amazonaws.com/ray-wheels/master/c8e3ed9eec30119092ef966ee7b8982c8954c333/ray-2.0.0.dev0-cp38-cp38-manylinux2014_x86_64.whl

--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -1,5 +1,8 @@
 name: push-to-master
-on: pull_request
+on:
+  push:
+    branches:
+      - master
 jobs:
   test-ray-master:
     runs-on: ubuntu-latest

--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -10,7 +10,7 @@ Key Features and Updates
   * FIX-#3615: Relax some deps in development env (#4365)
   * FIX-#4370: Fix broken docstring links (#4375)
   * FIX-#4392: Align Modin XGBoost with xgb>=1.6 (#4393)
-  * FIX-#4385: Get rid from `use-deprecated` option in `pip` (#4386)
+  * FIX-#4385: Get rid of `use-deprecated` option in `pip` (#4386)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
 * Benchmarking enhancements

--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -10,6 +10,7 @@ Key Features and Updates
   * FIX-#3615: Relax some deps in development env (#4365)
   * FIX-#4370: Fix broken docstring links (#4375)
   * FIX-#4392: Align Modin XGBoost with xgb>=1.6 (#4393)
+  * FIX-#4385: Get rid from `use-deprecated` option in `pip` (#4386)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
 * Benchmarking enhancements


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

PR removes using of deprecated functionality of pip during creating of dev env.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4385  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
