### PR TITLE
FIX-#4373: Fix invalid file path when trying `read_csv_glob` with `usecols` parameter

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -13,6 +13,7 @@ Key Features and Updates
   * FIX-#4385: Get rid of `use-deprecated` option in `pip` (#4386)
   * FIX-#3527: Fix parquet partitioning issue causing negative row length partitions (#4368)
   * FIX-#4330: Override the memory limit to start ray 1.11.0 on Macs (#4335)
+  * FIX-#4373: Fix invalid file path when trying `read_csv_glob` with `usecols` parameter (#4405)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
 * Benchmarking enhancements

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -138,7 +138,7 @@ class CSVGlobDispatcher(CSVDispatcher):
         if usecols is not None and usecols_md[1] != "integer":
             del kwargs["usecols"]
             all_cols = pandas.read_csv(
-                OpenFile(filepath_or_buffer, "rb"),
+                filepath_or_buffer,
                 **dict(kwargs, nrows=0, skipfooter=0),
             ).columns
             usecols = all_cols.get_indexer_for(list(usecols_md[0]))

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -127,6 +127,15 @@ class TestCsvGlob:
             with pytest.raises(FileNotFoundError):
                 pd.read_csv_glob("s3://nyc-tlc/trip data/yellow_tripdata_2020-")
 
+    def test_read_csv_glob_4373(self):
+        columns, filename = ["col0"], "1x1.csv"
+        pd.DataFrame([[1]], columns=columns).to_csv(filename)
+
+        kwargs = {"filepath_or_buffer": filename, "usecols": columns}
+        modin_df = pd.read_csv_glob(**kwargs)
+        pandas_df = pandas.read_csv(**kwargs)
+        df_equals(modin_df, pandas_df)
+
     @pytest.mark.parametrize(
         "parse_dates",
         [pytest.param(value, id=id) for id, value in parse_dates_values_by_id.items()],


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoliimyachev@mail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4373 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
