### PR TITLE
PERF-#4705: Improve perf of arithmetic operations between `Series` objects with shared `.index`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -29,6 +29,7 @@ Key Features and Updates
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)
   * PERF-#4325: Improve perf of multi-column assignment in `__setitem__` when no new column names are assigning (#4455)
   * PERF-#3844: Improve perf of `drop` operation (#4694)
+  * PERF-#4705: Improve perf of arithmetic operations between `Series` objects with shared `.index` (#4689)
 * Benchmarking enhancements
   * FEAT-#4706: Add Modin ClassLogger to PandasDataframePartitionManager (#4707)
 * Refactor Codebase
@@ -77,3 +78,4 @@ Contributors
 @devin-petersohn
 @YarShev
 @naren-ponder
+@jbrockmendel

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -2393,8 +2393,9 @@ class Series(SeriesCompat, BasePandasDataset):
             Prepared `other`.
         """
         if isinstance(other, Series):
-            new_self = self.copy()
-            new_other = other.copy()
+            # NB: deep=False is important for performance bc it retains obj.index._id
+            new_self = self.copy(deep=False)
+            new_other = other.copy(deep=False)
             if self.name == other.name:
                 new_self.name = new_other.name = self.name
             else:


### PR DESCRIPTION
```
import modin.config as cfg
cfg.BenchmarkMode.put(True)

import ray
ray.init()
import modin.pandas as pd
import numpy as np

arr = np.random.randn(100_000, 2)
df = pd.DataFrame(arr)
df.index = pd.MultiIndex.from_product([list('abcdefghij'), np.arange(10_000)])
df = pd.concat([df]*10)

In [4]: %timeit df[0] + df[1]
337 ms ± 6.7 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- master
264 ms ± 6.93 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- PR

In [5]: df = pd.concat([df]*10)

In [6]: %timeit df[0] + df[1]
3.29 s ± 132 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- master
2.63 s ± 334 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)  # <- PR
```