### PR TITLE
FIX-#4438: Fix `reindex` function that doesn't preserve initial index metadata

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -16,6 +16,7 @@ Key Features and Updates
   * FIX-#4407: Align `insert` function with pandas in case of numpy array with several columns (#4408)
   * FIX-#4373: Fix invalid file path when trying `read_csv_glob` with `usecols` parameter (#4405)
   * FIX-#4394: Fix issue with multiindex metadata desync (#4395)
+  * FIX-#4438: Fix `reindex` function that doesn't preserve initial index metadata (#4442)
   * FIX-#4425: Add parameters to groupby pct_change (#4429)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -510,8 +510,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # Reindex/reset_index (may shuffle data)
     def reindex(self, axis, labels, **kwargs):
-        new_index = self.index if axis else labels
-        new_columns = labels if axis else self.columns
+        new_index, _ = (self.index, None) if axis else self.index.reindex(labels)
+        new_columns, _ = self.columns.reindex(labels) if axis else (self.columns, None)
         new_modin_frame = self._modin_frame.apply_full_axis(
             axis,
             lambda df: df.reindex(labels=labels, axis=axis, **kwargs),

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -510,8 +510,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # Reindex/reset_index (may shuffle data)
     def reindex(self, axis, labels, **kwargs):
-        new_index, _ = (self.index, None) if axis else self.index.reindex(labels)
-        new_columns, _ = self.columns.reindex(labels) if axis else (self.columns, None)
+        new_index = self.index if axis else labels
+        new_columns = labels if axis else self.columns
         new_modin_frame = self._modin_frame.apply_full_axis(
             axis,
             lambda df: df.reindex(labels=labels, axis=axis, **kwargs),

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2214,17 +2214,15 @@ class BasePandasDataset(object):
             )
         )
 
-    def _copy_index_metadata(
-        self, source_index, destination_index
-    ):  # noqa: PR01, RT01, D200
+    def _copy_index_metadata(self, source, destination):  # noqa: PR01, RT01, D200
         """
-        Copy metadata from `source_index` to `destination_index` inplace.
+        Copy Index metadata from `source` to `destination` inplace.
         """
-        if hasattr(source_index, "name") and hasattr(destination_index, "name"):
-            destination_index.name = source_index.name
-        if hasattr(source_index, "names") and hasattr(destination_index, "names"):
-            destination_index.names = source_index.names
-        return destination_index
+        if hasattr(source, "name") and hasattr(destination, "name"):
+            destination.name = source.name
+        if hasattr(source, "names") and hasattr(destination, "names"):
+            destination.names = source.names
+        return destination
 
     def _ensure_index(self, index_like, axis=0):  # noqa: PR01, RT01, D200
         """
@@ -2262,7 +2260,7 @@ class BasePandasDataset(object):
         if index is not None:
             if not isinstance(index, pandas.Index):
                 index = self._copy_index_metadata(
-                    self.index, self._ensure_index(index, axis=0)
+                    source=self.index, destination=self._ensure_index(index, axis=0)
                 )
             if not index.equals(self.index):
                 new_query_compiler = self._query_compiler.reindex(
@@ -2274,7 +2272,7 @@ class BasePandasDataset(object):
         if columns is not None:
             if not isinstance(columns, pandas.Index):
                 columns = self._copy_index_metadata(
-                    self.columns, self._ensure_index(columns, axis=1)
+                    source=self.columns, destination=self._ensure_index(columns, axis=1)
                 )
             if not columns.equals(self.columns):
                 final_query_compiler = new_query_compiler.reindex(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2230,7 +2230,8 @@ class BasePandasDataset(object):
         """
         if (
             self._query_compiler.has_multiindex(axis=axis)
-            and isinstance(index_like, list)
+            and is_list_like(index_like)
+            and len(index_like) > 0
             and isinstance(index_like[0], tuple)
         ):
             try:

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2231,9 +2231,13 @@ class BasePandasDataset(object):
         if (
             self._query_compiler.has_multiindex(axis=axis)
             and isinstance(index_like, list)
-            and all(map(lambda elem: isinstance(elem, tuple), index_like))
+            and isinstance(index_like[0], tuple)
         ):
