### PR TITLE
FIX-#4436: Fix to_pydatetime dtype for timezone None.

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -17,6 +17,7 @@ Key Features and Updates
   * FIX-#4373: Fix invalid file path when trying `read_csv_glob` with `usecols` parameter (#4405)
   * FIX-#4394: Fix issue with multiindex metadata desync (#4395)
   * FIX-#4425: Add parameters to groupby pct_change (#4429)
+  * FIX-#4436: Fix to_pydatetime dtype for timezone None (#4437).
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
 * Benchmarking enhancements

--- a/modin/core/dataframe/algebra/default2pandas/default.py
+++ b/modin/core/dataframe/algebra/default2pandas/default.py
@@ -78,17 +78,26 @@ class DefaultMethod(Operator):
             """
             df = cls.frame_wrapper(df)
             result = fn(df, *args, **kwargs)
-
             if (
                 not isinstance(result, pandas.Series)
                 and not isinstance(result, pandas.DataFrame)
                 and func != "to_numpy"
                 and func != pandas.DataFrame.to_numpy
             ):
+                # When applying a DatetimeProperties function, if we don't
+                # specify the dtype for the DataFrame, the frame might get the
+                # wrong dtype, e.g. for to_pydatetime in
+                # https://github.com/modin-project/modin/issues/4436
+                astype_kwargs = {}
+                dtype = getattr(result, "dtype", None)
+                if dtype and isinstance(
+                    df, pandas.core.indexes.accessors.DatetimeProperties
+                ):
+                    astype_kwargs["dtype"] = dtype
                 result = (
-                    pandas.DataFrame(result)
+                    pandas.DataFrame(result, **astype_kwargs)
                     if is_list_like(result)
-                    else pandas.DataFrame([result])
+                    else pandas.DataFrame([result], **astype_kwargs)
                 )
             if isinstance(result, pandas.Series):
                 if result.name is None:

--- a/modin/core/dataframe/algebra/default2pandas/default.py
+++ b/modin/core/dataframe/algebra/default2pandas/default.py
@@ -78,6 +78,7 @@ class DefaultMethod(Operator):
             """
             df = cls.frame_wrapper(df)
             result = fn(df, *args, **kwargs)
+
             if (
                 not isinstance(result, pandas.Series)
                 and not isinstance(result, pandas.DataFrame)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -177,9 +177,10 @@ def _dt_func_map(func_name):
     def dt_op_builder(df, *args, **kwargs):
         """Apply specified function against ``dt`` accessor of the passed frame."""
         dt_s = df.squeeze(axis=1).dt
-        return pandas.DataFrame(
-            getattr(pandas.Series.dt, func_name)(dt_s, *args, **kwargs)
-        )
+        dt_func_result = getattr(pandas.Series.dt, func_name)(dt_s, *args, **kwargs)
+        # If we don't specify the dtype for the frame, the frame might get the
+        # wrong dtype, e.g. for to_pydatetime in https://github.com/modin-project/modin/issues/4436
+        return pandas.DataFrame(dt_func_result, dtype=dt_func_result.dtype)
 
     return dt_op_builder
 


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Fix to_pydatetime dtype for timezone None.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4436 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
