### PR TITLE
FEAT-#4619: Integrate mypy static type checking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,13 +34,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 1
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: actions/setup-python@v2
         with:
-          activate-environment: modin
-          environment-file: environment-dev.yml
-          python-version: 3.8
-          channel-priority: strict
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          python-version: "3.8.x"
+          architecture: "x64"
+      - run: pip install -r requirements-dev.txt
       - run: mypy --config-file mypy.ini
 
   build-docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,22 @@ jobs:
       - run: pip install black
       - run: black --check --diff modin/ asv_bench/benchmarks scripts/doc_checker.py
 
+  lint-mypy:
+    name: lint (mypy)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: modin
+          environment-file: environment-dev.yml
+          python-version: 3.8
+          channel-priority: strict
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+      - run: mypy --config-file mypy.ini
+
   build-docs:
     name: build docs
     runs-on: ubuntu-latest
@@ -187,7 +203,7 @@ jobs:
         run: python -m pytest modin/test/test_headers.py
 
   test-clean-install-ubuntu:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -208,7 +224,7 @@ jobs:
           MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3]))"
 
   test-clean-install-windows:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: windows-latest
     defaults:
       run:
@@ -229,7 +245,7 @@ jobs:
           MODIN_ENGINE=ray python -c "import modin.pandas as pd; print(pd.DataFrame([1,2,3]))"
 
   test-internals:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -265,7 +281,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-defaults:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -315,7 +331,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-omnisci:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -349,7 +365,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-asv-benchmarks:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -415,7 +431,7 @@ jobs:
         if: failure()
 
   test-all:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -492,7 +508,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-experimental:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -523,7 +539,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-cloud:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -557,7 +573,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-windows:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: windows-latest
     defaults:
       run:
@@ -612,7 +628,7 @@ jobs:
       - uses: codecov/codecov-action@v2
 
   test-pyarrow:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -643,7 +659,7 @@ jobs:
       - run: python -m pytest modin/pandas/test/test_io.py::TestCsv --verbose
 
   test-spreadsheet:
-    needs: [lint-flake8, lint-black, test-api, test-headers]
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/contributing/pre-commit
+++ b/contributing/pre-commit
@@ -11,4 +11,7 @@ printf "running flake8. This script will preempt the commit if flake8 fails.\n"
 flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py
 printf "flake8 passed!\n"
 
+printf "running mypy. This script will preempt the commit if mypy fails.\n"
+mypy --config-file mypy.ini
+printf "mypy passed!\n"
 printf "pre-commit hook finished!\n"

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -36,6 +36,7 @@ Key Features and Updates
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
 * Dependencies
   * FEAT-#4598: Add support for pandas 1.4.3 (#4599)
+  * FEAT-#4619: Integrate mypy static type checking (#4620)
 * New Features
   * FEAT-4463: Add experimental fuzzydata integration for testing against a randomized dataframe workflow (#4556)
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -36,7 +36,7 @@ dependencies:
   - scikit-learn
   - pymssql
   - psycopg2
-  - mypy==0.961
+  - mypy
   - pandas-stubs
   - pip:
       - xgboost>=1.6.0

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -36,6 +36,8 @@ dependencies:
   - scikit-learn
   - pymssql
   - psycopg2
+  - mypy==0.961
+  - pandas-stubs==1.4.2.220626
   - pip:
       - xgboost>=1.6.0
       - modin-spreadsheet>=0.1.1

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -37,7 +37,7 @@ dependencies:
   - pymssql
   - psycopg2
   - mypy==0.961
-  - pandas-stubs==1.4.2.220626
+  - pandas-stubs
   - pip:
       - xgboost>=1.6.0
       - modin-spreadsheet>=0.1.1

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -411,7 +411,7 @@ class LogMemoryInterval(EnvironmentVariable, type=int):
         super().put(value)
 
     @classmethod
-    def get(cls):
+    def get(cls) -> int:
         """
         Get ``LogMemoryInterval`` with extra checks.
 
@@ -445,7 +445,7 @@ class LogFileSize(EnvironmentVariable, type=int):
         super().put(value)
 
     @classmethod
-    def get(cls):
+    def get(cls) -> int:
         """
         Get ``LogFileSize`` with extra checks.
 

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -238,7 +238,7 @@ class Parameter(object):
         return cls._value_source
 
     @classmethod
-    def get(cls):
+    def get(cls) -> typing.Any:
         """
         Get config value.
 

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -10,7 +10,7 @@
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
-# type: ignore
+
 import os
 import sys
 import pytest

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -10,7 +10,7 @@
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
-
+# type: ignore
 import os
 import sys
 import pytest

--- a/modin/logging/class_logger.py
+++ b/modin/logging/class_logger.py
@@ -17,7 +17,7 @@ Module contains ``ClassLogger`` class.
 ``ClassLogger`` is used for adding logging to Modin classes and their subclasses.
 """
 
-from typing import Optional
+from typing import Dict, Optional
 
 from .logger_decorator import enable_logging
 
@@ -38,8 +38,8 @@ class ClassLogger:
         cls,
         modin_layer: Optional[str] = None,
         class_name: Optional[str] = None,
-        log_level: Optional[str] = "info",
-        **kwargs,
+        log_level: str = "info",
+        **kwargs: Dict,
     ) -> None:
         """
         Apply logging decorator to all children of LoggerBase.

--- a/modin/logging/config.py
+++ b/modin/logging/config.py
@@ -27,6 +27,7 @@ import psutil
 import pandas
 import threading
 import time
+from typing import Optional
 
 import modin
 from modin.config import LogMemoryInterval, LogFileSize, LogMode
@@ -37,7 +38,9 @@ __LOGGER_CONFIGURED__: bool = False
 class ModinFormatter(logging.Formatter):  # noqa: PR01
     """Implement custom formatter to log at microsecond granularity."""
 
-    def formatTime(self, record, datefmt=None):
+    def formatTime(
+        self, record: logging.LogRecord, datefmt: Optional[str] = None
+    ) -> str:
         """
         Return the creation time of the specified LogRecord as formatted text.
 
