### PR TITLE
REFACTOR-#4629: Add type annotations to `modin/config`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -36,6 +36,7 @@ Key Features and Updates
   * REFACTOR-#4530: Standardize access to physical data in partitions (#4563)
   * REFACTOR-#4534: Replace logging meta class with class decorator (#4535)
   * REFACTOR-#4708: Delete combine dtypes (#4709)
+  * REFACTOR-#4629: Add type annotations to modin/config (#4685)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/modin/config/__main__.py
+++ b/modin/config/__main__.py
@@ -57,9 +57,9 @@ def export_config_help(filename: str) -> None:
                 if obj.__name__ != "RayRedisPassword"
                 else "random string",
                 # `Notes` `-` underlining can't be correctly parsed inside csv table by sphinx
-                "Description": dedent(obj.__doc__).replace("Notes\n-----", "Notes:\n")
-                if obj.__doc__
-                else "",
+                "Description": dedent(obj.__doc__ or "").replace(
+                    "Notes\n-----", "Notes:\n"
+                ),
                 "Options": obj.choices,
             }
             configs_data.append(data)

--- a/modin/config/__main__.py
+++ b/modin/config/__main__.py
@@ -27,7 +27,7 @@ import pandas
 import argparse
 
 
-def print_config_help():
+def print_config_help() -> None:
     """Print configs help messages."""
     for objname in sorted(globals()):
         obj = globals()[objname]
@@ -35,7 +35,7 @@ def print_config_help():
             print(f"{obj.get_help()}\n\tCurrent value: {obj.get()}")  # noqa: T201
 
 
-def export_config_help(filename: str):
+def export_config_help(filename: str) -> None:
     """
     Export all configs help messages to the CSV file.
 
@@ -57,7 +57,9 @@ def export_config_help(filename: str):
                 if obj.__name__ != "RayRedisPassword"
                 else "random string",
                 # `Notes` `-` underlining can't be correctly parsed inside csv table by sphinx
-                "Description": dedent(obj.__doc__).replace("Notes\n-----", "Notes:\n"),
+                "Description": dedent(obj.__doc__).replace("Notes\n-----", "Notes:\n")
+                if obj.__doc__
+                else "",
                 "Options": obj.choices,
             }
             configs_data.append(data)

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -41,6 +41,8 @@ class EnvironmentVariable(Parameter, type=str, abstract=True):
 
         Raises
         ------
+        TypeError
+            If `varname` is None.
         KeyError
             If value is absent.
         """

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -23,6 +23,7 @@ import secrets
 from .pubsub import Parameter, _TYPE_PARAMS, ExactStr, ValueSource
 from typing import Optional
 
+
 class EnvironmentVariable(Parameter, type=str, abstract=True):
     """Base class for environment variables-based configuration."""
 

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -45,7 +45,7 @@ class EnvironmentVariable(Parameter, type=str, abstract=True):
             If value is absent.
         """
         if cls.varname is None:
-            raise KeyError("varname is None")
+            raise TypeError("varname should not be None")
         return os.environ[cls.varname]
 
     @classmethod

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -21,12 +21,12 @@ from packaging import version
 import secrets
 
 from .pubsub import Parameter, _TYPE_PARAMS, ExactStr, ValueSource
-
+from typing import Optional
 
 class EnvironmentVariable(Parameter, type=str, abstract=True):
     """Base class for environment variables-based configuration."""
 
-    varname: str = None
+    varname: Optional[str] = None
 
     @classmethod
     def _get_raw_from_config(cls) -> str:
@@ -73,7 +73,7 @@ class Engine(EnvironmentVariable, type=str):
     choices = ("Ray", "Dask", "Python", "Native")
 
     @classmethod
-    def _get_default(cls):
+    def _get_default(cls) -> str:
         """
         Get default value of the config.
 
@@ -170,7 +170,7 @@ class CpuCount(EnvironmentVariable, type=int):
     varname = "MODIN_CPUS"
 
     @classmethod
-    def _get_default(cls):
+    def _get_default(cls) -> int:
         """
         Get default value of the config.
 
@@ -208,7 +208,7 @@ class NPartitions(EnvironmentVariable, type=int):
     varname = "MODIN_NPARTITIONS"
 
     @classmethod
-    def _put(cls, value):
+    def _put(cls, value: int) -> None:
         """
         Put specific value if NPartitions wasn't set by a user yet.
 
@@ -226,7 +226,7 @@ class NPartitions(EnvironmentVariable, type=int):
             cls.put(value)
 
     @classmethod
-    def _get_default(cls):
+    def _get_default(cls) -> int:
         """
         Get default value of the config.
 
@@ -318,17 +318,17 @@ class ProgressBar(EnvironmentVariable, type=bool):
     default = False
 
     @classmethod
-    def enable(cls):
+    def enable(cls) -> None:
         """Enable ``ProgressBar`` feature."""
         cls.put(True)
 
     @classmethod
-    def disable(cls):
+    def disable(cls) -> None:
         """Disable ``ProgressBar`` feature."""
         cls.put(False)
 
     @classmethod
-    def put(cls, value):
+    def put(cls, value: bool) -> None:
         """
         Set ``ProgressBar`` value only if synchronous benchmarking is disabled.
 
