### PR TITLE
DOCS-#4628: add to_parquet partial support notes

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -38,6 +38,7 @@ Key Features and Updates
   * TEST-#2564: Add caching and use mamba for conda setups in GH (#4607)
 * Documentation improvements
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
+  * DOCS-#4628: Add to_parquet partial support notes (#4648)
 * Dependencies
   * FEAT-#4598: Add support for pandas 1.4.3 (#4599)
   * FEAT-#4619: Integrate mypy static type checking (#4620)
@@ -55,3 +56,4 @@ Contributors
 @RehanSD
 @helmeleegy
 @anmyachev
+@d33bs

--- a/docs/supported_apis/dataframe_supported.rst
+++ b/docs/supported_apis/dataframe_supported.rst
@@ -418,7 +418,14 @@ default to pandas.
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
 | ``to_latex``               | `to_latex`_               | D                      |                                                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
-| ``to_parquet``             | `to_parquet`_             | D                      |                                                    |
+| ``to_parquet``             | `to_parquet`_             | P                      | **Dask**: Defaults to Pandas implementation as a   |
+|                            |                           |                        | single file. **Ray**: Parallel implementation with |
+|                            |                           |                        | potentially multiple file output only if path      |
+|                            |                           |                        | parameter is a string, does not end with ".gz",    |
+|                            |                           |                        | ".bz2", ".zip", or ".xz" and compression parameter |
+|                            |                           |                        | is not none or "snappy". In these cases, paths     |
+|                            |                           |                        | with Modin on Ray for ``to_parquet`` are           |
+|                            |                           |                        | `directory` and not file paths.                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
 | ``to_period``              | `to_period`_              | D                      |                                                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+

--- a/docs/supported_apis/dataframe_supported.rst
+++ b/docs/supported_apis/dataframe_supported.rst
@@ -418,14 +418,14 @@ default to pandas.
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
 | ``to_latex``               | `to_latex`_               | D                      |                                                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
-| ``to_parquet``             | `to_parquet`_             | P                      | **Dask**: Defaults to Pandas implementation as a   |
-|                            |                           |                        | single file. **Ray**: Parallel implementation with |
-|                            |                           |                        | potentially multiple file output only if path      |
-|                            |                           |                        | parameter is a string, does not end with ".gz",    |
-|                            |                           |                        | ".bz2", ".zip", or ".xz" and compression parameter |
-|                            |                           |                        | is not none or "snappy". In these cases, paths     |
-|                            |                           |                        | with Modin on Ray for ``to_parquet`` are           |
-|                            |                           |                        | `directory` and not file paths.                    |
+| ``to_parquet``             | `to_parquet`_             | P                      | **Dask**: Defaults to Pandas implementation and 
+|                            |                           |                        | writes a  single output file. 
+|                            |                           |                        | **Ray**: Parallel implementation only if path  |
+|                            |                           |                        | parameter is a string; does not end with ".gz",    |
+|                            |                           |                        | ".bz2", ".zip", or ".xz"; and compression parameter |
+|                            |                           |                        | is not ``None`` or "snappy". In these cases, the |
+|                            |                           |                        | ``path`` parameter specifies a directory where |
+|                            |                           |                        | one file is written per row partition of the Modin dataframe. |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
 | ``to_period``              | `to_period`_              | D                      |                                                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+

--- a/docs/supported_apis/dataframe_supported.rst
+++ b/docs/supported_apis/dataframe_supported.rst
@@ -418,14 +418,15 @@ default to pandas.
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
 | ``to_latex``               | `to_latex`_               | D                      |                                                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
-| ``to_parquet``             | `to_parquet`_             | P                      | **Dask**: Defaults to Pandas implementation and 
-|                            |                           |                        | writes a  single output file. 
-|                            |                           |                        | **Ray**: Parallel implementation only if path  |
+| ``to_parquet``             | `to_parquet`_             | P                      | **Dask**: Defaults to Pandas implementation and    |
+|                            |                           |                        | writes a  single output file.                      |
+|                            |                           |                        | **Ray**: Parallel implementation only if path      |
 |                            |                           |                        | parameter is a string; does not end with ".gz",    |
-|                            |                           |                        | ".bz2", ".zip", or ".xz"; and compression parameter |
-|                            |                           |                        | is not ``None`` or "snappy". In these cases, the |
-|                            |                           |                        | ``path`` parameter specifies a directory where |
-|                            |                           |                        | one file is written per row partition of the Modin dataframe. |
+|                            |                           |                        | ".bz2", ".zip", or ".xz"; and compression parameter|
+|                            |                           |                        | is not ``None`` or "snappy". In these cases, the   |
+|                            |                           |                        | ``path`` parameter specifies a directory where     |
+|                            |                           |                        | one file is written per row partition of the Modin |
+|                            |                           |                        | dataframe.                                         |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
 | ``to_period``              | `to_period`_              | D                      |                                                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+


### PR DESCRIPTION
Documentation update to specify Dask vs Ray differences and parallel implementation cases of to_parquet with Ray as per discussion within #4624.

Note: no tests added as update only changes documentation.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4628 
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
