### PR TITLE
FIX-#4582: Inherit custom log layer

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -9,6 +9,7 @@ Key Features and Updates
   * FIX-#4570: Replace ``np.bool`` -> ``np.bool_`` (#4571)
   * FIX-#4543: Fix `read_csv` in case skiprows=<0, []> (#4544)
   * FIX-#4059: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
+  * FIX-#4582: Inherit custom log layer (#4583)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
 * Benchmarking enhancements

--- a/modin/logging/class_logger.py
+++ b/modin/logging/class_logger.py
@@ -31,10 +31,12 @@ class ClassLogger:
     This mixin must go first in class bases declaration to have the desired effect.
     """
 
+    _modin_logging_layer = "PANDAS-API"
+
     @classmethod
     def __init_subclass__(
         cls,
-        modin_layer: str = "PANDAS-API",
+        modin_layer: Optional[str] = None,
         class_name: Optional[str] = None,
         log_level: Optional[str] = "info",
         **kwargs,
@@ -53,5 +55,7 @@ class ClassLogger:
             The log level (INFO, DEBUG, WARNING, etc.).
         **kwargs : dict
         """
+        modin_layer = modin_layer or cls._modin_logging_layer
         super().__init_subclass__(**kwargs)
         enable_logging(modin_layer, class_name, log_level)(cls)
+        cls._modin_logging_layer = modin_layer

--- a/modin/test/test_logging.py
+++ b/modin/test/test_logging.py
@@ -144,6 +144,6 @@ def test_class_inheritance(monkeypatch, get_log_messages):
         "STOP::CUSTOM::Foo.method1",
         "START::CUSTOM::Foo.method1",
         "STOP::CUSTOM::Foo.method1",
-        "START::PANDAS-API::Bar.method2",
-        "STOP::PANDAS-API::Bar.method2",
+        "START::CUSTOM::Bar.method2",
+        "STOP::CUSTOM::Bar.method2",
     ]


### PR DESCRIPTION
Signed-off-by: Vasily Litvinov <fam1ly.n4me@yandex.ru>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Fix inheritance of custom log layer. It's still possible to use `PANDAS-API` log layer in subclasses, but to do so one has to set it explicitly.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4582
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
