### PR TITLE
REFACTOR-#4722: Stop suppressing undefined name lint

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -42,6 +42,7 @@ Key Features and Updates
   * REFACTOR-#4708: Delete combine dtypes (#4709)
   * REFACTOR-#4629: Add type annotations to modin/config (#4685)
   * REFACTOR-#4717: Improve PartitionMgr.get_indices() usage (#4718)
+  * REFACTOR-#4722: Stop suppressing undefined name lint (#4723)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/modin/_compat/pandas_api/latest/base.py
+++ b/modin/_compat/pandas_api/latest/base.py
@@ -13,18 +13,28 @@
 
 """Module for 'latest pandas' compatibility layer for Dataset (common DataFrame/Series)."""
 
+import numpy as np
 import pandas
 from pandas.core.dtypes.common import is_datetime_or_timedelta_dtype
 from pandas.util._validators import validate_bool_kwarg, validate_ascending
 from pandas._libs.lib import no_default
-from pandas._typing import StorageOptions, CompressionOptions, IndexLabel
+from pandas._typing import (
+    StorageOptions,
+    CompressionOptions,
+    IndexLabel,
+    TimedeltaConvertibleTypes,
+    Axis,
+)
 import pickle as pkl
 from numpy import nan
-from typing import Sequence, Hashable, Optional
+from typing import Sequence, Hashable, Optional, TYPE_CHECKING
 
 from ..abc import BaseCompatibleBasePandasDataset
 from .utils import create_stat_method
 from modin.utils import _inherit_docstrings
+
+if TYPE_CHECKING:
+    from modin.pandas.base import BasePandasDataset
 
 
 class LatestCompatibleBasePandasDataset(BaseCompatibleBasePandasDataset):

--- a/modin/_compat/pandas_api/latest/base.py
+++ b/modin/_compat/pandas_api/latest/base.py
@@ -16,6 +16,7 @@
 import numpy as np
 import pandas
 from pandas.core.dtypes.common import is_datetime_or_timedelta_dtype
