### PR TITLE
REFACTOR-#4708: Delete combine dtypes.

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -33,6 +33,7 @@ Key Features and Updates
 * Refactor Codebase
   * REFACTOR-#4530: Standardize access to physical data in partitions (#4563)
   * REFACTOR-#4534: Replace logging meta class with class decorator (#4535)
+  * REFACTOR-#4708: Delete combine dtypes (#4709)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -961,35 +961,6 @@ class PandasDataframe(ClassLogger):
             self._dtypes,
         )
 
-    @classmethod
-    def combine_dtypes(cls, list_of_dtypes, column_names):
-        """
-        Describe how data types should be combined when they do not match.
-
-        Parameters
-        ----------
-        list_of_dtypes : list
-            A list of pandas Series with the data types.
-        column_names : list
-            The names of the columns that the data types map to.
-
-        Returns
-        -------
-        pandas.Series
-             A pandas Series containing the finalized data types.
-        """
-        # Compute dtypes by getting collecting and combining all of the partitions. The
-        # reported dtypes from differing rows can be different based on the inference in
-        # the limited data seen by each worker. We use pandas to compute the exact dtype
-        # over the whole column for each column.
-        dtypes = (
-            pandas.concat(list_of_dtypes, axis=1)
-            .apply(lambda row: find_common_type(row.values), axis=1)
-            .squeeze(axis=0)
-        )
-        dtypes.index = column_names
-        return dtypes
-
     @lazy_metadata_decorator(apply_axis="both")
     def astype(self, col_dtypes):
         """

--- a/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/dataframe/dataframe.py
@@ -17,13 +17,8 @@ Module contains class ``PyarrowOnRayDataframe``.
 ``PyarrowOnRayDataframe`` is a dataframe class with PyArrow storage format and Ray engine.
 """
 
-import pandas
-from pandas.core.dtypes.cast import find_common_type
-
 from ..partitioning.partition_manager import PyarrowOnRayDataframePartitionManager
 from modin.core.dataframe.pandas.dataframe.dataframe import PandasDataframe
-
-import ray
 
 
 class PyarrowOnRayDataframe(PandasDataframe):
@@ -63,39 +58,6 @@ class PyarrowOnRayDataframe(PandasDataframe):
             Parameter is deprecated and affects nothing.
         """
         self._filter_empties()
-
-    @classmethod
-    def combine_dtypes(cls, list_of_dtypes, column_names):
-        """
-        Get common for all partitions dtype for each of the columns.
-
-        Parameters
-        ----------
-        list_of_dtypes : array-like
-            Array with references to the partitions dtypes objects.
-        column_names : array-like or pandas.Index
-            Columns names to use for resulting Series.
-
-        Returns
-        -------
-        pandas.Series
-            pandas.Series where index is columns names and values are
-            columns dtypes.
-
-        Notes
-        -----
-        The reported dtypes from differing rows can be different based
-        on the inference in the limited data seen by each worker. We
-        use pandas to compute the exact dtype over the whole column for
-        each column.
-        """
-        dtypes = (
-            pandas.concat(ray.get(list_of_dtypes), axis=1)
-            .apply(lambda row: find_common_type(row.values), axis=1)
-            .squeeze(axis=0)
-        )
-        dtypes.index = column_names
-        return dtypes
 
     def to_pandas(self):
         """


### PR DESCRIPTION
## What do these changes do?

REFACTOR-#4708: Delete combine dtypes.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4708
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