@@ -349,7 +349,7 @@ class BenchmarkMode(EnvironmentVariable, type=bool):
     default = False
 
     @classmethod
-    def put(cls, value):
+    def put(cls, value: bool) -> None:
         """
         Set ``BenchmarkMode`` value only if progress bar feature is disabled.
 
@@ -371,17 +371,17 @@ class LogMode(EnvironmentVariable, type=ExactStr):
     default = "disable"
 
     @classmethod
-    def enable(cls):
+    def enable(cls) -> None:
         """Enable all logging levels."""
         cls.put("enable")
 
     @classmethod
-    def disable(cls):
+    def disable(cls) -> None:
         """Disable logging feature."""
         cls.put("disable")
 
     @classmethod
-    def enable_api_only(cls):
+    def enable_api_only(cls) -> None:
         """Enable API level logging."""
         cls.put("enable_api_only")
 
@@ -393,7 +393,7 @@ class LogMemoryInterval(EnvironmentVariable, type=int):
     default = 5
 
     @classmethod
-    def put(cls, value):
+    def put(cls, value: int) -> None:
         """
         Set ``LogMemoryInterval`` with extra checks.
 
@@ -427,7 +427,7 @@ class LogFileSize(EnvironmentVariable, type=int):
     default = 10
 
     @classmethod
-    def put(cls, value):
+    def put(cls, value: int) -> None:
         """
         Set ``LogFileSize`` with extra checks.
 
@@ -484,7 +484,7 @@ class OmnisciLaunchParameters(EnvironmentVariable, type=dict):
     }
 
     @classmethod
-    def get(self):
+    def get(self) -> dict:
         """
         Get the resulted command-line options.
 
@@ -515,7 +515,7 @@ class MinPartitionSize(EnvironmentVariable, type=int):
     default = 32
 
     @classmethod
-    def put(cls, value):
+    def put(cls, value: int) -> None:
         """
         Set ``MinPartitionSize`` with extra checks.
 
@@ -529,7 +529,7 @@ class MinPartitionSize(EnvironmentVariable, type=int):
         super().put(value)
 
     @classmethod
-    def get(cls):
+    def get(cls) -> int:
         """
         Get ``MinPartitionSize`` with extra checks.
 
@@ -564,7 +564,7 @@ class ReadSqlEngine(EnvironmentVariable, type=str):
     choices = ("Pandas", "Connectorx")
 
 
-def _check_vars():
+def _check_vars() -> None:
     """
     Check validity of environment variables.
 

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -43,6 +43,8 @@ class EnvironmentVariable(Parameter, type=str, abstract=True):
         KeyError
             If value is absent.
         """
+        if cls.varname is None:
+            raise KeyError("varname is None")
         return os.environ[cls.varname]
 
     @classmethod

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -122,15 +122,15 @@ class Parameter(object):
 
     Attributes
     ----------
-    choices : sequence of str
+    choices : Optional[Sequence[str]]
         Array with possible options of ``Parameter`` values.
     type : str
         String that denotes ``Parameter`` type.
-    default : Any
+    default : Optional[Any]
         ``Parameter`` default value.
     is_abstract : bool, default: True
         Whether or not ``Parameter`` is abstract.
-    _value_source : int
+    _value_source : Optional[int]
         Source of the ``Parameter`` value, should be set by
         ``ValueSource``.
     """

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -13,7 +13,7 @@
 
 """Module houses ``Parameter`` class - base class for all configs."""
 
-import collections
+from collections import defaultdict
 from typing import Any, Callable, NamedTuple, Optional, Sequence, Union
 
 
@@ -140,6 +140,9 @@ class Parameter(object):
     default: Optional[Any] = None
     is_abstract = True
     _value_source: Optional[int] = None
+    _value: Any = _UNSET
+    _subs: list = []
+    _once: defaultdict[Any, list] = defaultdict(list)
 
     @classmethod
     def _get_raw_from_config(cls) -> str:
@@ -196,7 +199,7 @@ class Parameter(object):
         cls.is_abstract = abstract
         cls._value = _UNSET
         cls._subs = []
-        cls._once = collections.defaultdict(list)
+        cls._once = defaultdict(list)
         super().__init_subclass__(**kw)
 
     @classmethod

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -106,7 +106,7 @@ _TYPE_PARAMS = {
 _UNSET = object()
 
 
-class ValueSource(IntEnum):
+class ValueSource(IntEnum):  # noqa: PR01
     """Class that describes the method of getting the value for a parameter."""
 
     # got from default, i.e. neither user nor configuration source had the value

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -14,7 +14,6 @@
 """Module houses ``Parameter`` class - base class for all configs."""
 
 import collections
-from subprocess import call
 from typing import Any, Callable, NamedTuple, Optional, Sequence, Union
 
 
@@ -71,7 +70,7 @@ _TYPE_PARAMS = {
     ),
     int: TypeDescriptor(
         decode=lambda value: int(value.strip()),
-        normalize=int, # type: ignore
+        normalize=int,  # type: ignore
         verify=lambda value: isinstance(value, int)
         or (isinstance(value, str) and value.strip().isdigit()),
         help="an integer value",
@@ -179,7 +178,7 @@ class Parameter(object):
         """
         raise NotImplementedError()
 
