### PR TITLE
TEST-#2073: Check that read_csv can use a parse_dates dict.

### DIFF
--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -148,6 +148,8 @@ class TestCsvGlob:
         [pytest.param(value, id=id) for id, value in parse_dates_values_by_id.items()],
     )
     def test_read_single_csv_with_parse_dates(self, parse_dates):
+        if isinstance(parse_dates, dict):
+            pytest.xfail("raises KeyError when dict is not empty")
         try:
             pandas_df = pandas.read_csv(time_parsing_csv_path, parse_dates=parse_dates)
         except Exception as pandas_exception:

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -149,7 +149,7 @@ class TestCsvGlob:
     )
     def test_read_single_csv_with_parse_dates(self, parse_dates):
         if isinstance(parse_dates, dict):
-            pytest.xfail("raises KeyError when dict is not empty")
+            pytest.xfail("raises KeyError when dict is not empty. See GH#5325")
         try:
             pandas_df = pandas.read_csv(time_parsing_csv_path, parse_dates=parse_dates)
         except Exception as pandas_exception:

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -129,6 +129,7 @@ parse_dates_values_by_id = {
     "list_of_list_of_ints": [[1, 2, 3]],
     "list_of_list_of_strings_and_ints": [["year", 2, "date"]],
     "empty_list": [],
+    "dict": {"year_and_month": [1, 2], "day": ["date"]},
     "nonexistent_string_column": ["z"],
     "nonexistent_int_column": [99],
 }


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Check that read_csv can use a parse_dates dict.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2073
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
