### PR TITLE
DOCS-#0000: Correct typo in flow/modin/core/io/index.rst

### DIFF
--- a/docs/flow/modin/core/io/index.rst
+++ b/docs/flow/modin/core/io/index.rst
@@ -21,7 +21,7 @@ Data File Splitting Mechanism
 
 Modin's file splitting mechanism differs depending on the data format type:
 
-* text format type - the file is split into bytes according to user specified arguments(?).
+* text format type - the file is split into bytes according to user specified arguments.
   In the simplest case, when no row related parameters (such as ``nrows`` or
   ``skiprows``) are passed, data chunk limits (start and end bytes) are derived
   by dividing the file size by the number of partitions (chunks can


### PR DESCRIPTION
Leftover from https://github.com/modin-project/modin/pull/4514 and referenced in https://github.com/modin-project/modin/pull/4514#discussion_r890815750

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
