### PR TITLE
FIX-#4657: Use `fsspec` for handling s3/http-like paths instead of `s3fs`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -28,6 +28,7 @@ Key Features and Updates
   * FIX-#4686: Propagate metadata and drain call queue in unwrap_partitions (#4697)
   * FIX-#4652: Support categorical data in `from_dataframe` (#4737)
   * FIX-#4756: Correctly propagate `storage_options` in `read_parquet` (#4764)
+  * FIX-#4657: Use `fsspec` for handling s3/http-like paths instead of `s3fs` (#4710)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/examples/cloud/aws_example.yaml
+++ b/examples/cloud/aws_example.yaml
@@ -104,7 +104,6 @@ initialization_commands: []
 
 # List of shell commands to run to set up nodes.
 setup_commands:
-    - pip install s3fs
     - pip install modin
     - echo 'export MODIN_RAY_CLUSTER=True' >> ~/.bashrc
     # Consider uncommenting these if you also want to run apt-get commands during setup

--- a/examples/spreadsheet/requirements.txt
+++ b/examples/spreadsheet/requirements.txt
@@ -1,4 +1,3 @@
-s3fs
 ray==1.1.0
 git+https://github.com/modin-project/modin
 modin-spreadsheet

--- a/examples/spreadsheet/tutorial.ipynb
+++ b/examples/spreadsheet/tutorial.ipynb
@@ -261,7 +261,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3.8.13 ('modin')",
    "language": "python",
    "name": "python3"
   },
@@ -275,7 +275,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.13"
+  },
+  "vscode": {
+   "interpreter": {
+    "hash": "cac7361f75dfdd3ef51ed7ac40d85b964e426cda360e5fd1128718636d2f0619"
+   }
   }
  },
  "nbformat": 4,

--- a/examples/spreadsheet/tutorial.ipynb
+++ b/examples/spreadsheet/tutorial.ipynb
@@ -261,7 +261,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3.8.13 ('modin')",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -275,12 +275,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
-  },
-  "vscode": {
-   "interpreter": {
-    "hash": "cac7361f75dfdd3ef51ed7ac40d85b964e426cda360e5fd1128718636d2f0619"
-   }
+   "version": "3.8.5"
   }
  },
  "nbformat": 4,

--- a/examples/tutorial/jupyter/execution/pandas_on_dask/requirements.txt
+++ b/examples/tutorial/jupyter/execution/pandas_on_dask/requirements.txt
@@ -1,5 +1,4 @@
 fsspec
-s3fs
 jupyterlab
 ipywidgets
 modin[dask]

--- a/examples/tutorial/jupyter/execution/pandas_on_ray/requirements.txt
+++ b/examples/tutorial/jupyter/execution/pandas_on_ray/requirements.txt
@@ -1,5 +1,4 @@
 fsspec
-s3fs
 jupyterlab
 ipywidgets
 tqdm

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -284,11 +284,12 @@ class FileDispatcher(ClassLogger):
                     EndpointConnectionError,
                     ConnectTimeoutError,
                 ):
-                    pass
-                fs, _ = fsspec.core.url_to_fs(
-                    file_path, anon=True, **new_storage_options
-                )
-                return exists or fs.exists(file_path)
+                    fs, _ = fsspec.core.url_to_fs(
+                        file_path, anon=True, **new_storage_options
+                    )
+                    exists = fs.exists(file_path)
+
+                return exists
         return os.path.exists(file_path)
 
     @classmethod

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -279,9 +279,9 @@ class FileDispatcher(ClassLogger):
                     new_storage_options = {}
 
                 fs, _ = fsspec.core.url_to_fs(file_path, **new_storage_options)
-                is_exist = False
+                exists = False
                 try:
-                    is_exist = fs.exists(file_path)
+                    exists = fs.exists(file_path)
                 except (
                     NoCredentialsError,
                     PermissionError,
@@ -292,7 +292,7 @@ class FileDispatcher(ClassLogger):
                 fs, _ = fsspec.core.url_to_fs(
                     file_path, anon=True, **new_storage_options
                 )
-                return is_exist or fs.exists(file_path)
+                return exists or fs.exists(file_path)
         return os.path.exists(file_path)
 
     @classmethod

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -257,7 +257,12 @@ class FileDispatcher(ClassLogger):
             Whether file exists or not.
         """
         if isinstance(file_path, str):
-            if fsspec.core.split_protocol(file_path)[0] in ("s3", "S3", "https", "http"):
+            if fsspec.core.split_protocol(file_path)[0] in (
+                "s3",
+                "S3",
+                "https",
+                "http",
+            ):
                 if file_path.startswith("S"):
                     file_path = f"s{file_path[1:]}"
 

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -257,40 +257,43 @@ class FileDispatcher(ClassLogger):
         bool
             Whether file exists or not.
         """
-        if isinstance(file_path, str):
-            if fsspec.core.split_protocol(file_path)[0] in _SUPPORTED_PROTOCOLS:
-                # `file_path` may start with a capital letter, which isn't supported by `fsspec.core.url_to_fs` used below.
-                file_path = file_path[0].lower() + file_path[1:]
+        if (
+            isinstance(file_path, str)
+            and fsspec.core.split_protocol(file_path)[0] in _SUPPORTED_PROTOCOLS
+        ):
+            # `file_path` may start with a capital letter, which isn't supported by `fsspec.core.url_to_fs` used below.
+            file_path = file_path[0].lower() + file_path[1:]
 
-                from botocore.exceptions import (
-                    NoCredentialsError,
-                    EndpointConnectionError,
-                    ConnectTimeoutError,
+            from botocore.exceptions import (
+                NoCredentialsError,
+                EndpointConnectionError,
+                ConnectTimeoutError,
+            )
+
+            if storage_options is not None:
+                new_storage_options = dict(storage_options)
+                new_storage_options.pop("anon", None)
+            else:
+                new_storage_options = {}
+
+            fs, _ = fsspec.core.url_to_fs(file_path, **new_storage_options)
+            exists = False
+            try:
+                exists = fs.exists(file_path)
+            except (
+                NoCredentialsError,
+                PermissionError,
+                EndpointConnectionError,
+                ConnectTimeoutError,
+            ):
+                fs, _ = fsspec.core.url_to_fs(
+                    file_path, anon=True, **new_storage_options
                 )
+                exists = fs.exists(file_path)
 
-                if storage_options is not None:
-                    new_storage_options = dict(storage_options)
-                    new_storage_options.pop("anon", None)
-                else:
-                    new_storage_options = {}
-
-                fs, _ = fsspec.core.url_to_fs(file_path, **new_storage_options)
-                exists = False
-                try:
-                    exists = fs.exists(file_path)
-                except (
-                    NoCredentialsError,
-                    PermissionError,
-                    EndpointConnectionError,
-                    ConnectTimeoutError,
-                ):
-                    fs, _ = fsspec.core.url_to_fs(
-                        file_path, anon=True, **new_storage_options
-                    )
-                    exists = fs.exists(file_path)
-
-                return exists
-        return os.path.exists(file_path)
+            return exists
+        else:
+            return os.path.exists(file_path)
 
     @classmethod
     def deploy(cls, func, *args, num_returns=1, **kwargs):  # noqa: PR01

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -282,7 +282,6 @@ class FileDispatcher(ClassLogger):
                     )
                     exists = fs.exists(path)
                 return exists
-
         return os.path.exists(file_path)
 
     @classmethod

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -275,9 +275,9 @@ class FileDispatcher(ClassLogger):
                     new_storage_options = {}
 
                 fs, _ = fsspec.core.url_to_fs(file_path, **new_storage_options)
-                exists = False
+                is_exist = False
                 try:
-                    exists = fs.exists(file_path)
+                    is_exist = fs.exists(file_path)
                 except (
                     NoCredentialsError,
                     PermissionError,
@@ -288,7 +288,7 @@ class FileDispatcher(ClassLogger):
                 fs, _ = fsspec.core.url_to_fs(
                     file_path, anon=True, **new_storage_options
                 )
-                return exists or fs.exists(file_path)
+                return is_exist or fs.exists(file_path)
         return os.path.exists(file_path)
 
     @classmethod

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -263,8 +263,8 @@ class FileDispatcher(ClassLogger):
                 "https",
                 "http",
             ):
-                if file_path.startswith("S"):
-                    file_path = f"s{file_path[1:]}"
+                # `file_path` may start with a capital letter, which isn't supported by `fsspec.core.url_to_fs` used below.
+                file_path = file_path[0].lower() + file_path[1:]
 
                 from botocore.exceptions import (
                     NoCredentialsError,

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -277,11 +277,11 @@ class FileDispatcher(ClassLogger):
                 try:
                     exists = fs.exists(path)
                 except (NoCredentialsError, PermissionError, EndpointConnectionError):
-                    fs, path = fsspec.core.url_to_fs(
-                        file_path, anon=True, **new_storage_options
-                    )
-                    exists = fs.exists(path)
-                return exists
+                    pass
+                fs, path = fsspec.core.url_to_fs(
+                    file_path, anon=True, **new_storage_options
+                )
+                return exists or fs.exists(path)
         return os.path.exists(file_path)
 
     @classmethod

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -23,7 +23,6 @@ import os
 from modin.config import StorageFormat
 from modin.logging import ClassLogger
 import numpy as np
-from pandas.io.common import is_fsspec_url, is_url
 
 NOT_IMPLEMENTED_MESSAGE = "Implement in children classes!"
 
@@ -212,7 +211,7 @@ class FileDispatcher(ClassLogger):
         absolute path will be returned.
         """
         if isinstance(file_path, str) and (
-            is_fsspec_url(file_path) or is_url(file_path)
+            fsspec.core.split_protocol(file_path)[0] in ("s3", "S3", "https", "http")
         ):
             return file_path
         else:
@@ -258,7 +257,7 @@ class FileDispatcher(ClassLogger):
             Whether file exists or not.
         """
         if isinstance(file_path, str):
-            if is_fsspec_url(file_path) or is_url(file_path):
+            if fsspec.core.split_protocol(file_path)[0] in ("s3", "S3", "https", "http"):
                 if file_path.startswith("S"):
                     file_path = f"s{file_path[1:]}"
 

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -25,6 +25,7 @@ from modin.logging import ClassLogger
 import numpy as np
 
 NOT_IMPLEMENTED_MESSAGE = "Implement in children classes!"
+_SUPPORTED_PROTOCOLS = {"s3", "S3", "http", "https"}
 
 
 class OpenFile:
@@ -211,7 +212,7 @@ class FileDispatcher(ClassLogger):
         absolute path will be returned.
         """
         if isinstance(file_path, str) and (
-            fsspec.core.split_protocol(file_path)[0] in ("s3", "S3", "https", "http")
+            fsspec.core.split_protocol(file_path)[0] in _SUPPORTED_PROTOCOLS
         ):
             return file_path
         else:
@@ -257,12 +258,7 @@ class FileDispatcher(ClassLogger):
             Whether file exists or not.
         """
         if isinstance(file_path, str):
-            if fsspec.core.split_protocol(file_path)[0] in (
-                "s3",
-                "S3",
-                "https",
-                "http",
-            ):
+            if fsspec.core.split_protocol(file_path)[0] in _SUPPORTED_PROTOCOLS:
                 # `file_path` may start with a capital letter, which isn't supported by `fsspec.core.url_to_fs` used below.
                 file_path = file_path[0].lower() + file_path[1:]
 

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -408,7 +408,12 @@ class CSVGlobDispatcher(CSVDispatcher):
         fs, _ = fsspec.core.url_to_fs(file_path)
         try:
             return get_file_path(fs)
-        except (NoCredentialsError, EndpointConnectionError, ConnectTimeoutError):
+        except (
+            NoCredentialsError,
+            PermissionError,
+            EndpointConnectionError,
+            ConnectTimeoutError,
+        ):
             fs, _ = fsspec.core.url_to_fs(file_path, anon=True)
         return get_file_path(fs)
 

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -30,6 +30,8 @@ from modin.config import NPartitions
 from modin.core.io.file_dispatcher import OpenFile
 from modin.core.io.text.csv_dispatcher import CSVDispatcher
 
+_SUPPORTED_PROTOCOLS = {"s3", "S3"}
+
 
 class CSVGlobDispatcher(CSVDispatcher):
     """Class contains utils for reading multiple `.csv` files simultaneously."""
@@ -330,7 +332,7 @@ class CSVGlobDispatcher(CSVDispatcher):
             True if the path is valid.
         """
         if isinstance(file_path, str):
-            if fsspec.core.split_protocol(file_path)[0] in ("s3", "S3"):
+            if fsspec.core.split_protocol(file_path)[0] in _SUPPORTED_PROTOCOLS:
                 # `file_path` may start with a capital letter, which isn't supported by `fsspec.core.url_to_fs` used below.
                 file_path = file_path[0].lower() + file_path[1:]
 
@@ -384,7 +386,7 @@ class CSVGlobDispatcher(CSVDispatcher):
         list
             List of strings of absolute file paths.
         """
-        if fsspec.core.split_protocol(file_path)[0] in ("s3", "S3"):
+        if fsspec.core.split_protocol(file_path)[0] in _SUPPORTED_PROTOCOLS:
             # `file_path` may start with a capital letter, which isn't supported by `fsspec.core.url_to_fs` used below.
             file_path = file_path[0].lower() + file_path[1:]
 

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -346,9 +346,9 @@ class CSVGlobDispatcher(CSVDispatcher):
                     new_storage_options = {}
 
                 fs, _ = fsspec.core.url_to_fs(file_path, **new_storage_options)
-                is_exist = False
+                exists = False
                 try:
-                    is_exist = fs.exists(file_path)
+                    exists = fs.exists(file_path)
                 except (
                     NoCredentialsError,
                     PermissionError,
@@ -359,7 +359,7 @@ class CSVGlobDispatcher(CSVDispatcher):
                 fs, _ = fsspec.core.url_to_fs(
                     file_path, anon=True, **new_storage_options
                 )
-                return is_exist or len(fs.glob(file_path)) > 0
+                return exists or len(fs.glob(file_path)) > 0
 
             if fsspec.core.split_protocol(file_path)[0] in ("http", "https"):
                 raise NotImplementedError(

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -24,6 +24,7 @@ import fsspec
 
 import pandas
 import pandas._libs.lib as lib
+from pandas.io.common import is_url
 
 from modin.config import NPartitions
 from modin.core.io.file_dispatcher import OpenFile
@@ -361,7 +362,7 @@ class CSVGlobDispatcher(CSVDispatcher):
                 )
                 return exists or len(fs.glob(file_path)) > 0
 
-            if fsspec.core.split_protocol(file_path)[0] in ("http", "https"):
+            if is_url(file_path):
                 raise NotImplementedError(
                     "`read_csv_glob` supports only s3-like paths."
                 )

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -360,7 +360,7 @@ class CSVGlobDispatcher(CSVDispatcher):
                 fs, path = fsspec.core.url_to_fs(
                     file_path, anon=True, **new_storage_options
                 )
-                return exists or fs.exists(path)
+                return exists or len(fs.glob(path)) > 0
         return len(glob.glob(file_path)) > 0
 
     @classmethod

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -358,10 +358,10 @@ class CSVGlobDispatcher(CSVDispatcher):
                     EndpointConnectionError,
                     ConnectTimeoutError,
                 ):
-                    pass
-                fs, _ = fsspec.core.url_to_fs(
-                    file_path, anon=True, **new_storage_options
-                )
+                    fs, _ = fsspec.core.url_to_fs(
+                        file_path, anon=True, **new_storage_options
+                    )
+                    exists = len(fs.glob(file_path)) > 0
                 return exists or len(fs.glob(file_path)) > 0
 
             if is_url(file_path):
@@ -407,8 +407,7 @@ class CSVGlobDispatcher(CSVDispatcher):
             try:
                 return get_file_path(fs)
             except (NoCredentialsError, EndpointConnectionError, ConnectTimeoutError):
-                pass
-            fs, _ = fsspec.core.url_to_fs(file_path, anon=True)
+                fs, _ = fsspec.core.url_to_fs(file_path, anon=True)
             return get_file_path(fs)
         else:
             relative_paths = glob.glob(file_path)

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -346,10 +346,10 @@ class CSVGlobDispatcher(CSVDispatcher):
                 else:
                     new_storage_options = {}
 
-                fs, path = fsspec.core.url_to_fs(file_path, **new_storage_options)
+                fs, _ = fsspec.core.url_to_fs(file_path, **new_storage_options)
                 is_exist = False
                 try:
-                    is_exist = fs.exists(path)
+                    is_exist = fs.exists(file_path)
                 except (
                     NoCredentialsError,
                     PermissionError,
@@ -357,10 +357,10 @@ class CSVGlobDispatcher(CSVDispatcher):
                     ConnectTimeoutError,
                 ):
                     pass
-                fs, path = fsspec.core.url_to_fs(
+                fs, _ = fsspec.core.url_to_fs(
                     file_path, anon=True, **new_storage_options
                 )
-                return is_exist or len(fs.glob(path)) > 0
+                return is_exist or len(fs.glob(file_path)) > 0
 
             if is_url(file_path):
                 raise NotImplementedError(
@@ -397,7 +397,7 @@ class CSVGlobDispatcher(CSVDispatcher):
             def get_file_path(fs_handle) -> List[str]:
                 file_paths = fs_handle.glob(file_path)
                 if len(file_paths) == 0 and not fs_handle.exists(file_path):
-                    return [file_path]
+                    raise FileNotFoundError(f"Path <{file_path}> isn't available.")
                 s3_addresses = [f"s3://{path}" for path in file_paths]
                 return s3_addresses
 

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -24,7 +24,6 @@ import fsspec
 
 import pandas
 import pandas._libs.lib as lib
-from pandas.io.common import is_fsspec_url, is_url
 
 from modin.config import NPartitions
 from modin.core.io.file_dispatcher import OpenFile
@@ -330,7 +329,7 @@ class CSVGlobDispatcher(CSVDispatcher):
             True if the path is valid.
         """
         if isinstance(file_path, str):
-            if is_fsspec_url(file_path):
+            if fsspec.core.split_protocol(file_path)[0] in ("s3", "S3"):
                 if file_path.startswith("S"):
                     file_path = f"s{file_path[1:]}"
 
@@ -362,7 +361,7 @@ class CSVGlobDispatcher(CSVDispatcher):
                 )
                 return is_exist or len(fs.glob(file_path)) > 0
 
-            if is_url(file_path):
+            if fsspec.core.split_protocol(file_path)[0] in ("http", "https"):
                 raise NotImplementedError(
                     "`read_csv_glob` supports only s3-like paths."
                 )
@@ -384,7 +383,7 @@ class CSVGlobDispatcher(CSVDispatcher):
         list
             List of strings of absolute file paths.
         """
-        if is_fsspec_url(file_path) or is_url(file_path):
+        if fsspec.core.split_protocol(file_path)[0] in ("s3", "S3"):
             if file_path.startswith("S"):
                 file_path = f"s{file_path[1:]}"
 

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -330,8 +330,8 @@ class CSVGlobDispatcher(CSVDispatcher):
         """
         if isinstance(file_path, str):
             if fsspec.core.split_protocol(file_path)[0] in ("s3", "S3"):
-                if file_path.startswith("S"):
-                    file_path = f"s{file_path[1:]}"
+                # `file_path` may start with a capital letter, which isn't supported by `fsspec.core.url_to_fs` used below.
+                file_path = file_path[0].lower() + file_path[1:]
 
                 from botocore.exceptions import (
                     NoCredentialsError,
@@ -384,8 +384,8 @@ class CSVGlobDispatcher(CSVDispatcher):
             List of strings of absolute file paths.
         """
         if fsspec.core.split_protocol(file_path)[0] in ("s3", "S3"):
-            if file_path.startswith("S"):
-                file_path = f"s{file_path[1:]}"
+            # `file_path` may start with a capital letter, which isn't supported by `fsspec.core.url_to_fs` used below.
+            file_path = file_path[0].lower() + file_path[1:]
 
             from botocore.exceptions import (
                 NoCredentialsError,

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -389,11 +389,9 @@ class CSVGlobDispatcher(CSVDispatcher):
             )
 
             def get_file_path(fs_handle) -> List[str]:
-                file_paths = (
-                    fs_handle.glob(file_path)
-                    if fs_handle.exists(file_path)
-                    else [file_path]
-                )
+                file_paths = fs_handle.glob(file_path)
+                if len(file_paths) == 0 and not fs_handle.exists(file_path):
+                    file_paths = [file_path]
                 s3_addresses = ["{}{}".format("s3://", path) for path in file_paths]
                 return s3_addresses
 

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -361,7 +361,7 @@ class CSVGlobDispatcher(CSVDispatcher):
                     fs, _ = fsspec.core.url_to_fs(
                         file_path, anon=True, **new_storage_options
                     )
-                    exists = len(fs.glob(file_path)) > 0
+                    exists = fs.exists(file_path)
                 return exists or len(fs.glob(file_path)) > 0
 
             if is_url(file_path):

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -126,7 +126,10 @@ class TestCsvGlob:
     def test_read_csv_without_glob(self):
         with pytest.warns(UserWarning, match=r"Shell-style wildcard"):
             with pytest.raises(FileNotFoundError):
-                pd.read_csv_glob("s3://dask-data/nyc-taxi/2015/yellow_tripdata_2015-")
+                pd.read_csv_glob(
+                    "s3://dask-data/nyc-taxi/2015/yellow_tripdata_2015-",
+                    storage_options={"anon": True},
+                )
 
     def test_read_csv_glob_4373(self):
         columns, filename = ["col0"], "1x1.csv"
@@ -165,24 +168,25 @@ class TestCsvGlob:
     Engine.get() != "Ray", reason="Currently only support Ray engine for glob paths."
 )
 def test_read_multiple_csv_s3():
-    modin_df = pd.read_csv_glob("S3://noaa-ghcn-pds/csv/178*.csv")
+    path = "S3://modin-datasets/testing/multiple_csv/test_data*.csv"
 
-    # We have to specify the columns because the column names are not identical. Since we specified the column names, we also have to skip the original column names.
-    pandas_dfs = [
-        pandas.read_csv(
-            "s3://noaa-ghcn-pds/csv/178{}.csv".format(i),
-            names=modin_df.columns,
-            skiprows=[0],
-        )
-        for i in range(10)
-    ]
-    pandas_df = pd.concat(pandas_dfs)
+    def _pandas_read_csv_glob(path, storage_options):
+        pandas_dfs = [
+            pandas.read_csv(
+                f"{path.lower().split('*')[0]}{i}.csv", storage_options=storage_options
+            )
+            for i in range(2)
+        ]
+        return pandas.concat(pandas_dfs).reset_index(drop=True)
 
-    # Indexes get messed up when concatting so we reset both.
-    pandas_df = pandas_df.reset_index(drop=True)
-    modin_df = modin_df.reset_index(drop=True)
-
-    df_equals(modin_df, pandas_df)
+    eval_general(
+        pd,
+        pandas,
+        lambda module, **kwargs: pd.read_csv_glob(path, **kwargs).reset_index(drop=True)
+        if hasattr(module, "read_csv_glob")
+        else _pandas_read_csv_glob(path, **kwargs),
+        storage_options={"anon": True},
+    )
 
 
 test_default_to_pickle_filename = "test_default_to_pickle.pkl"
@@ -199,7 +203,7 @@ test_default_to_pickle_filename = "test_default_to_pickle.pkl"
 def test_read_multiple_csv_s3_storage_opts(storage_options):
     path = "s3://modin-datasets/testing/multiple_csv/"
 
-    def pandas_read_csv_glob(path, storage_options):
+    def _pandas_read_csv_glob(path, storage_options):
         pandas_df = pandas.concat(
             [
                 pandas.read_csv(
@@ -216,7 +220,7 @@ def test_read_multiple_csv_s3_storage_opts(storage_options):
         pandas,
         lambda module, **kwargs: pd.read_csv_glob(path, **kwargs)
         if hasattr(module, "read_csv_glob")
-        else pandas_read_csv_glob(path, **kwargs),
+        else _pandas_read_csv_glob(path, **kwargs),
         storage_options=storage_options,
     )
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1046,16 +1046,9 @@ class TestCsv:
         condition="config.getoption('--simulate-cloud').lower() != 'off'",
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #2340",
     )
-    def test_read_csv_default_to_pandas_url(self):
-        # We haven't implemented read_csv from https, but if it's implemented, then this needs to change
-        if self._has_pandas_fallback_reason():
-            warning_match = "No such file"
-        else:
-            warning_match = ""
+    def test_read_csv_url(self):
         eval_io(
             fn_name="read_csv",
-            modin_warning=UserWarning,
-            modin_warning_str_match=warning_match,
             # read_csv kwargs
             filepath_or_buffer="https://raw.githubusercontent.com/modin-project/modin/master/modin/pandas/test/data/blah.csv",
             # It takes about ~17Gb of RAM for Omnisci to import the whole table from this test

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -982,13 +982,6 @@ class TestCsv:
             storage_options=storage_options,
         )
 
-    def test_read_csv_s3_http_path(self):
-        eval_io(
-            fn_name="read_csv",
-            filepath_or_buffer="https://modin-test.s3.us-west-1.amazonaws.com/yellow_tripdata_2015-01.csv",
-            nrows=10,
-        )
-
     @pytest.mark.skipif(
         PandasCompatVersion.CURRENT == PandasCompatVersion.PY36,
         reason="storage_options not supported for older pandas",

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -982,6 +982,13 @@ class TestCsv:
             storage_options=storage_options,
         )
 
+    def test_read_csv_s3_http_path(self):
+        eval_io(
+            fn_name="read_csv",
+            filepath_or_buffer="https://modin-test.s3.us-west-1.amazonaws.com/yellow_tripdata_2015-01.csv",
+            nrows=10,
+        )
+
     @pytest.mark.skipif(
         PandasCompatVersion.CURRENT == PandasCompatVersion.PY36,
         reason="storage_options not supported for older pandas",

--- a/modin/test/storage_formats/base/test_internals.py
+++ b/modin/test/storage_formats/base/test_internals.py
@@ -71,7 +71,6 @@ def test_insert_item(axis, item_length, loc, replace):
     md_res = md_item1._query_compiler.insert_item(
         axis=axis, loc=index_loc, value=md_item2._query_compiler, replace=replace
     ).to_pandas()
-    # breakpoint()
     df_equals(md_res, pd_res)
 
     index_loc = get_loc(pd_item2, loc)


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR changes handling of `s3`-like paths from direct `s3fs` to `fsspec` for `read_csv`/`read_csv_glob`. Also some tests for `read_csv_glob` was stabilizied.

In the result:
1. `s3fs` package is used in test system only now
2. New approach allows to switch on parallel implementation of `read_csv` in case `http/https`-like paths instead of defaulting to pandas.

Exceptions: `read_csv_glob` still doesn't support `http`-like paths because `fsspec.HTTPFileSystem.glob` isn't working as expected (always gives empty list instead of all files in remote directory).

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4657  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
