### PR TITLE
FIX-#4634: Check for FrozenList as `by` in `df.groupby()`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -19,6 +19,7 @@ Key Features and Updates
   * FIX-#4584: Enable pdb debug when running cloud tests (#4585)
   * FIX-#4564: Workaround import issues in Ray: auto-import pandas on python start if env var is set (#4603)
   * FIX-#4641: Reindex pandas partitions in `df.describe()` (#4651)
+  * FIX-#4634: Check for FrozenList as `by` in `df.groupby()` (#4667)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -21,6 +21,7 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_numeric_dtype,
 )
+from pandas.core.indexes.frozen import FrozenList
 from pandas.util._validators import validate_bool_kwarg
 from pandas.io.formats.printing import pprint_thing
 from pandas._libs.lib import no_default
@@ -434,7 +435,7 @@ class DataFrame(BasePandasDataset):
 
         if callable(by):
             by = self.index.map(by)
-        elif hashable(by) and not isinstance(by, pandas.Grouper):
+        elif hashable(by) and not isinstance(by, (pandas.Grouper, FrozenList)):
             drop = by in self.columns
             idx_name = by
             if by is not None and by in self._query_compiler.get_index_names(axis):
@@ -3015,6 +3016,7 @@ class DataFrame(BasePandasDataset):
         elif isinstance(key, DataFrame):
             return self.where(key)
         elif is_mi_columns:
+            print("we are here???")
             return self._default_to_pandas(pandas.DataFrame.__getitem__, key)
             # return self._getitem_multilevel(key)
         else:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -3016,7 +3016,6 @@ class DataFrame(BasePandasDataset):
         elif isinstance(key, DataFrame):
             return self.where(key)
         elif is_mi_columns:
-            print("we are here???")
             return self._default_to_pandas(pandas.DataFrame.__getitem__, key)
             # return self._getitem_multilevel(key)
         else:

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -2063,3 +2063,10 @@ def test_sum_with_level():
     }
     modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
     eval_general(modin_df, pandas_df, lambda df: df.set_index("C").groupby("C").sum())
+
+
+def test_groupby_with_frozenlist():
+    pandas_df = pandas.DataFrame(data={"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]})
+    pandas_df = pandas_df.set_index(["a", "b"])
+    modin_df = from_pandas(pandas_df)
+    eval_general(modin_df, pandas_df, lambda df: df.groupby(df.index.names).count())


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
`FrozenList` should be treated as a "list-like" object in `groupby`. However, compared to most list-like objects, `FrozenList` is actually hashable, which causes us to go down the wrong code path. This PR addresses that issue.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4634 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