+from pandas.core.window.ewm import ExponentialMovingWindow
 from pandas.util._validators import validate_bool_kwarg, validate_ascending
 from pandas._libs.lib import no_default
 from pandas._typing import (

--- a/modin/_compat/pandas_api/latest/base.py
+++ b/modin/_compat/pandas_api/latest/base.py
@@ -17,7 +17,7 @@ import pandas
 from pandas.core.dtypes.common import is_datetime_or_timedelta_dtype
 from pandas.core.window.ewm import ExponentialMovingWindow
 from pandas.util._validators import validate_bool_kwarg, validate_ascending
-from pandas._libs.lib import no_default
+from pandas._libs.lib import no_default, NoDefault
 from pandas._typing import (
     StorageOptions,
     CompressionOptions,
@@ -37,6 +37,9 @@ if TYPE_CHECKING:
     from modin.pandas.base import BasePandasDataset
 
 nan = np.nan
+
+# See https://github.com/pandas-dev/pandas/blob/v1.4.3/pandas/core/generic.py#L195
+bool_t = bool
 
 
 class LatestCompatibleBasePandasDataset(BaseCompatibleBasePandasDataset):

--- a/modin/_compat/pandas_api/latest/base.py
+++ b/modin/_compat/pandas_api/latest/base.py
@@ -13,7 +13,6 @@
 
 """Module for 'latest pandas' compatibility layer for Dataset (common DataFrame/Series)."""
 
-import numpy as np
 import pandas
 from pandas.core.dtypes.common import is_datetime_or_timedelta_dtype
 from pandas.core.window.ewm import ExponentialMovingWindow
@@ -27,7 +26,7 @@ from pandas._typing import (
     Axis,
 )
 import pickle as pkl
-from numpy import nan
+import numpy as np
 from typing import Sequence, Hashable, Optional, TYPE_CHECKING
 
 from ..abc import BaseCompatibleBasePandasDataset
@@ -36,6 +35,8 @@ from modin.utils import _inherit_docstrings
 
 if TYPE_CHECKING:
     from modin.pandas.base import BasePandasDataset
+
+nan = np.nan
 
 
 class LatestCompatibleBasePandasDataset(BaseCompatibleBasePandasDataset):

--- a/modin/_compat/pandas_api/latest/dataframe.py
+++ b/modin/_compat/pandas_api/latest/dataframe.py
@@ -23,7 +23,7 @@ from typing import (
 )
 import pandas
 from pandas.util._validators import validate_bool_kwarg
-from pandas._libs.lib import no_default
+from pandas._libs.lib import no_default, NoDefault
 from pandas._typing import (
     CompressionOptions,
     FilePath,

--- a/modin/_compat/pandas_api/latest/dataframe.py
+++ b/modin/_compat/pandas_api/latest/dataframe.py
@@ -13,11 +13,23 @@
 
 """Module for 'latest pandas' compatibility layer for DataFrame."""
 
-from typing import Optional, Union, IO
+from datetime import datetime
+from typing import (
+    Optional,
+    Union,
+    IO,
+    Hashable,
+    Sequence,
+)
 import pandas
 from pandas.util._validators import validate_bool_kwarg
 from pandas._libs.lib import no_default
-from pandas._typing import StorageOptions
+from pandas._typing import (
+    CompressionOptions,
+    FilePath,
+    StorageOptions,
+    WriteBuffer,
+)
 from numpy import nan
 
 from ..abc import BaseCompatibleDataFrame

--- a/modin/_compat/pandas_api/latest/io.py
+++ b/modin/_compat/pandas_api/latest/io.py
@@ -16,8 +16,28 @@
 import inspect
 import pandas
 from pandas._libs.lib import no_default
+from pandas._typing import (
+    CompressionOptions,
+    CSVEngine,
+    DtypeArg,
+    ReadCsvBuffer,
+    FilePath,
+    StorageOptions,
+    IntStrT,
+)
 import pickle
-from typing import Optional, Dict, Any, OrderedDict, List
+from typing import (
+    Optional,
+    Dict,
+    Any,
+    OrderedDict,
+    List,
+    Sequence,
+    Literal,
+    Hashable,
+    Callable,
+    Iterable,
+)
 
 from modin.utils import _inherit_docstrings, Engine
 from modin.error_message import ErrorMessage

--- a/modin/_compat/pandas_api/latest/series.py
+++ b/modin/_compat/pandas_api/latest/series.py
@@ -13,10 +13,13 @@
 
 """Module for 'latest pandas' compatibility layer for Series."""
 
+from typing import IO, Hashable
+
 import numpy as np
 import pandas
 from pandas.util._validators import validate_bool_kwarg
 from pandas._libs.lib import no_default
+from pandas._typing import Axis
 
 from ..abc.series import BaseCompatibleSeries
 

--- a/modin/_compat/pandas_api/latest/series.py
+++ b/modin/_compat/pandas_api/latest/series.py
@@ -18,7 +18,7 @@ from typing import IO, Hashable, TYPE_CHECKING
 import numpy as np
 import pandas
 from pandas.util._validators import validate_bool_kwarg
-from pandas._libs.lib import no_default
+from pandas._libs.lib import no_default, NoDefault
 from pandas._typing import Axis
 
 from ..abc.series import BaseCompatibleSeries

--- a/modin/_compat/pandas_api/latest/series.py
+++ b/modin/_compat/pandas_api/latest/series.py
@@ -13,7 +13,7 @@
 
 """Module for 'latest pandas' compatibility layer for Series."""
 
-from typing import IO, Hashable
+from typing import IO, Hashable, TYPE_CHECKING
 
 import numpy as np
 import pandas
@@ -22,6 +22,9 @@ from pandas._libs.lib import no_default
 from pandas._typing import Axis
 
 from ..abc.series import BaseCompatibleSeries
+
+if TYPE_CHECKING:
+    from modin.pandas.dataframe import DataFrame
 
 
 class LatestCompatibleSeries(BaseCompatibleSeries):

--- a/modin/_compat/pandas_api/latest/utils.py
+++ b/modin/_compat/pandas_api/latest/utils.py
@@ -13,7 +13,7 @@
 
 """Module for utility functions used by 'latest pandas' compatibility layer."""
 
-from pandas._libs.lib import no_default
+from pandas._libs.lib import no_default, NoDefault
 
 
 def create_stat_method(name):

--- a/modin/_compat/pandas_api/py36/io.py
+++ b/modin/_compat/pandas_api/py36/io.py
@@ -298,7 +298,8 @@ def read_stata(
 @_inherit_docstrings(pandas.read_pickle)
 @enable_logging
 def read_pickle(
-    filepath_or_buffer: "FilePathOrBuffer", compression: Optional[str] = "infer"
+    filepath_or_buffer: Union[str, pathlib.Path, IO[AnyStr]],
+    compression: Optional[str] = "infer",
 ):
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 

--- a/modin/_compat/pandas_api/py36/series.py
+++ b/modin/_compat/pandas_api/py36/series.py
@@ -13,11 +13,16 @@
 
 """Module for 'Python 3.6 pandas' compatibility layer for Series."""
 
+from typing import TYPE_CHECKING
+
 import numpy as np
 import pandas
 
 from ..abc.series import BaseCompatibleSeries
 from modin.utils import _inherit_docstrings
+
+if TYPE_CHECKING:
+    from modin.pandas import DataFrame
 
 
 @_inherit_docstrings(pandas.Series)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -36,6 +36,9 @@ from modin.core.dataframe.base.dataframe.utils import (
     Axis,
     JoinType,
 )
+from modin.core.dataframe.base.exchange.dataframe_protocol.dataframe import (
+    ProtocolDataframe,
+)
 from modin.pandas.indexing import is_range_like
 from modin.pandas.utils import is_full_grab_slice, check_both_not_none
 from modin.logging import ClassLogger

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/dataframe/dataframe.py
@@ -15,6 +15,9 @@
 
 from modin.core.dataframe.pandas.dataframe.dataframe import PandasDataframe
 from modin.core.dataframe.base.dataframe.utils import Axis, JoinType
+from modin.core.dataframe.base.exchange.dataframe_protocol.dataframe import (
+    ProtocolDataframe,
+)
 from modin.experimental.core.storage_formats.omnisci.query_compiler import (
     DFAlgQueryCompiler,
 )
@@ -2077,7 +2080,7 @@ class OmnisciOnNativeDataframe(PandasDataframe):
         )
 
     @classmethod
-    def from_dataframe(cls, df: "ProtocolDataframe") -> "OmnisciOnNativeDataframe":
+    def from_dataframe(cls, df: ProtocolDataframe) -> "OmnisciOnNativeDataframe":
         """
         Convert a DataFrame implementing the dataframe exchange protocol to a Core Modin Dataframe.
 

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/exchange/dataframe_protocol/column.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/exchange/dataframe_protocol/column.py
@@ -16,7 +16,7 @@
 import pyarrow as pa
 import pandas
 import numpy as np
-from typing import Any, Optional, Tuple, Dict, Iterable
+from typing import Any, Optional, Tuple, Dict, Iterable, TYPE_CHECKING
 from math import ceil
 
 from modin.core.dataframe.base.exchange.dataframe_protocol.utils import (
@@ -33,6 +33,9 @@ from modin.core.dataframe.base.exchange.dataframe_protocol.dataframe import (
 from modin.utils import _inherit_docstrings
 from .buffer import OmnisciProtocolBuffer
 from .utils import arrow_dtype_to_arrow_c, arrow_types_map
+
+if TYPE_CHECKING:
+    from .dataframe import OmnisciProtocolDataframe
 
 
 @_inherit_docstrings(ProtocolColumn)
@@ -254,7 +257,7 @@ class OmnisciProtocolColumn(ProtocolColumn):
     def num_chunks(self) -> int:
         return self._col.num_chunks()
 
-    def get_chunks(self, n_chunks: Optional[int] = None) -> Iterable["Column"]:
+    def get_chunks(self, n_chunks: Optional[int] = None) -> Iterable[ProtocolColumn]:
         for chunk in self._col.get_chunks(n_chunks):
             yield OmnisciProtocolColumn(chunk)
 

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/exchange/dataframe_protocol/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/exchange/dataframe_protocol/dataframe.py
@@ -24,6 +24,7 @@ from modin.experimental.core.execution.native.implementations.omnisci_on_native.
 from modin.core.dataframe.base.exchange.dataframe_protocol.dataframe import (
     ProtocolDataframe,
 )
+from modin.pandas.indexing import is_range_like
 from modin.utils import _inherit_docstrings
 from modin.error_message import ErrorMessage
 from modin.experimental.core.execution.native.implementations.omnisci_on_native.df_algebra import (

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -23,7 +23,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas._libs.lib import no_default
 from pandas._typing import IndexKeyFunc
-from typing import Union, Optional, Hashable
+from typing import Union, Optional, Hashable, TYPE_CHECKING
 import warnings
 
 from modin.utils import _inherit_docstrings, to_pandas, Engine
@@ -34,6 +34,10 @@ from .utils import from_pandas, is_scalar, _doc_binary_op
 from .accessor import CachedAccessor, SparseAccessor
 from . import _update_engine
 from modin._compat.pandas_api.classes import SeriesCompat
+
+
+if TYPE_CHECKING:
+    from .dataframe import DataFrame
 
 
 @_inherit_docstrings(

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -23,7 +23,7 @@ from pandas.core.dtypes.common import (
 )
 from pandas._libs.lib import no_default
 from pandas._typing import IndexKeyFunc
-from typing import Union, Optional
+from typing import Union, Optional, Hashable
 import warnings
 
 from modin.utils import _inherit_docstrings, to_pandas, Engine

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ filterwarnings =
 
 [flake8]
 max-line-length = 88
-ignore = E203, E266, E501, W503, F821
+ignore = E203, E266, E501, W503
 select = B,C,E,F,W,T,B9,NIC
 per-file-ignores =
     modin/pandas/__init__.py:E402,F401


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Re-enables lint F821, which checks for undefined symbols. This also fixes all occurrences of the error that were suppressed, usually by adding the appropriate import (usually from `typing` or `pandas._typing`).

The only error that was not type-only was `modin/experimental/core/execution/native/implementations/omnisci_on_native/exchange/dataframe_protocol/dataframe.py:191:52: F821 undefined name 'is_range_like'`: I fixed this by adding `from modin.pandas.indexing import is_range_like`, which appears to not use any pandas-specific functions. I'm not sure how to write a test that would check for this fix.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4722 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->