### PR TITLE
FIX-#4543: Fix `read_csv` in case skiprows=<0, []>

### DIFF
--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -31,6 +31,7 @@ Key Features and Updates
   * FIX-#4464: Refactor Ray utils and quick fix groupby.count failing on virtual partitions (#4490)
   * FIX-#4436: Fix to_pydatetime dtype for timezone None (#4437)
   * FIX-#4541: Fix merge_asof with non-unique right index (#4542)
+  * FIX-#4543: Fix `read_csv` in case skiprows=<0, []> (#4544)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
   * PERF-#4493: Use partition size caches more in Modin dataframe (#4495)

--- a/docs/release_notes/release_notes-0.15.0.rst
+++ b/docs/release_notes/release_notes-0.15.0.rst
@@ -31,7 +31,6 @@ Key Features and Updates
   * FIX-#4464: Refactor Ray utils and quick fix groupby.count failing on virtual partitions (#4490)
   * FIX-#4436: Fix to_pydatetime dtype for timezone None (#4437)
   * FIX-#4541: Fix merge_asof with non-unique right index (#4542)
-  * FIX-#4543: Fix `read_csv` in case skiprows=<0, []> (#4544)
 * Performance enhancements
   * FEAT-#4320: Add connectorx as an alternative engine for read_sql (#4346)
   * PERF-#4493: Use partition size caches more in Modin dataframe (#4495)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -6,7 +6,7 @@ Key Features and Updates
 ------------------------
 
 * Stability and Bugfixes
-  *
+  * FIX-#4543: Fix `read_csv` in case skiprows=<0, []> (#4544)
 * Performance enhancements
   *
 * Benchmarking enhancements
@@ -33,3 +33,4 @@ Key Features and Updates
 Contributors
 ------------
 @mvashishtha
+@prutskov

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -1149,7 +1149,6 @@ class TextFileDispatcher(FileDispatcher):
         bool
             Whether to use inferred column names in ``read_csv`` of the workers or not.
         """
-
         if names not in [None, lib.no_default]:
             return False
         if skipfooter != 0:

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -1018,7 +1018,7 @@ class TextFileDispatcher(FileDispatcher):
             )
 
         is_quoting = kwargs["quoting"] != QUOTE_NONE
-        use_inferred_column_names = cls._should_use_inferred_column_names(
+        use_inferred_column_names = cls.uses_inferred_column_names(
             names, skiprows, kwargs.get("skipfooter", 0), kwargs.get("usecols", None)
         )
 
@@ -1114,25 +1114,25 @@ class TextFileDispatcher(FileDispatcher):
 
         return mask
 
-    @classmethod
+    @staticmethod
     @logger_decorator(
-        "PANDAS-API", "TextFileDispatcher._should_use_inferred_column_names", "INFO"
+        "PANDAS-API", "TextFileDispatcher.uses_inferred_column_names", "INFO"
     )
-    def _should_use_inferred_column_names(cls, names, skiprows, skipfooter, usecols):
+    def uses_inferred_column_names(names, skiprows, skipfooter, usecols):
         """
-        Tells whether need to use inferred column names in workers or not.
+        Tell whether need to use inferred column names in workers or not.
 
         1) ``False`` is returned in 2 cases and means next:
-            1.a) `names` parameter was provided from high-level API. In this case parameter
+            1.a) `names` parameter was provided from the API layer. In this case parameter
             `names` must be provided as `names` parameter for ``read_csv`` in the workers.
-            1.b) `names` parameter wasn't provided from high-level API. In this case column names
+            1.b) `names` parameter wasn't provided from the API layer. In this case column names
             inference must happen in each partition.
-        2) ``True`` is returned in a case when inferred column names from pre-reading stage must be
+        2) ``True`` is returned in case when inferred column names from pre-reading stage must be
             provided as `names` parameter for ``read_csv`` in the workers.
 
-        In case `names` was provided the other parameters isn't checked. Otherwise, inferred column
+        In case `names` was provided, the other parameters aren't checked. Otherwise, inferred column
         names should be used in a case of not full data reading which is defined by `skipfooter` parameter,
-        when need to skip lines at the bottom of file or by `skiprows` parameter, when need to skip lines on
+        when need to skip lines at the bottom of file or by `skiprows` parameter, when need to skip lines at
         the top of file (but if `usecols` was provided, column names inference must happen in the workers).
 
         Parameters

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -792,7 +792,7 @@ class TextFileDispatcher(FileDispatcher):
         pre_reading = skiprows_partitioning = skiprows_md = 0
         if isinstance(skiprows, int):
             skiprows_partitioning = skiprows
