### PR TITLE
FIX-#4676: drain sub-virtual-partition call queues.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.10.x"
+          python-version: "3.8.x"
           architecture: "x64"
       # The `numpydoc` version here MUST match the versions in the dev requirements files.
       - run: pip install pytest pytest-cov pydocstyle numpydoc==1.1.0 xgboost

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
           fetch-depth: 1
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.8.x"
+          python-version: "3.10.x"
           architecture: "x64"
       # The `numpydoc` version here MUST match the versions in the dev requirements files.
       - run: pip install pytest pytest-cov pydocstyle numpydoc==1.1.0 xgboost

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -29,6 +29,7 @@ Key Features and Updates
   * FIX-#4652: Support categorical data in `from_dataframe` (#4737)
   * FIX-#4756: Correctly propagate `storage_options` in `read_parquet` (#4764)
   * FIX-#4657: Use `fsspec` for handling s3/http-like paths instead of `s3fs` (#4710)
+  * FIX-#4676: drain sub-virtual-partition call queues (#4695)    
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/execution/dask/implementations/pandas_on_dask/dataframe/dataframe.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/dataframe/dataframe.py
@@ -73,10 +73,10 @@ class PandasOnDaskDataframe(PandasDataframe):
         elif partition.axis == axis:
             return [
                 ptn.apply(lambda df: len(df) if not axis else len(df.columns))._data
-                for ptn in partition.list_of_partitions_to_combine
+                for ptn in partition.list_of_block_partitions
             ]
         return [
-            partition.list_of_partitions_to_combine[0]
+            partition.list_of_block_partitions[0]
             .apply(lambda df: len(df) if not axis else (len(df.columns)))
             ._data
         ]

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -13,6 +13,10 @@
 
 """Module houses classes responsible for storing a virtual partition and applying a function to it."""
 
+# Only python 3.9+  can parametrize standard collections like list:
+# https://peps.python.org/pep-0585/#implementation
+from __future__ import annotations
+
 from distributed import Future
 from distributed.utils import get_ip
 from dask.distributed import wait

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -74,7 +74,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = None
 
     @property
-    def list_of_block_partitions(self) -> List[partition_type]:
+    def list_of_block_partitions(self) -> list[partition_type]:
         """
         Get the list of block partitions that compose this partition.
 

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -16,7 +16,6 @@
 from distributed import Future
 from distributed.utils import get_ip
 from dask.distributed import wait
-from typing import List
 
 import pandas
 
@@ -46,6 +45,8 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
     """
 
     axis = None
