### PR TITLE
DOCS-#4611: Tell users to install engine when installing from GitHub.

### DIFF
--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -146,10 +146,13 @@ also use ``pip``.
 
 .. code-block:: bash
 
-  pip install git+https://github.com/modin-project/modin
+  pip install modin[all] git+https://github.com/modin-project/modin
 
 This will install directly from the repo without you having to manually clone it! Please be aware
 that these changes have not made it into a release and may not be completely stable.
+
+If you would like to install Modin with a specific engine, you can use ``modin[ray]`` or ``modin[dask]`` instead of ``modin[all]`` in the command above.
+For more documentation about installing particula rengines, see the `README PyPI installation instructions`_.
 
 Windows
 -------
@@ -195,4 +198,5 @@ Once cloned, ``cd`` into the ``modin`` directory and use ``pip`` to install:
 .. _`Intel Distribution of Modin`: https://software.intel.com/content/www/us/en/develop/tools/oneapi/components/distribution-of-modin.html#gs.86stqv
 .. _`Intel Distribution of Modin Getting Started`: https://www.intel.com/content/www/us/en/developer/articles/technical/intel-distribution-of-modin-getting-started-guide.html
 .. |reg|    unicode:: U+000AE .. REGISTERED SIGN
+.. _`README PyPI installation instructions.`: https://github.com/modin-project/modin/blob/master/README.md#from-pypi
 .. _Colab: https://colab.research.google.com/


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

DOCS-#4611: Tell users to install engine when installing from GitHub.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4611 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