-        elif is_list_like(skiprows):
+        elif is_list_like(skiprows) and len(skiprows) > 0:
             skiprows_md = np.sort(skiprows)
             if np.all(np.diff(skiprows_md) == 1):
                 # `skiprows` is uniformly distributed array.
@@ -1021,7 +1021,7 @@ class TextFileDispatcher(FileDispatcher):
         # In these cases we should pass additional metadata
         # to the workers to match pandas output
         pass_names = names in [None, lib.no_default] and (
-            skiprows not in [None, 0] or kwargs["skipfooter"] != 0
+            skiprows not in [None, 0, []] or kwargs["skipfooter"] != 0
         )
 
         pd_df_metadata = cls.read_callback(

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -1018,7 +1018,7 @@ class TextFileDispatcher(FileDispatcher):
             )
 
         is_quoting = kwargs["quoting"] != QUOTE_NONE
-        use_inferred_column_names = cls.uses_inferred_column_names(
+        use_inferred_column_names = cls._uses_inferred_column_names(
             names, skiprows, kwargs.get("skipfooter", 0), kwargs.get("usecols", None)
         )
 
@@ -1116,9 +1116,9 @@ class TextFileDispatcher(FileDispatcher):
 
     @staticmethod
     @logger_decorator(
-        "PANDAS-API", "TextFileDispatcher.uses_inferred_column_names", "INFO"
+        "PANDAS-API", "TextFileDispatcher._uses_inferred_column_names", "INFO"
     )
-    def uses_inferred_column_names(names, skiprows, skipfooter, usecols):
+    def _uses_inferred_column_names(names, skiprows, skipfooter, usecols):
         """
         Tell whether need to use inferred column names in workers or not.
 

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -1019,7 +1019,7 @@ class TextFileDispatcher(FileDispatcher):
 
         is_quoting = kwargs["quoting"] != QUOTE_NONE
 
-        def _check_skiprows(skiprows):
+        def _calc_skiprows_conditions(skiprows):
             if skiprows is not None:
                 if isinstance(skiprows, int) and skiprows == 0:
                     return False
@@ -1033,7 +1033,7 @@ class TextFileDispatcher(FileDispatcher):
         # In these cases we should pass additional metadata
         # to the workers to match pandas output
         pass_names = names in [None, lib.no_default] and (
-            _check_skiprows(skiprows) or kwargs["skipfooter"] != 0
+            _calc_skiprows_conditions(skiprows) or kwargs["skipfooter"] != 0
         )
 
         pd_df_metadata = cls.read_callback(

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -1018,8 +1018,6 @@ class TextFileDispatcher(FileDispatcher):
             )
 
         is_quoting = kwargs["quoting"] != QUOTE_NONE
-        # In these cases we should pass additional metadata
-        # to the workers to match pandas output
 
         def _check_skiprows(skiprows):
             if skiprows is not None:
@@ -1032,6 +1030,8 @@ class TextFileDispatcher(FileDispatcher):
             else:
                 return False
 
+        # In these cases we should pass additional metadata
+        # to the workers to match pandas output
         pass_names = names in [None, lib.no_default] and (
             _check_skiprows(skiprows) or kwargs["skipfooter"] != 0
         )
@@ -1076,6 +1076,7 @@ class TextFileDispatcher(FileDispatcher):
                 header_size=header_size,
                 pre_reading=pre_reading,
             )
+
         partition_ids, index_ids, dtypes_ids = cls._launch_tasks(
             splits, callback=cls.read_callback, **partition_kwargs
         )

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -1021,7 +1021,7 @@ class TextFileDispatcher(FileDispatcher):
         # In these cases we should pass additional metadata
         # to the workers to match pandas output
         pass_names = names in [None, lib.no_default] and (
-            skiprows is not None or kwargs["skipfooter"] != 0
+            skiprows not in [None, 0] or kwargs["skipfooter"] != 0
         )
 
         pd_df_metadata = cls.read_callback(
@@ -1064,7 +1064,6 @@ class TextFileDispatcher(FileDispatcher):
                 header_size=header_size,
                 pre_reading=pre_reading,
             )
-
         partition_ids, index_ids, dtypes_ids = cls._launch_tasks(
             splits, callback=cls.read_callback, **partition_kwargs
         )

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -1123,12 +1123,17 @@ class TextFileDispatcher(FileDispatcher):
         Tells whether need to use inferred column names in workers or not.
 
         1) ``False`` is returned in 2 cases and means next:
-            1.a) `names` paramter was provided from high-level API. In this case parameter
+            1.a) `names` parameter was provided from high-level API. In this case parameter
             `names` must be provided as `names` parameter for ``read_csv`` in the workers.
             1.b) `names` parameter wasn't provided from high-level API. In this case column names
             inference must happen in each partition.
         2) ``True`` is returned in a case when inferred column names from pre-reading stage must be
             provided as `names` parameter for ``read_csv`` in the workers.
+
+        In case `names` was provided the other parameters isn't checked. Otherwise, inferred column
+        names should be used in a case of not full data reading which is defined by `skipfooter` parameter,
+        when need to skip lines at the bottom of file or by `skiprows` parameter, when need to skip lines on
+        the top of file (but if `usecols` was provided, column names inference must happen in the workers).
 
         Parameters
         ----------

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -1023,17 +1023,15 @@ class TextFileDispatcher(FileDispatcher):
             if skiprows is not None:
                 if isinstance(skiprows, int) and skiprows == 0:
                     return False
-                elif is_list_like(skiprows):
+                if is_list_like(skiprows):
                     return kwargs.get("usecols", None) is None
-                else:
-                    return True
-            else:
-                return False
+                return True
+            return False
 
         # In these cases we should pass additional metadata
         # to the workers to match pandas output
         pass_names = names in [None, lib.no_default] and (
-            _calc_skiprows_conditions(skiprows) or kwargs["skipfooter"] != 0
+            kwargs["skipfooter"] != 0 or _calc_skiprows_conditions(skiprows)
         )
 
         pd_df_metadata = cls.read_callback(

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -1020,8 +1020,20 @@ class TextFileDispatcher(FileDispatcher):
         is_quoting = kwargs["quoting"] != QUOTE_NONE
         # In these cases we should pass additional metadata
         # to the workers to match pandas output
+
+        def _check_skiprows(skiprows):
+            if skiprows is not None:
+                if isinstance(skiprows, int) and skiprows == 0:
+                    return False
+                elif is_list_like(skiprows):
+                    return kwargs.get("usecols", None) is None
+                else:
+                    return True
+            else:
+                return False
+
         pass_names = names in [None, lib.no_default] and (
-            skiprows not in [None, 0, []] or kwargs["skipfooter"] != 0
+            _check_skiprows(skiprows) or kwargs["skipfooter"] != 0
         )
 
         pd_df_metadata = cls.read_callback(

--- a/modin/pandas/test/data/issue_4543.csv
+++ b/modin/pandas/test/data/issue_4543.csv
@@ -1,0 +1,4 @@
+str_data,float_data,country
+fanta,3.14,usa
+cocacola,9.8,france
+sprite,89.2,china

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1000,7 +1000,7 @@ class TestCsv:
             cast_to_str=StorageFormat.get() != "Omnisci",
         )
 
-    @pytest.mark.parametrize("skiprows", [None, 0])
+    @pytest.mark.parametrize("skiprows", [None, 0, []])
     def test_read_csv_skiprows_with_usecols(self, skiprows):
         usecols = {"float_data": "float64"}
         eval_io(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1000,6 +1000,18 @@ class TestCsv:
             cast_to_str=StorageFormat.get() != "Omnisci",
         )
 
+    @pytest.mark.parametrize("skiprows", [None, 0])
+    def test_read_csv_skiprows_with_usecols(self, skiprows):
+        usecols = {"float_data": "float64"}
+        eval_io(
+            fn_name="read_csv",
+            # read_csv kwargs
+            filepath_or_buffer="modin/pandas/test/data/issue_4543.csv",
+            skiprows=skiprows,
+            usecols=usecols.keys(),
+            dtype=usecols,
+        )
+
     def test_read_csv_sep_none(self):
         eval_io(
             fn_name="read_csv",

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1000,7 +1000,7 @@ class TestCsv:
             cast_to_str=StorageFormat.get() != "Omnisci",
         )
 
-    @pytest.mark.parametrize("skiprows", [None, 0, []])
+    @pytest.mark.parametrize("skiprows", [None, 0, [], [1, 2], np.arange(0, 2)])
     def test_read_csv_skiprows_with_usecols(self, skiprows):
         usecols = {"float_data": "float64"}
         eval_io(


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR fixes corner cases when `read_csv` is used with `skiprows` + `usecols` parameters.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4543  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