@@ -66,7 +69,7 @@ class ModinFormatter(logging.Formatter):  # noqa: PR01
         return s
 
 
-def bytes_int_to_str(num_bytes, suffix="B"):
+def bytes_int_to_str(num_bytes: int, suffix: str = "B") -> str:
     """
     Scale bytes to its human-readable format (e.g: 1253656678 => '1.17GB').
 
@@ -83,14 +86,17 @@ def bytes_int_to_str(num_bytes, suffix="B"):
         Human-readable string format.
     """
     factor = 1000
+    bytes: float = num_bytes
     for unit in ["", "K", "M", "G", "T", "P"]:
-        if num_bytes < factor:
-            return f"{num_bytes:.2f}{unit}{suffix}"
-        num_bytes /= factor
-    return f"{num_bytes * 1000:.2f}P{suffix}"
+        if bytes < factor:
+            return f"{bytes:.2f}{unit}{suffix}"
+        bytes /= factor
+    return f"{bytes * 1000:.2f}P{suffix}"
 
 
-def _create_logger(namespace, job_id, log_name, log_level):
+def _create_logger(
+    namespace: str, job_id: str, log_name: str, log_level: int
+) -> logging.Logger:
     """
     Create and configure logger as Modin expects it to be.
 
@@ -131,7 +137,7 @@ def _create_logger(namespace, job_id, log_name, log_level):
     return logger
 
 
-def configure_logging():
+def configure_logging() -> None:
     """Configure Modin logging by setting up directory structure and formatting."""
     global __LOGGER_CONFIGURED__
     job_id = uuid.uuid4().hex
@@ -172,7 +178,7 @@ def configure_logging():
     __LOGGER_CONFIGURED__ = True
 
 
-def memory_thread(logger, sleep_time):
+def memory_thread(logger: logging.Logger, sleep_time: int) -> None:
     """
     Configure Modin logging system memory profiling thread.
 
@@ -191,7 +197,7 @@ def memory_thread(logger, sleep_time):
         time.sleep(sleep_time)
 
 
-def get_logger(namespace="modin.logger.default"):
+def get_logger(namespace: str = "modin.logger.default") -> logging.Logger:
     """
     Configure Modin logger based on Modin config and returns the logger.
 

--- a/modin/logging/config.py
+++ b/modin/logging/config.py
@@ -86,6 +86,7 @@ def bytes_int_to_str(num_bytes: int, suffix: str = "B") -> str:
         Human-readable string format.
     """
     factor = 1000
+    # Convert n_bytes to float b/c we divide it by factor
     n_bytes: float = num_bytes
     for unit in ["", "K", "M", "G", "T", "P"]:
         if n_bytes < factor:

--- a/modin/logging/config.py
+++ b/modin/logging/config.py
@@ -56,8 +56,8 @@ class ModinFormatter(logging.Formatter):  # noqa: PR01
 
         Returns
         -------
-        datetime
-            Datetime object containing microsecond timestamp.
+        str
+            Datetime string containing microsecond timestamp.
         """
         ct = dt.datetime.fromtimestamp(record.created)
         if datefmt:
@@ -86,12 +86,12 @@ def bytes_int_to_str(num_bytes: int, suffix: str = "B") -> str:
         Human-readable string format.
     """
     factor = 1000