+    partition_type = PandasOnDaskDataframePartition
+    instance_type = Future
 
     def __init__(
         self, list_of_partitions, get_ip=False, full_axis=True, call_queue=None
@@ -72,11 +73,8 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         # drain call queues for that.
         self._list_of_block_partitions = None
 
-    partition_type = PandasOnDaskDataframePartition
-    instance_type = Future
-
     @property
-    def list_of_block_partitions(self) -> List[partition_type]:
+    def list_of_block_partitions(self) -> list[partition_type]:
         """
         Get the list of block partitions that compose this partition.
 

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -46,64 +46,70 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
 
     axis = None
 
-    def __init__(self, list_of_blocks, get_ip=False, full_axis=True, call_queue=None):
-        if isinstance(list_of_blocks, PandasOnDaskDataframePartition):
-            list_of_blocks = [list_of_blocks]
+    def __init__(
+        self, list_of_partitions, get_ip=False, full_axis=True, call_queue=None
+    ):
+        if isinstance(list_of_partitions, PandasOnDaskDataframePartition):
+            list_of_partitions = [list_of_partitions]
         self.call_queue = call_queue or []
         self.full_axis = full_axis
-        # In the simple case, none of the partitions that will compose this
-        # partition are themselves virtual partition. The partitions that will
-        # be combined are just the partitions as given to the constructor.
-        if not any(
-            isinstance(obj, PandasOnDaskDataframeVirtualPartition)
-            for obj in list_of_blocks
-        ):
-            self.list_of_partitions_to_combine = list_of_blocks
-            return
-        # Check that all axis are the same in `list_of_blocks`
+        # Check that all avirtual partition axes are the same in `list_of_partitions`
         # We should never have mismatching axis in the current implementation. We add this
         # defensive assertion to ensure that undefined behavior does not happen.
         assert (
             len(
                 set(
                     obj.axis
-                    for obj in list_of_blocks
+                    for obj in list_of_partitions
                     if isinstance(obj, PandasOnDaskDataframeVirtualPartition)
                 )
             )
-            == 1
+            <= 1
         )
-        # When the axis of all virtual partitions matches this axis,
-        # extend and combine the lists of physical partitions.
-        if (
-            next(
-                obj
-                for obj in list_of_blocks
-                if isinstance(obj, PandasOnDaskDataframeVirtualPartition)
-            ).axis
-            == self.axis
-        ):
-            new_list_of_blocks = []
-            for obj in list_of_blocks:
-                new_list_of_blocks.extend(
-                    obj.list_of_partitions_to_combine
-                ) if isinstance(
-                    obj, PandasOnDaskDataframeVirtualPartition
-                ) else new_list_of_blocks.append(
-                    obj
-                )
-            self.list_of_partitions_to_combine = new_list_of_blocks
-        # Materialize partitions if the axis of this virtual does not match the virtual partitions
-        else:
-            self.list_of_partitions_to_combine = [
-                obj.force_materialization().list_of_partitions_to_combine[0]
-                if isinstance(obj, PandasOnDaskDataframeVirtualPartition)
-                else obj
-                for obj in list_of_blocks
-            ]
+        self._list_of_constituent_partitions = list_of_partitions
+        # Defer computing _list_of_block_partitions because we might need to
+        # drain call queues for that.
+        self._list_of_block_partitions = None
 
     partition_type = PandasOnDaskDataframePartition
     instance_type = Future
+
+    @property
+    def list_of_block_partitions(self):
+        if self._list_of_block_partitions is None:
+            self._list_of_block_partitions = []
+            # Extract block partitions from the block and virtual partitions
+            # that constitute this partition.
+            for partition in self._list_of_constituent_partitions:
+                if isinstance(partition, PandasOnDaskDataframeVirtualPartition):
+                    if partition.axis == self.axis:
+                        # We are building a virtual partition out of another
+                        # virtual partition `partition` that contains its own
+                        # list of block partitions,
+                        # partition.list_of_block_partitions. `partition`
+                        # may have its own call queue, which has to be applied
+                        # to the entire `partition` before we execute any
+                        # further operations on its block parittions.
+                        partition.drain_call_queue()
+                        self._list_of_block_partitions.extend(
+                            partition.list_of_block_partitions
+                        )
+                    else:
+                        # If this virtual partition is made of virtual
+                        # partitions for the other axes, squeeze such
+                        # partitions into a single block so that this
+                        # partition only holds a one-dimensional list of
+                        # blocks. We could change this implementation to
+                        # hold a 2-d list of blocks, but that would complicate
+                        # the code quite a bit.
+                        self._list_of_block_partitions.append(
+                            partition.force_materialization().list_of_block_partitions[
+                                0
+                            ]
+                        )
+                else:
+                    self._list_of_block_partitions.append(partition)
+        return self._list_of_block_partitions
 
     @property
     def list_of_blocks(self):
@@ -113,12 +119,12 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         Returns
         -------
         List
-            A list of ``distributed.Future``.
+            A list of ``ray.ObjectRef``.
         """
         # Defer draining call queue until we get the partitions
         # TODO Look into draining call queue at the same time as the task
-        result = [None] * len(self.list_of_partitions_to_combine)
-        for idx, partition in enumerate(self.list_of_partitions_to_combine):
+        result = [None] * len(self.list_of_block_partitions)
+        for idx, partition in enumerate(self.list_of_block_partitions):
             partition.drain_call_queue()
             result[idx] = partition._data
         return result
@@ -134,8 +140,8 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
             A list of IPs as ``distributed.Future`` or str.
         """
         # Defer draining call queue until we get the ip address
-        result = [None] * len(self.list_of_partitions_to_combine)
-        for idx, partition in enumerate(self.list_of_partitions_to_combine):
+        result = [None] * len(self.list_of_block_partitions)
+        for idx, partition in enumerate(self.list_of_block_partitions):
             partition.drain_call_queue()
             result[idx] = partition._ip_cache
         return result
@@ -323,7 +329,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         materialized = super(
             PandasOnDaskDataframeVirtualPartition, self
         ).force_materialization(get_ip=get_ip)
-        self.list_of_partitions_to_combine = materialized.list_of_partitions_to_combine
+        self._list_of_block_partitions = materialized.list_of_block_partitions
         return materialized
 
     def mask(self, row_indices, col_indices):
@@ -345,7 +351,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         """
         return (
             self.force_materialization()
-            .list_of_partitions_to_combine[0]
+            .list_of_block_partitions[0]
             .mask(row_indices, col_indices)
         )
 
@@ -357,7 +363,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         -------
         pandas DataFrame.
         """
-        return self.force_materialization().list_of_partitions_to_combine[0].to_pandas()
+        return self.force_materialization().list_of_block_partitions[0].to_pandas()
 
     _length_cache = None
 
@@ -373,10 +379,10 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         if self._length_cache is None:
             if self.axis == 0:
                 self._length_cache = sum(
-                    obj.length() for obj in self.list_of_partitions_to_combine
+                    obj.length() for obj in self.list_of_block_partitions
                 )
             else:
-                self._length_cache = self.list_of_partitions_to_combine[0].length()
+                self._length_cache = self.list_of_block_partitions[0].length()
         return self._length_cache
 
     _width_cache = None
@@ -393,10 +399,10 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         if self._width_cache is None:
             if self.axis == 1:
                 self._width_cache = sum(
-                    obj.width() for obj in self.list_of_partitions_to_combine
+                    obj.width() for obj in self.list_of_block_partitions
                 )
             else:
-                self._width_cache = self.list_of_partitions_to_combine[0].width()
+                self._width_cache = self.list_of_block_partitions[0].width()
         return self._width_cache
 
     def drain_call_queue(self, num_splits=None):
@@ -417,7 +423,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         drained = super(PandasOnDaskDataframeVirtualPartition, self).apply(
             drain, num_splits=num_splits
         )
-        self.list_of_partitions_to_combine = drained
+        self._list_of_block_partitions = drained
         self.call_queue = []
 
     def wait(self):
@@ -448,7 +454,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         The keyword arguments are sent as a dictionary.
         """
         return type(self)(
-            self.list_of_partitions_to_combine,
+            self.list_of_block_partitions,
             full_axis=self.full_axis,
             call_queue=self.call_queue + [(func, args, kwargs)],
         )

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -54,7 +54,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
             list_of_partitions = [list_of_partitions]
         self.call_queue = call_queue or []
         self.full_axis = full_axis
-        # Check that all avirtual partition axes are the same in `list_of_partitions`
+        # Check that all virtual partition axes are the same in `list_of_partitions`
         # We should never have mismatching axis in the current implementation. We add this
         # defensive assertion to ensure that undefined behavior does not happen.
         assert (

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -16,6 +16,7 @@
 from distributed import Future
 from distributed.utils import get_ip
 from dask.distributed import wait
+from typing import List
 
 import pandas
 
@@ -75,7 +76,15 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
     instance_type = Future
 
     @property
-    def list_of_block_partitions(self):
+    def list_of_block_partitions(self) -> List[partition_type]:
+        """
+        Get the list of block partitions that compose this partition.
+
+        Returns
+        -------
+        List
+            A list of ``PandasOnDaskDataframePartition``.
+        """
         if self._list_of_block_partitions is None:
             self._list_of_block_partitions = []
             # Extract block partitions from the block and virtual partitions
@@ -469,7 +478,7 @@ class PandasOnDaskDataframeColumnPartition(PandasOnDaskDataframeVirtualPartition
 
     Parameters
     ----------
-    list_of_blocks : list
+    list_of_partitions : list
         List of ``PandasOnDaskDataframePartition`` objects.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.
@@ -491,7 +500,7 @@ class PandasOnDaskDataframeRowPartition(PandasOnDaskDataframeVirtualPartition):
 
     Parameters
     ----------
-    list_of_blocks : list
+    list_of_partitions : list
         List of ``PandasOnDaskDataframePartition`` objects.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -32,7 +32,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
 
     Parameters
     ----------
-    list_of_blocks : Union[list, PandasOnDaskDataframePartition]
+    list_of_partitions : Union[list, PandasOnDaskDataframePartition]
         List of ``PandasOnDaskDataframePartition`` and
         ``PandasOnDaskDataframeVirtualPartition`` objects, or a single
         ``PandasOnDaskDataframePartition``.

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -13,10 +13,6 @@
 
 """Module houses classes responsible for storing a virtual partition and applying a function to it."""
 
-# Only python 3.9+  can parametrize standard collections like list:
-# https://peps.python.org/pep-0585/#implementation
-from __future__ import annotations
-
 from distributed import Future
 from distributed.utils import get_ip
 from dask.distributed import wait
@@ -78,7 +74,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = None
 
     @property
-    def list_of_block_partitions(self) -> list[partition_type]:
+    def list_of_block_partitions(self) -> list:
         """
         Get the list of block partitions that compose this partition.
 

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -74,7 +74,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = None
 
     @property
-    def list_of_block_partitions(self) -> list[partition_type]:
+    def list_of_block_partitions(self) -> List[partition_type]:
         """
         Get the list of block partitions that compose this partition.
 

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -125,7 +125,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         Returns
         -------
         List
-            A list of ``ray.ObjectRef``.
+            A list of ``distributed.Future``.
         """
         # Defer draining call queue until we get the partitions
         # TODO Look into draining call queue at the same time as the task

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -475,7 +475,7 @@ class PandasOnDaskDataframeColumnPartition(PandasOnDaskDataframeVirtualPartition
 
     Parameters
     ----------
-    list_of_partitions : list
+    list_of_partitions : Union[list, PandasOnDaskDataframePartition]
         List of ``PandasOnDaskDataframePartition`` objects.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.
@@ -497,7 +497,7 @@ class PandasOnDaskDataframeRowPartition(PandasOnDaskDataframeVirtualPartition):
 
     Parameters
     ----------
-    list_of_partitions : list
+    list_of_partitions : Union[list, PandasOnDaskDataframePartition]
         List of ``PandasOnDaskDataframePartition`` objects.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -473,6 +473,7 @@ class PandasOnDaskDataframeColumnPartition(PandasOnDaskDataframeVirtualPartition
 
     Parameters
     ----------
+    list_of_partitions : Union[list, PandasOnDaskDataframePartition]
         List of ``PandasOnDaskDataframePartition`` and
         ``PandasOnDaskDataframeColumnPartition`` objects, or a single
         ``PandasOnDaskDataframePartition``.
@@ -496,6 +497,7 @@ class PandasOnDaskDataframeRowPartition(PandasOnDaskDataframeVirtualPartition):
 
     Parameters
     ----------
+    list_of_partitions : Union[list, PandasOnDaskDataframePartition]
         List of ``PandasOnDaskDataframePartition`` and
         ``PandasOnDaskDataframeRowPartition`` objects, or a single
         ``PandasOnDaskDataframePartition``.

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -473,8 +473,9 @@ class PandasOnDaskDataframeColumnPartition(PandasOnDaskDataframeVirtualPartition
 
     Parameters
     ----------
-    list_of_partitions : Union[list, PandasOnDaskDataframePartition]
-        List of ``PandasOnDaskDataframePartition`` objects.
+        List of ``PandasOnDaskDataframePartition`` and
+        ``PandasOnDaskDataframeColumnPartition`` objects, or a single
+        ``PandasOnDaskDataframePartition``.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.
     full_axis : bool, default: True
@@ -495,8 +496,9 @@ class PandasOnDaskDataframeRowPartition(PandasOnDaskDataframeVirtualPartition):
 
     Parameters
     ----------
-    list_of_partitions : Union[list, PandasOnDaskDataframePartition]
-        List of ``PandasOnDaskDataframePartition`` objects.
+        List of ``PandasOnDaskDataframePartition`` and
+        ``PandasOnDaskDataframeRowPartition`` objects, or a single
+        ``PandasOnDaskDataframePartition``.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.
     full_axis : bool, default: True

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -16,6 +16,7 @@
 import pandas
 import ray
 from ray.util import get_node_ip_address
+from typing import List
 
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
@@ -72,7 +73,15 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = None
 
     @property
-    def list_of_block_partitions(self):
+    def list_of_block_partitions(self) -> List[partition_type]:
+        """
+        Get the list of block partitions that compose this partition.
+
+        Returns
+        -------
+        List
+            A list of ``PandasOnRayDataframePartition``.
+        """
         if self._list_of_block_partitions is None:
             self._list_of_block_partitions = []
             # Extract block partitions from the block and virtual partitions
@@ -83,7 +92,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
                         # We are building a virtual partition out of another
                         # virtual partition `partition` that contains its own
                         # list of block partitions,
-                        # partition.list_of_partitions_to_combine. `partition`
+                        # partition.list_of_blocks. `partition`
                         # may have its own call queue, which has to be applied
                         # to the entire `partition` before we execute any
                         # further operations on its block parittions.
@@ -476,7 +485,7 @@ class PandasOnRayDataframeColumnPartition(PandasOnRayDataframeVirtualPartition):
 
     Parameters
     ----------
-    list_of_blocks : list
+    list_of_partitions : list
         List of ``PandasOnRayDataframePartition`` objects.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.
@@ -498,7 +507,7 @@ class PandasOnRayDataframeRowPartition(PandasOnRayDataframeVirtualPartition):
 
     Parameters
     ----------
-    list_of_blocks : list
+    list_of_partitions : list
         List of ``PandasOnRayDataframePartition`` objects.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -46,70 +46,67 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
     instance_type = ray.ObjectRef
     axis = None
 
-    def __init__(self, list_of_blocks, get_ip=False, full_axis=True, call_queue=None):
-        if isinstance(list_of_blocks, PandasOnRayDataframePartition):
-            list_of_blocks = [list_of_blocks]
+    def __init__(
+        self, list_of_partitions, get_ip=False, full_axis=True, call_queue=None
+    ):
+        if isinstance(list_of_partitions, PandasOnRayDataframePartition):
+            list_of_partitions = [list_of_partitions]
         self.full_axis = full_axis
         self.call_queue = call_queue or []
-        # In the simple case, none of the partitions that will compose this
-        # partition are themselves virtual partition. The partitions that will
-        # be combined are just the partitions as given to the constructor.
-        if not any(
-            isinstance(obj, PandasOnRayDataframeVirtualPartition)
-            for obj in list_of_blocks
-        ):
-            self.list_of_partitions_to_combine = list_of_blocks
-            return
-        # Check that all axis are the same in `list_of_blocks`
+        # Check that all virtual partition axes are the same in `list_of_partitions`
         # We should never have mismatching axis in the current implementation. We add this
         # defensive assertion to ensure that undefined behavior does not happen.
         assert (
             len(
                 set(
                     obj.axis
-                    for obj in list_of_blocks
+                    for obj in list_of_partitions
                     if isinstance(obj, PandasOnRayDataframeVirtualPartition)
                 )
             )
-            == 1
+            <= 1
         )
-        # When the axis of all virtual partitions matches this axis,
-        # extend and combine the lists of physical partitions.
-        if (
-            next(
-                obj
-                for obj in list_of_blocks
-                if isinstance(obj, PandasOnRayDataframeVirtualPartition)
-            ).axis
-            == self.axis
-        ):
-            new_list_of_blocks = []
-            for obj in list_of_blocks:
-                if isinstance(obj, PandasOnRayDataframeVirtualPartition):
-                    # We are building a virtual partition out of another
-                    # virtual partition `obj` that contains its own list of
-                    # block partitions, obj.list_of_partitions_to_combine.
-                    # `obj` may have its own call queue, which has to be
-                    # applied to the entire `obj` before we execute any
-                    # further operations on its block parittions. We could
-                    # make this object hold `obj` instead of `obj`'s list
-                    # of block partitions, and then defer draining the call
-                    # queue and getting the new block partitions to whenever
-                    # we need to use self.list_of_partitions_to_combine, but
-                    # that would complicate this class's code quite a bit.
-                    obj.drain_call_queue()
-                    new_list_of_blocks.extend(obj.list_of_partitions_to_combine)
+        self._list_of_constituent_partitions = list_of_partitions
+        # Defer computing _list_of_block_partitions because we might need to
+        # drain call queues for that.
+        self._list_of_block_partitions = None
+
+    @property
+    def list_of_block_partitions(self):
+        if self._list_of_block_partitions is None:
+            self._list_of_block_partitions = []
+            # Extract block partitions from the block and virtual partitions
+            # that constitute this partition.
+            for partition in self._list_of_constituent_partitions:
+                if isinstance(partition, PandasOnRayDataframeVirtualPartition):
+                    if partition.axis == self.axis:
+                        # We are building a virtual partition out of another
+                        # virtual partition `partition` that contains its own
+                        # list of block partitions,
+                        # partition.list_of_partitions_to_combine. `partition`
+                        # may have its own call queue, which has to be applied
+                        # to the entire `partition` before we execute any
+                        # further operations on its block parittions.
+                        partition.drain_call_queue()
+                        self._list_of_block_partitions.extend(
+                            partition.list_of_block_partitions
+                        )
+                    else:
+                        # If this virtual partition is made of virtual
+                        # partitions for the other axes, squeeze such
+                        # partitions into a single block so that this
+                        # partition only holds a one-dimensional list of
+                        # blocks. We could change this implementation to
+                        # hold a 2-d list of blocks, but that would complicate
+                        # the code quite a bit.
+                        self._list_of_block_partitions.append(
+                            partition.force_materialization().list_of_block_partitions[
+                                0
+                            ]
+                        )
                 else:
-                    new_list_of_blocks.append(obj)
-            self.list_of_partitions_to_combine = new_list_of_blocks
-        # Materialize partitions if the axis of this virtual does not match the virtual partitions
-        else:
-            self.list_of_partitions_to_combine = [
-                obj.force_materialization().list_of_partitions_to_combine[0]
-                if isinstance(obj, PandasOnRayDataframeVirtualPartition)
-                else obj
-                for obj in list_of_blocks
-            ]
+                    self._list_of_block_partitions.append(partition)
+        return self._list_of_block_partitions
 
     @property
     def list_of_blocks(self):
@@ -123,8 +120,8 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         """
         # Defer draining call queue until we get the partitions
         # TODO Look into draining call queue at the same time as the task
-        result = [None] * len(self.list_of_partitions_to_combine)
-        for idx, partition in enumerate(self.list_of_partitions_to_combine):
+        result = [None] * len(self.list_of_block_partitions)
+        for idx, partition in enumerate(self.list_of_block_partitions):
             partition.drain_call_queue()
             result[idx] = partition._data
         return result
@@ -140,8 +137,8 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             A list of IPs as ``ray.ObjectRef`` or str.
         """
         # Defer draining call queue until we get the ip address
-        result = [None] * len(self.list_of_partitions_to_combine)
-        for idx, partition in enumerate(self.list_of_partitions_to_combine):
+        result = [None] * len(self.list_of_block_partitions)
+        for idx, partition in enumerate(self.list_of_block_partitions):
             partition.drain_call_queue()
             result[idx] = partition._ip_cache
         return result
@@ -337,7 +334,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         materialized = super(
             PandasOnRayDataframeVirtualPartition, self
         ).force_materialization(get_ip=get_ip)
-        self.list_of_partitions_to_combine = materialized.list_of_partitions_to_combine
+        self._list_of_block_partitions = materialized.list_of_block_partitions
         return materialized
 
     def mask(self, row_indices, col_indices):
@@ -359,7 +356,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         """
         return (
             self.force_materialization()
-            .list_of_partitions_to_combine[0]
+            .list_of_block_partitions[0]
             .mask(row_indices, col_indices)
         )
 
@@ -371,7 +368,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         -------
         pandas DataFrame.
         """
-        return self.force_materialization().list_of_partitions_to_combine[0].to_pandas()
+        return self.force_materialization().list_of_block_partitions[0].to_pandas()
 
     _length_cache = None
 
@@ -387,10 +384,10 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         if self._length_cache is None:
             if self.axis == 0:
                 self._length_cache = sum(
-                    obj.length() for obj in self.list_of_partitions_to_combine
+                    obj.length() for obj in self.list_of_block_partitions
                 )
             else:
-                self._length_cache = self.list_of_partitions_to_combine[0].length()
+                self._length_cache = self.list_of_block_partitions[0].length()
         return self._length_cache
 
     _width_cache = None
@@ -407,10 +404,10 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         if self._width_cache is None:
             if self.axis == 1:
                 self._width_cache = sum(
-                    obj.width() for obj in self.list_of_partitions_to_combine
+                    obj.width() for obj in self.list_of_block_partitions
                 )
             else:
-                self._width_cache = self.list_of_partitions_to_combine[0].width()
+                self._width_cache = self.list_of_block_partitions[0].width()
         return self._width_cache
 
     def drain_call_queue(self, num_splits=None):
@@ -431,7 +428,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         drained = super(PandasOnRayDataframeVirtualPartition, self).apply(
             drain, num_splits=num_splits
         )
-        self.list_of_partitions_to_combine = drained
+        self._list_of_block_partitions = drained
         self.call_queue = []
 
     def wait(self):
@@ -464,7 +461,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         handle it correctly either way. The keyword arguments are sent as a dictionary.
         """
         return type(self)(
-            self.list_of_partitions_to_combine,
+            self.list_of_block_partitions,
             full_axis=self.full_axis,
             call_queue=self.call_queue + [(func, args, kwargs)],
         )

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -482,7 +482,7 @@ class PandasOnRayDataframeColumnPartition(PandasOnRayDataframeVirtualPartition):
 
     Parameters
     ----------
-    list_of_partitions : list
+    list_of_partitions : Union[list, PandasOnRayDataframePartition]
         List of ``PandasOnRayDataframePartition`` objects.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.
@@ -504,7 +504,7 @@ class PandasOnRayDataframeRowPartition(PandasOnRayDataframeVirtualPartition):
 
     Parameters
     ----------
-    list_of_partitions : list
+    list_of_partitions : Union[list, PandasOnRayDataframePartition]
         List of ``PandasOnRayDataframePartition`` objects.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -16,7 +16,6 @@
 import pandas
 import ray
 from ray.util import get_node_ip_address
-from typing import List
 
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
@@ -73,7 +72,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = None
 
     @property
-    def list_of_block_partitions(self) -> List[partition_type]:
+    def list_of_block_partitions(self) -> list[partition_type]:
         """
         Get the list of block partitions that compose this partition.
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -30,7 +30,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
 
     Parameters
     ----------
-    list_of_blocks : Union[list, PandasOnRayDataframePartition]
+    list_of_partitions : Union[list, PandasOnRayDataframePartition]
         List of ``PandasOnRayDataframePartition`` and
         ``PandasOnRayDataframeVirtualPartition`` objects, or a single
         ``PandasOnRayDataframePartition``.

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -85,13 +85,22 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         ):
             new_list_of_blocks = []
             for obj in list_of_blocks:
-                new_list_of_blocks.extend(
-                    obj.list_of_partitions_to_combine
-                ) if isinstance(
-                    obj, PandasOnRayDataframeVirtualPartition
-                ) else new_list_of_blocks.append(
-                    obj
-                )
+                if isinstance(obj, PandasOnRayDataframeVirtualPartition):
+                    # We are building a virtual partition out of another
+                    # virtual partition `obj` that contains its own list of
+                    # block partitions, obj.list_of_partitions_to_combine.
+                    # `obj` may have its own call queue, which has to be
+                    # applied to the entire `obj` before we execute any
+                    # further operations on its block parittions. We could
+                    # make this object hold `obj` instead of `obj`'s list
+                    # of block partitions, and then defer draining the call
+                    # queue and getting the new block partitions to whenever
+                    # we need to use self.list_of_partitions_to_combine, but
+                    # that would complicate this class's code quite a bit.
+                    obj.drain_call_queue()
+                    new_list_of_blocks.extend(obj.list_of_partitions_to_combine)
+                else:
+                    new_list_of_blocks.append(obj)
             self.list_of_partitions_to_combine = new_list_of_blocks
         # Materialize partitions if the axis of this virtual does not match the virtual partitions
         else:

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -482,7 +482,9 @@ class PandasOnRayDataframeColumnPartition(PandasOnRayDataframeVirtualPartition):
     Parameters
     ----------
     list_of_partitions : Union[list, PandasOnRayDataframePartition]
-        List of ``PandasOnRayDataframePartition`` objects.
+        List of ``PandasOnRayDataframePartition`` and
+        ``PandasOnRayDataframeColumnPartition`` objects, or a single
+        ``PandasOnRayDataframePartition``.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.
     full_axis : bool, default: True
@@ -504,7 +506,9 @@ class PandasOnRayDataframeRowPartition(PandasOnRayDataframeVirtualPartition):
     Parameters
     ----------
     list_of_partitions : Union[list, PandasOnRayDataframePartition]
-        List of ``PandasOnRayDataframePartition`` objects.
+        List of ``PandasOnRayDataframePartition`` and
+        ``PandasOnRayDataframeRowPartition`` objects, or a single
+        ``PandasOnRayDataframePartition``.
     get_ip : bool, default: False
         Whether to get node IP addresses to conforming partitions or not.
     full_axis : bool, default: True

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -13,10 +13,6 @@
 
 """Module houses classes responsible for storing a virtual partition and applying a function to it."""
 
-# Only python 3.9+  can parametrize standard collections like list:
-# https://peps.python.org/pep-0585/#implementation
-from __future__ import annotations
-
 import pandas
 import ray
 from ray.util import get_node_ip_address
@@ -76,7 +72,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = None
 
     @property
-    def list_of_block_partitions(self) -> list[partition_type]:
+    def list_of_block_partitions(self) -> list:
         """
         Get the list of block partitions that compose this partition.
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -72,7 +72,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = None
 
     @property
-    def list_of_block_partitions(self) -> List[partition_type]:
+    def list_of_block_partitions(self) -> list[partition_type]:
         """
         Get the list of block partitions that compose this partition.
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -88,7 +88,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         # Extract block partitions from the block and virtual partitions that
         # constitute this partition.
         for partition in self._list_of_constituent_partitions:
-            if isinstance(partition, PandasOnRayDataframeColumnPartition):
+            if isinstance(partition, PandasOnRayDataframeVirtualPartition):
                 if partition.axis == self.axis:
                     # We are building a virtual partition out of another
                     # virtual partition `partition` that contains its own list

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -72,7 +72,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = None
 
     @property
-    def list_of_block_partitions(self) -> list[partition_type]:
+    def list_of_block_partitions(self) -> List[partition_type]:
         """
         Get the list of block partitions that compose this partition.
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -82,39 +82,36 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         List
             A list of ``PandasOnRayDataframePartition``.
         """
-        if self._list_of_block_partitions is None:
-            self._list_of_block_partitions = []
-            # Extract block partitions from the block and virtual partitions
-            # that constitute this partition.
-            for partition in self._list_of_constituent_partitions:
-                if isinstance(partition, PandasOnRayDataframeVirtualPartition):
-                    if partition.axis == self.axis:
-                        # We are building a virtual partition out of another
-                        # virtual partition `partition` that contains its own
-                        # list of block partitions,
-                        # partition.list_of_blocks. `partition`
-                        # may have its own call queue, which has to be applied
-                        # to the entire `partition` before we execute any
-                        # further operations on its block parittions.
-                        partition.drain_call_queue()
-                        self._list_of_block_partitions.extend(
-                            partition.list_of_block_partitions
-                        )
-                    else:
-                        # If this virtual partition is made of virtual
-                        # partitions for the other axes, squeeze such
-                        # partitions into a single block so that this
-                        # partition only holds a one-dimensional list of
-                        # blocks. We could change this implementation to
-                        # hold a 2-d list of blocks, but that would complicate
-                        # the code quite a bit.
-                        self._list_of_block_partitions.append(
-                            partition.force_materialization().list_of_block_partitions[
-                                0
-                            ]
-                        )
+        if self._list_of_block_partitions is not None:
+            return self._list_of_block_partitions
+        self._list_of_block_partitions = []
+        # Extract block partitions from the block and virtual partitions that
+        # constitute this partition.
+        for partition in self._list_of_constituent_partitions:
+            if isinstance(partition, PandasOnRayDataframeColumnPartition):
+                if partition.axis == self.axis:
+                    # We are building a virtual partition out of another
+                    # virtual partition `partition` that contains its own list
+                    # of block partitions, partition.list_of_block_partitions.
+                    # `partition` may have its own call queue, which has to be
+                    # applied to the entire `partition` before we execute any
+                    # further operations on its block parittions.
+                    partition.drain_call_queue()
+                    self._list_of_block_partitions.extend(
+                        partition.list_of_block_partitions
+                    )
                 else:
-                    self._list_of_block_partitions.append(partition)
+                    # If this virtual partition is made of virtual partitions
+                    # for the other axes, squeeze such partitions into a single
+                    # block so that this partition only holds a one-dimensional
+                    # list of blocks. We could change this implementation to
+                    # hold a 2-d list of blocks, but that would complicate the
+                    # code quite a bit.
+                    self._list_of_block_partitions.append(
+                        partition.force_materialization().list_of_block_partitions[0]
+                    )
+            else:
+                self._list_of_block_partitions.append(partition)
         return self._list_of_block_partitions
 
     @property

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -13,6 +13,10 @@
 
 """Module houses classes responsible for storing a virtual partition and applying a function to it."""
 
+# Only python 3.9+  can parametrize standard collections like list:
+# https://peps.python.org/pep-0585/#implementation
+from __future__ import annotations
+
 import pandas
 import ray
 from ray.util import get_node_ip_address

--- a/modin/experimental/batch/pipeline.py
+++ b/modin/experimental/batch/pipeline.py
@@ -228,7 +228,7 @@ class PandasQueryPipeline(object):
                         "Fan out is only supported with DataFrames with 1 partition."
                     )
                 partitions[0] = partitions[0].force_materialization()
-                partition_list = partitions[0].list_of_partitions_to_combine
+                partition_list = partitions[0].list_of_block_partitions
                 partitions[0] = partitions[0].add_to_apply_calls(node.func, 0)
                 partitions[0].drain_call_queue(num_splits=1)
                 new_dfs = []
@@ -267,7 +267,7 @@ class PandasQueryPipeline(object):
                 for i in range(self.num_partitions):
                     new_dfs.append(
                         type(partitions[0])(
-                            partitions[0].list_of_partitions_to_combine,
+                            partitions[0].list_of_block_partitions,
                             full_axis=partitions[0].full_axis,
                         ).add_to_apply_calls(mask_partition, i)
                     )
@@ -366,7 +366,7 @@ class PandasQueryPipeline(object):
         for id, df in id_df_iter:
             partitions = []
             for row_partition in df:
-                partitions.append(row_partition.list_of_partitions_to_combine)
+                partitions.append(row_partition.list_of_block_partitions)
             partitions = np.array(partitions)
             partition_mgr_class = PandasOnRayDataframe._partition_mgr_cls
             index, internal_rows = partition_mgr_class.get_indices(0, partitions)

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -11,19 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from modin.core.execution.ray.implementations.pandas_on_ray.partitioning.virtual_partition import (
-    PandasOnRayDataframeColumnPartition,
-)
-from modin.core.execution.dask.implementations.pandas_on_dask.partitioning.virtual_partition import (
-    PandasOnDaskDataframeColumnPartition,
-)
-from modin.core.execution.ray.implementations.pandas_on_ray.partitioning.partition import (
-    PandasOnRayDataframePartition,
-)
-from modin.core.execution.dask.implementations.pandas_on_dask.partitioning.partition import (
-    PandasOnDaskDataframePartition,
-)
-from modin.core.execution.dask.common.engine_wrapper import DaskWrapper
+
 import modin.pandas as pd
 from modin.pandas.test.utils import create_test_dfs, test_data_values, df_equals
 from modin.config import NPartitions, Engine
@@ -31,9 +19,37 @@ from modin.config import NPartitions, Engine
 import pandas
 import pytest
 
-import ray
-
 NPartitions.put(4)
+
+if Engine.get() == "Ray":
+    import ray
+    from modin.core.execution.ray.implementations.pandas_on_ray.partitioning.partition import (
+        PandasOnRayDataframePartition,
+    )
+    from modin.core.execution.ray.implementations.pandas_on_ray.partitioning.virtual_partition import (
+        PandasOnRayDataframeColumnPartition,
+    )
+
+    block_partition_class = PandasOnRayDataframePartition
+    virtual_partition_class = PandasOnRayDataframeColumnPartition
+    put = ray.put
+elif Engine.get() == "Dask":
+    from modin.core.execution.dask.implementations.pandas_on_dask.partitioning.virtual_partition import (
+        PandasOnDaskDataframeColumnPartition,
+    )
+    from modin.core.execution.dask.implementations.pandas_on_dask.partitioning.partition import (
+        PandasOnDaskDataframePartition,
+    )
+    from modin.core.execution.dask.common.engine_wrapper import DaskWrapper
+
+    # initialize modin dataframe to initialize dask
+    pd.DataFrame()
+
+    def put(x):
+        return DaskWrapper.put(x)
+
+    block_partition_class = PandasOnDaskDataframePartition
+    virtual_partition_class = PandasOnDaskDataframeColumnPartition
 
 
 def test_aligning_blocks():
@@ -231,27 +247,84 @@ def test_rebalance_partitions(test_type):
     Engine.get() not in ("Dask", "Ray"),
     reason="Only Dask and Ray engines have virtual partitions.",
 )
-def test_making_virtual_partition_out_of_virtual_partitions_with_call_queue():
-    if Engine.get() == "Ray":
-        block_partition_class = PandasOnRayDataframePartition
-        virtual_partition_class = PandasOnRayDataframeColumnPartition
-        put = ray.put
-    else:
-        # initialize modin dataframe to initialize dask
-        pd.DataFrame()
+def test_making_virtual_partition_out_of_virtual_partitions_with_call_queues():
 
-        def put(x):
-            return DaskWrapper.put(x)
-
-        block_partition_class = PandasOnDaskDataframePartition
-        virtual_partition_class = PandasOnDaskDataframeColumnPartition
-
-    blocks = [
+    level_zero_blocks_first = [
         block_partition_class(put(pandas.DataFrame([0]))),
         block_partition_class(put(pandas.DataFrame([1]))),
     ]
-    level_one_virtual = virtual_partition_class(blocks, full_axis=False)
-    level_one_virtual = level_one_virtual.add_to_apply_calls(lambda df: df[::-1])
-    level_two_virtual = virtual_partition_class([level_one_virtual], full_axis=True)
+    level_one_virtual_first = virtual_partition_class(
+        level_zero_blocks_first, full_axis=False
+    )
+    level_one_virtual_first = level_one_virtual_first.add_to_apply_calls(
+        lambda df: df[::-1]
+    )
+    level_zero_blocks_second = [
+        block_partition_class(put(pandas.DataFrame([2]))),
+        block_partition_class(put(pandas.DataFrame([3]))),
+    ]
+    level_one_virtual_second = virtual_partition_class(
+        level_zero_blocks_second, full_axis=False
+    )
+    level_one_virtual_second = level_one_virtual_second.add_to_apply_calls(
+        lambda df: df[::-1]
+    )
+    level_two_virtual = virtual_partition_class(
+        [level_one_virtual_first, level_one_virtual_second], full_axis=True
+    )
     level_two_virtual_result = level_two_virtual.apply(lambda df: df, num_splits=1)[0]
-    df_equals(level_two_virtual_result.to_pandas(), pd.DataFrame([1, 0], index=[0, 0]))
+    df_equals(
+        level_two_virtual_result.to_pandas(),
+        pd.DataFrame([1, 0, 3, 2], index=[0, 0, 0, 0]),
+    )
+
+
+@pytest.mark.skipif(
+    Engine.get() not in ("Dask", "Ray"),
+    reason="Only Dask and Ray engines have virtual partitions.",
+)
+def test_making_virtual_partition_out_of_block_partition_and_virtual_partition_with_call_queues():
+
+    level_zero_blocks = [
+        block_partition_class(put(pandas.DataFrame([0, 1]))),
+        block_partition_class(put(pandas.DataFrame([2, 3]))),
+    ]
+    level_zero_blocks[0] = level_zero_blocks[0].add_to_apply_calls(lambda df: df[::-1])
+    level_one_virtual = virtual_partition_class(level_zero_blocks[1])
+    level_one_virtual = level_one_virtual.add_to_apply_calls(lambda df: df[::-1])
+    level_two_virtual = virtual_partition_class(
+        [level_zero_blocks[0], level_one_virtual], full_axis=True
+    )
+    level_two_virtual_result = level_two_virtual.apply(lambda df: df, num_splits=1)[0]
+    df_equals(
+        level_two_virtual_result.to_pandas(),
+        pd.DataFrame([1, 0, 3, 2], index=[1, 0, 1, 0]),
+    )
+
+
+@pytest.mark.skipif(
+    Engine.get() not in ("Dask", "Ray"),
+    reason="Only Dask and Ray engines have virtual partitions.",
+)
+def test_virtual_partitions_with_call_queues_at_three_levels():
+
+    block = block_partition_class(put(pandas.DataFrame([1])))
+    level_one_virtual = virtual_partition_class([block])
+    level_one_virtual = level_one_virtual.add_to_apply_calls(
+        lambda df: pandas.concat([df, pandas.DataFrame([2])])
+    )
+    level_two_virtual = virtual_partition_class([level_one_virtual])
+    level_two_virtual = level_two_virtual.add_to_apply_calls(
+        lambda df: pandas.concat([df, pandas.DataFrame([3])])
+    )
+    level_three_virtual = virtual_partition_class([level_two_virtual])
+    level_three_virtual = level_three_virtual.add_to_apply_calls(
+        lambda df: pandas.concat([df, pandas.DataFrame([4])])
+    )
+    level_three_virtual_result = level_three_virtual.apply(lambda df: df, num_splits=1)[
+        0
+    ]
+    df_equals(
+        level_three_virtual_result.to_pandas(),
+        pd.DataFrame([1, 2, 3, 4], index=[0, 0, 0, 0]),
+    )

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -265,7 +265,7 @@ class TestBuildVirtualPartition:
     ):
         # reverse the dataframe along the virtual partition axis.
         def reverse(df):
-                return df.iloc[::-1, :] if axis == 0 else df.iloc[:, ::-1]
+            return df.iloc[::-1, :] if axis == 0 else df.iloc[:, ::-1]
 
         level_zero_blocks_first = [
             block_partition_class(put(pandas.DataFrame([0]))),
@@ -298,18 +298,19 @@ class TestBuildVirtualPartition:
             expected_df,
         )
 
-    def test_from_block_partition_and_virtual_partition_with_call_queues(
+    def test_from_block_and_virtual_partition_with_call_queues(
         self,
         axis,
         virtual_partition_class,
     ):
-        # make function the dataframe along the virtual partition axis.
+        # make a function that reverses the dataframe along the virtual
+        # partition axis.
         # for testing axis == 0, start with two 2-rows-by-1-column blocks. for
         # axis == 1, start with two 1-rows-by-2-column blocks.
         def reverse(df):
-           return df.iloc[::-1, :] if axis == 0 else df.iloc[:, ::-1]
-        
-        block_data = [[0, 1], [2, 3]] if axis ==0 else [[[0, 1]], [[2, 3]]]
+            return df.iloc[::-1, :] if axis == 0 else df.iloc[:, ::-1]
+
+        block_data = [[0, 1], [2, 3]] if axis == 0 else [[[0, 1]], [[2, 3]]]
         level_zero_blocks = [
             block_partition_class(put(pandas.DataFrame(block_data[0]))),
             block_partition_class(put(pandas.DataFrame(block_data[1]))),

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-
 import modin.pandas as pd
 from modin.pandas.test.utils import create_test_dfs, test_data_values, df_equals
 from modin.config import NPartitions, Engine

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -239,8 +239,10 @@ def test_making_virtual_partition_out_of_virtual_partitions_with_call_queue():
     else:
         # initialize modin dataframe to initialize dask
         pd.DataFrame()
+
         def put(x):
-            DaskWrapper.put(x)
+            return DaskWrapper.put(x)
+
         block_partition_class = PandasOnDaskDataframePartition
         virtual_partition_class = PandasOnDaskDataframeColumnPartition
 

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -264,15 +264,8 @@ class TestBuildVirtualPartition:
         self, axis, virtual_partition_class
     ):
         # reverse the dataframe along the virtual partition axis.
-        if axis == 0:
-
-            def reverse(df):
-                return df.iloc[::-1, :]
-
-        else:
-
-            def reverse(df):
-                return df.iloc[:, ::-1]
+        def reverse(df):
+                return df.iloc[::-1, :] if axis == 0 else df.iloc[:, ::-1]
 
         level_zero_blocks_first = [
             block_partition_class(put(pandas.DataFrame([0]))),
@@ -313,18 +306,10 @@ class TestBuildVirtualPartition:
         # make function the dataframe along the virtual partition axis.
         # for testing axis == 0, start with two 2-rows-by-1-column blocks. for
         # axis == 1, start with two 1-rows-by-2-column blocks.
-        if axis == 0:
-
-            def reverse(df):
-                return df.iloc[::-1, :]
-
-            block_data = [[0, 1], [2, 3]]
-        else:
-
-            def reverse(df):
-                return df.iloc[:, ::-1]
-
-            block_data = [[[0, 1]], [[2, 3]]]
+        def reverse(df):
+           return df.iloc[::-1, :] if axis == 0 else df.iloc[:, ::-1]
+        
+        block_data = [[0, 1], [2, 3]] if axis ==0 else [[[0, 1]], [[2, 3]]]
         level_zero_blocks = [
             block_partition_class(put(pandas.DataFrame(block_data[0]))),
             block_partition_class(put(pandas.DataFrame(block_data[1]))),


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Drain the call queues of virtual partition `P1` that constitutes part of a virtual partition `P2` before using the blocks constituting `P1`. Otherwise, we drop the call queue of `P1`.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x]  passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4676
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
