### PR TITLE
FIX-#4680: fix `read_csv` that started defaulting to pandas again in case of reading from buffer

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -20,6 +20,7 @@ Key Features and Updates
   * FIX-#4564: Workaround import issues in Ray: auto-import pandas on python start if env var is set (#4603)
   * FIX-#4641: Reindex pandas partitions in `df.describe()` (#4651)
   * FIX-#4634: Check for FrozenList as `by` in `df.groupby()` (#4667)
+  * FIX-#4680: Fix `read_csv` that started defaulting to pandas again in case of reading from buffer (#4681)
   * FIX-#4491: Wait for all partitions in parallel in benchmark mode (#4656)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -987,7 +987,7 @@ class TextFileDispatcher(FileDispatcher):
         )
 
         use_modin_impl = cls.check_parameters_support(
-            filepath_or_buffer,
+            filepath_or_buffer_md,
             kwargs,
             skiprows_md,
             header_size,
@@ -1003,7 +1003,7 @@ class TextFileDispatcher(FileDispatcher):
         )
 
         pd_df_metadata = cls.read_callback(
-            filepath_or_buffer,
+            filepath_or_buffer_md,
             **dict(kwargs, nrows=1, skipfooter=0, index_col=index_col),
         )
         column_names = pd_df_metadata.columns


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4680 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