-            return pandas.MultiIndex.from_tuples(index_like)
+            try:
+                return pandas.MultiIndex.from_tuples(index_like)
+            except TypeError:
+                # not all tuples
+                pass
         return ensure_index(index_like)
 
     def reindex(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2235,9 +2235,7 @@ class BasePandasDataset(object):
             return self._default_to_pandas("reindex", copy=copy, **kwargs)
         new_query_compiler = None
         if index is not None:
-            if not isinstance(index, pandas.Index):
-                index = pandas.Index(index)
-            if not index.equals(self.index):
+            if not isinstance(index, pandas.Index) or not index.equals(self.index):
                 new_query_compiler = self._query_compiler.reindex(
                     axis=0, labels=index, **kwargs
                 )
@@ -2245,9 +2243,9 @@ class BasePandasDataset(object):
             new_query_compiler = self._query_compiler
         final_query_compiler = None
         if columns is not None:
-            if not isinstance(columns, pandas.Index):
-                columns = pandas.Index(columns)
-            if not columns.equals(self.columns):
+            if not isinstance(columns, pandas.Index) or not columns.equals(
+                self.columns
+            ):
                 final_query_compiler = new_query_compiler.reindex(
                     axis=1, labels=columns, **kwargs
                 )

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2230,6 +2230,7 @@ class BasePandasDataset(object):
         """
         if (
             self._query_compiler.has_multiindex(axis=axis)
+            and not isinstance(index_like, pandas.Index)
             and is_list_like(index_like)
             and len(index_like) > 0
             and isinstance(index_like[0], tuple)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -689,6 +689,25 @@ def test_reindex_4438():
     new_pandas_df = pandas_df.reindex(columns=new_index)
     df_equals(new_modin_df, new_pandas_df)
 
+    # multiindex case
+    multi_index = pandas.MultiIndex.from_arrays(
+        [("a", "b", "c"), ("a", "b", "c")], names=["first", "second"]
+    )
+    new_multi_index = list(reversed(multi_index))
+
+    modin_df = pd.DataFrame([1, 2, 3], index=multi_index)
+    pandas_df = pandas.DataFrame([1, 2, 3], index=multi_index)
+    new_modin_df = modin_df.reindex(new_multi_index)
+    new_pandas_df = pandas_df.reindex(new_multi_index)
+    df_equals(new_modin_df, new_pandas_df)
+
+    # multicolumn case
+    modin_df = pd.DataFrame(np.array([[1], [2], [3]]).T, columns=multi_index)
+    pandas_df = pandas.DataFrame(np.array([[1], [2], [3]]).T, columns=multi_index)
+    new_modin_df = modin_df.reindex(columns=new_multi_index)
+    new_pandas_df = pandas_df.reindex(columns=new_multi_index)
+    df_equals(new_modin_df, new_pandas_df)
+
 
 def test_reindex_like():
     df1 = pd.DataFrame(

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -708,6 +708,13 @@ def test_reindex_4438():
     new_pandas_df = pandas_df.reindex(columns=new_multi_index)
     df_equals(new_modin_df, new_pandas_df)
 
+    # index + multiindex case
+    modin_df = pd.DataFrame([1, 2, 3], index=index)
+    pandas_df = pandas.DataFrame([1, 2, 3], index=index)
+    new_modin_df = modin_df.reindex(new_multi_index)
+    new_pandas_df = pandas_df.reindex(new_multi_index)
+    df_equals(new_modin_df, new_pandas_df)
+
 
 def test_reindex_like():
     df1 = pd.DataFrame(

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -671,6 +671,25 @@ def test_reindex():
     )
 
 
+def test_reindex_4438():
+    index = pd.date_range(end="1/1/2018", periods=3, freq="h", name="some meta")
+    new_index = list(reversed(index))
+
+    # index case
+    modin_df = pd.DataFrame([1, 2, 3], index=index)
+    pandas_df = pandas.DataFrame([1, 2, 3], index=index)
+    new_modin_df = modin_df.reindex(new_index)
+    new_pandas_df = pandas_df.reindex(new_index)
+    df_equals(new_modin_df, new_pandas_df)
+
+    # column case
+    modin_df = pd.DataFrame(np.array([[1], [2], [3]]).T, columns=index)
+    pandas_df = pandas.DataFrame(np.array([[1], [2], [3]]).T, columns=index)
+    new_modin_df = modin_df.reindex(columns=new_index)
+    new_pandas_df = pandas_df.reindex(columns=new_index)
+    df_equals(new_modin_df, new_pandas_df)
+
+
 def test_reindex_like():
     df1 = pd.DataFrame(
         [


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoliimyachev@mail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4438 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
