### PR TITLE
REFACTOR-#4717: Improve PartitionMgr.get_indices() usage

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -34,6 +34,7 @@ Key Features and Updates
 * Refactor Codebase
   * REFACTOR-#4530: Standardize access to physical data in partitions (#4563)
   * REFACTOR-#4534: Replace logging meta class with class decorator (#4535)
+  * REFACTOR-#4717: Improve PartitionMgr.get_indices() usage (#4718)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -426,9 +426,8 @@ class PandasDataframe(ClassLogger):
         """
         if partitions is None:
             partitions = self._partitions
-        return self._partition_mgr_cls.get_indices(
-            axis, partitions, lambda df: df.axes[axis]
-        )
+        new_index, _ = self._partition_mgr_cls.get_indices(axis, partitions)
+        return new_index
 
     def _filter_empties(self):
         """Remove empty partitions from `self._partitions` to avoid triggering excess computation."""

--- a/modin/core/io/pickle/pickle_dispatcher.py
+++ b/modin/core/io/pickle/pickle_dispatcher.py
@@ -81,12 +81,8 @@ class PickleExperimentalDispatcher(FileDispatcher):
         # while num_splits is 1, need only one value
         partition_ids = cls.build_partition(partition_ids, lengths, [widths[0]])
 
-        new_index = cls.frame_cls._partition_mgr_cls.get_indices(
-            0, partition_ids, lambda df: df.axes[0]
-        )
-        new_columns = cls.frame_cls._partition_mgr_cls.get_indices(
-            1, partition_ids, lambda df: df.axes[1]
-        )
+        new_index, _ = cls.frame_cls._partition_mgr_cls.get_indices(0, partition_ids)
+        new_columns, _ = cls.frame_cls._partition_mgr_cls.get_indices(1, partition_ids)
 
         return cls.query_compiler_cls(
             cls.frame_cls(partition_ids, new_index, new_columns)

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -177,11 +177,15 @@ def from_partitions(
     labels_axis_to_sync = None
     if index is None:
         labels_axis_to_sync = 1
-        index = partition_mgr_class.get_indices(0, parts, lambda df: df.axes[0])
+        index, internal_indices = partition_mgr_class.get_indices(0, parts)
+        if row_lengths is None:
+            row_lengths = [len(idx) for idx in internal_indices]
 
     if columns is None:
         labels_axis_to_sync = 0 if labels_axis_to_sync is None else -1
-        columns = partition_mgr_class.get_indices(1, parts, lambda df: df.axes[1])
+        columns, internal_indices = partition_mgr_class.get_indices(1, parts)
+        if column_widths is None:
+            column_widths = [len(idx) for idx in internal_indices]
 
     frame = partition_frame_class(
         parts,

--- a/modin/experimental/core/storage_formats/pyarrow/query_compiler.py
+++ b/modin/experimental/core/storage_formats/pyarrow/query_compiler.py
@@ -282,7 +282,7 @@ class PyarrowQueryCompiler(PandasQueryCompiler):
         old_blocks = self.data if compute_diff else None
         # FIXME: `PandasDataframe.get_indices` was deprecated, this call should be
         # replaced either by `PandasDataframe._compute_axis_label` or by `PandasDataframe.axes`.
-        new_indices = data_object.get_indices(
+        new_indices, _ = data_object.get_indices(
             axis=axis,
             index_func=lambda df: arrow_index_extraction(df, axis),
             old_blocks=old_blocks,


### PR DESCRIPTION
Signed-off-by: Vasily Litvinov <fam1ly.n4me@yandex.ru>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Make some sane default for `index_func=None` argument of `PartitionManager.get_indices()`, which improves its usability.
Also return internal partition indices as well as the total frame index - this allows to compute the `row_lengths` / `column_widths` information later on without some separate remote calls.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4717
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
