### PR TITLE
TEST-#4610: Remove explicit installation of `black`/`flake8` for omnisci ci-notebooks

### DIFF
--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -52,6 +52,7 @@ jobs:
       # install test dependencies
       - run: pip install pytest pytest-cov black flake8 flake8-print flake8-no-implicit-concat
         if: matrix.execution != 'omnisci_on_native'
+      # Reproduce problem
       - run: conda install black flake8 flake8-print jupyter nbformat nbconvert -c conda-forge
         if: matrix.execution == 'omnisci_on_native'
       - run: pip list

--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -52,8 +52,7 @@ jobs:
       # install test dependencies
       - run: pip install pytest pytest-cov black flake8 flake8-print flake8-no-implicit-concat
         if: matrix.execution != 'omnisci_on_native'
-      # Reproduce problem
-      - run: conda install black flake8 flake8-print jupyter nbformat nbconvert -c conda-forge
+      - run: conda install flake8-print jupyter nbformat nbconvert -c conda-forge
         if: matrix.execution == 'omnisci_on_native'
       - run: pip list
         if: matrix.execution != 'omnisci_on_native'

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -31,7 +31,7 @@ Key Features and Updates
 * Update testing suite
   * TEST-#4508: Reduce test_partition_api pytest threads to deflake it (#4551)
   * TEST-#4550: Use much less data in test_partition_api (#4554)
-  * TEST-#4610: Remove explicit installation of `black`/`flake8`` for omnisci ci-notebooks (#4609)
+  * TEST-#4610: Remove explicit installation of `black`/`flake8` for omnisci ci-notebooks (#4609)
 * Documentation improvements
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
 * Dependencies

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -31,6 +31,7 @@ Key Features and Updates
 * Update testing suite
   * TEST-#4508: Reduce test_partition_api pytest threads to deflake it (#4551)
   * TEST-#4550: Use much less data in test_partition_api (#4554)
+  * TEST-#4610: Remove explicit installation of `black`/`flake8`` for omnisci ci-notebooks (#4609)
 * Documentation improvements
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
 * Dependencies


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
This PR removes explicit installation of black and flake8 packages from conda for `ci-notebooks` (omnisci_on_native) because the packages were already installed from pip.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4610  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
