### PR TITLE
FIX-#4564: Workaround import issues in Ray: auto-import pandas on python start if env var is set

### DIFF
--- a/docs/getting_started/troubleshooting.rst
+++ b/docs/getting_started/troubleshooting.rst
@@ -298,6 +298,7 @@ If you're using some pre-configured Ray cluster to run Modin, it's possible you 
 be seeing spurious errors like
 
 .. code-block::
+
   ray.exceptions.RaySystemError: System error: partially initialized module 'pandas' has no attribute 'core' (most likely due to a circular import)
   traceback: Traceback (most recent call last):
     File "/usr/share/miniconda/envs/modin/lib/python3.8/site-packages/ray/serialization.py", line 340, in deserialize_objects

--- a/docs/getting_started/troubleshooting.rst
+++ b/docs/getting_started/troubleshooting.rst
@@ -293,3 +293,39 @@ or
 
 .. _issue: https://github.com/modin-project/modin/issues
 .. _Slack: https://modin.org/slack.html
+
+
+Spurious error "cannot import partially initialised pandas module" on custom Ray cluster
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+If you're using some pre-configured Ray cluster to run Modin, it's possible you would
+be seeing spurious errors like
+
+.. code-block::
+  ray.exceptions.RaySystemError: System error: partially initialized module 'pandas' has no attribute 'core' (most likely due to a circular import)
+  traceback: Traceback (most recent call last):
+    File "/usr/share/miniconda/envs/modin/lib/python3.8/site-packages/ray/serialization.py", line 340, in deserialize_objects
+      obj = self._deserialize_object(data, metadata, object_ref)
+    File "/usr/share/miniconda/envs/modin/lib/python3.8/site-packages/ray/serialization.py", line 237, in _deserialize_object
+      return self._deserialize_msgpack_data(data, metadata_fields)
+    File "/usr/share/miniconda/envs/modin/lib/python3.8/site-packages/ray/serialization.py", line 192, in _deserialize_msgpack_data
+      python_objects = self._deserialize_pickle5_data(pickle5_data)
+    File "/usr/share/miniconda/envs/modin/lib/python3.8/site-packages/ray/serialization.py", line 180, in _deserialize_pickle5_data
+      obj = pickle.loads(in_band, buffers=buffers)
+    File "/usr/share/miniconda/envs/modin/lib/python3.8/site-packages/pandas/__init__.py", line 135, in <module>
+      from pandas import api, arrays, errors, io, plotting, testing, tseries
+    File "/usr/share/miniconda/envs/modin/lib/python3.8/site-packages/pandas/testing.py", line 6, in <module>
+      from pandas._testing import (
+    File "/usr/share/miniconda/envs/modin/lib/python3.8/site-packages/pandas/_testing/__init__.py", line 979, in <module>
+      cython_table = pd.core.common._cython_table.items()
+  AttributeError: partially initialized module 'pandas' has no attribute 'core' (most likely due to a circular import)
+
+**Solution**
+
+Modin contains a workaround that should automatically do ``import pandas`` upon worker process starts.
+
+It is triggered by the presence of non-empty ``__MODIN_AUTOIMPORT_PANDAS__`` environment variable which
+Modin sets up automatically on the Ray clusters it spawns, but it might be missing on pre-configured clusters.
+
+So if you're seeing the issue like shown above, please make sure you set this environment variable on all
+worker nodes of your cluster before actually spawning the workers.

--- a/docs/getting_started/troubleshooting.rst
+++ b/docs/getting_started/troubleshooting.rst
@@ -291,10 +291,6 @@ or
     df = pd.DataFrame([0, 1, 2, 3])
     print(df)
 
-.. _issue: https://github.com/modin-project/modin/issues
-.. _Slack: https://modin.org/slack.html
-
-
 Spurious error "cannot import partially initialised pandas module" on custom Ray cluster
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 
@@ -329,3 +325,6 @@ Modin sets up automatically on the Ray clusters it spawns, but it might be missi
 
 So if you're seeing the issue like shown above, please make sure you set this environment variable on all
 worker nodes of your cluster before actually spawning the workers.
+
+.. _issue: https://github.com/modin-project/modin/issues
+.. _Slack: https://modin.org/slack.html

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -11,6 +11,7 @@ Key Features and Updates
   * FIX-#4059: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * FIX-#4589: Pin protobuf<4.0.0 to fix ray (#4590)
   * FIX-#4577: Set attribute of Modin dataframe to updated value (#4588)
+  * FIX-#4564: Workaround import issues in Ray: auto-import pandas on python start if env var is set (#4603)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
 * Benchmarking enhancements

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -9,12 +9,7 @@ pyyaml
 recommonmark
 sphinx
 sphinx-click
-# Pin ray to < 1.13.0 to work around GH#4564
-# TODO(https://github.com/modin-project/modin/issues/4564): let ray go past 1.13.0.
-ray[default]>=1.4.0,<1.13.0
-# Following https://github.com/ray-project/ray/pull/25648, pin protobuf < 4,
-# because versions >= 4.0.0 are incompatible with ray<1.13.0.
-protobuf<4.0.0
+ray[default]>=1.4.0
 git+https://github.com/modin-project/modin.git@master#egg=modin[all]
 sphinxcontrib_plantuml
 sphinx-issues

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -41,12 +41,7 @@ dependencies:
       - modin-spreadsheet>=0.1.1
       - tqdm
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
-      # Pin ray to < 1.13.0 to work around GH#4564
-      # TODO(https://github.com/modin-project/modin/issues/4564): let ray go past 1.13.0.
-      - ray[default]>=1.4.0,<1.13.0
-      # Following https://github.com/ray-project/ray/pull/25648, pin protobuf < 4,
-      # because versions >= 4.0.0 are incompatible with ray<1.13.0.
-      - protobuf<4.0.0
+      - ray[default]>=1.4.0
       - connectorx>=0.2.6a4
       # TODO: remove when resolving GH#4398
       - redis>=3.5.0,<4.0.0

--- a/modin-autoimport-pandas.pth
+++ b/modin-autoimport-pandas.pth
@@ -1,0 +1,1 @@
+import os; os.environ.get("__MODIN_AUTOIMPORT_PANDAS_WORKAROUND__", None) and __import__("pandas")

--- a/modin-autoimport-pandas.pth
+++ b/modin-autoimport-pandas.pth
@@ -1,1 +1,1 @@
-import os; os.environ.get("__MODIN_AUTOIMPORT_PANDAS_WORKAROUND__", None) and __import__("pandas")
+import os; os.environ.get("__MODIN_AUTOIMPORT_PANDAS__", None) and __import__("pandas")

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -83,7 +83,6 @@ class Engine(EnvironmentVariable, type=str):
         """
         from modin.utils import (
             MIN_RAY_VERSION,
-            MAX_RAY_VERSION_EXCLUSIVE,
             MIN_DASK_VERSION,
         )
 
@@ -95,14 +94,11 @@ class Engine(EnvironmentVariable, type=str):
         except ImportError:
             pass
         else:
-            if (
-                version.parse(ray.__version__) < MIN_RAY_VERSION
-                or version.parse(ray.__version__) >= MAX_RAY_VERSION_EXCLUSIVE
-            ):
+            if version.parse(ray.__version__) < MIN_RAY_VERSION:
                 raise ImportError(
                     "Please `pip install modin[ray]` to install compatible Ray "
                     + "version "
-                    + f"(>={MIN_RAY_VERSION},<{MAX_RAY_VERSION_EXCLUSIVE})."
+                    + f"(>={MIN_RAY_VERSION})."
                 )
             return "Ray"
         try:

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -172,7 +172,7 @@ def initialize_ray(
         for varname, varvalue in extra_init_kw["runtime_env"]["env_vars"].items():
             if str(env_vars.get(varname, "")) != str(varvalue):
                 ErrorMessage.single_warning(
-                    "If initialising Ray yourself, please ensure its runtime env "
+                    "When using a pre-initialized Ray cluster, please ensure that the runtime env "
                     + f"sets environment variable {varname} to {varvalue}"
                 )
 

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -75,26 +75,6 @@ def _move_stdlib_ahead_of_site_packages(*args):
         sys.path.insert(site_packages_path_index, os.path.dirname(site_packages_path))
 
 
-def _import_pandas(*args):
-    """
-    Import pandas to make sure all its machinery is ready.
-
-    This prevents a race condition between two threads deserializing functions
-    and trying to import pandas at the same time.
-
-    Parameters
-    ----------
-    *args : tuple
-        Ignored, added for compatibility with Ray.
-
-    Notes
-    -----
-    This function is expected to be run on all workers before any
-    serialization or deserialization starts.
-    """
-    import pandas  # noqa F401
-
-
 def initialize_ray(
     override_is_cluster=False,
     override_redis_address: str = None,
@@ -243,7 +223,7 @@ def initialize_ray(
     ray.worker.global_worker.run_function_on_all_workers(
         _move_stdlib_ahead_of_site_packages
     )
-    ray.worker.global_worker.run_function_on_all_workers(_import_pandas)
+
     num_cpus = int(ray.cluster_resources()["CPU"])
     num_gpus = int(ray.cluster_resources().get("GPU", 0))
     if StorageFormat.get() == "Cudf":

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -169,12 +169,7 @@ def initialize_ray(
                 for i in range(GpuCount.get()):
                     GPU_MANAGERS.append(GPUManager.remote(i))
     else:  # ray is already initialized, check runtime env config
-        main_cfg = ray.worker.global_worker.core_worker.get_job_config()
-        try:
-            runtime_env = json.loads(main_cfg.runtime_env_info.serialized_runtime_env)
-        except json.JSONDecodeError:
-            runtime_env = {}
-        env_vars = runtime_env.get("envVars", {})
+        env_vars = ray.get_runtime_context().runtime_env.get("env_vars", {})
         for varname, varvalue in extra_init_kw["runtime_env"]["env_vars"].items():
             if str(env_vars.get(varname, "")) != str(varvalue):
                 ErrorMessage.single_warning(

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -33,6 +33,7 @@ from modin.config import (
     NPartitions,
     ValueSource,
 )
+from modin.error_message import ErrorMessage
 
 ObjectIDType = ray.ObjectRef
 if version.parse(ray.__version__) >= version.parse("1.2.0"):
@@ -125,8 +126,6 @@ def initialize_ray(
                 **extra_init_kw,
             )
         else:
-            from modin.error_message import ErrorMessage
-
             # This string is intentionally formatted this way. We want it indented in
             # the warning message.
             ErrorMessage.not_initialized(

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -18,7 +18,6 @@ import sys
 import psutil
 from packaging import version
 import warnings
-import json
 
 import ray
 

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -167,14 +167,16 @@ def initialize_ray(
             if not GPU_MANAGERS:
                 for i in range(GpuCount.get()):
                     GPU_MANAGERS.append(GPUManager.remote(i))
-    else:  # ray is already initialized, check runtime env config
-        env_vars = ray.get_runtime_context().runtime_env.get("env_vars", {})
-        for varname, varvalue in extra_init_kw["runtime_env"]["env_vars"].items():
-            if str(env_vars.get(varname, "")) != str(varvalue):
-                ErrorMessage.single_warning(
-                    "When using a pre-initialized Ray cluster, please ensure that the runtime env "
-                    + f"sets environment variable {varname} to {varvalue}"
-                )
+
+    # Now ray is initialized, check runtime env config - especially useful if we join
+    # an externally pre-configured cluster
+    env_vars = ray.get_runtime_context().runtime_env.get("env_vars", {})
+    for varname, varvalue in extra_init_kw["runtime_env"]["env_vars"].items():
+        if str(env_vars.get(varname, "")) != str(varvalue):
+            ErrorMessage.single_warning(
+                "When using a pre-initialized Ray cluster, please ensure that the runtime env "
+                + f"sets environment variable {varname} to {varvalue}"
+            )
 
     num_cpus = int(ray.cluster_resources()["CPU"])
     num_gpus = int(ray.cluster_resources().get("GPU", 0))

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -36,9 +36,6 @@ from modin.config import Engine, StorageFormat, IsExperimental
 from modin._version import get_versions
 
 MIN_RAY_VERSION = version.parse("1.4.0")
-# TODO(https://github.com/modin-project/modin/issues/4564):
-# once ray can go past 1.13.0, remove this constant and stop checking it.
-MAX_RAY_VERSION_EXCLUSIVE = version.parse("1.13.0")
 MIN_DASK_VERSION = version.parse("2.22.0")
 
 PANDAS_API_URL_TEMPLATE = f"https://pandas.pydata.org/pandas-docs/version/{pandas.__version__}/reference/api/{{}}.html"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,12 +3,7 @@ numpy>=1.18.5
 pyarrow>=4.0.1
 dask[complete]>=2.22.0,<2022.2.0
 distributed>=2.22.0,<2022.2.0
-# Pin ray to < 1.13.0 to work around GH#4564
-# TODO(https://github.com/modin-project/modin/issues/4564): let ray go past 1.13.0.
-ray[default]>=1.4.0,<1.13.0
-# Following https://github.com/ray-project/ray/pull/25648, pin protobuf < 4,
-# because versions >= 4.0.0 are incompatible with ray<1.13.0.
-protobuf<4.0.0
+ray[default]>=1.4.0
 redis>=3.5.0,<4.0.0
 psutil
 fsspec

--- a/setup.py
+++ b/setup.py
@@ -5,16 +5,10 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 dask_deps = ["dask>=2.22.0,<2022.2.0", "distributed>=2.22.0,<2022.2.0"]
-# TODO: remove redis dependency when resolving GH#4398
-# Pin ray to < 1.13.0 to work around GH#4564
-# TODO(https://github.com/modin-project/modin/issues/4564): let ray go past 1.13.0.
-# Following https://github.com/ray-project/ray/pull/25648, pin protobuf < 4,
-# because versions >= 4.0.0 are incompatible with ray<1.13.0.
 ray_deps = [
-    "ray[default]>=1.4.0,<1.13.0",
+    "ray[default]>=1.4.0",
     "pyarrow>=4.0.1",
     "redis>=3.5.0,<4.0.0",
-    "protobuf<4.0.0",
 ]
 remote_deps = ["rpyc==4.1.5", "cloudpickle", "boto3"]
 spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]

--- a/setup.py
+++ b/setup.py
@@ -19,18 +19,19 @@ all_deps = dask_deps + ray_deps + remote_deps + spreadsheet_deps
 # This file provides the "import pandas before Ray init" feature if specific
 # environment variable is set (see https://github.com/modin-project/modin/issues/4564).
 cmdclass = versioneer.get_cmdclass()
+extra_files = ["modin-autoimport-pandas.pth"]
 
 
 class AddPthFileBuild(cmdclass["build_py"]):
     def _get_data_files(self):
         return (super()._get_data_files() or []) + [
-            (".", ".", self.build_lib, ["modin-autoimport-pandas.pth"])
+            (".", ".", self.build_lib, extra_files)
         ]
 
 
 class AddPthFileSDist(cmdclass["sdist"]):
     def make_distribution(self):
-        self.filelist.append("modin-autoimport-pandas.pth")
+        self.filelist.extend(extra_files)
         return super().make_distribution()
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Based on what I found in https://github.com/modin-project/modin/issues/4564#issuecomment-1165419056, I think the real root cause of #4564 (and other similar issues with inability to import pandas) is the Python bug https://bugs.python.org/issue38884, which rises from the fact that they seem to have dropped the idea of the import lock in Python 3.3+.

This PR aims to workaround that by doing the following:
1. Create special `.pth` file to be shipped which, when package is installed, is placed under `site-packages` automatically and, when processed by Python interpreter, imports `pandas` if special environment variable is set
2. Change `setup.py` so this special file is part of both source and binary distributions
3. Initialize Ray so it sets this environment variable on each worker
4. Check Ray configuration if Ray was pre-initialized and warn the user to set the variables if they don't match

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4564 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
