### PR TITLE
FIX-#4491: Wait for all partitions in parallel in benchmark mode

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -20,7 +20,7 @@ Key Features and Updates
   * FIX-#4564: Workaround import issues in Ray: auto-import pandas on python start if env var is set (#4603)
   * FIX-#4641: Reindex pandas partitions in `df.describe()` (#4651)
   * FIX-#4634: Check for FrozenList as `by` in `df.groupby()` (#4667)
-  * FIX-#4491: Wait for all partitions in parallel in benchmark mode (#4491)
+  * FIX-#4491: Wait for all partitions in parallel in benchmark mode (#4656)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -20,6 +20,7 @@ Key Features and Updates
   * FIX-#4564: Workaround import issues in Ray: auto-import pandas on python start if env var is set (#4603)
   * FIX-#4641: Reindex pandas partitions in `df.describe()` (#4651)
   * FIX-#4634: Check for FrozenList as `by` in `df.groupby()` (#4667)
+  * FIX-#4491: Wait for all partitions in parallel in benchmark mode (#4491)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)
@@ -66,3 +67,4 @@ Contributors
 @helmeleegy
 @anmyachev
 @d33bs
+@noloerino

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -53,7 +53,7 @@ def wait_computations_if_benchmark_mode(func):
     if BenchmarkMode.get():
 
         @wraps(func)
-        def wait(*args, **kwargs):
+        def wait(cls, *args, **kwargs):
             """Wait for computation results."""
             result = func(*args, **kwargs)
             if isinstance(result, tuple):
@@ -69,8 +69,7 @@ def wait_computations_if_benchmark_mode(func):
             [part.drain_call_queue() for part in partitions.flatten()]
             # The partition manager invokes the relevant .wait() method under
             # the hood, which should wait in parallel for all computations to finish
-            partition_mgr_cls = args[0]
-            partition_mgr_cls.wait_partitions(partitions.flatten())
+            cls.wait_partitions(partitions.flatten())
             return result
 
         return wait
@@ -811,7 +810,7 @@ class PandasDataframePartitionManager(ABC):
     @classmethod
     def wait_partitions(cls, partitions):
         """
-        Wait on the objects wrapped by `partitions` in parallel, without materializing them.
+        Wait on the objects wrapped by `partitions`, without materializing them.
 
         This method will block until all computations in the list have completed.
 

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -53,7 +53,7 @@ def wait_computations_if_benchmark_mode(func):
     if BenchmarkMode.get():
 
         @wraps(func)
-        def wait(cls, *args, **kwargs):
+        def wait(*args, **kwargs):
             """Wait for computation results."""
             result = func(*args, **kwargs)
             if isinstance(result, tuple):
@@ -69,7 +69,10 @@ def wait_computations_if_benchmark_mode(func):
             [part.drain_call_queue() for part in partitions.flatten()]
             # The partition manager invokes the relevant .wait() method under
             # the hood, which should wait in parallel for all computations to finish
-            cls.wait_partitions(partitions.flatten())
+            # (We can't just add a `cls` argument to this `wait` function, since doing so
+            # seems to be incompatible with the way function decorators work)
+            partition_mgr_cls = args[0]
+            partition_mgr_cls.wait_partitions(partitions.flatten())
             return result
 
         return wait

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -72,7 +72,7 @@ def wait_computations_if_benchmark_mode(func):
             # the return `True` value from the lambda
             # TODO(https://github.com/modin-project/modin/issues/4491): Wait
             # for all the partitions in parallel.
-            all(map(lambda partition: partition.wait() or True, partitions.flatten()))
+            ray.get(list(map(lambda partition: partition._data, partitions.flatten())))
             return result
 
         return wait

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -53,9 +53,9 @@ def wait_computations_if_benchmark_mode(func):
     if BenchmarkMode.get():
 
         @wraps(func)
-        def wait(*args, **kwargs):
+        def wait(cls, *args, **kwargs):
             """Wait for computation results."""
-            result = func(*args, **kwargs)
+            result = func(cls, *args, **kwargs)
             if isinstance(result, tuple):
                 partitions = result[0]
             else:
@@ -71,8 +71,7 @@ def wait_computations_if_benchmark_mode(func):
             # the hood, which should wait in parallel for all computations to finish
             # (We can't just add a `cls` argument to this `wait` function, since doing so
             # seems to be incompatible with the way function decorators work)
-            partition_mgr_cls = args[0]
-            partition_mgr_cls.wait_partitions(partitions.flatten())
+            cls.wait_partitions(partitions.flatten())
             return result
 
         return wait

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -69,7 +69,8 @@ def wait_computations_if_benchmark_mode(func):
             [part.drain_call_queue() for part in partitions.flatten()]
             # The partition manager invokes the relevant .wait() method under
             # the hood, which should wait in parallel for all computations to finish
-            PandasDataframePartitionManager.wait_partitions(partitions.flatten())
+            partition_mgr_cls = args[0]
+            partition_mgr_cls.wait_partitions(partitions.flatten())
             return result
 
         return wait

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -56,7 +56,10 @@ def wait_computations_if_benchmark_mode(func):
         def wait(*args, **kwargs):
             """Wait for computation results."""
             # Importing at the start of the file would cause a circular import
-            from modin.core.execution.ray.implementations.pandas_on_ray.partitioning import PandasOnRayDataframePartitionManager
+            from modin.core.execution.ray.implementations.pandas_on_ray.partitioning import (
+                PandasOnRayDataframePartitionManager,
+            )
+
             result = func(*args, **kwargs)
             if isinstance(result, tuple):
                 partitions = result[0]
@@ -71,7 +74,9 @@ def wait_computations_if_benchmark_mode(func):
             [part.drain_call_queue() for part in partitions.flatten()]
             # The PandasOnRay partition manager invokes ray.get under the hood, which waits
             # in parallel for all computations to finish
-            PandasOnRayDataframePartitionManager.get_objects_from_partitions(partitions.flatten())
+            PandasOnRayDataframePartitionManager.get_objects_from_partitions(
+                partitions.flatten()
+            )
             return result
 
         return wait

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -51,12 +51,12 @@ def wait_computations_if_benchmark_mode(func):
     `func` should return NumPy array with partitions.
     """
     if BenchmarkMode.get():
