### PR TITLE
FIX-#4577: Set attribute of Modin dataframe to updated value

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -10,6 +10,7 @@ Key Features and Updates
   * FIX-#4543: Fix `read_csv` in case skiprows=<0, []> (#4544)
   * FIX-#4059: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * FIX-#4589: Pin protobuf<4.0.0 to fix ray (#4590)
+  * FIX-#4577: Set attribute of Modin dataframe to updated value (#4588)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
 * Benchmarking enhancements
@@ -40,3 +41,4 @@ Contributors
 @NickCrews
 @prutskov
 @vnlitvinov
+@pyrito

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2498,6 +2498,10 @@ class DataFrame(BasePandasDataset):
             pass
         elif key in self and key not in dir(self):
             self.__setitem__(key, value)
+            # Note: return immediately so we don't keep this `key` as dataframe state.
+            # `__getattr__` will return the columns not present in `dir(self)`, so we do not need
+            # to manually track this state in the `dir`.
+            return
         elif isinstance(value, pandas.Series):
             warnings.warn(
                 "Modin doesn't allow columns to be created via a new attribute name - see "

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -275,9 +275,18 @@ def test___setattr__mutating_column():
     df_equals(modin_df, pandas_df)
     # Check that the col0 attribute reflects the value update.
     df_equals(modin_df.col0, pandas_df.col0)
+
+    pandas_df.col0 = pd.Series([5])
     modin_df.col0 = pd.Series([5])
+
+    # Check that the col0 attribute reflects this update
+    df_equals(modin_df, pandas_df)
+
+    pandas_df.loc[0, "col0"] = 4
     modin_df.loc[0, "col0"] = 4
 
+    # Check that the col0 attribute reflects update via loc
+    df_equals(modin_df, pandas_df)
     assert modin_df.col0.equals(modin_df["col0"])
 
 


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR addresses issue #4577 which ended up being quite a simple fix but involved a fair amount of soul-searching (thank you to @RehanSD for helping me with this on your day off). Previously, update to DataFrame columns via attribute manipulation would handle things correctly internally, but wouldn't set the attribute properly for the Modin DataFrame. As a result, if a column were to be set to a list, it would return a list when we tried to access the column by attribute (when it really should have been a pandas Series). The test included has a good example of this behavior. 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4577 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
