### PR TITLE
FIX-#4593: Ensure Modin warns when setting columns via attributes

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -13,6 +13,7 @@ Key Features and Updates
   * FIX-#4577: Set attribute of Modin dataframe to updated value (#4588)
   * FIX-#4411: Fix binary_op between datetime64 Series and pandas timedelta (#4592)
   * FIX-#4582: Inherit custom log layer (#4583)
+  * FIX-#4593: Ensure Modin warns when setting columns via attributes (#4621)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
 * Benchmarking enhancements
@@ -47,3 +48,4 @@ Contributors
 @pyrito
 @suhailrehman
 @RehanSD
+@helmeleegy

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2496,18 +2496,18 @@ class DataFrame(BasePandasDataset):
         # - `_siblings`, which Modin initializes before it appears in __dict__
         if key in ["_query_compiler", "_siblings"] or key in self.__dict__:
             pass
-        elif key in self and key not in dir(self):
+        elif key not in dir(self):
+            if key not in self:
+                warnings.warn(
+                    "Modin doesn't allow columns to be created via a new attribute name - see "
+                    + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
+                    UserWarning,
+                )
             self.__setitem__(key, value)
             # Note: return immediately so we don't keep this `key` as dataframe state.
             # `__getattr__` will return the columns not present in `dir(self)`, so we do not need
             # to manually track this state in the `dir`.
             return
-        elif isinstance(value, pandas.Series):
-            warnings.warn(
-                "Modin doesn't allow columns to be created via a new attribute name - see "
-                + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
-                UserWarning,
-            )
         object.__setattr__(self, key, value)
 
     def __setitem__(self, key, value):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2498,7 +2498,7 @@ class DataFrame(BasePandasDataset):
             pass
         elif key not in dir(self) and key not in self and not is_list_like(value):
             # Assigning a scalar to a non-existing attribute should not result in a
-            # broadcasted column, but rather just an an attribute
+            # broadcasted column, but rather just a new attribute.
             pass
         elif key not in dir(self):
             if key not in self:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2496,6 +2496,10 @@ class DataFrame(BasePandasDataset):
         # - `_siblings`, which Modin initializes before it appears in __dict__
         if key in ["_query_compiler", "_siblings"] or key in self.__dict__:
             pass
+        elif key not in dir(self) and key not in self and not is_list_like(value):
+            # Assigning a scalar to a non-existing attribute should not result in a
+            # broadcasted column, but rather just an an attribute
+            pass
         elif key not in dir(self):
             if key not in self:
                 warnings.warn(

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2496,22 +2496,18 @@ class DataFrame(BasePandasDataset):
         # - `_siblings`, which Modin initializes before it appears in __dict__
         if key in ["_query_compiler", "_siblings"] or key in self.__dict__:
             pass
-        elif key not in dir(self) and key not in self and not is_list_like(value):
-            # Assigning a scalar to a non-existing attribute should not result in a
-            # broadcasted column, but rather just a new attribute.
-            pass
-        elif key not in dir(self):
-            if key not in self:
-                warnings.warn(
-                    "Modin doesn't allow columns to be created via a new attribute name - see "
-                    + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
-                    UserWarning,
-                )
+        elif key in self and key not in dir(self):
             self.__setitem__(key, value)
             # Note: return immediately so we don't keep this `key` as dataframe state.
             # `__getattr__` will return the columns not present in `dir(self)`, so we do not need
             # to manually track this state in the `dir`.
             return
+        elif is_list_like(value):
+            warnings.warn(
+                "Modin doesn't allow columns to be created via a new attribute name - see "
+                + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
+                UserWarning,
+            )
         object.__setattr__(self, key, value)
 
     def __setitem__(self, key, value):

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -290,7 +290,8 @@ def test___setattr__mutating_column():
     df_equals(modin_df, pandas_df)
     assert modin_df.col0.equals(modin_df["col0"])
 
-    # Check that adding a new col via attributes raises warning
+    # Check that attempting to add a new col via attributes raises warning
+    # and adds the provided list as a new attribute and not a column.
     with pytest.warns(
         UserWarning,
         match="Modin doesn't allow columns to be created via a new attribute name - see",
@@ -298,9 +299,12 @@ def test___setattr__mutating_column():
         modin_df.col1 = [4]
 
     with warnings.catch_warnings():
-        warnings.simplefilter("error")
+        warnings.filterwarnings(
+            action="error", 
+            message="Modin doesn't allow columns to be created via a new attribute name - see")
         modin_df.col1 = [5]
         modin_df.new_attr = 6
+        modin_df.col0 = 7
 
     assert "new_attr" in dir(
         modin_df
@@ -309,6 +313,7 @@ def test___setattr__mutating_column():
         "new_attr" not in modin_df
     ), "New attribute was not correctly added to columns."
     assert modin_df.new_attr == 6, "Modin attribute value was set incorrectly."
+    assert isinstance(modin_df.col0, pd.Series), "Scalar was not broadcasted properly to an existing column."
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -300,8 +300,7 @@ def test___setattr__mutating_column():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         modin_df.col1 = [5]
-        modin_df.col0 = 6
-        modin_df.new_attr = 7
+        modin_df.new_attr = 6
 
     assert "new_attr" in dir(
         modin_df
@@ -310,7 +309,6 @@ def test___setattr__mutating_column():
         "new_attr" not in modin_df
     ), "New attribute was not correctly added to columns."
     assert modin_df.new_attr == 7, "Modin attribute value was set incorrectly."
-    assert isinstance(modin_df.col0, pd.Series), "Scalar was not broadcasted correctly."
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -301,7 +301,8 @@ def test___setattr__mutating_column():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             action="error",
-            message="Modin doesn't allow columns to be created via a new attribute name - see")
+            message="Modin doesn't allow columns to be created via a new attribute name - see",
+        )
         modin_df.col1 = [5]
         modin_df.new_attr = 6
         modin_df.col0 = 7
