### PR TITLE
FIX-#4518: Fix Modin Logging to report specific Modin warnings/errors

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -21,6 +21,7 @@ Key Features and Updates
   * FIX-#4414: Add missing f prefix on f-strings found at https://codereview.doctor (#4415)
   * FIX-#4461: Fix S3 CSV data path (#4462)
   * FIX-#4449: Drain the call queue before waiting on result in benchmark mode (#4472)
+  * FIX-#4518: Fix Modin Logging to report specific Modin warnings/errors (#4519)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
 * Benchmarking enhancements

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -24,7 +24,7 @@ class ErrorMessage(object):
     def not_implemented(cls, message=""):
         if message == "":
             message = "This functionality is not yet available in Modin."
-        get_logger().debug(f"Modin Error: NotImplementedError: {message}")
+        get_logger().info(f"Modin Error: NotImplementedError: {message}")
         raise NotImplementedError(
             f"{message}\n"
             + "To request implementation, file an issue at "
@@ -62,7 +62,7 @@ class ErrorMessage(object):
     @classmethod
     def catch_bugs_and_request_email(cls, failure_condition, extra_log=""):
         if failure_condition:
-            get_logger().debug(f"Modin Error: Internal Error: {extra_log}")
+            get_logger().info(f"Modin Error: Internal Error: {extra_log}")
             raise Exception(
                 "Internal Error. "
                 + "Please visit https://github.com/modin-project/modin/issues "

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -35,14 +35,14 @@ class ErrorMessage(object):
     @classmethod
     def single_warning(cls, message):
         message_hash = hash(message)
-        logger = get_logger()
-        logger.debug(f"Modin Warning: Single Warning: {message} was raised.")
         if message_hash in cls.printed_warnings:
             logger.debug(
                 f"Modin Warning: Single Warning: {message} was raised and suppressed."
             )
             return
 
+        logger = get_logger()
+        logger.debug(f"Modin Warning: Single Warning: {message} was raised.")
         warnings.warn(message)
         cls.printed_warnings.add(message_hash)
 

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -38,7 +38,9 @@ class ErrorMessage(object):
         logger = get_logger()
         logger.debug(f"Modin Warning: Single Warning: {message} was raised.")
         if message_hash in cls.printed_warnings:
-            logger.debug(f"Modin Warning: Single Warning: {message} was raised and suppressed.")
+            logger.debug(
+                f"Modin Warning: Single Warning: {message} was raised and suppressed."
+            )
             return
 
         warnings.warn(message)

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -35,13 +35,13 @@ class ErrorMessage(object):
     @classmethod
     def single_warning(cls, message):
         message_hash = hash(message)
+        logger = get_logger()
         if message_hash in cls.printed_warnings:
             logger.debug(
                 f"Modin Warning: Single Warning: {message} was raised and suppressed."
             )
             return
 
-        logger = get_logger()
         logger.debug(f"Modin Warning: Single Warning: {message} was raised.")
         warnings.warn(message)
         cls.printed_warnings.add(message_hash)

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -12,7 +12,7 @@
 # governing permissions and limitations under the License.
 
 import warnings
-from modin.logging import logger_decorator
+from modin.logging import get_logger
 
 
 class ErrorMessage(object):
@@ -21,10 +21,11 @@ class ErrorMessage(object):
     printed_warnings = set()
 
     @classmethod
-    @logger_decorator("MODIN-ERROR", "ErrorMessage.not_implemented", "debug")
     def not_implemented(cls, message=""):
         if message == "":
             message = "This functionality is not yet available in Modin."
+        logger = get_logger()
+        logger.debug("Modin Error: NotImplementedError {}".format(message))
         raise NotImplementedError(
             f"{message}\n"
             + "To request implementation, file an issue at "
@@ -33,9 +34,10 @@ class ErrorMessage(object):
         )
 
     @classmethod
-    @logger_decorator("MODIN-ERROR", "ErrorMessage.single_warning", "debug")
     def single_warning(cls, message):
         message_hash = hash(message)
+        logger = get_logger()
+        logger.debug("Modin Warning: Single Warning {}".format(message))
         if message_hash in cls.printed_warnings:
             return
 
@@ -43,7 +45,6 @@ class ErrorMessage(object):
         cls.printed_warnings.add(message_hash)
 
     @classmethod
-    @logger_decorator("MODIN-ERROR", "ErrorMessage.default_to_pandas", "debug")
     def default_to_pandas(cls, message=""):
         if message != "":
             message = f"{message} defaulting to pandas implementation."
@@ -57,14 +58,15 @@ class ErrorMessage(object):
                 + "https://modin.readthedocs.io/en/stable/supported_apis/defaulting_to_pandas.html for explanation."
             )
             cls.printed_default_to_pandas = True
+        logger = get_logger()
+        logger.debug("Modin Warning: Default to pandas {}".format(message))
         warnings.warn(message)
 
     @classmethod
-    @logger_decorator(
-        "MODIN-ERROR", "ErrorMessage.catch_bugs_and_request_email", "debug"
-    )
     def catch_bugs_and_request_email(cls, failure_condition, extra_log=""):
         if failure_condition:
+            logger = get_logger()
+            logger.debug("Modin Error: Internal Error {}".format(extra_log))
             raise Exception(
                 "Internal Error. "
                 + "Please visit https://github.com/modin-project/modin/issues "
@@ -74,23 +76,30 @@ class ErrorMessage(object):
             )
 
     @classmethod
-    @logger_decorator("MODIN-ERROR", "ErrorMessage.non_verified_udf", "debug")
     def non_verified_udf(cls):
+        logger = get_logger()
+        logger.debug("Modin Warning: Non Verified UDF")
         warnings.warn(
             "User-defined function verification is still under development in Modin. "
             + "The function provided is not verified."
         )
 
     @classmethod
-    @logger_decorator("MODIN-ERROR", "ErrorMessage.mismatch_with_pandas", "debug")
     def missmatch_with_pandas(cls, operation, message):
+        logger = get_logger()
+        logger.debug(
+            "Modin Warning: {} mismatch with pandas, Message: {}".format(
+                operation, message
+            )
+        )
         cls.single_warning(
             f"`{operation}` implementation has mismatches with pandas:\n{message}."
         )
 
     @classmethod
-    @logger_decorator("MODIN-ERROR", "ErrorMessage.not_initialized", "debug")
     def not_initialized(cls, engine, code):
+        logger = get_logger()
+        logger.debug("Modin Warning: {} not initialized".format(engine))
         warnings.warn(
             f"{engine} execution environment not yet initialized. Initializing...\n"
             + "To remove this warning, run the following python code before doing dataframe operations:\n"

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -25,7 +25,7 @@ class ErrorMessage(object):
         if message == "":
             message = "This functionality is not yet available in Modin."
         logger = get_logger()
-        logger.debug("Modin Error: NotImplementedError {}".format(message))
+        logger.debug("Modin Error: NotImplementedError: {}".format(message))
         raise NotImplementedError(
             f"{message}\n"
             + "To request implementation, file an issue at "
@@ -37,7 +37,7 @@ class ErrorMessage(object):
     def single_warning(cls, message):
         message_hash = hash(message)
         logger = get_logger()
-        logger.debug("Modin Warning: Single Warning {}".format(message))
+        logger.debug("Modin Warning: Single Warning: {}".format(message))
         if message_hash in cls.printed_warnings:
             return
 
@@ -59,14 +59,14 @@ class ErrorMessage(object):
             )
             cls.printed_default_to_pandas = True
         logger = get_logger()
-        logger.debug("Modin Warning: Default to pandas {}".format(message))
+        logger.debug("Modin Warning: Default to pandas: {}".format(message))
         warnings.warn(message)
 
     @classmethod
     def catch_bugs_and_request_email(cls, failure_condition, extra_log=""):
         if failure_condition:
             logger = get_logger()
-            logger.debug("Modin Error: Internal Error {}".format(extra_log))
+            logger.debug("Modin Error: Internal Error: {}".format(extra_log))
             raise Exception(
                 "Internal Error. "
                 + "Please visit https://github.com/modin-project/modin/issues "
@@ -88,7 +88,7 @@ class ErrorMessage(object):
     def missmatch_with_pandas(cls, operation, message):
         logger = get_logger()
         logger.debug(
-            "Modin Warning: {} mismatch with pandas, Message: {}".format(
+            "Modin Warning: {} mismatch with pandas: {}".format(
                 operation, message
             )
         )
@@ -99,7 +99,7 @@ class ErrorMessage(object):
     @classmethod
     def not_initialized(cls, engine, code):
         logger = get_logger()
-        logger.debug("Modin Warning: {} not initialized".format(engine))
+        logger.debug("Modin Warning: Not Initialized: {}".format(engine))
         warnings.warn(
             f"{engine} execution environment not yet initialized. Initializing...\n"
             + "To remove this warning, run the following python code before doing dataframe operations:\n"

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -35,7 +35,6 @@ class ErrorMessage(object):
     @classmethod
     def single_warning(cls, message):
         message_hash = hash(message)
-        get_logger().debug(f"Modin Warning: Single Warning: {message}")
         if message_hash in cls.printed_warnings:
             return
 

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -35,8 +35,10 @@ class ErrorMessage(object):
     @classmethod
     def single_warning(cls, message):
         message_hash = hash(message)
-        get_logger().debug(f"Modin Warning: Single Warning: {message}")
+        logger = get_logger()
+        logger.debug(f"Modin Warning: Single Warning: {message} was raised.")
         if message_hash in cls.printed_warnings:
+            logger.debug(f"Modin Warning: Single Warning: {message} was raised and suppressed.")
             return
 
         warnings.warn(message)

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -24,8 +24,7 @@ class ErrorMessage(object):
     def not_implemented(cls, message=""):
         if message == "":
             message = "This functionality is not yet available in Modin."
-        logger = get_logger()
-        logger.debug("Modin Error: NotImplementedError: {}".format(message))
+        get_logger().debug(f"Modin Error: NotImplementedError: {message}")
         raise NotImplementedError(
             f"{message}\n"
             + "To request implementation, file an issue at "
@@ -36,8 +35,7 @@ class ErrorMessage(object):
     @classmethod
     def single_warning(cls, message):
         message_hash = hash(message)
-        logger = get_logger()
-        logger.debug("Modin Warning: Single Warning: {}".format(message))
+        get_logger().debug(f"Modin Warning: Single Warning: {message}")
         if message_hash in cls.printed_warnings:
             return
 
@@ -58,15 +56,13 @@ class ErrorMessage(object):
                 + "https://modin.readthedocs.io/en/stable/supported_apis/defaulting_to_pandas.html for explanation."
             )
             cls.printed_default_to_pandas = True
-        logger = get_logger()
-        logger.debug("Modin Warning: Default to pandas: {}".format(message))
+        get_logger().debug(f"Modin Warning: Default to pandas: {message}")
         warnings.warn(message)
 
     @classmethod
     def catch_bugs_and_request_email(cls, failure_condition, extra_log=""):
         if failure_condition:
-            logger = get_logger()
-            logger.debug("Modin Error: Internal Error: {}".format(extra_log))
+            get_logger().debug(f"Modin Error: Internal Error: {extra_log}")
             raise Exception(
                 "Internal Error. "
                 + "Please visit https://github.com/modin-project/modin/issues "
@@ -77,8 +73,7 @@ class ErrorMessage(object):
 
     @classmethod
     def non_verified_udf(cls):
-        logger = get_logger()
-        logger.debug("Modin Warning: Non Verified UDF")
+        get_logger().debug("Modin Warning: Non Verified UDF")
         warnings.warn(
             "User-defined function verification is still under development in Modin. "
             + "The function provided is not verified."
@@ -86,9 +81,8 @@ class ErrorMessage(object):
 
     @classmethod
     def missmatch_with_pandas(cls, operation, message):
-        logger = get_logger()
-        logger.debug(
-            "Modin Warning: {} mismatch with pandas: {}".format(operation, message)
+        get_logger().debug(
+            f"Modin Warning: {operation} mismatch with pandas: {message}"
         )
         cls.single_warning(
             f"`{operation}` implementation has mismatches with pandas:\n{message}."
@@ -96,8 +90,7 @@ class ErrorMessage(object):
 
     @classmethod
     def not_initialized(cls, engine, code):
-        logger = get_logger()
-        logger.debug("Modin Warning: Not Initialized: {}".format(engine))
+        get_logger().debug(f"Modin Warning: Not Initialized: {engine}")
         warnings.warn(
             f"{engine} execution environment not yet initialized. Initializing...\n"
             + "To remove this warning, run the following python code before doing dataframe operations:\n"

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -88,9 +88,7 @@ class ErrorMessage(object):
     def missmatch_with_pandas(cls, operation, message):
         logger = get_logger()
         logger.debug(
-            "Modin Warning: {} mismatch with pandas: {}".format(
-                operation, message
-            )
+            "Modin Warning: {} mismatch with pandas: {}".format(operation, message)
         )
         cls.single_warning(
             f"`{operation}` implementation has mismatches with pandas:\n{message}."

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -35,6 +35,7 @@ class ErrorMessage(object):
     @classmethod
     def single_warning(cls, message):
         message_hash = hash(message)
+        get_logger().debug(f"Modin Warning: Single Warning: {message}")
         if message_hash in cls.printed_warnings:
             return
 


### PR DESCRIPTION
Signed-off-by: Naren Krishna <naren@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Modin Logging currently reports several lines like:

> 88001, 4538414592, 2022-05-26,16:44:07.377470, START::MODIN-ERROR::ErrorMessage.catch_bugs_and_request_email
> 88001, 4538414592, 2022-05-26,16:44:07.377538, STOP::MODIN-ERROR::ErrorMessage.catch_bugs_and_request_email

We want to only report the specific errors and not the API calls to these functions that do not raise the actual exceptions.


- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4518 ? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
