### PR TITLE
TEST-#4508: Reduce test_partition_api pytest threads to deflake it.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -257,7 +257,10 @@ jobs:
       - run: python -m pytest modin/test/storage_formats/base/test_internals.py
       - run: python -m pytest modin/test/storage_formats/pandas/test_internals.py
       - run: python -m pytest modin/test/test_envvar_npartitions.py
-      - run: python -m pytest -n 2 modin/test/test_partition_api.py
+      # TODO(https://github.com/modin-project/modin/issues/4550): this test is
+      # slow (~140 sec), but using 2 cores usually causes ray worker crashes.
+      # Fix the crashes and increase cores to 2.
+      - run: python -m pytest modin/test/test_partition_api.py
       - run: python -m pytest modin/test/test_utils.py
       - run: python -m pytest asv_bench/test/test_utils.py
       - run: python -m pytest modin/test/exchange/dataframe_protocol/base

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -22,7 +22,7 @@ Key Features and Updates
 * Developer API enhancements
   *
 * Update testing suite
-  *
+  * TEST-#4550: Reduce test_partition_api pytest threads to deflake it (#4551)
 * Documentation improvements
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
 * Dependencies

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -22,7 +22,7 @@ Key Features and Updates
 * Developer API enhancements
   *
 * Update testing suite
-  * TEST-#4550: Reduce test_partition_api pytest threads to deflake it (#4551)
+  * TEST-#4508: Reduce test_partition_api pytest threads to deflake it (#4551)
 * Documentation improvements
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
 * Dependencies


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Reduce test_partition_api pytest threads to deflake it.

I was able to reproduce the failure in 3/3 CI runs on a branch where the CI in push.yml only ran this test. I reduced the number of pytest cores to the default of 1 and 4/4 runs passed. 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4508
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
