### PR TITLE
FIX-#4503: Stop the memory logging thread after session exit.

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -24,6 +24,7 @@ Key Features and Updates
   * FIX-#4449: Drain the call queue before waiting on result in benchmark mode (#4472)
   * FIX-#4481: Allow clipping with a Modin Series of bounds (#4486)  
   * FIX-#4504: Support na_action in applymap (#4505)
+  * FIX-#4503: Stop the memory logging thread after session exit (#4515)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
 * Benchmarking enhancements

--- a/modin/logging/config.py
+++ b/modin/logging/config.py
@@ -33,9 +33,8 @@ from modin.config import LogMemoryInterval, LogMode
 __LOGGER_CONFIGURED__: bool = False
 
 
-# Turn off __LOGGER_CONFIGURED__ on interpreter termination. The memory thread
-# will stop logging and terminate once __LOGGER_CONFIGURED__ is off.
 def _turn_off_logging():
+    """Turn off __LOGGER_CONFIGURED__."""
     global __LOGGER_CONFIGURED__
     __LOGGER_CONFIGURED__ = False
 
@@ -156,6 +155,8 @@ def memory_thread(logger, sleep_time):
         The interval at which to profile system memory.
     """
     while True:
+        # Stop logging once __LOGGER_CONFIGURED__ is off, presumably because
+        # the interpreter has exited.
         if not __LOGGER_CONFIGURED__:
             break
         svmem = psutil.virtual_memory()


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Make the memory thread [daemonic](https://docs.python.org/3/library/threading.html#thread-objects) so that "the entire Python program exits when only daemon threads are left."

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4503
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