-    bytes: float = num_bytes
+    n_bytes: float = num_bytes
     for unit in ["", "K", "M", "G", "T", "P"]:
-        if bytes < factor:
-            return f"{bytes:.2f}{unit}{suffix}"
-        bytes /= factor
-    return f"{bytes * 1000:.2f}P{suffix}"
+        if n_bytes < factor:
+            return f"{n_bytes:.2f}{unit}{suffix}"
+        n_bytes /= factor
+    return f"{n_bytes * 1000:.2f}P{suffix}"
 
 
 def _create_logger(

--- a/modin/logging/logger_decorator.py
+++ b/modin/logging/logger_decorator.py
@@ -103,10 +103,7 @@ def enable_logging(
         elif isinstance(obj, staticmethod):
             return staticmethod(decorator(obj.__func__))
 
-        assert isinstance(modin_layer, str), (
-            "obj is not a type or class/static method "
-            "and modin_layer is somehow not a string!"
-        )
+        assert isinstance(modin_layer, str), "modin_layer is somehow not a string!"
 
         start_line = f"START::{modin_layer.upper()}::{name or obj.__name__}"
         stop_line = f"STOP::{modin_layer.upper()}::{name or obj.__name__}"

--- a/modin/logging/logger_decorator.py
+++ b/modin/logging/logger_decorator.py
@@ -103,7 +103,10 @@ def enable_logging(
         elif isinstance(obj, staticmethod):
             return staticmethod(decorator(obj.__func__))
 
-        assert isinstance(modin_layer, str)
+        assert isinstance(modin_layer, str), (
+            "obj is not a type or class/static method "
+            "and modin_layer is somehow not a string!"
+        )
 
         start_line = f"START::{modin_layer.upper()}::{name or obj.__name__}"
         stop_line = f"STOP::{modin_layer.upper()}::{name or obj.__name__}"

--- a/mypy.ini
+++ b/mypy.ini
@@ -10,12 +10,14 @@ follow_imports = silent
 # be strict
 disallow_untyped_calls=True
 disallow_untyped_defs=True
-warn_return_any=True
 strict_optional=True
 warn_no_return=True
 warn_redundant_casts=True
 warn_unused_ignores=True
-disallow_any_generics=True
+# Should we disallow generics?
+disallow_any_generics=False
 warn_unreachable=True
 
-files = **/modin/*.py
+# We will add more files over time to increase coverage
+; files = **/modin/*.py
+files = **/modin/logging/*.py

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,4 @@
 [mypy]
-python_version = 3.9
 # Ignoring missing imports can be dangerous, should do this at module-by-module level
 ignore_missing_imports = True
 show_error_codes = True
@@ -14,7 +13,6 @@ strict_optional=True
 warn_no_return=True
 warn_redundant_casts=True
 warn_unused_ignores=True
-# Should we disallow generics?
 disallow_any_generics=False
 warn_unreachable=True
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,21 @@
+[mypy]
+python_version = 3.9
+# Ignoring missing imports can be dangerous, should do this at module-by-module level
+ignore_missing_imports = True
+show_error_codes = True
+show_column_numbers = True
+check_untyped_defs = True
+follow_imports = silent
+
+# be strict
+disallow_untyped_calls=True
+disallow_untyped_defs=True
+warn_return_any=True
+strict_optional=True
+warn_no_return=True
+warn_redundant_casts=True
+warn_unused_ignores=True
+disallow_any_generics=True
+warn_unreachable=True
+
+files = **/modin/*.py

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,3 +46,6 @@ flake8
 numpydoc==1.1.0
 # experimental version of fuzzydata requires at least 0.0.6 to successfully resolve all dependencies
 fuzzydata>=0.0.6
+# Pin versions of mypy and pandas stubs for stability
+mypy==0.961
+pandas-stubs==1.4.2.220626

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,6 +46,5 @@ flake8
 numpydoc==1.1.0
 # experimental version of fuzzydata requires at least 0.0.6 to successfully resolve all dependencies
 fuzzydata>=0.0.6
-# Pin versions of mypy for stability
-mypy==0.961
+mypy
 pandas-stubs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -46,6 +46,6 @@ flake8
 numpydoc==1.1.0
 # experimental version of fuzzydata requires at least 0.0.6 to successfully resolve all dependencies
 fuzzydata>=0.0.6
-# Pin versions of mypy and pandas stubs for stability
+# Pin versions of mypy for stability
 mypy==0.961
-pandas-stubs==1.4.2.220626
+pandas-stubs


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
This PR addresses #4619 and implements the first cut of mypy integration. The goal is to start off with small modules and work our way up to the majority of our codebase. I decided to start off with the logging module since the amount of code is fairly small. Please note that this PR is still in the works as I need to add CI integration and make other changes. 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4619 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
