### PR TITLE
FIX-#4411: Fix binary_op between datetime64 Series and pandas timedelta

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -11,6 +11,7 @@ Key Features and Updates
   * FIX-#4059: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * FIX-#4589: Pin protobuf<4.0.0 to fix ray (#4590)
   * FIX-#4577: Set attribute of Modin dataframe to updated value (#4588)
+  * FIX-#4411: Fix binary_op between datetime64 Series and pandas timedelta (#4592)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
 * Benchmarking enhancements

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -222,7 +222,7 @@ class BasePandasDataset(ClassLogger):
         self,
         other,
         axis,
-        type_check=False,
+        dtype_check=False,
         compare_index=False,
     ):
         """
@@ -236,7 +236,7 @@ class BasePandasDataset(ClassLogger):
             Specifies axis along which to do validation. When `1` or `None`
             is specified, validation is done along `index`, if `0` is specified
             validation is done along `columns` of `other` frame.
-        type_check : bool, default: False
+        dtype_check : bool, default: False
             Validates that both frames have compatible dtypes.
         compare_index : bool, default: False
             Compare Index if True.
@@ -291,7 +291,7 @@ class BasePandasDataset(ClassLogger):
             if not self.index.equals(other.index):
                 raise TypeError("Cannot perform operation with non-equal index")
         # Do dtype checking.
-        if type_check:
+        if dtype_check:
             if not all(
                 (is_numeric_dtype(self_dtype) and is_numeric_dtype(other_dtype))
                 or (is_object_dtype(self_dtype) and is_object_dtype(other_dtype))
@@ -381,7 +381,7 @@ class BasePandasDataset(ClassLogger):
             return self._default_to_pandas(
                 getattr(self._pandas_class, op), other, **kwargs
             )
-        other = self._validate_other(other, axis, type_check=True)
+        other = self._validate_other(other, axis, dtype_check=True)
         exclude_list = [
             "__add__",
             "__radd__",

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -235,14 +235,6 @@ class BasePandasDataset(ClassLogger):
             Specifies axis along which to do validation. When `1` or `None`
             is specified, validation is done along `index`, if `0` is specified
             validation is done along `columns` of `other` frame.
-        numeric_only : bool, default: False
-            Validates that both frames have only numeric dtypes.
-        numeric_or_time_only : bool, default: False
-            Validates that both frames have either numeric or time dtypes.
-        numeric_or_object_only : bool, default: False
-            Validates that both frames have either numeric or object dtypes.
-        comparison_dtypes_only : bool, default: False
-            Validates that both frames have either numeric or time or equal dtypes.
         compare_index : bool, default: False
             Compare Index if True.
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1141,18 +1141,12 @@ def test_between_time():
     )
 
 
-def test_time_ops():
+def test_add_series_to_timedeltaindex():
     # Make a pandas.core.indexes.timedeltas.TimedeltaIndex
     deltas = pd.to_timedelta([1], unit="h")
-    modin_series = pd.Series(np.datetime64("2000-12-12")) + deltas
-    pandas_series = pandas.Series(np.datetime64("2000-12-12")) + deltas
-
-    df_equals(modin_series, pandas_series)
-
-    modin_series = pd.Series(np.datetime64("2000-12-12")) - deltas
-    pandas_series = pandas.Series(np.datetime64("2000-12-12")) - deltas
-
-    df_equals(modin_series, pandas_series)
+    test_series = create_test_series(np.datetime64("2000-12-12"))
+    eval_general(*test_series, lambda s: s + deltas)
+    eval_general(*test_series, lambda s: s - deltas)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1141,6 +1141,20 @@ def test_between_time():
     )
 
 
+def test_time_ops():
+    # Make a pandas.core.indexes.timedeltas.TimedeltaIndex
+    deltas = pd.to_timedelta([1], unit="h")
+    modin_series = pd.Series(np.datetime64("2000-12-12")) + deltas
+    pandas_series = pandas.Series(np.datetime64("2000-12-12")) + deltas
+
+    df_equals(modin_series, pandas_series)
+
+    modin_series = pd.Series(np.datetime64("2000-12-12")) - deltas
+    pandas_series = pandas.Series(np.datetime64("2000-12-12")) - deltas
+
+    df_equals(modin_series, pandas_series)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_bfill(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR addresses #4411 which tried to add a pandas.timedeltas to a datetime64 Series. The bug ended up being tied up with how we validated binary operations, so I took the liberty to clean up code in `_validate_other` since I didn't see any of the dtype flags used anywhere else in the code. I also added in a test to validate the original posted issue. 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4411 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
