### PR TITLE
FIX-#4641: Reindex pandas partitions in `df.describe()`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -18,6 +18,7 @@ Key Features and Updates
   * FIX-#4593: Ensure Modin warns when setting columns via attributes (#4621)
   * FIX-#4584: Enable pdb debug when running cloud tests (#4585)
   * FIX-#4564: Workaround import issues in Ray: auto-import pandas on python start if env var is set (#4603)
+  * FIX-#4641: Reindex pandas partitions in `df.describe()` (#4651)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1577,6 +1577,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
         def describe_builder(df, internal_indices=[]):
             """Apply `describe` function to the subset of columns in a single partition."""
+            # The index of the resulting dataframe is the same amongst all partitions
+            # when dealing with the same data type. However, if we work with columns
+            # that contain strings, we can get extra values in our result index such as
+            # 'unique', 'top', and 'freq'. Since we call describe() on each partition,
+            # we can have cases where certain partitions do not contain any of the
+            # object string data leading to an index mismatch between partitions.
+            # Thus, we must reindex each partition with the global new_index.
             return df.iloc[:, internal_indices].describe(**kwargs).reindex(new_index)
 
         return self.__constructor__(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1577,7 +1577,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
         def describe_builder(df, internal_indices=[]):
             """Apply `describe` function to the subset of columns in a single partition."""
-            return df.iloc[:, internal_indices].describe(**kwargs)
+            return df.iloc[:, internal_indices].describe(**kwargs).reindex(new_index)
 
         return self.__constructor__(
             self._modin_frame.apply_full_axis_select_indices(

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -182,12 +182,11 @@ def test_2195(datetime_is_numeric, has_numeric_column):
 
 
 def test_describe_different_index():
-    df = pd.DataFrame(np.zeros((2, 60)))
-    pdf = pandas.DataFrame(np.zeros((2, 60)))
-    df["new"] = "abc"
-    pdf["new"] = "abc"
-    df_equals(df.describe(include="all"), pdf.describe(include="all"))
-    df_equals(df.describe(include="all").T, pdf.describe(include="all").T)
+    modin_df = pd.DataFrame(np.zeros((2, 60)))
+    pandas_df = pandas.DataFrame(np.zeros((2, 60)))
+    modin_df["new"] = pandas_df["new"] = "abc"
+    df_equals(modin_df.describe(include="all"), pandas_df.describe(include="all"))
+    df_equals(modin_df.describe(include="all").T, pandas_df.describe(include="all").T)
 
 
 @pytest.mark.parametrize(

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -181,6 +181,15 @@ def test_2195(datetime_is_numeric, has_numeric_column):
     )
 
 
+def test_describe_different_index():
+    df = pd.DataFrame(np.zeros((2, 60)))
+    pdf = pandas.DataFrame(np.zeros((2, 60)))
+    df["new"] = "abc"
+    pdf["new"] = "abc"
+    df_equals(df.describe(include="all"), pdf.describe(include="all"))
+    df_equals(df.describe(include="all").T, pdf.describe(include="all").T)
+
+
 @pytest.mark.parametrize(
     "exclude,include",
     [

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -184,13 +184,8 @@ def test_2195(datetime_is_numeric, has_numeric_column):
 # Issue: https://github.com/modin-project/modin/issues/4641
 def test_describe_column_partition_has_different_index():
     pandas_df = pandas.DataFrame(test_data["int_data"])
-    # The index of the resulting dataframe is the same amongst all partitions
-    # when dealing with only numerical data. However, if we work with columns
-    # that contain strings, we will get extra values in our result index such as
-    # 'unique', 'top', and 'freq'. Since we call describe() on each partition,
-    # we can have cases where certain partitions do not contain any of the
-    # object string data. Thus, we add an extra string column to make sure
-    # that we are setting the index correctly for all partitions.
+    # We add a string column to test the case where partitions with mixed data
+    # types have different 'describe' rows, which causes an index mismatch.
     pandas_df["string_column"] = "abc"
     modin_df = pd.DataFrame(pandas_df)
     eval_general(modin_df, pandas_df, lambda df: df.describe(include="all"))


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
`df.describe(include='all')` can sometimes encounter cases where partitions have different indexes as a result of having different data types (e.g. categorial data returns different summaries as opposed to numerical data). Since we already know what the index of the final DataFrame should look like, we can set the correct index for the partition via `reindex`. Special thanks to @mvashishtha and @RehanSD for helping me understand what was going on in the lower-levels of Modin. This was a fun one to track down. 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4641 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
