### PR TITLE
FIX-#4686: Propagate metadata and drain call queue in unwrap_partitions.

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -24,7 +24,7 @@ Key Features and Updates
   * FIX-#4491: Wait for all partitions in parallel in benchmark mode (#4656)
   * FIX-#4358: MultiIndex `loc` shouldn't drop levels for full-key lookups (#4608)
   * FIX-#4658: Expand exception handling for `read_*` functions from s3 storages (#4659)
-  * FIX-#4686: Propagate metadta and drain call queue in unwrap_partitions (#4697)
+  * FIX-#4686: Propagate metadata and drain call queue in unwrap_partitions (#4697)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -24,6 +24,7 @@ Key Features and Updates
   * FIX-#4491: Wait for all partitions in parallel in benchmark mode (#4656)
   * FIX-#4358: MultiIndex `loc` shouldn't drop levels for full-key lookups (#4608)
   * FIX-#4658: Expand exception handling for `read_*` functions from s3 storages (#4659)
+  * FIX-#4686: Propagate metadta and drain call queue in unwrap_partitions (#4697)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -53,6 +53,11 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
     if axis is None:
 
         def _unwrap_partitions():
+            api_layer_object._query_compiler._modin_frame._propagate_index_objs(None)
+            [
+                p.drain_call_queue()
+                for p in api_layer_object._query_compiler._modin_frame._partitions.flatten()
+            ]
             if get_ip:
                 return [
                     [(partition._ip_cache, partition._data) for partition in row]
@@ -76,6 +81,7 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
             f"Do not know how to unwrap '{actual_engine}' underlying partitions"
         )
     else:
+        api_layer_object._query_compiler._modin_frame._propagate_index_objs(None)
         partitions = api_layer_object._query_compiler._modin_frame._partition_mgr_cls.axis_partition(
             api_layer_object._query_compiler._modin_frame._partitions, axis ^ 1
         )

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -50,28 +50,24 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
             f"Only API Layer objects may be passed in here, got {type(api_layer_object)} instead."
         )
 
+    modin_frame = api_layer_object._query_compiler._modin_frame
     if axis is None:
 
         def _unwrap_partitions():
-            api_layer_object._query_compiler._modin_frame._propagate_index_objs(None)
-            [
-                p.drain_call_queue()
-                for p in api_layer_object._query_compiler._modin_frame._partitions.flatten()
-            ]
+            modin_frame._propagate_index_objs(None)
+            [p.drain_call_queue() for p in modin_frame._partitions.flatten()]
             if get_ip:
                 return [
                     [(partition._ip_cache, partition._data) for partition in row]
-                    for row in api_layer_object._query_compiler._modin_frame._partitions
+                    for row in modin_frame._partitions
                 ]
             else:
                 return [
                     [partition._data for partition in row]
-                    for row in api_layer_object._query_compiler._modin_frame._partitions
+                    for row in modin_frame._partitions
                 ]
 
-        actual_engine = type(
-            api_layer_object._query_compiler._modin_frame._partitions[0][0]
-        ).__name__
+        actual_engine = type(modin_frame._partitions[0][0]).__name__
         if actual_engine in (
             "PandasOnRayDataframePartition",
             "PandasOnDaskDataframePartition",
@@ -81,9 +77,9 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
             f"Do not know how to unwrap '{actual_engine}' underlying partitions"
         )
     else:
