### PR TITLE
PERF: cache indexers

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -33,6 +33,7 @@ import pandas.core.generic
 from pandas.core.indexing import convert_to_index_sliceable
 from pandas.util._validators import validate_percentile
 from pandas._libs.lib import no_default
+from pandas.util._decorators import cache_readonly
 from pandas._typing import (
     IndexKeyFunc,
     TimedeltaConvertibleTypes,
@@ -934,8 +935,8 @@ class BasePandasDataset(BasePandasDatasetCompat):
         new_query_compiler = self._query_compiler.astype(col_dtypes)
         return self._create_or_update_from_compiler(new_query_compiler, not copy)
 
-    @property
-    def at(self, axis=None):  # noqa: PR01, RT01, D200
+    @cache_readonly
+    def at(self):
         """
         Get a single value for a row/column label pair.
         """
@@ -1544,8 +1545,8 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         return self.iloc[:n]
 
-    @property
-    def iat(self, axis=None):  # noqa: PR01, RT01, D200
+    @cache_readonly
+    def iat(self):
         """
         Get a single value for a row/column pair by integer position.
         """
@@ -1618,8 +1619,8 @@ class BasePandasDataset(BasePandasDatasetCompat):
 
     isnull = isna
 
-    @property
-    def iloc(self):  # noqa: RT01, D200
+    @cache_readonly
+    def iloc(self):
         """
         Purely integer-location based indexing for selection by position.
         """
@@ -1687,8 +1688,8 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         return self._binary_op("lt", other, axis=axis, level=level, dtypes=np.bool_)
 
-    @property
-    def loc(self):  # noqa: RT01, D200
+    @cache_readonly
+    def loc(self):
         """
         Get a group of rows and columns by label(s) or a boolean array.
         """


### PR DESCRIPTION
Resolves #4702

and avoid _default_to_pandas in a few places.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4702
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
