### PR TITLE
FIX-#4584: Enable pdb debug when running cloud tests

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -9,6 +9,7 @@ Key Features and Updates
   * FIX-#4570: Replace ``np.bool`` -> ``np.bool_`` (#4571)
   * FIX-#4543: Fix `read_csv` in case skiprows=<0, []> (#4544)
   * FIX-#4059: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
+  * FIX-#4584: Enable pdb debug when running cloud tests (#4585)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
 * Benchmarking enhancements

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -129,6 +129,18 @@ def simulate_cloud(request):
     if mode == "off":
         yield
         return
+    if (
+        request.config.getoption("usepdb")
+        and request.config.getoption("capture") != "no"
+    ):
+        with request.config.pluginmanager.getplugin(
+            "capturemanager"
+        ).global_and_fixture_disabled():
+            print(
+                "WARNING! You're running tests in simulate-cloud mode. "
+                + "To enable pdb in remote side please disable output capturing "
+                + "by passing '-s' or '--capture=no' to pytest command line"
+            )
 
     if mode not in ("normal", "experimental"):
         raise ValueError(f"Unsupported --simulate-cloud mode: {mode}")

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -136,10 +136,10 @@ def simulate_cloud(request):
         with request.config.pluginmanager.getplugin(
             "capturemanager"
         ).global_and_fixture_disabled():
-            print(
+            sys.stderr.write(
                 "WARNING! You're running tests in simulate-cloud mode. "
                 + "To enable pdb in remote side please disable output capturing "
-                + "by passing '-s' or '--capture=no' to pytest command line"
+                + "by passing '-s' or '--capture=no' to pytest command line\n"
             )
 
     if mode not in ("normal", "experimental"):

--- a/modin/experimental/cloud/local_cluster.py
+++ b/modin/experimental/cloud/local_cluster.py
@@ -22,6 +22,10 @@ from .rpyc_proxy import WrappingConnection, WrappingService
 from .tracing.tracing_connection import TracingWrappingConnection
 from modin.config import DoTraceRpyc
 
+_IS_PYTEST_DEBUG = (
+    any(arg.endswith("pytest") for arg in sys.argv) and "--pdb" in sys.argv
+)
+
 
 class LocalWrappingConnection(
     TracingWrappingConnection if DoTraceRpyc.get() else WrappingConnection
@@ -57,9 +61,9 @@ class LocalConnection(Connection):
             redirect.write(f"Running: {cmd}\n")
         return subprocess.Popen(
             cmd,
-            stdin=subprocess.DEVNULL,
-            stdout=redirect,
-            stderr=redirect,
+            stdin=None if _IS_PYTEST_DEBUG and not capture_out else subprocess.DEVNULL,
+            stdout=None if _IS_PYTEST_DEBUG and not capture_out else redirect,
+            stderr=None if _IS_PYTEST_DEBUG and not capture_out else redirect,
         )
 
     @staticmethod


### PR DESCRIPTION
Signed-off-by: Vasily Litvinov <fam1ly.n4me@yandex.ru>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Enable using `pdb.set_trace()` and stuff like that on remote side of cloud connection, to facilitate debugging cloud-related issues.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4584 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
