### PR TITLE
FEAT-#4670: Implement convert_dtypes by mapping across partitions

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -30,7 +30,8 @@ Key Features and Updates
   * REFACTOR-#4530: Standardize access to physical data in partitions (#4563)
   * REFACTOR-#4534: Replace logging meta class with class decorator (#4535)
 * Pandas API implementations and improvements
-  *
+  * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
+
 * OmniSci enhancements
   *
 * XGBoost enhancements
@@ -52,7 +53,6 @@ Key Features and Updates
 * New Features
   * FEAT-4463: Add experimental fuzzydata integration for testing against a randomized dataframe workflow (#4556)
   * FEAT-#4419: Extend virtual partitioning API to pandas on Dask (#4420)
-  * FEAT-#4670:  Implement convert_dtypes by mapping across partitions (#4671)
 
 
 Contributors

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -52,6 +52,7 @@ Key Features and Updates
 * New Features
   * FEAT-4463: Add experimental fuzzydata integration for testing against a randomized dataframe workflow (#4556)
   * FEAT-#4419: Extend virtual partitioning API to pandas on Dask (#4420)
+  * FEAT-#4670:  Implement convert_dtypes by mapping across partitions (#4671)
 
 
 Contributors
@@ -66,3 +67,4 @@ Contributors
 @helmeleegy
 @anmyachev
 @d33bs
+@noloerino

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -31,7 +31,6 @@ Key Features and Updates
   * REFACTOR-#4534: Replace logging meta class with class decorator (#4535)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
-
 * OmniSci enhancements
   *
 * XGBoost enhancements

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1397,15 +1397,38 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     def convert_dtypes(
         self,
         infer_objects: bool = True,
-        convert_objects: bool = True,
+        convert_string: bool = True,
         convert_integer: bool = True,
         convert_boolean: bool = True,
         convert_floating: bool = True,
     ):
+        """
+        Convert columns to best possible dtypes using dtypes supporting ``pd.NA``.
+
+        Parameters
+        ----------
+        infer_objects : bool, default: True
+            Whether object dtypes should be converted to the best possible types.
+        convert_string : bool, default: True
+            Whether object dtypes should be converted to ``pd.StringDtype()``.
+        convert_integer : bool, default: True
+            Whether, if possbile, conversion should be done to integer extension types.
+        convert_boolean : bool, default: True
+            Whether  object dtypes should be converted to ``pd.BooleanDtype()``.
+        convert_floating : bool, default: True
+            Whether, if possible, conversion can be done to floating extension types.
+            If `convert_integer` is also True, preference will be give to integer dtypes
+            if the floats can be faithfully casted to integers.
+
+        Returns
+        -------
+        BaseQueryCompiler
+            New QueryCompiler with updated dtypes.
+        """
         return DataFrameDefault.register(pandas.DataFrame.convert_dtypes)(
             self,
             infer_objects=infer_objects,
-            convert_objects=convert_objects,
+            convert_string=convert_string,
             convert_integer=convert_integer,
             convert_boolean=convert_boolean,
             convert_floating=convert_floating,

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1394,6 +1394,23 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             self, dtype=col_dtypes, **kwargs
         )
 
+    def convert_dtypes(
+        self,
+        infer_objects: bool = True,
+        convert_objects: bool = True,
+        convert_integer: bool = True,
+        convert_boolean: bool = True,
+        convert_floating: bool = True,
+    ):
+        return DataFrameDefault.register(pandas.DataFrame.convert_dtypes)(
+            self,
+            infer_objects=infer_objects,
+            convert_objects=convert_objects,
+            convert_integer=convert_integer,
+            convert_boolean=convert_boolean,
+            convert_floating=convert_floating,
+        )
+
     @property
     def dtypes(self):
         """

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1414,7 +1414,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         convert_integer : bool, default: True
             Whether, if possbile, conversion should be done to integer extension types.
         convert_boolean : bool, default: True
-            Whether  object dtypes should be converted to ``pd.BooleanDtype()``.
+            Whether object dtypes should be converted to ``pd.BooleanDtype()``.
         convert_floating : bool, default: True
             Whether, if possible, conversion can be done to floating extension types.
             If `convert_integer` is also True, preference will be give to integer dtypes

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1347,6 +1347,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     abs = Map.register(pandas.DataFrame.abs, dtypes="copy")
     applymap = Map.register(pandas.DataFrame.applymap)
     conj = Map.register(lambda df, *args, **kwargs: pandas.DataFrame(np.conj(df)))
+    convert_dtypes = Map.register(pandas.DataFrame.convert_dtypes)
     invert = Map.register(pandas.DataFrame.__invert__)
     isin = Map.register(pandas.DataFrame.isin, dtypes=np.bool_)
     isna = Map.register(pandas.DataFrame.isna, dtypes=np.bool_)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1669,12 +1669,13 @@ class BasePandasDataset(ClassLogger):
         """
         Convert columns to best possible dtypes using dtypes supporting ``pd.NA``.
         """
-        return self._default_to_pandas(
-            "convert_dtypes",
-            infer_objects=infer_objects,
-            convert_string=convert_string,
-            convert_integer=convert_integer,
-            convert_boolean=convert_boolean,
+        return self.__constructor__(
+            query_compiler=self._query_compiler.convert_dtypes(
+                infer_objects=infer_objects,
+                convert_string=convert_string,
+                convert_integer=convert_integer,
+                convert_boolean=convert_boolean,
+            )
         )
 
     def isin(self, values):  # noqa: PR01, RT01, D200

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1675,6 +1675,7 @@ class BasePandasDataset(ClassLogger):
                 convert_string=convert_string,
                 convert_integer=convert_integer,
                 convert_boolean=convert_boolean,
+                convert_floating=convert_floating,
             )
         )
 

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -605,6 +605,7 @@ def test_convert_dtypes_multiple_row_partitions():
     # Column 0 should have an int dtype
     modin_part2 = pd.DataFrame([1]).convert_dtypes()
     modin_df = pd.concat([modin_part1, modin_part2])
+    assert modin_df._query_compiler._modin_frame._partitions.shape == (2, 1)
     pandas_df = pandas.DataFrame(["a", 1], index=[0, 0])
     # The initial dataframes should be the same
     df_equals(modin_df, pandas_df)
@@ -614,7 +615,6 @@ def test_convert_dtypes_multiple_row_partitions():
     modin_result = modin_df.convert_dtypes()
     pandas_result = pandas_df.convert_dtypes()
     df_equals(modin_result, pandas_result)
-    assert modin_df._query_compiler._modin_frame._partitions.shape == (2, 1)
     assert modin_result.dtypes.equals(pandas_result.dtypes)
 
 

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -557,11 +557,11 @@ def test_astype_category_large():
     assert modin_result.dtypes.equals(pandas_result.dtypes)
 
 
-@pytest.mark.parametrize("infer_objects", (True, False))
-@pytest.mark.parametrize("convert_string", (True, False))
-@pytest.mark.parametrize("convert_integer", (True, False))
-@pytest.mark.parametrize("convert_boolean", (True, False))
-@pytest.mark.parametrize("convert_floating", (True, False))
+@pytest.mark.parametrize("infer_objects", (True, False), ids=("infer_objects", ""))
+@pytest.mark.parametrize("convert_string", (True, False), ids=("convert_string", ""))
+@pytest.mark.parametrize("convert_integer", (True, False), ids=("convert_integer", ""))
+@pytest.mark.parametrize("convert_boolean", (True, False), ids=("convert_boolean", ""))
+@pytest.mark.parametrize("convert_floating", (True, False), ids=("convert_floating", ""))
 def test_convert_dtypes(
     infer_objects, convert_string, convert_integer, convert_boolean, convert_floating
 ):

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -557,6 +557,31 @@ def test_astype_category_large():
     assert modin_result.dtypes.equals(pandas_result.dtypes)
 
 
+@pytest.mark.parametrize("infer_objects", (True, False))
+@pytest.mark.parametrize("convert_string", (True, False))
+@pytest.mark.parametrize("convert_integer", (True, False))
+@pytest.mark.parametrize("convert_boolean", (True, False))
+@pytest.mark.parametrize("convert_floating", (True, False))
+def test_convert_dtypes(
+    infer_objects, convert_string, convert_integer, convert_boolean, convert_floating
+):
+    # Sanity check, copied from pandas documentation:
+    # https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.convert_dtypes.html
+    data = {
+        "a": pd.Series([1, 2, 3], dtype=np.dtype("int32")),
+        "b": pd.Series(["x", "y", "z"], dtype=np.dtype("O")),
+        "c": pd.Series([True, False, np.nan], dtype=np.dtype("O")),
+        "d": pd.Series(["h", "i", np.nan], dtype=np.dtype("O")),
+        "e": pd.Series([10, np.nan, 20], dtype=np.dtype("float")),
+        "f": pd.Series([np.nan, 100.5, 200], dtype=np.dtype("float")),
+    }
+    modin_df = pd.DataFrame(data)
+    pandas_df = pandas.DataFrame(data)
+    modin_result = modin_df.convert_dtypes()
+    pandas_result = pandas_df.convert_dtypes()
+    assert modin_result.dtypes.equals(pandas_result.dtypes)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
 @pytest.mark.parametrize("bound_type", ["list", "series"], ids=["list", "series"])

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -575,10 +575,17 @@ def test_convert_dtypes(
         "e": pd.Series([10, np.nan, 20], dtype=np.dtype("float")),
         "f": pd.Series([np.nan, 100.5, 200], dtype=np.dtype("float")),
     }
+    kwargs = {
+        "infer_objects": infer_objects,
+        "convert_string": convert_string,
+        "convert_integer": convert_integer,
+        "convert_boolean": convert_boolean,
+        "convert_floating": convert_floating,
+    }
     modin_df = pd.DataFrame(data)
     pandas_df = pandas.DataFrame(data)
-    modin_result = modin_df.convert_dtypes()
-    pandas_result = pandas_df.convert_dtypes()
+    modin_result = modin_df.convert_dtypes(**kwargs)
+    pandas_result = pandas_df.convert_dtypes(**kwargs)
     assert modin_result.dtypes.equals(pandas_result.dtypes)
 
 

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -16,9 +16,9 @@ import numpy as np
 import pandas
 from pandas.testing import assert_index_equal, assert_series_equal
 import matplotlib
-
 import modin.pandas as pd
 from modin.utils import get_current_execution
+
 from modin.pandas.test.utils import (
     random_state,
     RAND_LOW,

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -17,7 +17,6 @@ import pandas
 from pandas.testing import assert_index_equal, assert_series_equal
 import matplotlib
 
-from modin.config.envvars import MinPartitionSize
 import modin.pandas as pd
 from modin.utils import get_current_execution
 from modin.pandas.test.utils import (
@@ -606,7 +605,7 @@ def test_convert_dtypes_multiple_row_partitions():
     # Column 0 should have an int dtype
     modin_part2 = pd.DataFrame([1]).convert_dtypes()
     modin_df = pd.concat([modin_part1, modin_part2])
-    pandas_df = pandas.concat([pandas.DataFrame(["a"]), pandas.DataFrame([1])])
+    pandas_df = pandas.DataFrame(["a", 1], index=[0, 0])
     # The initial dataframes should be the same
     df_equals(modin_df, pandas_df)
     # TODO(https://github.com/modin-project/modin/pull/3805): delete

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -561,7 +561,9 @@ def test_astype_category_large():
 @pytest.mark.parametrize("convert_string", (True, False), ids=("convert_string", ""))
 @pytest.mark.parametrize("convert_integer", (True, False), ids=("convert_integer", ""))
 @pytest.mark.parametrize("convert_boolean", (True, False), ids=("convert_boolean", ""))
-@pytest.mark.parametrize("convert_floating", (True, False), ids=("convert_floating", ""))
+@pytest.mark.parametrize(
+    "convert_floating", (True, False), ids=("convert_floating", "")
+)
 def test_convert_dtypes(
     infer_objects, convert_string, convert_integer, convert_boolean, convert_floating
 ):

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -599,6 +599,10 @@ def test_convert_dtypes_single_partition(
     assert modin_result.dtypes.equals(pandas_result.dtypes)
 
 
+@pytest.mark.skipif(
+    get_current_execution() == "BaseOnPython",
+    reason="BaseOnPython cannot not have multiple partitions.",
+)
 def test_convert_dtypes_multiple_row_partitions():
     # Column 0 should have string dtype
     modin_part1 = pd.DataFrame(["a"]).convert_dtypes()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Implements `convert_dtypes` by mapping across partitions instead of defaulting to pandas.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4670 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
