### PR TITLE
TEST-#4426: Stop passing is_default kwarg to Modin and pandas.

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -33,6 +33,7 @@ Key Features and Updates
   * FEAT-#4359: Add __dataframe__ method to the protocol dataframe (#4360)
 * Update testing suite
   * TEST-#4363: Use Ray from pypi in CI (#4364)
+  * TEST-#4426: Stop passing is_default kwarg to Modin and pandas (#4428)
 * Documentation improvements
   * DOCS-#4296: Fix docs warnings (#4297)
   * DOCS-#4388: Turn off fail_on_warning option for docs build (#4389)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -117,11 +117,7 @@ def test_mixed_dtypes_groupby(as_index):
 
         modin_groupby_equals_pandas(modin_groupby, pandas_groupby)
         eval_ngroups(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.ffill(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill())
         eval_general(
             modin_groupby,
             pandas_groupby,
@@ -132,11 +128,7 @@ def test_mixed_dtypes_groupby(as_index):
         eval_mean(modin_groupby, pandas_groupby)
         eval_any(modin_groupby, pandas_groupby)
         eval_min(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.idxmax(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmax())
         eval_ndim(modin_groupby, pandas_groupby)
         eval_cumsum(modin_groupby, pandas_groupby)
         eval_general(
@@ -153,27 +145,11 @@ def test_mixed_dtypes_groupby(as_index):
             eval_apply(modin_groupby, pandas_groupby, func)
 
         eval_dtypes(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.first(),
-        )
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.backfill(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.first())
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.backfill())
         eval_cummin(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.bfill(),
-        )
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.idxmin(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.bfill())
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmin())
         eval_prod(modin_groupby, pandas_groupby)
         if as_index:
             eval_std(modin_groupby, pandas_groupby)
@@ -200,11 +176,7 @@ def test_mixed_dtypes_groupby(as_index):
             eval_agg(modin_groupby, pandas_groupby, func)
             eval_aggregate(modin_groupby, pandas_groupby, func)
 
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.last(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.last())
         eval_general(
             modin_groupby,
             pandas_groupby,
@@ -217,11 +189,7 @@ def test_mixed_dtypes_groupby(as_index):
         eval_ngroup(modin_groupby, pandas_groupby)
         eval_nunique(modin_groupby, pandas_groupby)
         eval_median(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.head(n),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n))
         eval_cumprod(modin_groupby, pandas_groupby)
         eval_general(
             modin_groupby,
@@ -246,17 +214,9 @@ def test_mixed_dtypes_groupby(as_index):
         )
         eval_fillna(modin_groupby, pandas_groupby)
         eval_count(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.tail(n),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.tail(n))
         eval_quantile(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.take(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.take())
         eval___getattr__(modin_groupby, pandas_groupby, "col2")
         eval_groups(modin_groupby, pandas_groupby)
 
@@ -317,8 +277,8 @@ class GetColumn:
         [GetColumn("col1")],  # 20
     ],
 )
-@pytest.mark.parametrize("as_index", [True])
-@pytest.mark.parametrize("col1_category", [True])
+@pytest.mark.parametrize("as_index", [True, False])
+@pytest.mark.parametrize("col1_category", [True, False])
 def test_simple_row_groupby(by, as_index, col1_category):
     pandas_df = pandas.DataFrame(
         {
@@ -355,11 +315,7 @@ def test_simple_row_groupby(by, as_index, col1_category):
     modin_groupby_equals_pandas(modin_groupby, pandas_groupby)
     eval_ngroups(modin_groupby, pandas_groupby)
     eval_shift(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.ffill(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill())
     eval_general(
         modin_groupby,
         pandas_groupby,
@@ -369,11 +325,7 @@ def test_simple_row_groupby(by, as_index, col1_category):
     eval_mean(modin_groupby, pandas_groupby)
     eval_any(modin_groupby, pandas_groupby)
     eval_min(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.idxmax(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmax())
     eval_ndim(modin_groupby, pandas_groupby)
     if not check_df_columns_have_nans(modin_df, by):
         # cum* functions produce undefined results for columns with NaNs so we run them only when "by" columns contain no NaNs
@@ -398,26 +350,10 @@ def test_simple_row_groupby(by, as_index, col1_category):
         eval_apply(modin_groupby, pandas_groupby, func)
 
     eval_dtypes(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.first(),
-    )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.backfill(),
-    )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.bfill(),
-    )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.idxmin(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.first())
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.backfill())
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.bfill())
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmin())
     eval_prod(modin_groupby, pandas_groupby)
     if as_index:
         eval_std(modin_groupby, pandas_groupby)
@@ -453,11 +389,7 @@ def test_simple_row_groupby(by, as_index, col1_category):
             check_exception_type=None if is_pandas_bug_case else True,
         )
 
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.last(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.last())
     eval_general(
         modin_groupby,
         pandas_groupby,
@@ -479,11 +411,7 @@ def test_simple_row_groupby(by, as_index, col1_category):
         check_exception_type=None if (col1_category and not as_index) else True,
     )
     eval_median(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.head(n),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n))
     eval_general(
         modin_groupby,
         pandas_groupby,
@@ -521,17 +449,9 @@ def test_simple_row_groupby(by, as_index, col1_category):
             lambda df: df.size(),
             check_exception_type=None,
         )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.tail(n),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.tail(n))
     eval_quantile(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.take(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.take())
     if isinstance(by, list) and not any(
         isinstance(o, (pd.Series, pandas.Series)) for o in by
     ):
@@ -597,11 +517,7 @@ def test_single_group_row_groupby():
     eval_ngroups(modin_groupby, pandas_groupby)
     eval_shift(modin_groupby, pandas_groupby)
     eval_skew(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.ffill(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill())
     eval_general(
         modin_groupby,
         pandas_groupby,
@@ -611,11 +527,7 @@ def test_single_group_row_groupby():
     eval_mean(modin_groupby, pandas_groupby)
     eval_any(modin_groupby, pandas_groupby)
     eval_min(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.idxmax(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmax())
     eval_ndim(modin_groupby, pandas_groupby)
     eval_cumsum(modin_groupby, pandas_groupby)
     eval_general(
@@ -631,27 +543,11 @@ def test_single_group_row_groupby():
         eval_apply(modin_groupby, pandas_groupby, func)
 
     eval_dtypes(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.first(),
-    )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.backfill(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.first())
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.backfill())
     eval_cummin(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.bfill(),
-    )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.idxmin(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.bfill())
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmin())
     eval_prod(modin_groupby, pandas_groupby)
     eval_std(modin_groupby, pandas_groupby)
 
@@ -668,11 +564,7 @@ def test_single_group_row_groupby():
         eval_agg(modin_groupby, pandas_groupby, func)
         eval_aggregate(modin_groupby, pandas_groupby, func)
 
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.last(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.last())
     eval_general(
         modin_groupby,
         pandas_groupby,
@@ -687,11 +579,7 @@ def test_single_group_row_groupby():
     eval_ngroup(modin_groupby, pandas_groupby)
     eval_nunique(modin_groupby, pandas_groupby)
     eval_median(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.head(n),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n))
     eval_cumprod(modin_groupby, pandas_groupby)
     eval_general(
         modin_groupby,
@@ -717,17 +605,9 @@ def test_single_group_row_groupby():
     eval_fillna(modin_groupby, pandas_groupby)
     eval_count(modin_groupby, pandas_groupby)
     eval_size(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.tail(n),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.tail(n))
     eval_quantile(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.take(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.take())
     eval___getattr__(modin_groupby, pandas_groupby, "col2")
     eval_groups(modin_groupby, pandas_groupby)
 
@@ -754,11 +634,7 @@ def test_large_row_groupby(is_by_category):
     eval_ngroups(modin_groupby, pandas_groupby)
     eval_shift(modin_groupby, pandas_groupby)
     eval_skew(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.ffill(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill())
     eval_general(
         modin_groupby,
         pandas_groupby,
@@ -768,11 +644,7 @@ def test_large_row_groupby(is_by_category):
     eval_mean(modin_groupby, pandas_groupby)
     eval_any(modin_groupby, pandas_groupby)
     eval_min(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.idxmax(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmax())
     eval_ndim(modin_groupby, pandas_groupby)
     eval_cumsum(modin_groupby, pandas_groupby)
     eval_general(
@@ -788,27 +660,11 @@ def test_large_row_groupby(is_by_category):
         eval_apply(modin_groupby, pandas_groupby, func)
 
     eval_dtypes(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.first(),
-    )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.backfill(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.first())
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.backfill())
     eval_cummin(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.bfill(),
-    )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.idxmin(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.bfill())
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmin())
     # eval_prod(modin_groupby, pandas_groupby) causes overflows
     eval_std(modin_groupby, pandas_groupby)
 
@@ -826,11 +682,7 @@ def test_large_row_groupby(is_by_category):
         eval_agg(modin_groupby, pandas_groupby, func)
         eval_aggregate(modin_groupby, pandas_groupby, func)
 
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.last(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.last())
     eval_general(
         modin_groupby,
         pandas_groupby,
@@ -845,11 +697,7 @@ def test_large_row_groupby(is_by_category):
     eval_ngroup(modin_groupby, pandas_groupby)
     eval_nunique(modin_groupby, pandas_groupby)
     eval_median(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.head(n),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n))
     # eval_cumprod(modin_groupby, pandas_groupby) causes overflows
     eval_general(
         modin_groupby,
@@ -875,17 +723,9 @@ def test_large_row_groupby(is_by_category):
     eval_fillna(modin_groupby, pandas_groupby)
     eval_count(modin_groupby, pandas_groupby)
     eval_size(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.tail(n),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.tail(n))
     eval_quantile(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.take(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.take())
     eval_groups(modin_groupby, pandas_groupby)
 
 
@@ -911,11 +751,7 @@ def test_simple_col_groupby():
     eval_ngroups(modin_groupby, pandas_groupby)
     eval_shift(modin_groupby, pandas_groupby)
     eval_skew(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.ffill(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill())
     eval_general(
         modin_groupby,
         pandas_groupby,
@@ -927,16 +763,8 @@ def test_simple_col_groupby():
     eval_min(modin_groupby, pandas_groupby)
     eval_ndim(modin_groupby, pandas_groupby)
 
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.idxmax(),
-    )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.idxmin(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmax())
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmin())
     eval_quantile(modin_groupby, pandas_groupby)
 
     # https://github.com/pandas-dev/pandas/issues/21127
@@ -955,28 +783,12 @@ def test_simple_col_groupby():
     for func in apply_functions:
         eval_apply(modin_groupby, pandas_groupby, func)
 
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.first(),
-    )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.backfill(),
-    )
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.bfill(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.first())
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.backfill())
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.bfill())
     eval_prod(modin_groupby, pandas_groupby)
     eval_std(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.last(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.last())
     eval_general(
         modin_groupby,
         pandas_groupby,
@@ -1016,11 +828,7 @@ def test_simple_col_groupby():
     eval_fillna(modin_groupby, pandas_groupby)
     eval_count(modin_groupby, pandas_groupby)
     eval_size(modin_groupby, pandas_groupby)
-    eval_general(
-        modin_groupby,
-        pandas_groupby,
-        lambda df: df.take(),
-    )
+    eval_general(modin_groupby, pandas_groupby, lambda df: df.take())
     eval_groups(modin_groupby, pandas_groupby)
 
 
@@ -1066,11 +874,7 @@ def test_series_groupby(by, as_index_series_or_dataframe):
         modin_groupby_equals_pandas(modin_groupby, pandas_groupby)
         eval_ngroups(modin_groupby, pandas_groupby)
         eval_shift(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.ffill(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill())
         eval_general(
             modin_groupby,
             pandas_groupby,
@@ -1080,11 +884,7 @@ def test_series_groupby(by, as_index_series_or_dataframe):
         eval_mean(modin_groupby, pandas_groupby)
         eval_any(modin_groupby, pandas_groupby)
         eval_min(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.idxmax(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmax())
         eval_ndim(modin_groupby, pandas_groupby)
         eval_cumsum(modin_groupby, pandas_groupby)
         eval_general(
@@ -1099,27 +899,11 @@ def test_series_groupby(by, as_index_series_or_dataframe):
         for func in apply_functions:
             eval_apply(modin_groupby, pandas_groupby, func)
 
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.first(),
-        )
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.backfill(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.first())
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.backfill())
         eval_cummin(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.bfill(),
-        )
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.idxmin(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.bfill())
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmin())
         eval_prod(modin_groupby, pandas_groupby)
         if as_index:
             eval_std(modin_groupby, pandas_groupby)
@@ -1131,11 +915,7 @@ def test_series_groupby(by, as_index_series_or_dataframe):
             eval_agg(modin_groupby, pandas_groupby, func)
             eval_aggregate(modin_groupby, pandas_groupby, func)
 
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.last(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.last())
         eval_general(
             modin_groupby,
             pandas_groupby,
@@ -1150,11 +930,7 @@ def test_series_groupby(by, as_index_series_or_dataframe):
         eval_ngroup(modin_groupby, pandas_groupby)
         eval_nunique(modin_groupby, pandas_groupby)
         eval_median(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.head(n),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n))
         eval_cumprod(modin_groupby, pandas_groupby)
 
         transform_functions = [lambda df: df + 4, lambda df: -df - 10]
@@ -1167,17 +943,9 @@ def test_series_groupby(by, as_index_series_or_dataframe):
 
         eval_fillna(modin_groupby, pandas_groupby)
         eval_count(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.tail(n),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.tail(n))
         eval_quantile(modin_groupby, pandas_groupby)
-        eval_general(
-            modin_groupby,
-            pandas_groupby,
-            lambda df: df.take(),
-        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.take())
         eval_groups(modin_groupby, pandas_groupby)
 
 

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -118,21 +118,24 @@ def test_mixed_dtypes_groupby(as_index):
         modin_groupby_equals_pandas(modin_groupby, pandas_groupby)
         eval_ngroups(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.ffill(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.ffill(),
         )
         eval_general(
             modin_groupby,
             pandas_groupby,
             lambda df: df.sem(),
             modin_df_almost_equals_pandas,
-            is_default=True,
         )
         eval_shift(modin_groupby, pandas_groupby)
         eval_mean(modin_groupby, pandas_groupby)
         eval_any(modin_groupby, pandas_groupby)
         eval_min(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.idxmax(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.idxmax(),
         )
         eval_ndim(modin_groupby, pandas_groupby)
         eval_cumsum(modin_groupby, pandas_groupby)
@@ -141,7 +144,6 @@ def test_mixed_dtypes_groupby(as_index):
             pandas_groupby,
             lambda df: df.pct_change(),
             modin_df_almost_equals_pandas,
-            is_default=True,
         )
         eval_cummax(modin_groupby, pandas_groupby)
 
@@ -152,17 +154,25 @@ def test_mixed_dtypes_groupby(as_index):
 
         eval_dtypes(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.first(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.first(),
         )
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.backfill(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.backfill(),
         )
         eval_cummin(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.bfill(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.bfill(),
         )
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.idxmin(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.idxmin(),
         )
         eval_prod(modin_groupby, pandas_groupby)
         if as_index:
@@ -191,14 +201,15 @@ def test_mixed_dtypes_groupby(as_index):
             eval_aggregate(modin_groupby, pandas_groupby, func)
 
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.last(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.last(),
         )
         eval_general(
             modin_groupby,
             pandas_groupby,
             lambda df: df.mad(),
             modin_df_almost_equals_pandas,
-            is_default=True,
         )
         eval_max(modin_groupby, pandas_groupby)
         eval_len(modin_groupby, pandas_groupby)
@@ -207,7 +218,9 @@ def test_mixed_dtypes_groupby(as_index):
         eval_nunique(modin_groupby, pandas_groupby)
         eval_median(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.head(n), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.head(n),
         )
         eval_cumprod(modin_groupby, pandas_groupby)
         eval_general(
@@ -215,7 +228,6 @@ def test_mixed_dtypes_groupby(as_index):
             pandas_groupby,
             lambda df: df.cov(),
             modin_df_almost_equals_pandas,
-            is_default=True,
         )
 
         transform_functions = [lambda df: df, lambda df: df + df]
@@ -235,11 +247,15 @@ def test_mixed_dtypes_groupby(as_index):
         eval_fillna(modin_groupby, pandas_groupby)
         eval_count(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.tail(n), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.tail(n),
         )
         eval_quantile(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.take(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.take(),
         )
         eval___getattr__(modin_groupby, pandas_groupby, "col2")
         eval_groups(modin_groupby, pandas_groupby)
@@ -301,8 +317,8 @@ class GetColumn:
         [GetColumn("col1")],  # 20
     ],
 )
-@pytest.mark.parametrize("as_index", [True, False])
-@pytest.mark.parametrize("col1_category", [True, False])
+@pytest.mark.parametrize("as_index", [True])
+@pytest.mark.parametrize("col1_category", [True])
 def test_simple_row_groupby(by, as_index, col1_category):
     pandas_df = pandas.DataFrame(
         {
@@ -339,18 +355,25 @@ def test_simple_row_groupby(by, as_index, col1_category):
     modin_groupby_equals_pandas(modin_groupby, pandas_groupby)
     eval_ngroups(modin_groupby, pandas_groupby)
     eval_shift(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.ffill(),
+    )
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.sem(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_mean(modin_groupby, pandas_groupby)
     eval_any(modin_groupby, pandas_groupby)
     eval_min(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmax(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.idxmax(),
+    )
     eval_ndim(modin_groupby, pandas_groupby)
     if not check_df_columns_have_nans(modin_df, by):
         # cum* functions produce undefined results for columns with NaNs so we run them only when "by" columns contain no NaNs
@@ -364,7 +387,6 @@ def test_simple_row_groupby(by, as_index, col1_category):
         pandas_groupby,
         lambda df: df.pct_change(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
 
     apply_functions = [
@@ -376,12 +398,26 @@ def test_simple_row_groupby(by, as_index, col1_category):
         eval_apply(modin_groupby, pandas_groupby, func)
 
     eval_dtypes(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.first(), is_default=True)
     eval_general(
-        modin_groupby, pandas_groupby, lambda df: df.backfill(), is_default=True
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.first(),
     )
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.bfill(), is_default=True)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmin(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.backfill(),
+    )
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.bfill(),
+    )
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.idxmin(),
+    )
     eval_prod(modin_groupby, pandas_groupby)
     if as_index:
         eval_std(modin_groupby, pandas_groupby)
@@ -417,13 +453,16 @@ def test_simple_row_groupby(by, as_index, col1_category):
             check_exception_type=None if is_pandas_bug_case else True,
         )
 
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.last(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.last(),
+    )
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.mad(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_general(modin_groupby, pandas_groupby, lambda df: df.rank())
     eval_max(modin_groupby, pandas_groupby)
@@ -440,13 +479,16 @@ def test_simple_row_groupby(by, as_index, col1_category):
         check_exception_type=None if (col1_category and not as_index) else True,
     )
     eval_median(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.head(n),
+    )
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.cov(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
 
     if not check_df_columns_have_nans(modin_df, by):
@@ -469,7 +511,6 @@ def test_simple_row_groupby(by, as_index, col1_category):
         pandas_groupby,
         lambda df: df.corr(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_fillna(modin_groupby, pandas_groupby)
     eval_count(modin_groupby, pandas_groupby)
@@ -480,9 +521,17 @@ def test_simple_row_groupby(by, as_index, col1_category):
             lambda df: df.size(),
             check_exception_type=None,
         )
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.tail(n), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.tail(n),
+    )
     eval_quantile(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.take(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.take(),
+    )
     if isinstance(by, list) and not any(
         isinstance(o, (pd.Series, pandas.Series)) for o in by
     ):
@@ -548,18 +597,25 @@ def test_single_group_row_groupby():
     eval_ngroups(modin_groupby, pandas_groupby)
     eval_shift(modin_groupby, pandas_groupby)
     eval_skew(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.ffill(),
+    )
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.sem(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_mean(modin_groupby, pandas_groupby)
     eval_any(modin_groupby, pandas_groupby)
     eval_min(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmax(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.idxmax(),
+    )
     eval_ndim(modin_groupby, pandas_groupby)
     eval_cumsum(modin_groupby, pandas_groupby)
     eval_general(
@@ -567,7 +623,6 @@ def test_single_group_row_groupby():
         pandas_groupby,
         lambda df: df.pct_change(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_cummax(modin_groupby, pandas_groupby)
 
@@ -576,13 +631,27 @@ def test_single_group_row_groupby():
         eval_apply(modin_groupby, pandas_groupby, func)
 
     eval_dtypes(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.first(), is_default=True)
     eval_general(
-        modin_groupby, pandas_groupby, lambda df: df.backfill(), is_default=True
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.first(),
+    )
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.backfill(),
     )
     eval_cummin(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.bfill(), is_default=True)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmin(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.bfill(),
+    )
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.idxmin(),
+    )
     eval_prod(modin_groupby, pandas_groupby)
     eval_std(modin_groupby, pandas_groupby)
 
@@ -599,13 +668,16 @@ def test_single_group_row_groupby():
         eval_agg(modin_groupby, pandas_groupby, func)
         eval_aggregate(modin_groupby, pandas_groupby, func)
 
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.last(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.last(),
+    )
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.mad(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_rank(modin_groupby, pandas_groupby)
     eval_max(modin_groupby, pandas_groupby)
@@ -615,14 +687,17 @@ def test_single_group_row_groupby():
     eval_ngroup(modin_groupby, pandas_groupby)
     eval_nunique(modin_groupby, pandas_groupby)
     eval_median(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.head(n),
+    )
     eval_cumprod(modin_groupby, pandas_groupby)
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.cov(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
 
     transform_functions = [lambda df: df + 4, lambda df: -df - 10]
@@ -638,14 +713,21 @@ def test_single_group_row_groupby():
         pandas_groupby,
         lambda df: df.corr(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_fillna(modin_groupby, pandas_groupby)
     eval_count(modin_groupby, pandas_groupby)
     eval_size(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.tail(n), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.tail(n),
+    )
     eval_quantile(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.take(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.take(),
+    )
     eval___getattr__(modin_groupby, pandas_groupby, "col2")
     eval_groups(modin_groupby, pandas_groupby)
 
@@ -672,18 +754,25 @@ def test_large_row_groupby(is_by_category):
     eval_ngroups(modin_groupby, pandas_groupby)
     eval_shift(modin_groupby, pandas_groupby)
     eval_skew(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.ffill(),
+    )
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.sem(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_mean(modin_groupby, pandas_groupby)
     eval_any(modin_groupby, pandas_groupby)
     eval_min(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmax(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.idxmax(),
+    )
     eval_ndim(modin_groupby, pandas_groupby)
     eval_cumsum(modin_groupby, pandas_groupby)
     eval_general(
@@ -691,7 +780,6 @@ def test_large_row_groupby(is_by_category):
         pandas_groupby,
         lambda df: df.pct_change(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_cummax(modin_groupby, pandas_groupby)
 
@@ -700,13 +788,27 @@ def test_large_row_groupby(is_by_category):
         eval_apply(modin_groupby, pandas_groupby, func)
 
     eval_dtypes(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.first(), is_default=True)
     eval_general(
-        modin_groupby, pandas_groupby, lambda df: df.backfill(), is_default=True
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.first(),
+    )
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.backfill(),
     )
     eval_cummin(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.bfill(), is_default=True)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmin(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.bfill(),
+    )
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.idxmin(),
+    )
     # eval_prod(modin_groupby, pandas_groupby) causes overflows
     eval_std(modin_groupby, pandas_groupby)
 
@@ -724,13 +826,16 @@ def test_large_row_groupby(is_by_category):
         eval_agg(modin_groupby, pandas_groupby, func)
         eval_aggregate(modin_groupby, pandas_groupby, func)
 
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.last(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.last(),
+    )
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.mad(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_rank(modin_groupby, pandas_groupby)
     eval_max(modin_groupby, pandas_groupby)
@@ -740,14 +845,17 @@ def test_large_row_groupby(is_by_category):
     eval_ngroup(modin_groupby, pandas_groupby)
     eval_nunique(modin_groupby, pandas_groupby)
     eval_median(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.head(n), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.head(n),
+    )
     # eval_cumprod(modin_groupby, pandas_groupby) causes overflows
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.cov(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
 
     transform_functions = [lambda df: df + 4, lambda df: -df - 10]
@@ -763,14 +871,21 @@ def test_large_row_groupby(is_by_category):
         pandas_groupby,
         lambda df: df.corr(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_fillna(modin_groupby, pandas_groupby)
     eval_count(modin_groupby, pandas_groupby)
     eval_size(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.tail(n), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.tail(n),
+    )
     eval_quantile(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.take(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.take(),
+    )
     eval_groups(modin_groupby, pandas_groupby)
 
 
@@ -796,21 +911,32 @@ def test_simple_col_groupby():
     eval_ngroups(modin_groupby, pandas_groupby)
     eval_shift(modin_groupby, pandas_groupby)
     eval_skew(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.ffill(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.ffill(),
+    )
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.sem(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_mean(modin_groupby, pandas_groupby)
     eval_any(modin_groupby, pandas_groupby)
     eval_min(modin_groupby, pandas_groupby)
     eval_ndim(modin_groupby, pandas_groupby)
 
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmax(), is_default=True)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.idxmin(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.idxmax(),
+    )
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.idxmin(),
+    )
     eval_quantile(modin_groupby, pandas_groupby)
 
     # https://github.com/pandas-dev/pandas/issues/21127
@@ -824,26 +950,38 @@ def test_simple_col_groupby():
         pandas_groupby,
         lambda df: df.pct_change(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     apply_functions = [lambda df: -df, lambda df: df.sum(axis=1)]
     for func in apply_functions:
         eval_apply(modin_groupby, pandas_groupby, func)
 
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.first(), is_default=True)
     eval_general(
-        modin_groupby, pandas_groupby, lambda df: df.backfill(), is_default=True
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.first(),
     )
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.bfill(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.backfill(),
+    )
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.bfill(),
+    )
     eval_prod(modin_groupby, pandas_groupby)
     eval_std(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.last(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.last(),
+    )
     eval_general(
         modin_groupby,
         pandas_groupby,
         lambda df: df.mad(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_max(modin_groupby, pandas_groupby)
     eval_var(modin_groupby, pandas_groupby)
@@ -859,7 +997,6 @@ def test_simple_col_groupby():
         pandas_groupby,
         lambda df: df.cov(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
 
     transform_functions = [lambda df: df + 4, lambda df: -df - 10]
@@ -875,12 +1012,15 @@ def test_simple_col_groupby():
         pandas_groupby,
         lambda df: df.corr(),
         modin_df_almost_equals_pandas,
-        is_default=True,
     )
     eval_fillna(modin_groupby, pandas_groupby)
     eval_count(modin_groupby, pandas_groupby)
     eval_size(modin_groupby, pandas_groupby)
-    eval_general(modin_groupby, pandas_groupby, lambda df: df.take(), is_default=True)
+    eval_general(
+        modin_groupby,
+        pandas_groupby,
+        lambda df: df.take(),
+    )
     eval_groups(modin_groupby, pandas_groupby)
 
 
@@ -927,20 +1067,23 @@ def test_series_groupby(by, as_index_series_or_dataframe):
         eval_ngroups(modin_groupby, pandas_groupby)
         eval_shift(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.ffill(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.ffill(),
         )
         eval_general(
             modin_groupby,
             pandas_groupby,
             lambda df: df.sem(),
             modin_df_almost_equals_pandas,
-            is_default=True,
         )
         eval_mean(modin_groupby, pandas_groupby)
         eval_any(modin_groupby, pandas_groupby)
         eval_min(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.idxmax(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.idxmax(),
         )
         eval_ndim(modin_groupby, pandas_groupby)
         eval_cumsum(modin_groupby, pandas_groupby)
@@ -949,7 +1092,6 @@ def test_series_groupby(by, as_index_series_or_dataframe):
             pandas_groupby,
             lambda df: df.pct_change(),
             modin_df_almost_equals_pandas,
-            is_default=True,
         )
         eval_cummax(modin_groupby, pandas_groupby)
 
@@ -958,17 +1100,25 @@ def test_series_groupby(by, as_index_series_or_dataframe):
             eval_apply(modin_groupby, pandas_groupby, func)
 
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.first(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.first(),
         )
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.backfill(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.backfill(),
         )
         eval_cummin(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.bfill(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.bfill(),
         )
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.idxmin(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.idxmin(),
         )
         eval_prod(modin_groupby, pandas_groupby)
         if as_index:
@@ -982,14 +1132,15 @@ def test_series_groupby(by, as_index_series_or_dataframe):
             eval_aggregate(modin_groupby, pandas_groupby, func)
 
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.last(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.last(),
         )
         eval_general(
             modin_groupby,
             pandas_groupby,
             lambda df: df.mad(),
             modin_df_almost_equals_pandas,
-            is_default=True,
         )
         eval_rank(modin_groupby, pandas_groupby)
         eval_max(modin_groupby, pandas_groupby)
@@ -1000,7 +1151,9 @@ def test_series_groupby(by, as_index_series_or_dataframe):
         eval_nunique(modin_groupby, pandas_groupby)
         eval_median(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.head(n), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.head(n),
         )
         eval_cumprod(modin_groupby, pandas_groupby)
 
@@ -1015,11 +1168,15 @@ def test_series_groupby(by, as_index_series_or_dataframe):
         eval_fillna(modin_groupby, pandas_groupby)
         eval_count(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.tail(n), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.tail(n),
         )
         eval_quantile(modin_groupby, pandas_groupby)
         eval_general(
-            modin_groupby, pandas_groupby, lambda df: df.take(), is_default=True
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.take(),
         )
         eval_groups(modin_groupby, pandas_groupby)
 


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4426 
- [N/A] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