-    def __init_subclass__(cls, type: Any, abstract: bool=False, **kw: dict):
+    def __init_subclass__(cls, type: Any, abstract: bool = False, **kw: dict):
         """
         Initialize subclass.
 

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -14,7 +14,7 @@
 """Module houses ``Parameter`` class - base class for all configs."""
 
 from collections import defaultdict
-from typing import Any, Callable, NamedTuple, Optional, Sequence, Union
+from typing import Any, Callable, DefaultDict, NamedTuple, Optional, Sequence, Union
 
 
 class TypeDescriptor(NamedTuple):
@@ -142,7 +142,7 @@ class Parameter(object):
     _value_source: Optional[int] = None
     _value: Any = _UNSET
     _subs: list = []
-    _once: defaultdict[Any, list] = defaultdict(list)
+    _once: DefaultDict[Any, list] = defaultdict(list)
 
     @classmethod
     def _get_raw_from_config(cls) -> str:

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -14,7 +14,7 @@
 """Module houses ``Parameter`` class - base class for all configs."""
 
 from collections import defaultdict
-from typing import Any, Callable, DefaultDict, NamedTuple, Optional, Sequence, Union
+from typing import Any, Callable, DefaultDict, NamedTuple, Optional, Sequence
 
 
 class TypeDescriptor(NamedTuple):
@@ -227,7 +227,7 @@ class Parameter(object):
         return cls.default
 
     @classmethod
-    def get_value_source(cls) -> Union[int, None]:
+    def get_value_source(cls) -> Optional[int]:
         """
         Get value source of the config.
 

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -228,17 +228,20 @@ class Parameter(object):
         return cls.default
 
     @classmethod
-    def get_value_source(cls) -> Optional[ValueSource]:
+    def get_value_source(cls) -> ValueSource:
         """
         Get value source of the config.
 
         Returns
         -------
-        Optional[ValueSource]
+        ValueSource
         """
         if cls._value_source is None:
             # dummy call to .get() to initialize the value
             cls.get()
+        assert (
+            cls._value_source is not None
+        ), "_value_source must be initialized by now in get()"
         return cls._value_source
 
     @classmethod

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -14,6 +14,7 @@
 """Module houses ``Parameter`` class - base class for all configs."""
 
 from collections import defaultdict
+from enum import IntEnum
 from typing import Any, Callable, DefaultDict, NamedTuple, Optional, Sequence
 
 
@@ -105,7 +106,7 @@ _TYPE_PARAMS = {
 _UNSET = object()
 
 
-class ValueSource:
+class ValueSource(IntEnum):
     """Class that describes the method of getting the value for a parameter."""
 
     # got from default, i.e. neither user nor configuration source had the value
@@ -130,7 +131,7 @@ class Parameter(object):
         ``Parameter`` default value.
     is_abstract : bool, default: True
         Whether or not ``Parameter`` is abstract.
-    _value_source : Optional[int]
+    _value_source : Optional[ValueSource]
         Source of the ``Parameter`` value, should be set by
         ``ValueSource``.
     """
@@ -139,7 +140,7 @@ class Parameter(object):
     type = str
     default: Optional[Any] = None
     is_abstract = True
-    _value_source: Optional[int] = None
+    _value_source: Optional[ValueSource] = None
     _value: Any = _UNSET
     _subs: list = []
     _once: DefaultDict[Any, list] = defaultdict(list)
@@ -227,13 +228,13 @@ class Parameter(object):
         return cls.default
 
     @classmethod
-    def get_value_source(cls) -> Optional[int]:
+    def get_value_source(cls) -> Optional[ValueSource]:
         """
         Get value source of the config.
 
         Returns
         -------
-        int
+        Optional[ValueSource]
         """
         if cls._value_source is None:
             # dummy call to .get() to initialize the value

--- a/mypy.ini
+++ b/mypy.ini
@@ -18,4 +18,4 @@ warn_unreachable=True
 
 # We will add more files over time to increase coverage
 ; files = **/modin/*.py
-files = **/modin/logging/*.py
+files = **/modin/config/*.py, **/modin/logging/*.py


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR adds type annotations and various fixes found by `mypy` to `modin/config`. 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4629 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