-        # Importing at the start of the file would cause a circular import
-        from modin.core.execution.ray.implementations.pandas_on_ray.partitioning import PandasOnRayDataframePartitionManager
 
         @wraps(func)
         def wait(*args, **kwargs):
             """Wait for computation results."""
+            # Importing at the start of the file would cause a circular import
+            from modin.core.execution.ray.implementations.pandas_on_ray.partitioning import PandasOnRayDataframePartitionManager
             result = func(*args, **kwargs)
             if isinstance(result, tuple):
                 partitions = result[0]

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
@@ -13,6 +13,8 @@
 
 """Module houses class that implements ``PandasDataframePartitionManager``."""
 
+from dask.distributed import wait
+
 from modin.core.dataframe.pandas.partitioning.partition_manager import (
     PandasDataframePartitionManager,
 )
@@ -48,3 +50,17 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
             The objects wrapped by `partitions`.
         """
         return DaskWrapper.materialize([partition._data for partition in partitions])
+
+    @classmethod
+    def wait_partitions(cls, partitions):
+        """
+        Wait on the objects wrapped by `partitions` in parallel, without materializing them.
+
+        This method will block until all computations in the list have completed.
+
+        Parameters
+        ----------
+        partitions : np.ndarray
+            NumPy array with ``PandasDataframePartition``-s.
+        """
+        wait([partition._data for partition in partitions], return_when="ALL_COMPLETED")

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -110,6 +110,20 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         return ray.get([partition._data for partition in partitions])
 
     @classmethod
+    def wait_partitions(cls, partitions):
+        """
+        Wait on the objects wrapped by `partitions` in parallel, without materializing them.
+
+        This method will block until all computations in the list have completed.
+
+        Parameters
+        ----------
+        partitions : np.ndarray
+            NumPy array with ``PandasDataframePartition``-s.
+        """
+        ray.wait([partition._data for partition in partitions], num_returns=len(partitions))
+
+    @classmethod
     @progress_bar_wrapper
     def map_partitions(cls, partitions, map_func):
         """

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -121,7 +121,9 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         partitions : np.ndarray
             NumPy array with ``PandasDataframePartition``-s.
         """
-        ray.wait([partition._data for partition in partitions], num_returns=len(partitions))
+        ray.wait(
+            [partition._data for partition in partitions], num_returns=len(partitions)
+        )
 
     @classmethod
     @progress_bar_wrapper


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
When running in benchmark mode, results from partitions are waited for with a single call to `ray.get` rather than iterating over each partition and calling `ray.wait` under the hood. As the original issue (#4491) suggests, the performance improvement seems to be fairly negligible.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4491 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
