### PR TITLE
FIX-#4409: Fix `eval_insert` utility that doesn't actually check results of `insert` function

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -38,6 +38,7 @@ Key Features and Updates
   * FIX-#4422: get rid of case sensitivity for `warns_that_defaulting_to_pandas` (#4423)
   * TEST-#4426: Stop passing is_default kwarg to Modin and pandas (#4428)
   * FIX-#4439: Fix flake8 CI fail (#4440)
+  * FIX-#4409: Fix `eval_insert` utility that doesn't actually check results of `insert` function (#4410)
 * Documentation improvements
   * DOCS-#4296: Fix docs warnings (#4297)
   * DOCS-#4388: Turn off fail_on_warning option for docs build (#4389)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1139,7 +1139,7 @@ class DataFrame(BasePandasDataset):
         elif isinstance(value, np.ndarray) and len(value.shape) > 1:
             if value.shape[1] == 1:
                 # Transform into columnar table and take first column
-                value = value.copy().T[0]
+                value = value.squeeze(axis=1)
             else:
                 raise ValueError(
                     f"Expected a 1D array, got an array with shape {value.shape}"

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1136,14 +1136,6 @@ class DataFrame(BasePandasDataset):
                     f"Expected a 1D array, got an array with shape {value.shape}"
                 )
             value = value.squeeze(axis=1)
-        elif isinstance(value, np.ndarray) and len(value.shape) > 1:
-            if value.shape[1] == 1:
-                # Transform into columnar table and take first column
-                value = value.squeeze(axis=1)
-            else:
-                raise ValueError(
-                    f"Expected a 1D array, got an array with shape {value.shape}"
-                )
         if not self._query_compiler.lazy_execution and len(self.index) == 0:
             if not hasattr(value, "index"):
                 try:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1136,6 +1136,11 @@ class DataFrame(BasePandasDataset):
                     f"Expected a 1D array, got an array with shape {value.shape}"
                 )
             value = value.squeeze(axis=1)
+        elif isinstance(value, np.ndarray) and len(value.shape) > 1:
+            if value.shape[1] > 1:
+                raise ValueError(
+                    f"Expected a 1D array, got an array with shape {value.shape}"
+                )
         if not self._query_compiler.lazy_execution and len(self.index) == 0:
             if not hasattr(value, "index"):
                 try:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1137,7 +1137,10 @@ class DataFrame(BasePandasDataset):
                 )
             value = value.squeeze(axis=1)
         elif isinstance(value, np.ndarray) and len(value.shape) > 1:
-            if value.shape[1] > 1:
+            if value.shape[1] == 1:
+                # Transform into columnar table and take first column
+                value = value.copy().T[0]
+            else:
                 raise ValueError(
                     f"Expected a 1D array, got an array with shape {value.shape}"
                 )

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1161,7 +1161,11 @@ class DataFrame(BasePandasDataset):
                 and not isinstance(value, (pandas.Series, Series))
                 and len(value) != len(self.index)
             ):
-                raise ValueError("Length of values does not match length of index")
+                raise ValueError(
+                    "Length of values ({}) does not match length of index ({})".format(
+                        len(value), len(self.index)
+                    )
+                )
             if not allow_duplicates and column in self.columns:
                 raise ValueError(f"cannot insert {column}, already exists")
             if not -len(self.columns) <= loc <= len(self.columns):

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -71,6 +71,7 @@ def eval_insert(modin_df, pandas_df, **kwargs):
         modin_df,
         pandas_df,
         operation=lambda df, **kwargs: df.insert(**kwargs),
+        __inplace__=True,
         **_kwargs,
     )
 
@@ -1049,7 +1050,6 @@ def test_insert_4407():
             loc=0,
             col=f"test_col{idx}",
             value=value,
-            __inplace__=True,
             comparator=lambda df1, df2: comparator(df1, df2),
         )
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4409 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
