### PR TITLE
FIX-#4449 Drain the call queue before waiting on result in benchmark mode.

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -18,6 +18,7 @@ Key Features and Updates
   * FIX-#4394: Fix issue with multiindex metadata desync (#4395)
   * FIX-#4425: Add parameters to groupby pct_change (#4429)
   * FIX-#4461: Fix S3 CSV data path (#4462)
+  * FIX-#4449: Drain the call queue before waiting on result in benchmark mode (#4472)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
 * Benchmarking enhancements

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -60,6 +60,13 @@ def wait_computations_if_benchmark_mode(func):
                 partitions = result[0]
             else:
                 partitions = result
+            # When partitions have a deferred call queue, calling
+            # parittion.wait() on each partition serially will serially kick
+            # off each deferred computation and wait for each partition to
+            # finish before kicking off the next one. Instead, we want to
+            # serially kick off all the deferred computations so that they can
+            # all run aynschronously, then serially wait on all the results.
+            [part.drain_call_queue() for row in partitions for part in row]
             # need to go through all the values of the map iterator
             # since `wait` does not return anything, we need to explicitly add
             # the return `True` value from the lambda

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -65,7 +65,7 @@ def wait_computations_if_benchmark_mode(func):
             # off each deferred computation and wait for each partition to
             # finish before kicking off the next one. Instead, we want to
             # serially kick off all the deferred computations so that they can
-            # all run aynschronously, then serially wait on all the results.
+            # all run asynchronously, then wait on all the results.
             [part.drain_call_queue() for part in partitions.flatten()]
             # need to go through all the values of the map iterator
             # since `wait` does not return anything, we need to explicitly add

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -70,6 +70,8 @@ def wait_computations_if_benchmark_mode(func):
             # need to go through all the values of the map iterator
             # since `wait` does not return anything, we need to explicitly add
             # the return `True` value from the lambda
+            # TODO(https://github.com/modin-project/modin/issues/4491): Wait
+            # for all the partitions in parallel.
             all(map(lambda partition: partition.wait() or True, partitions.flatten()))
             return result
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4449 
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