@@ -313,8 +314,8 @@ def test___setattr__mutating_column():
         "new_attr" not in modin_df
     ), "New attribute was not correctly added to columns."
     assert modin_df.new_attr == 6, "Modin attribute value was set incorrectly."
-    assert (
-        isinstance(modin_df.col0, pd.Series)
+    assert isinstance(
+        modin_df.col0, pd.Series
     ), "Scalar was not broadcasted properly to an existing column."
 
 

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -294,14 +294,16 @@ def test___setattr__mutating_column():
     # and adds the provided list as a new attribute and not a column.
     with pytest.warns(
         UserWarning,
-        match="Modin doesn't allow columns to be created via a new attribute name - see",
+        match="Modin doesn't allow columns to be created via a new attribute name - see"
+        + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
     ):
         modin_df.col1 = [4]
 
     with warnings.catch_warnings():
         warnings.filterwarnings(
             action="error",
-            message="Modin doesn't allow columns to be created via a new attribute name - see",
+            message="Modin doesn't allow columns to be created via a new attribute name - see"
+            + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
         )
         modin_df.col1 = [5]
         modin_df.new_attr = 6

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -32,6 +32,7 @@ from modin.pandas.test.utils import (
 )
 from modin.config import NPartitions
 from modin.test.test_utils import warns_that_defaulting_to_pandas
+from pandas.core.dtypes.common import is_list_like
 
 NPartitions.put(4)
 
@@ -290,7 +291,7 @@ def test___setattr__mutating_column():
     df_equals(modin_df, pandas_df)
     assert modin_df.col0.equals(modin_df["col0"])
 
-    # Check taht adding a new col via attributes raises warning
+    # Check that adding a new col via attributes raises warning
     with pytest.warns(
         UserWarning,
         match="Modin doesn't allow columns to be created via a new attribute name - see",
@@ -300,7 +301,7 @@ def test___setattr__mutating_column():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         modin_df.col1 = [5]
-        modin_df.col1 = 6
+        modin_df.col0 = 6
         modin_df.new_attr = 7
 
     assert "new_attr" in dir(
@@ -310,7 +311,7 @@ def test___setattr__mutating_column():
         "new_attr" not in modin_df
     ), "New attribute was not correctly added to columns."
     assert modin_df.new_attr == 7, "Modin attribute value was set incorrectly."
-    assert isinstance(modin_df.col1, pd.Series), "Scalar was not broadcasted correctly."
+    assert isinstance(modin_df.col0, pd.Series), "Scalar was not broadcasted correctly."
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -300,7 +300,7 @@ def test___setattr__mutating_column():
 
     with warnings.catch_warnings():
         warnings.filterwarnings(
-            action="error", 
+            action="error",
             message="Modin doesn't allow columns to be created via a new attribute name - see")
         modin_df.col1 = [5]
         modin_df.new_attr = 6
@@ -313,7 +313,9 @@ def test___setattr__mutating_column():
         "new_attr" not in modin_df
     ), "New attribute was not correctly added to columns."
     assert modin_df.new_attr == 6, "Modin attribute value was set incorrectly."
-    assert isinstance(modin_df.col0, pd.Series), "Scalar was not broadcasted properly to an existing column."
+    assert (
+        isinstance(modin_df.col0, pd.Series)
+    ), "Scalar was not broadcasted properly to an existing column."
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -308,7 +308,7 @@ def test___setattr__mutating_column():
     assert (
         "new_attr" not in modin_df
     ), "New attribute was not correctly added to columns."
-    assert modin_df.new_attr == 7, "Modin attribute value was set incorrectly."
+    assert modin_df.new_attr == 6, "Modin attribute value was set incorrectly."
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -294,7 +294,7 @@ def test___setattr__mutating_column():
     # and adds the provided list as a new attribute and not a column.
     with pytest.warns(
         UserWarning,
-        match="Modin doesn't allow columns to be created via a new attribute name - see"
+        match="Modin doesn't allow columns to be created via a new attribute name - see "
         + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
     ):
         modin_df.col1 = [4]
@@ -302,7 +302,7 @@ def test___setattr__mutating_column():
     with warnings.catch_warnings():
         warnings.filterwarnings(
             action="error",
-            message="Modin doesn't allow columns to be created via a new attribute name - see"
+            message="Modin doesn't allow columns to be created via a new attribute name - see "
             + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
         )
         modin_df.col1 = [5]

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -32,7 +32,6 @@ from modin.pandas.test.utils import (
 )
 from modin.config import NPartitions
 from modin.test.test_utils import warns_that_defaulting_to_pandas
-from pandas.core.dtypes.common import is_list_like
 
 NPartitions.put(4)
 


### PR DESCRIPTION
Signed-off-by: Hazem Elmeleegy <hazem@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4593 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
