### PR TITLE
FIX-#4658: Expand exception handling for `read_*` functions from s3 storages

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -22,6 +22,7 @@ Key Features and Updates
   * FIX-#2064: Fix `iloc`/`loc` assignment when dataframe is empty (#4677)
   * FIX-#4634: Check for FrozenList as `by` in `df.groupby()` (#4667)
   * FIX-#4491: Wait for all partitions in parallel in benchmark mode (#4656)
+  * FIX-#4658: Expand exception handling for `read_*` functions from s3 storages (#4659)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -80,11 +80,12 @@ class OpenFile:
             The opened file.
         """
         try:
-            from botocore.exceptions import NoCredentialsError
+            from botocore.exceptions import NoCredentialsError, EndpointConnectionError
 
             credential_error_type = (
                 NoCredentialsError,
                 PermissionError,
+                EndpointConnectionError,
             )
         except ModuleNotFoundError:
             credential_error_type = ()
@@ -261,7 +262,10 @@ class FileDispatcher(ClassLogger):
                 S3FS = import_optional_dependency(
                     "s3fs", "Module s3fs is required to read S3FS files."
                 )
-                from botocore.exceptions import NoCredentialsError
+                from botocore.exceptions import (
+                    NoCredentialsError,
+                    EndpointConnectionError,
+                )
 
                 if storage_options is not None:
                     new_storage_options = dict(storage_options)
@@ -273,7 +277,7 @@ class FileDispatcher(ClassLogger):
                 exists = False
                 try:
                     exists = s3fs.exists(file_path) or exists
-                except (NoCredentialsError, PermissionError):
+                except (NoCredentialsError, PermissionError, EndpointConnectionError):
                     pass
                 s3fs = S3FS.S3FileSystem(anon=True, **new_storage_options)
                 return exists or s3fs.exists(file_path)

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -80,12 +80,11 @@ class OpenFile:
             The opened file.
         """
         try:
-            from botocore.exceptions import NoCredentialsError, EndpointConnectionError
+            from botocore.exceptions import NoCredentialsError
 
             credential_error_type = (
                 NoCredentialsError,
                 PermissionError,
-                EndpointConnectionError,
             )
         except ModuleNotFoundError:
             credential_error_type = ()

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -314,7 +314,10 @@ class CSVGlobDispatcher(CSVDispatcher):
                 S3FS = import_optional_dependency(
                     "s3fs", "Module s3fs is required to read S3FS files."
                 )
-                from botocore.exceptions import NoCredentialsError
+                from botocore.exceptions import (
+                    NoCredentialsError,
+                    EndpointConnectionError,
+                )
 
                 if storage_options is not None:
                     new_storage_options = dict(storage_options)
@@ -326,7 +329,7 @@ class CSVGlobDispatcher(CSVDispatcher):
                 exists = False
                 try:
                     exists = len(s3fs.glob(file_path)) > 0 or exists
-                except (NoCredentialsError, PermissionError):
+                except (NoCredentialsError, PermissionError, EndpointConnectionError):
                     pass
                 s3fs = S3FS.S3FileSystem(anon=True, **new_storage_options)
                 return exists or len(s3fs.glob(file_path)) > 0
@@ -355,7 +358,7 @@ class CSVGlobDispatcher(CSVDispatcher):
             S3FS = import_optional_dependency(
                 "s3fs", "Module s3fs is required to read S3FS files."
             )
-            from botocore.exceptions import NoCredentialsError
+            from botocore.exceptions import NoCredentialsError, EndpointConnectionError
 
             def get_file_path(fs_handle) -> List[str]:
                 file_paths = fs_handle.glob(file_path)
@@ -365,7 +368,7 @@ class CSVGlobDispatcher(CSVDispatcher):
             s3fs = S3FS.S3FileSystem(anon=False)
             try:
                 return get_file_path(s3fs)
-            except NoCredentialsError:
+            except (NoCredentialsError, EndpointConnectionError):
                 pass
             s3fs = S3FS.S3FileSystem(anon=True)
             return get_file_path(s3fs)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -940,6 +940,15 @@ class TestCsv:
             storage_options=storage_options,
         )
 
+    def test_read_csv_s3_issue4658(self):
+        eval_io(
+            fn_name="read_csv",
+            # read_csv kwargs
+            filepath_or_buffer="s3://dask-data/nyc-taxi/2015/yellow_tripdata_2015-01.csv",
+            nrows=10,
+            storage_options={"anon": True},
+        )
+
     @pytest.mark.parametrize("names", [list("XYZ"), None])
     @pytest.mark.parametrize("skiprows", [1, 2, 3, 4, None])
     def test_read_csv_skiprows_names(self, names, skiprows):


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
The PR expand the set of handled exceptions in `read_*` functions from s3 storages by `EndpointConnectionError` exception

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4658 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
