### PR TITLE
FIX-#4439: Fix `flake8` CI fail

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -37,6 +37,7 @@ Key Features and Updates
   * TEST-#4363: Use Ray from pypi in CI (#4364)
   * FIX-#4422: get rid of case sensitivity for `warns_that_defaulting_to_pandas` (#4423)
   * TEST-#4426: Stop passing is_default kwarg to Modin and pandas (#4428)
+  * FIX-#4439: Fix flake8 CI fail (#4440)
 * Documentation improvements
   * DOCS-#4296: Fix docs warnings (#4297)
   * DOCS-#4388: Turn off fail_on_warning option for docs build (#4389)

--- a/modin/config/__main__.py
+++ b/modin/config/__main__.py
@@ -32,7 +32,7 @@ def print_config_help():
     for objname in sorted(globals()):
         obj = globals()[objname]
         if isinstance(obj, type) and issubclass(obj, Parameter) and not obj.is_abstract:
-            print(f"{obj.get_help()}\n\tCurrent value: {obj.get()}")  # noqa: T001
+            print(f"{obj.get_help()}\n\tCurrent value: {obj.get()}")  # noqa: T201
 
 
 def export_config_help(filename: str):

--- a/modin/experimental/cloud/tracing/parse_rpyc_trace.py
+++ b/modin/experimental/cloud/tracing/parse_rpyc_trace.py
@@ -54,12 +54,12 @@ def get_syncs(items):
 items = read_log((sys.argv[1:] or ["rpyc-trace.log"])[0])
 syncs = get_syncs(items)
 
-print(  # noqa: T001
+print(  # noqa: T201
     f"total time={sum(i['timing'] for i in syncs if i['kind'] == 'recv' and i['msg'] == 'MSG_REPLY')}"
 )
 
 longs = [i for i in syncs if i["timing"] > 0.5]
-print(f'longs ({len(longs)}) time={sum(i["timing"] for i in longs)}')  # noqa: T001
+print(f'longs ({len(longs)}) time={sum(i["timing"] for i in longs)}')  # noqa: T201
 
 s_sends = [i for i in syncs if i["kind"] == "send"]
 
@@ -68,10 +68,10 @@ buckets = collections.defaultdict(list)
 for i in s_sends:
     buckets[i.get("req", "<REVERSE>")].append(i["args"])
 
-print("-------------------")  # noqa: T001
+print("-------------------")  # noqa: T201
 for k, v in buckets.items():
-    print(f"{k}={len(v)}")  # noqa: T001
-print("-------------------")  # noqa: T001
+    print(f"{k}={len(v)}")  # noqa: T201
+print("-------------------")  # noqa: T201
 
 sends = {
     i["seq"]: i for i in items if i["kind"] == "send" and i["msg"] == "MSG_REQUEST"
@@ -187,42 +187,42 @@ for gsend, grecv in pairs:
         remote[got] = sent
     # remote[from_getattr_recv(grecv, False)] = from_getattr_send(gsend, False)
 
-print(f"total time getattrs={sum(x[1]['timing'] for x in getattrs)}")  # noqa: T001
+print(f"total time getattrs={sum(x[1]['timing'] for x in getattrs)}")  # noqa: T201
 
 # import pdb; pdb.set_trace()
 
-print("\n\n----[ getattr ]----")  # noqa: T001
+print("\n\n----[ getattr ]----")  # noqa: T201
 for gsend, grecv in getattrs:
-    print(f"{from_getattr_send(gsend)} --> {from_getattr_recv(grecv)}")  # noqa: T001
+    print(f"{from_getattr_send(gsend)} --> {from_getattr_recv(grecv)}")  # noqa: T201
 
 
-print("\n\n----[ hash ]----")  # noqa: T001
+print("\n\n----[ hash ]----")  # noqa: T201
 for i in syncs:
     if i.get("req", "") == "HANDLE_HASH" and i["kind"] == "send":
-        print(  # noqa: T001
+        print(  # noqa: T201
             from_hash_send(i), "-->", from_getattr_recv(responses.get(i["seq"]))
         )
 
-print("\n\n----[ str ]----")  # noqa: T001
+print("\n\n----[ str ]----")  # noqa: T201
 for i in syncs:
     if i.get("req", "") == "HANDLE_STR" and i["kind"] == "send":
-        print(  # noqa: T001
+        print(  # noqa: T201
             from_hash_send(i), "-->", from_getattr_recv(responses.get(i["seq"]))
         )
 
-print("\n\n----[ callattr ]----")  # noqa: T001
+print("\n\n----[ callattr ]----")  # noqa: T201
 for i in syncs:
     if i.get("req", "") == "HANDLE_CALLATTR" and i["kind"] == "send":
-        print(  # noqa: T001
+        print(  # noqa: T201
             from_callattr_send(i, remote=remote),
             "-->",
             from_getattr_recv(responses.get(i["seq"])),
         )
 
-print("\n\n----[ call ]----")  # noqa: T001
+print("\n\n----[ call ]----")  # noqa: T201
 for i in syncs:
     if i.get("req", "") == "HANDLE_CALL" and i["kind"] == "send":
-        print(  # noqa: T001
+        print(  # noqa: T201
             from_call_send(i, remote=remote),
             "-->",
             from_getattr_recv(responses.get(i["seq"])),

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/df_algebra.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/df_algebra.py
@@ -266,7 +266,7 @@ class DFAlgNode(abc.ABC):
         prefix : str, default: ''
             A prefix to add at each string of the dump.
         """
-        print(self.dumps(prefix))  # noqa: T001
+        print(self.dumps(prefix))  # noqa: T201
 
     def dumps(self, prefix=""):
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ per-file-ignores =
     modin/pandas/__init__.py:E402,F401
     stress_tests/kaggle/*:E402
     modin/experimental/pandas/__init__.py:E402
-    modin/_version.py:T001
+    modin/_version.py:T201
     modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py:E402
 
 [coverage:run]


### PR DESCRIPTION
Signed-off-by: alexander3774 <myskova977@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
In the new release of the `flake8-print` plugin error code `T001` was changed to `T201`. We need to reflect this change in the Modin CI to avoid CI fail.
<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4439  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