-        api_layer_object._query_compiler._modin_frame._propagate_index_objs(None)
-        partitions = api_layer_object._query_compiler._modin_frame._partition_mgr_cls.axis_partition(
-            api_layer_object._query_compiler._modin_frame._partitions, axis ^ 1
+        modin_frame._propagate_index_objs(None)
+        partitions = modin_frame._partition_mgr_cls.axis_partition(
+            modin_frame._partitions, axis ^ 1
         )
         return [
             part.force_materialization(get_ip=get_ip).unwrap(

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -51,10 +51,10 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
         )
 
     modin_frame = api_layer_object._query_compiler._modin_frame
+    modin_frame._propagate_index_objs(None)
     if axis is None:
 
         def _unwrap_partitions():
-            modin_frame._propagate_index_objs(None)
             [p.drain_call_queue() for p in modin_frame._partitions.flatten()]
             if get_ip:
                 return [
@@ -79,7 +79,6 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
             f"Do not know how to unwrap '{actual_engine}' underlying partitions"
         )
     else:
-        modin_frame._propagate_index_objs(None)
         partitions = modin_frame._partition_mgr_cls.axis_partition(
             modin_frame._partitions, axis ^ 1
         )

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -15,6 +15,12 @@
 
 import numpy as np
 
+from modin.core.execution.ray.implementations.pandas_on_ray.partitioning import (
+    PandasOnRayDataframePartition,
+)
+from modin.core.execution.dask.implementations.pandas_on_dask.partitioning.partition import (
+    PandasOnDaskDataframePartition,
+)
 from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.pandas.dataframe import DataFrame
 
@@ -67,14 +73,14 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
                     for row in modin_frame._partitions
                 ]
 
-        actual_engine = type(modin_frame._partitions[0][0]).__name__
-        if actual_engine in (
-            "PandasOnRayDataframePartition",
-            "PandasOnDaskDataframePartition",
+        partition_type = modin_frame._partitions[0][0]
+        if isinstance(
+            modin_frame._partitions[0][0],
+            (PandasOnRayDataframePartition, PandasOnDaskDataframePartition),
         ):
             return _unwrap_partitions()
         raise ValueError(
-            f"Do not know how to unwrap '{actual_engine}' underlying partitions"
+            f"Do not know how to unwrap '{partition_type}' underlying partitions"
         )
     else:
         modin_frame._propagate_index_objs(None)

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -15,12 +15,6 @@
 
 import numpy as np
 
-from modin.core.execution.ray.implementations.pandas_on_ray.partitioning import (
-    PandasOnRayDataframePartition,
-)
-from modin.core.execution.dask.implementations.pandas_on_dask.partitioning.partition import (
-    PandasOnDaskDataframePartition,
-)
 from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.pandas.dataframe import DataFrame
 
@@ -73,14 +67,16 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
                     for row in modin_frame._partitions
                 ]
 
-        partition_type = modin_frame._partitions[0][0]
-        if isinstance(
-            modin_frame._partitions[0][0],
-            (PandasOnRayDataframePartition, PandasOnDaskDataframePartition),
+        actual_engine = type(
+            api_layer_object._query_compiler._modin_frame._partitions[0][0]
+        ).__name__
+        if actual_engine in (
+            "PandasOnRayDataframePartition",
+            "PandasOnDaskDataframePartition",
         ):
             return _unwrap_partitions()
         raise ValueError(
-            f"Do not know how to unwrap '{partition_type}' underlying partitions"
+            f"Do not know how to unwrap '{actual_engine}' underlying partitions"
         )
     else:
         modin_frame._propagate_index_objs(None)

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -76,10 +76,7 @@ def test_unwrap_partitions(axis, reverse_index, reverse_columns):
     expected_partitions = expected_df._query_compiler._modin_frame._partitions
     if axis is None:
         actual_partitions = np.array(unwrap_partitions(df, axis=axis))
-        assert (
-            expected_partitions.shape[0] == actual_partitions.shape[0]
-            and expected_partitions.shape[1] == expected_partitions.shape[1]
-        )
+        expected_partitions.shape == expected_partitions.shape
         for row_idx in range(expected_partitions.shape[0]):
             for col_idx in range(expected_partitions.shape[1]):
                 df_equals(

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -76,7 +76,7 @@ def test_unwrap_partitions(axis, reverse_index, reverse_columns):
     expected_partitions = expected_df._query_compiler._modin_frame._partitions
     if axis is None:
         actual_partitions = np.array(unwrap_partitions(df, axis=axis))
-        expected_partitions.shape == expected_partitions.shape
+        expected_partitions.shape == actual_partitions.shape
         for row_idx in range(expected_partitions.shape[0]):
             for col_idx in range(expected_partitions.shape[1]):
                 df_equals(

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -76,7 +76,7 @@ def test_unwrap_partitions(axis, reverse_index, reverse_columns):
     expected_partitions = expected_df._query_compiler._modin_frame._partitions
     if axis is None:
         actual_partitions = np.array(unwrap_partitions(df, axis=axis))
-        expected_partitions.shape == actual_partitions.shape
+        assert expected_partitions.shape == actual_partitions.shape
         for row_idx in range(expected_partitions.shape[0]):
             for col_idx in range(expected_partitions.shape[1]):
                 df_equals(

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -68,7 +68,7 @@ def test_unwrap_partitions(axis, reverse_index, reverse_columns):
         return df
 
     df = get_df(pd, data)
-    # `df` should not have propagatated the index and column updates to its
+    # `df` should not have propagated the index and column updates to its
     # partitions yet. The partitions of `expected_df` should have the updated
     # metadata because we construct `expected_df` directly from the updated
     # pandas dataframe.


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

FIX-#4686: Propagate metadata and drain call queue in unwrap_partitions.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4686 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
