### PR TITLE
REFACTOR-#4510: Align experimental and regular IO modules initializations

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -38,6 +38,7 @@ Key Features and Updates
   * REFACTOR-#3642: Move PyArrow storage format usage from main feature to experimental ones (#4374)
   * REFACTOR-#4003: Delete the deprecated cloud mortgage example (#4406)
   * REFACTOR-#4513: Fix spelling mistakes in docs and docstrings (#4514)
+  * REFACTOR-#4510: Align experimental and regular IO modules initializations (#4511)
 * Pandas API implementations and improvements
   *
 * OmniSci enhancements

--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -24,7 +24,6 @@ from pandas._typing import CompressionOptions, StorageOptions
 
 from . import DataFrame
 from modin.config import IsExperimental, Engine
-from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 from ...pandas import _update_engine
 
 
@@ -97,6 +96,8 @@ def read_sql(
     modin.DataFrame
     """
     Engine.subscribe(_update_engine)
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
+
     assert IsExperimental.get(), "This only works in experimental mode"
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     return DataFrame(query_compiler=FactoryDispatcher.read_sql(**kwargs))
@@ -138,6 +139,8 @@ def read_custom_text(
     modin.DataFrame
     """
     Engine.subscribe(_update_engine)
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
+
     assert IsExperimental.get(), "This only works in experimental mode"
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     return DataFrame(query_compiler=FactoryDispatcher.read_custom_text(**kwargs))
@@ -265,6 +268,7 @@ def _read(**kwargs) -> DataFrame:
     [4652013 rows x 18 columns]
     """
     Engine.subscribe(_update_engine)
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     try:
         pd_obj = FactoryDispatcher.read_csv_glob(**kwargs)
@@ -323,6 +327,8 @@ def read_pickle_distributed(
     The number of partitions is equal to the number of input files.
     """
     Engine.subscribe(_update_engine)
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
+
     assert IsExperimental.get(), "This only works in experimental mode"
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     return DataFrame(query_compiler=FactoryDispatcher.read_pickle_distributed(**kwargs))
@@ -369,6 +375,8 @@ def to_pickle_distributed(
     """
     obj = self
     Engine.subscribe(_update_engine)
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
+
     if isinstance(self, DataFrame):
         obj = self._query_compiler
     FactoryDispatcher.to_pickle_distributed(

--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -95,11 +95,13 @@ def read_sql(
     -------
     modin.DataFrame
     """
+    _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
+
     Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     assert IsExperimental.get(), "This only works in experimental mode"
-    _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
+
     return DataFrame(query_compiler=FactoryDispatcher.read_sql(**kwargs))
 
 
@@ -138,11 +140,13 @@ def read_custom_text(
     -------
     modin.DataFrame
     """
+    _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
+
     Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     assert IsExperimental.get(), "This only works in experimental mode"
-    _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
+
     return DataFrame(query_compiler=FactoryDispatcher.read_custom_text(**kwargs))
 
 
@@ -326,11 +330,13 @@ def read_pickle_distributed(
     -----
     The number of partitions is equal to the number of input files.
     """
+    _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
+
     Engine.subscribe(_update_engine)
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     assert IsExperimental.get(), "This only works in experimental mode"
-    _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
+
     return DataFrame(query_compiler=FactoryDispatcher.read_pickle_distributed(**kwargs))
 
 


### PR DESCRIPTION
Signed-off-by: alexander3774 <myskova977@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Refactoring `modin.experimental.pandas.io` to be in line with changes introduced in #4017.
Closes #4510.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4510  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
