### PR TITLE
FIX-#3689: Add black and flake8 into development environment files

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -51,6 +51,7 @@ Key Features and Updates
   * FIX-#4327: Update min pin for xgboost version (#4328)
   * FIX-#4383: Remove `pathlib` from deps (#4384)
   * FIX-#4390: Add `redis` to Modin dependencies (#4396)
+  * FIX-#3689: Add black and flake8 into development environment files (#4480)
 
 Contributors
 ------------
@@ -65,3 +66,4 @@ Contributors
 @anmyachev
 @dchigarev
 @devin-petersohn
+@orcahmlee

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -45,3 +45,5 @@ dependencies:
       - connectorx>=0.2.6a4
       # TODO: remove when resolving GH#4398
       - redis>=3.5.0,<4.0.0
+      - black
+      - flake8

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,3 +35,5 @@ modin-spreadsheet>=0.1.1
 pymssql
 psycopg2
 connectorx>=0.2.6a4
+black
+flake8

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -19,3 +19,5 @@ dependencies:
   - xlrd
   - sqlalchemy
   - scipy
+  - black
+  - flake8

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -19,5 +19,6 @@ dependencies:
   - xlrd
   - sqlalchemy
   - scipy
-  - black
-  - flake8
+  - pip:
+      - black
+      - flake8

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -37,3 +37,5 @@ dependencies:
       - connectorx>=0.2.6a4
       # TODO: remove when resolving GH#4398
       - redis>=3.5.0,<4.0.0
+      - black
+      - flake8


### PR DESCRIPTION
Signed-off-by: Andrew Li <orcahmlee@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Add black and flake8 into requirements-dev.txt

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3689 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
