### PR TITLE
FIX-#4422: get rid of case sensitivity for warns_that_defaulting_to_pandas

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -33,6 +33,7 @@ Key Features and Updates
   * FEAT-#4359: Add __dataframe__ method to the protocol dataframe (#4360)
 * Update testing suite
   * TEST-#4363: Use Ray from pypi in CI (#4364)
+  * FIX-#4422: get rid of case sensetivity for `warns_that_defaulting_to_pandas` (#4423)
 * Documentation improvements
   * DOCS-#4296: Fix docs warnings (#4297)
   * DOCS-#4388: Turn off fail_on_warning option for docs build (#4389)
@@ -52,4 +53,5 @@ Contributors
 @jeffreykennethli
 @mvashishtha
 @anmyachev
+@dchigarev
 @devin-petersohn

--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -33,7 +33,7 @@ Key Features and Updates
   * FEAT-#4359: Add __dataframe__ method to the protocol dataframe (#4360)
 * Update testing suite
   * TEST-#4363: Use Ray from pypi in CI (#4364)
-  * FIX-#4422: get rid of case sensetivity for `warns_that_defaulting_to_pandas` (#4423)
+  * FIX-#4422: get rid of case sensitivity for `warns_that_defaulting_to_pandas` (#4423)
 * Documentation improvements
   * DOCS-#4296: Fix docs warnings (#4297)
   * DOCS-#4388: Turn off fail_on_warning option for docs build (#4389)

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -16,6 +16,7 @@ import modin.utils
 import json
 
 from textwrap import dedent, indent
+from modin.error_message import ErrorMessage
 
 
 # Note: classes below are used for purely testing purposes - they
@@ -251,7 +252,7 @@ def warns_that_defaulting_to_pandas():
         A WarningsChecker checking for a UserWarning saying that Modin is
         defaulting to Pandas.
     """
-    return pytest.warns(UserWarning, match="defaulting to pandas")
+    return pytest.warns(UserWarning, match="[Dd]efaulting to pandas")
 
 
 @pytest.mark.parametrize("as_json", [True, False])
@@ -263,3 +264,11 @@ def test_show_versions(as_json, capsys):
     if as_json:
         versions = json.loads(versions)
         assert versions["modin dependencies"]["modin"] == modin.__version__
+
+
+def test_warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas():
+        ErrorMessage.default_to_pandas()
+
+    with warns_that_defaulting_to_pandas():
+        ErrorMessage.default_to_pandas(message="Function name")


### PR DESCRIPTION
Signed-off-by: proxodilka <zeeron209@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4422 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
