### PR TITLE
REFACTOR-#4530: Standardize access to physical data in partitions

### DIFF
--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -513,11 +513,11 @@ def execute(
         if ASV_USE_ENGINE == "ray":
             from ray import wait
 
-            all(map(lambda partition: wait([partition.oid]), partitions))
+            all(map(lambda partition: wait([partition.physical_data]), partitions))
         elif ASV_USE_ENGINE == "dask":
             from dask.distributed import wait
 
-            all(map(lambda partition: wait(partition.future), partitions))
+            all(map(lambda partition: wait(partition.physical_data), partitions))
         elif ASV_USE_ENGINE == "python":
             pass
 

--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -513,11 +513,11 @@ def execute(
         if ASV_USE_ENGINE == "ray":
             from ray import wait
 
-            all(map(lambda partition: wait([partition.physical_data]), partitions))
+            all(map(lambda partition: wait([partition._data]), partitions))
         elif ASV_USE_ENGINE == "dask":
             from dask.distributed import wait
 
-            all(map(lambda partition: wait(partition.physical_data), partitions))
+            all(map(lambda partition: wait(partition._data), partitions))
         elif ASV_USE_ENGINE == "python":
             pass
 

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -12,7 +12,7 @@ Key Features and Updates
 * Benchmarking enhancements
   *
 * Refactor Codebase
-  *
+  * REFACTOR-#4530: Standardize access to physical data in partitions (#4563)
 * Pandas API implementations and improvements
   *
 * OmniSci enhancements
@@ -33,3 +33,4 @@ Key Features and Updates
 Contributors
 ------------
 @mvashishtha
+@prutskov

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -32,6 +32,20 @@ class PandasDataframePartition(ABC):  # pragma: no cover
 
     _length_cache = None
     _width_cache = None
+    _physical_data = None
+
+    @property
+    def physical_data(self):
+        """
+        Flush the `call_queue` and get the physical data wrapped by this partition.
+
+        Returns
+        -------
+        object
+            The physical data wrapped by this partition.
+        """
+        self.drain_call_queue()
+        return self._physical_data
 
     def get(self):
         """

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -37,7 +37,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
     @property
     def physical_data(self):
         """
-        Flush the `call_queue` and get the physical data wrapped by this partition.
+        Drain the `call_queue` and get the physical data wrapped by this partition.
 
         Returns
         -------

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -32,20 +32,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
 
     _length_cache = None
     _width_cache = None
-    _physical_data = None
-
-    @property
-    def physical_data(self):
-        """
-        Drain the `call_queue` and get the physical data wrapped by this partition.
-
-        Returns
-        -------
-        object
-            The physical data wrapped by this partition.
-        """
-        self.drain_call_queue()
-        return self._physical_data
+    _data = None
 
     def get(self):
         """

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
@@ -28,7 +28,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
 
     Parameters
     ----------
-    future : distributed.Future
+    physical_data : distributed.Future
         A reference to pandas DataFrame that need to be wrapped with this class.
     length : distributed.Future or int, optional
         Length or reference to it of wrapped pandas DataFrame.
@@ -40,9 +40,11 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         Call queue that needs to be executed on wrapped pandas DataFrame.
     """
 
-    def __init__(self, future, length=None, width=None, ip=None, call_queue=None):
-        assert isinstance(future, Future)
-        self.future = future
+    def __init__(
+        self, physical_data, length=None, width=None, ip=None, call_queue=None
+    ):
+        assert isinstance(physical_data, Future)
+        self._physical_data = physical_data
         if call_queue is None:
             call_queue = []
         self.call_queue = call_queue
@@ -60,7 +62,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
             The object from the distributed memory.
         """
         self.drain_call_queue()
-        return DaskWrapper.materialize(self.future)
+        return DaskWrapper.materialize(self._physical_data)
 
     def apply(self, func, *args, **kwargs):
         """
@@ -87,7 +89,11 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         call_queue = self.call_queue + [[func, args, kwargs]]
         if len(call_queue) > 1:
             futures = DaskWrapper.deploy(
-                apply_list_of_funcs, call_queue, self.future, num_returns=2, pure=False
+                apply_list_of_funcs,
+                call_queue,
+                self._physical_data,
+                num_returns=2,
+                pure=False,
             )
         else:
             # We handle `len(call_queue) == 1` in a different way because
@@ -95,7 +101,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
             func, args, kwargs = call_queue[0]
             futures = DaskWrapper.deploy(
                 apply_func,
-                self.future,
+                self._physical_data,
                 func,
                 *args,
                 num_returns=2,
@@ -127,7 +133,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         The keyword arguments are sent as a dictionary.
         """
         return PandasOnDaskDataframePartition(
-            self.future, call_queue=self.call_queue + [[func, args, kwargs]]
+            self._physical_data, call_queue=self.call_queue + [[func, args, kwargs]]
         )
 
     def drain_call_queue(self):
@@ -137,7 +143,11 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         call_queue = self.call_queue
         if len(call_queue) > 1:
             futures = DaskWrapper.deploy(
-                apply_list_of_funcs, call_queue, self.future, num_returns=2, pure=False
+                apply_list_of_funcs,
+                call_queue,
+                self._physical_data,
+                num_returns=2,
+                pure=False,
             )
         else:
             # We handle `len(call_queue) == 1` in a different way because
@@ -145,21 +155,21 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
             func, args, kwargs = call_queue[0]
             futures = DaskWrapper.deploy(
                 apply_func,
-                self.future,
+                self._physical_data,
                 func,
                 *args,
                 num_returns=2,
                 pure=False,
                 **kwargs,
             )
-        self.future = futures[0]
+        self._physical_data = futures[0]
         self._ip_cache = futures[1]
         self.call_queue = []
 
     def wait(self):
         """Wait completing computations on the object wrapped by the partition."""
         self.drain_call_queue()
-        wait(self.future)
+        wait(self._physical_data)
 
     def mask(self, row_labels, col_labels):
         """
@@ -198,7 +208,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
             A copy of this partition.
         """
         return PandasOnDaskDataframePartition(
-            self.future,
+            self._physical_data,
             length=self._length_cache,
             width=self._width_cache,
             ip=self._ip_cache,
@@ -249,7 +259,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
             The length of the object.
         """
         if self._length_cache is None:
-            self._length_cache = self.apply(lambda df: len(df)).future
+            self._length_cache = self.apply(lambda df: len(df))._physical_data
         if isinstance(self._length_cache, Future):
             self._length_cache = DaskWrapper.materialize(self._length_cache)
         return self._length_cache
@@ -264,7 +274,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
             The width of the object.
         """
         if self._width_cache is None:
-            self._width_cache = self.apply(lambda df: len(df.columns)).future
+            self._width_cache = self.apply(lambda df: len(df.columns))._physical_data
         if isinstance(self._width_cache, Future):
             self._width_cache = DaskWrapper.materialize(self._width_cache)
         return self._width_cache

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
@@ -47,6 +47,4 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
-        return DaskWrapper.materialize(
-            [partition.physical_data for partition in partitions]
-        )
+        return DaskWrapper.materialize([partition._data for partition in partitions])

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
@@ -47,4 +47,6 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
-        return DaskWrapper.materialize([partition.future for partition in partitions])
+        return DaskWrapper.materialize(
+            [partition.physical_data for partition in partitions]
+        )

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -43,6 +43,8 @@ class PandasOnDaskDataframeAxisPartition(PandasDataframeAxisPartition):
             raise NotImplementedError(
                 "Pandas on Dask execution requires full-axis partitions."
             )
+        for obj in list_of_blocks:
+            obj.drain_call_queue()
         # Unwrap from PandasDataframePartition object for ease of use
         self.list_of_blocks = [obj.physical_data for obj in list_of_blocks]
         if get_ip:

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -43,10 +43,8 @@ class PandasOnDaskDataframeAxisPartition(PandasDataframeAxisPartition):
             raise NotImplementedError(
                 "Pandas on Dask execution requires full-axis partitions."
             )
-        for obj in list_of_blocks:
-            obj.drain_call_queue()
         # Unwrap from PandasDataframePartition object for ease of use
-        self.list_of_blocks = [obj.future for obj in list_of_blocks]
+        self.list_of_blocks = [obj.physical_data for obj in list_of_blocks]
         if get_ip:
             self.list_of_ips = [obj._ip_cache for obj in list_of_blocks]
 

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -46,7 +46,7 @@ class PandasOnDaskDataframeAxisPartition(PandasDataframeAxisPartition):
         for obj in list_of_blocks:
             obj.drain_call_queue()
         # Unwrap from PandasDataframePartition object for ease of use
-        self.list_of_blocks = [obj.physical_data for obj in list_of_blocks]
+        self.list_of_blocks = [obj._data for obj in list_of_blocks]
         if get_ip:
             self.list_of_ips = [obj._ip_cache for obj in list_of_blocks]
 

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
@@ -52,7 +52,7 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
     @property
     def physical_data(self):
         """
-        Flush the `call_queue` and get the physical data wrapped by this partition.
+        Drain the `call_queue` and get the physical data wrapped by this partition.
 
         Returns
         -------

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
@@ -25,7 +25,7 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
 
     Parameters
     ----------
-    data : pandas.DataFrame
+    physical_data : pandas.DataFrame
         ``pandas.DataFrame`` that should be wrapped with this class.
     length : int, optional
         Length of `data` (number of rows in the input dataframe).
@@ -41,17 +41,30 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
     subclasses. There is no logic for updating in-place.
     """
 
-    def __init__(self, data, length=None, width=None, call_queue=None):
-        self.data = data
+    def __init__(self, physical_data, length=None, width=None, call_queue=None):
+        self._physical_data = physical_data
         if call_queue is None:
             call_queue = []
         self.call_queue = call_queue
         self._length_cache = length
         self._width_cache = width
 
+    @property
+    def physical_data(self):
+        """
+        Flush the `call_queue` and get the physical data wrapped by this partition.
+
+        Returns
+        -------
+        pandas.DataFrame
+            Copy of pandas DataFrame wrapped by this partition.
+        """
+        self.drain_call_queue()
+        return self._physical_data.copy()
+
     def get(self):
         """
-        Flush the `call_queue` and return copy of the data.
+        Flush the `call_queue` and return copy of the physical data.
 
         Returns
         -------
@@ -63,7 +76,7 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
         Since this object is a simple wrapper, just return the copy of data.
         """
         self.drain_call_queue()
-        return self.data.copy()
+        return self._physical_data.copy()
 
     def apply(self, func, *args, **kwargs):
         """
@@ -108,9 +121,11 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
                     raise e
             return result
 
-        self.data = call_queue_closure(self.data, self.call_queue)
+        self._physical_data = call_queue_closure(self._physical_data, self.call_queue)
         self.call_queue = []
-        return PandasOnPythonDataframePartition(func(self.data.copy(), *args, **kwargs))
+        return PandasOnPythonDataframePartition(
+            func(self._physical_data.copy(), *args, **kwargs)
+        )
 
     def add_to_apply_calls(self, func, *args, **kwargs):
         """
@@ -131,7 +146,8 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
             New ``PandasOnPythonDataframePartition`` object with extended call queue.
         """
         return PandasOnPythonDataframePartition(
-            self.data.copy(), call_queue=self.call_queue + [(func, args, kwargs)]
+            self._physical_data.copy(),
+            call_queue=self.call_queue + [(func, args, kwargs)],
         )
 
     def drain_call_queue(self):
@@ -197,7 +213,7 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
             The length of the object.
         """
         if self._length_cache is None:
-            self._length_cache = self.apply(self._length_extraction_fn()).data
+            self._length_cache = self.apply(self._length_extraction_fn())._physical_data
         return self._length_cache
 
     def width(self):
@@ -210,5 +226,5 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
             The width of the object.
         """
         if self._width_cache is None:
-            self._width_cache = self.apply(self._width_extraction_fn()).data
+            self._width_cache = self.apply(self._width_extraction_fn())._physical_data
         return self._width_cache

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/virtual_partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/virtual_partition.py
@@ -43,7 +43,7 @@ class PandasOnPythonDataframeAxisPartition(PandasDataframeAxisPartition):
         for obj in list_of_blocks:
             obj.drain_call_queue()
         # Unwrap from PandasDataframePartition object for ease of use
-        self.list_of_blocks = [obj.data for obj in list_of_blocks]
+        self.list_of_blocks = [obj.physical_data for obj in list_of_blocks]
 
     partition_type = PandasOnPythonDataframePartition
     instance_type = pandas.DataFrame

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/virtual_partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/virtual_partition.py
@@ -43,7 +43,7 @@ class PandasOnPythonDataframeAxisPartition(PandasDataframeAxisPartition):
         for obj in list_of_blocks:
             obj.drain_call_queue()
         # Unwrap from PandasDataframePartition object for ease of use
-        self.list_of_blocks = [obj.physical_data for obj in list_of_blocks]
+        self.list_of_blocks = [obj._data for obj in list_of_blocks]
 
     partition_type = PandasOnPythonDataframePartition
     instance_type = pandas.DataFrame

--- a/modin/core/execution/ray/generic/modin_aqp.py
+++ b/modin/core/execution/ray/generic/modin_aqp.py
@@ -51,7 +51,7 @@ def call_progress_bar(result_parts, line_no):
     except AttributeError:
         return
     pbar_id = str(cell_no) + "-" + str(line_no)
-    futures = [x.physical_data for row in result_parts for x in row]
+    futures = [x._data for row in result_parts for x in row]
     bar_format = (
         "{l_bar}{bar}{r_bar}"
         if "DEBUG_PROGRESS_BAR" in os.environ

--- a/modin/core/execution/ray/generic/modin_aqp.py
+++ b/modin/core/execution/ray/generic/modin_aqp.py
@@ -51,7 +51,7 @@ def call_progress_bar(result_parts, line_no):
     except AttributeError:
         return
     pbar_id = str(cell_no) + "-" + str(line_no)
-    futures = [x.oid for row in result_parts for x in row]
+    futures = [x.physical_data for row in result_parts for x in row]
     bar_format = (
         "{l_bar}{bar}{r_bar}"
         if "DEBUG_PROGRESS_BAR" in os.environ

--- a/modin/core/execution/ray/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/generic/partitioning/partition_manager.py
@@ -43,7 +43,7 @@ class GenericRayDataframePartitionManager(PandasDataframePartitionManager):
         """
         parts = ray.get(
             [
-                obj.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).oid
+                obj.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).physical_data
                 for row in partitions
                 for obj in row
             ]

--- a/modin/core/execution/ray/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/generic/partitioning/partition_manager.py
@@ -43,7 +43,7 @@ class GenericRayDataframePartitionManager(PandasDataframePartitionManager):
         """
         parts = ray.get(
             [
-                obj.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).physical_data
+                obj.apply(lambda df, **kwargs: df.to_numpy(**kwargs))._data
                 for row in partitions
                 for obj in row
             ]

--- a/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -235,7 +235,7 @@ class PandasOnRayIO(RayIO):
             max_retries=0,
         )
         # pending completion
-        ray.get([partition.physical_data for partition in result.flatten()])
+        ray.get([partition._data for partition in result.flatten()])
 
     @staticmethod
     def _to_parquet_check_support(kwargs):
@@ -308,4 +308,4 @@ class PandasOnRayIO(RayIO):
             lengths=None,
             enumerate_partitions=True,
         )
-        ray.get([part.physical_data for row in result for part in row])
+        ray.get([part._data for row in result for part in row])

--- a/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -235,7 +235,7 @@ class PandasOnRayIO(RayIO):
             max_retries=0,
         )
         # pending completion
-        ray.get([partition.oid for partition in result.flatten()])
+        ray.get([partition.physical_data for partition in result.flatten()])
 
     @staticmethod
     def _to_parquet_check_support(kwargs):
@@ -308,4 +308,4 @@ class PandasOnRayIO(RayIO):
             lengths=None,
             enumerate_partitions=True,
         )
-        ray.get([part.oid for row in result for part in row])
+        ray.get([part.physical_data for row in result for part in row])

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -31,7 +31,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
 
     Parameters
     ----------
-    object_id : ray.ObjectRef
+    physical_data : ray.ObjectRef
         A reference to ``pandas.DataFrame`` that need to be wrapped with this class.
     length : ray.ObjectRef or int, optional
         Length or reference to it of wrapped ``pandas.DataFrame``.
@@ -43,9 +43,11 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         Call queue that needs to be executed on wrapped ``pandas.DataFrame``.
     """
 
-    def __init__(self, object_id, length=None, width=None, ip=None, call_queue=None):
-        assert isinstance(object_id, ObjectIDType)
-        self.oid = object_id
+    def __init__(
+        self, physical_data, length=None, width=None, ip=None, call_queue=None
+    ):
+        assert isinstance(physical_data, ObjectIDType)
+        self._physical_data = physical_data
         if call_queue is None:
             call_queue = []
         self.call_queue = call_queue
@@ -77,7 +79,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         logger.debug(f"ENTER::Partition.get::{self._identity}")
         if len(self.call_queue):
             self.drain_call_queue()
-        result = ray.get(self.oid)
+        result = ray.get(self._physical_data)
         logger.debug(f"EXIT::Partition.get::{self._identity}")
         return result
 
@@ -106,16 +108,20 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         """
         logger = get_logger()
         logger.debug(f"ENTER::Partition.apply::{self._identity}")
-        oid = self.oid
+        physical_data = self._physical_data
         call_queue = self.call_queue + [(func, args, kwargs)]
         if len(call_queue) > 1:
             logger.debug(f"SUBMIT::_apply_list_of_funcs::{self._identity}")
-            result, length, width, ip = _apply_list_of_funcs.remote(call_queue, oid)
+            result, length, width, ip = _apply_list_of_funcs.remote(
+                call_queue, physical_data
+            )
         else:
             # We handle `len(call_queue) == 1` in a different way because
             # this dramatically improves performance.
             func, args, kwargs = call_queue[0]
-            result, length, width, ip = _apply_func.remote(oid, func, *args, **kwargs)
+            result, length, width, ip = _apply_func.remote(
+                physical_data, func, *args, **kwargs
+            )
             logger.debug(f"SUBMIT::_apply_func::{self._identity}")
         logger.debug(f"EXIT::Partition.apply::{self._identity}")
         return PandasOnRayDataframePartition(result, length, width, ip)
@@ -144,7 +150,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         handle it correctly either way. The keyword arguments are sent as a dictionary.
         """
         return PandasOnRayDataframePartition(
-            self.oid, call_queue=self.call_queue + [(func, args, kwargs)]
+            self._physical_data, call_queue=self.call_queue + [(func, args, kwargs)]
         )
 
     def drain_call_queue(self):
@@ -153,34 +159,34 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         logger.debug(f"ENTER::Partition.drain_call_queue::{self._identity}")
         if len(self.call_queue) == 0:
             return
-        oid = self.oid
+        physical_data = self._physical_data
         call_queue = self.call_queue
         if len(call_queue) > 1:
             logger.debug(f"SUBMIT::_apply_list_of_funcs::{self._identity}")
             (
-                self.oid,
+                self._physical_data,
                 self._length_cache,
                 self._width_cache,
                 self._ip_cache,
-            ) = _apply_list_of_funcs.remote(call_queue, oid)
+            ) = _apply_list_of_funcs.remote(call_queue, physical_data)
         else:
             # We handle `len(call_queue) == 1` in a different way because
             # this dramatically improves performance.
             func, args, kwargs = call_queue[0]
             logger.debug(f"SUBMIT::_apply_func::{self._identity}")
             (
-                self.oid,
+                self._physical_data,
                 self._length_cache,
                 self._width_cache,
                 self._ip_cache,
-            ) = _apply_func.remote(oid, func, *args, **kwargs)
+            ) = _apply_func.remote(physical_data, func, *args, **kwargs)
         logger.debug(f"EXIT::Partition.drain_call_queue::{self._identity}")
         self.call_queue = []
 
     def wait(self):
         """Wait completing computations on the object wrapped by the partition."""
         self.drain_call_queue()
-        ray.wait([self.oid])
+        ray.wait([self._physical_data])
 
     def __copy__(self):
         """
@@ -192,7 +198,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             A copy of this partition.
         """
         return PandasOnRayDataframePartition(
-            self.oid,
+            self._physical_data,
             length=self._length_cache,
             width=self._width_cache,
             ip=self._ip_cache,
@@ -283,7 +289,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 self.drain_call_queue()
             else:
                 self._length_cache, self._width_cache = _get_index_and_columns.remote(
-                    self.oid
+                    self._physical_data
                 )
         if isinstance(self._length_cache, ObjectIDType):
             self._length_cache = ray.get(self._length_cache)
@@ -303,7 +309,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 self.drain_call_queue()
             else:
                 self._length_cache, self._width_cache = _get_index_and_columns.remote(
-                    self.oid
+                    self._physical_data
                 )
         if isinstance(self._width_cache, ObjectIDType):
             self._width_cache = ray.get(self._width_cache)

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -109,7 +109,7 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
-        return ray.get([partition.oid for partition in partitions])
+        return ray.get([partition.physical_data for partition in partitions])
 
     @classmethod
     def concat(cls, axis, left_parts, right_parts):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -109,7 +109,7 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
-        return ray.get([partition.physical_data for partition in partitions])
+        return ray.get([partition._data for partition in partitions])
 
     @classmethod
     def concat(cls, axis, left_parts, right_parts):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -116,7 +116,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         result = [None] * len(self.list_of_partitions_to_combine)
         for idx, partition in enumerate(self.list_of_partitions_to_combine):
             partition.drain_call_queue()
-            result[idx] = partition.oid
+            result[idx] = partition.physical_data
         return result
 
     @property

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -111,12 +111,13 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         List
             A list of ``ray.ObjectRef``.
         """
-        # Draining call queue of partition is happening during access to physical
-        # data of partition. Defer draining call queue until we get the partitions.
-        # TODO: Look into draining call queue at the same time as the task.
-        return [
-            partition.physical_data for partition in self.list_of_partitions_to_combine
-        ]
+        # Defer draining call queue until we get the partitions
+        # TODO Look into draining call queue at the same time as the task
+        result = [None] * len(self.list_of_partitions_to_combine)
+        for idx, partition in enumerate(self.list_of_partitions_to_combine):
+            partition.drain_call_queue()
+            result[idx] = partition._data
+        return result
 
     @property
     def list_of_ips(self):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -111,13 +111,12 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         List
             A list of ``ray.ObjectRef``.
         """
-        # Defer draining call queue until we get the partitions
-        # TODO Look into draining call queue at the same time as the task
-        result = [None] * len(self.list_of_partitions_to_combine)
-        for idx, partition in enumerate(self.list_of_partitions_to_combine):
-            partition.drain_call_queue()
-            result[idx] = partition.physical_data
-        return result
+        # Draining call queue of partition is happening during access to physical
+        # data of partition. Defer draining call queue until we get the partitions.
+        # TODO: Look into draining call queue at the same time as the task.
+        return [
+            partition.physical_data for partition in self.list_of_partitions_to_combine
+        ]
 
     @property
     def list_of_ips(self):

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -53,15 +53,19 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
     if axis is None:
 
         def _unwrap_partitions():
-            return [
-                [
-                    (partition._ip_cache, partition.physical_data)
-                    if get_ip
-                    else partition.physical_data
-                    for partition in row
+            if get_ip:
+                return [
+                    [
+                        (partition._ip_cache, partition.physical_data)
+                        for partition in row
+                    ]
+                    for row in api_layer_object._query_compiler._modin_frame._partitions
                 ]
-                for row in api_layer_object._query_compiler._modin_frame._partitions
-            ]
+            else:
+                return [
+                    [partition.physical_data for partition in row]
+                    for row in api_layer_object._query_compiler._modin_frame._partitions
+                ]
 
         actual_engine = type(
             api_layer_object._query_compiler._modin_frame._partitions[0][0]

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -55,15 +55,12 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
         def _unwrap_partitions():
             if get_ip:
                 return [
-                    [
-                        (partition._ip_cache, partition.physical_data)
-                        for partition in row
-                    ]
+                    [(partition._ip_cache, partition._data) for partition in row]
                     for row in api_layer_object._query_compiler._modin_frame._partitions
                 ]
             else:
                 return [
-                    [partition.physical_data for partition in row]
+                    [partition._data for partition in row]
                     for row in api_layer_object._query_compiler._modin_frame._partitions
                 ]
 

--- a/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/axis_partition.py
+++ b/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/axis_partition.py
@@ -36,7 +36,7 @@ class PyarrowOnRayDataframeAxisPartition(BaseDataframeAxisPartition):
 
     def __init__(self, list_of_blocks):
         # Unwrap from PandasDataframePartition object for ease of use
-        self.list_of_blocks = [obj.physical_data for obj in list_of_blocks]
+        self.list_of_blocks = [obj._data for obj in list_of_blocks]
 
     def apply(self, func, num_splits=None, other_axis_partition=None, **kwargs):
         """

--- a/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/axis_partition.py
+++ b/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/axis_partition.py
@@ -36,7 +36,7 @@ class PyarrowOnRayDataframeAxisPartition(BaseDataframeAxisPartition):
 
     def __init__(self, list_of_blocks):
         # Unwrap from PandasDataframePartition object for ease of use
-        self.list_of_blocks = [obj.oid for obj in list_of_blocks]
+        self.list_of_blocks = [obj.physical_data for obj in list_of_blocks]
 
     def apply(self, func, num_splits=None, other_axis_partition=None, **kwargs):
         """

--- a/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/partition.py
+++ b/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/partition.py
@@ -29,7 +29,7 @@ class PyarrowOnRayDataframePartition(PandasOnRayDataframePartition):
 
     Parameters
     ----------
-    physical_data : ray.ObjectRef
+    data : ray.ObjectRef
         A reference to ``pyarrow.Table`` that needs to be wrapped with this class.
     length : ray.ObjectRef or int, optional
         Length or reference to it of wrapped ``pyarrow.Table``.

--- a/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/partition.py
+++ b/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/partition.py
@@ -29,7 +29,7 @@ class PyarrowOnRayDataframePartition(PandasOnRayDataframePartition):
 
     Parameters
     ----------
-    object_id : ray.ObjectRef
+    physical_data : ray.ObjectRef
         A reference to ``pyarrow.Table`` that needs to be wrapped with this class.
     length : ray.ObjectRef or int, optional
         Length or reference to it of wrapped ``pyarrow.Table``.

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -68,7 +68,7 @@ def test_unwrap_partitions(axis):
         for row_idx in range(expected_partitions.shape[0]):
             for col_idx in range(expected_partitions.shape[1]):
                 assert (
-                    expected_partitions[row_idx][col_idx].physical_data
+                    expected_partitions[row_idx][col_idx]._data
                     == actual_partitions[row_idx][col_idx]
                 )
     else:

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -67,16 +67,10 @@ def test_unwrap_partitions(axis):
         )
         for row_idx in range(expected_partitions.shape[0]):
             for col_idx in range(expected_partitions.shape[1]):
-                if Engine.get() == "Ray":
-                    assert (
-                        expected_partitions[row_idx][col_idx].oid
-                        == actual_partitions[row_idx][col_idx]
-                    )
-                if Engine.get() == "Dask":
-                    assert (
-                        expected_partitions[row_idx][col_idx].future
-                        == actual_partitions[row_idx][col_idx]
-                    )
+                assert (
+                    expected_partitions[row_idx][col_idx].physical_data
+                    == actual_partitions[row_idx][col_idx]
+                )
     else:
         expected_axis_partitions = (
             df._query_compiler._modin_frame._partition_mgr_cls.axis_partition(


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR unifies the API for accessing to the internal data in partition.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4530  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
