### PR TITLE
REFACTOR-#4284: move release note for #4285 under 0.15 release

### DIFF
--- a/docs/release_notes/release_notes-0.14.0.rst
+++ b/docs/release_notes/release_notes-0.14.0.rst
@@ -44,7 +44,6 @@ Key Features and Updates
   * REFACTOR-#4206: add assert check into `__init__` method of `PandasOnDaskDataframePartition` class (#4207)
   * REFACTOR-#3900: add flake8-no-implicit-concat plugin and refactor flake8 error codes (#3901)
   * REFACTOR-#4093: Refactor base to be smaller (#4220)
-  * REFACTOR-#4284: use variable length unpacking when getting results from `deploy` function (#4285)
   * REFACTOR-#4047: Rename `cluster` directory to `cloud` in examples (#4212)
   * REFACTOR-#3853: interacting with Dask interface through `DaskWrapper` class (#3854)
   * REFACTOR-#4322: Move is_reduce_fn outside of groupby_agg (#4323)

--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -18,7 +18,7 @@ Key Features and Updates
 * Benchmarking enhancements
   *
 * Refactor Codebase
-  *
+  * REFACTOR-#4284: use variable length unpacking when getting results from `deploy` function (#4285)
 * Pandas API implementations and improvements
   *
 * OmniSci enhancements
@@ -47,3 +47,4 @@ Contributors
 @wangxiaoying
 @jeffreykennethli
 @mvashishtha
+@anmyachev


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoliimyachev@mail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
