### PR TITLE
PERF-#3844: Improve perf of `drop` operation

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -28,6 +28,7 @@ Key Features and Updates
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)
   * PERF-#4325: Improve perf of multi-column assignment in `__setitem__` when no new column names are assigning (#4455)
+  * PERF-#3844: Improve perf of `drop` operation (#4694)
 * Benchmarking enhancements
   *
 * Refactor Codebase

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2291,14 +2291,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     def drop(self, index=None, columns=None):
         if index is not None:
-            index = np.sort(
-                self.index.get_indexer_for(self.index.difference(pandas.Index(index)))
-            )
+            index = np.sort(self.index.get_indexer_for(self.index.difference(index)))
         if columns is not None:
             columns = np.sort(
-                self.columns.get_indexer_for(
-                    self.columns.difference(pandas.Index(columns))
-                )
+                self.columns.get_indexer_for(self.columns.difference(columns))
             )
         new_modin_frame = self._modin_frame.mask(
             row_positions=index, col_positions=columns

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2291,15 +2291,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     def drop(self, index=None, columns=None):
         if index is not None:
-            # The unique here is to avoid duplicating rows with the same name
             index = np.sort(
-                self.index.get_indexer_for(self.index[~self.index.isin(index)].unique())
+                self.index.get_indexer_for(self.index.difference(pandas.Index(index)))
             )
         if columns is not None:
-            # The unique here is to avoid duplicating columns with the same name
             columns = np.sort(
                 self.columns.get_indexer_for(
-                    self.columns[~self.columns.isin(columns)].unique()
+                    self.columns.difference(pandas.Index(columns))
                 )
             )
         new_modin_frame = self._modin_frame.mask(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1236,13 +1236,11 @@ class BasePandasDataset(BasePandasDatasetCompat):
                 if not is_list_like(axes[axis]):
                     axes[axis] = [axes[axis]]
                 if errors == "raise":
-                    non_existant = pandas.Index(axes[axis]).difference(
+                    non_existent = pandas.Index(axes[axis]).difference(
                         getattr(self, axis)
                     )
-                    if len(non_existant):
-                        raise ValueError(
-                            "labels {} not contained in axis".format(non_existant)
-                        )
+                    if len(non_existent):
+                        raise ValueError(f"labels {non_existent} not contained in axis")
                 else:
                     axes[axis] = [
                         obj for obj in axes[axis] if obj in getattr(self, axis)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1229,44 +1229,27 @@ class BasePandasDataset(BasePandasDatasetCompat):
                 "Need to specify at least one of 'labels', 'index' or 'columns'"
             )
 
-        # TODO Clean up this error checking
-        if "index" not in axes:
-            axes["index"] = None
-        elif axes["index"] is not None:
-            if not is_list_like(axes["index"]):
-                axes["index"] = [axes["index"]]
-            if errors == "raise":
-                non_existant = [obj for obj in axes["index"] if obj not in self.index]
-                if len(non_existant):
-                    raise ValueError(
-                        "labels {} not contained in axis".format(non_existant)
+        for axis in ["index", "columns"]:
+            if axis not in axes:
+                axes[axis] = None
+            elif axes[axis] is not None:
+                if not is_list_like(axes[axis]):
+                    axes[axis] = [axes[axis]]
+                if errors == "raise":
+                    non_existant = pandas.Index(axes[axis]).difference(
+                        getattr(self, axis)
                     )
-            else:
-                axes["index"] = [obj for obj in axes["index"] if obj in self.index]
-                # If the length is zero, we will just do nothing
-                if not len(axes["index"]):
-                    axes["index"] = None
-
-        if "columns" not in axes:
-            axes["columns"] = None
-        elif axes["columns"] is not None:
-            if not is_list_like(axes["columns"]):
-                axes["columns"] = [axes["columns"]]
-            if errors == "raise":
-                non_existant = [
-                    obj for obj in axes["columns"] if obj not in self.columns
-                ]
-                if len(non_existant):
-                    raise ValueError(
-                        "labels {} not contained in axis".format(non_existant)
-                    )
-            else:
-                axes["columns"] = [
-                    obj for obj in axes["columns"] if obj in self.columns
-                ]
-                # If the length is zero, we will just do nothing
-                if not len(axes["columns"]):
-                    axes["columns"] = None
+                    if len(non_existant):
+                        raise ValueError(
+                            "labels {} not contained in axis".format(non_existant)
+                        )
+                else:
+                    axes[axis] = [
+                        obj for obj in axes[axis] if obj in getattr(self, axis)
+                    ]
+                    # If the length is zero, we will just do nothing
+                    if not len(axes[axis]):
+                        axes[axis] = None
 
         new_query_compiler = self._query_compiler.drop(
             index=axes["index"], columns=axes["columns"]


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR speedups sequential-execution part of `drop` implementation.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3844 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->

<details><summary>Benchmark results</summary>

<details><summary>Benchmark code</summary>

```python
import time

import pandas as pd
# import modin.pandas as pd
from modin.config import BenchmarkMode

BenchmarkMode.put(True)

def get_time(op):
    start = time.time()
    result = op()
    # print(result)
    return time.time() - start

if __name__ == "__main__":
    n_runs = 3
    nrows = 10_000_000

    df = pd.Series([0] * nrows)

    def operation():
        return df.drop(df.index)
        # return df.drop(df.index[:len(df.index) // 2])
        # return df.drop([0])

    all_time = 0
    print(f"\tZero call: {get_time(operation)} s")

    for i in range(n_runs):
        t = get_time(operation)
        print(f"\tIteration #{i}: {t} s")
        all_time += t

    print(f'Time drop op: {all_time / n_runs} s')

```

</details>

1. Performance results for operation `df.drop(df.index)`:

| n_rows, s | 10m | 50m | 100m |
| ----------- | :-----------: | :-----------: | :-----------: |
| modin #4694 | 0.016| 0.06 | 0.11 |
| modin master | 17.72 | 89.69 |178.57|
| pandas            | 0.048 | 0.17|0.36|

2. Performance results for operation `df.drop(df.index[:len(df.index) // 2])`:

| n_rows, s | 10m | 50m | 100m |
| ----------- | :-----------: | :-----------: | :-----------: |
| modin #4694 | 0.41| 1.67 | 3.38 |
| modin master | 9.63 | 51.77 |102.31|
| pandas            | 0.17 | 0.79|1.66|

3. Performance results for operation `df.drop([0])`:

| n_rows, s | 10m | 50m | 100m |
| ----------- | :-----------: | :-----------: | :-----------: |
| modin #4694 | 1.03| 5.11 | 10.62 |
| modin master | 1.11 | 6.4 |14.27|
| pandas            | 0.2 | 0.81|1.53|

</details>
