### PR TITLE
FIX-#3180: Stop defaulting to pandas for paths relative to home.

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -24,6 +24,7 @@ Key Features and Updates
   * FIX-#4491: Wait for all partitions in parallel in benchmark mode (#4656)
   * FIX-#4358: MultiIndex `loc` shouldn't drop levels for full-key lookups (#4608)
   * FIX-#4658: Expand exception handling for `read_*` functions from s3 storages (#4659)
+  * FIX-#3180: Stop defaulting to pandas for paths relative to home (#4724)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -55,6 +55,8 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         from pyarrow.parquet import ParquetDataset
         from modin.pandas.io import PQ_INDEX_REGEX
 
+        path = cls.get_path(path)
+
         if isinstance(path, str) and os.path.isdir(path):
             partitioned_columns = set()
             # We do a tree walk of the path directory because partitioned

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -55,8 +55,6 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         from pyarrow.parquet import ParquetDataset
         from modin.pandas.io import PQ_INDEX_REGEX
 
-        path = cls.get_path(path)
-
         if isinstance(path, str) and os.path.isdir(path):
             partitioned_columns = set()
             # We do a tree walk of the path directory because partitioned

--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -216,7 +216,7 @@ class FileDispatcher(ClassLogger):
         if isinstance(file_path, str) and S3_ADDRESS_REGEX.search(file_path):
             return file_path
         else:
-            return os.path.abspath(file_path)
+            return os.path.abspath(os.path.expanduser(file_path))
 
     @classmethod
     def file_size(cls, f):
@@ -284,7 +284,7 @@ class FileDispatcher(ClassLogger):
                     pass
                 s3fs = S3FS.S3FileSystem(anon=True, **new_storage_options)
                 return exists or s3fs.exists(file_path)
-        return os.path.exists(file_path)
+        return os.path.exists(os.path.expanduser(file_path))
 
     @classmethod
     def deploy(cls, func, *args, num_returns=1, **kwargs):  # noqa: PR01

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -197,7 +197,6 @@ def patch_expanduser(input_path_to_fake, fake_expansion, monkeypatch):
     original_expanduser = os.path.expanduser
 
     def patched_expanduser(path):
-        print(f"calling patched expanduser with path {path}")
         if path == input_path_to_fake:
             return fake_expansion
         else:

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1306,10 +1306,11 @@ class TestCsv:
         eval_to_file(modin_df, pandas_df, "to_csv", "csv")
 
 
-# Check that we are NOT defaulting to pandas for a path relative to user home.
+# Leave this test apart from the test classes, which skip the default to pandas
+# warning check. We want to make sure we are NOT defaulting to pandas for a
+# path relative to user home.
 # TODO(https://github.com/modin-project/modin/issues/3655): Get rid of this
-# check once we turn all default to pandas messages into errors.
-@pytest.mark.filterwarnings("error:.*defaulting to pandas.*:UserWarning")
+# commment once we turn all default to pandas messages into errors.
 def test_read_csv_relative_to_user_home(monkeypatch, make_csv_file):
     unique_filename = get_unique_filename()
 
@@ -1581,7 +1582,11 @@ class TestParquet:
             df_equals(test_df, read_df)
 
 
-@pytest.mark.filterwarnings("error:.*defaulting to pandas.*:UserWarning")
+# Leave this test apart from the test classes, which skip the default to pandas
+# warning check. We want to make sure we are NOT defaulting to pandas for a
+# path relative to user home.
+# TODO(https://github.com/modin-project/modin/issues/3655): Get rid of this
+# commment once we turn all default to pandas messages into errors.
 def test_read_parquet_relative_to_user_home(monkeypatch, make_parquet_file):
     unique_filename = get_unique_filename(extension="parquet")
     make_parquet_file(filename=unique_filename)


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

FIX-#3180: Stop defaulting to pandas for paths relative to home.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3180
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
