### PR TITLE
FEAT-#4725: Make index and columns lazy in Modin DataFrame

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -66,6 +66,7 @@ Key Features and Updates
   * FEAT-#4419: Extend virtual partitioning API to pandas on Dask (#4420)
   * FEAT-#4147: Add partial compatibility with Python 3.6 and pandas 1.1 (#4301)
   * FEAT-#4569: Add error message when `read_` function defaults to pandas (#4647)
+  * FEAT-#4725: Make index and columns lazy in Modin DataFrame (#4726)
 
 Contributors
 ------------

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -351,9 +351,9 @@ class PandasDataframe(ClassLogger):
             An index object containing the row labels.
         """
         if self._index_cache is None:
-            self._index_cache, internal_sizes = self._compute_axis_labels(0)
+            self._index_cache, row_lengths = self._compute_axis_labels(0)
             if self._row_lengths_cache is None:
-                self._row_lengths_cache = internal_sizes
+                self._row_lengths_cache = row_lengths
         return self._index_cache
 
     def _get_columns(self):
@@ -366,9 +366,9 @@ class PandasDataframe(ClassLogger):
             An index object containing the column labels.
         """
         if self._columns_cache is None:
-            self._columns_cache, internal_sizes = self._compute_axis_labels(1)
+            self._columns_cache, column_widths = self._compute_axis_labels(1)
             if self._column_widths_cache is None:
-                self._column_widths_cache = internal_sizes
+                self._column_widths_cache = column_widths
         return self._columns_cache
 
     def _set_index(self, new_index):

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -222,7 +222,7 @@ class PandasDataframe(ClassLogger):
                 any(val < 0 for val in column_widths),
                 "Column widths cannot be negative: {}".format(column_widths),
             )
-        self._filter_empties(compute=False)
+        self._filter_empties(compute_lengths=False)
 
     @property
     def _row_lengths(self):
@@ -436,7 +436,7 @@ class PandasDataframe(ClassLogger):
         -------
         pandas.Index
             Labels for the specified `axis`.
-        tuple of int
+        List of int
             Size of partitions alongsize specified `axis`.
         """
         if partitions is None:
@@ -444,16 +444,16 @@ class PandasDataframe(ClassLogger):
         new_index, internal_idx = self._partition_mgr_cls.get_indices(axis, partitions)
         return new_index, list(map(len, internal_idx))
 
-    def _filter_empties(self, compute=True):
+    def _filter_empties(self, compute_lengths=True):
         """
         Remove empty partitions from `self._partitions` to avoid triggering excess computation.
 
         Parameters
         ----------
-        compute : bool, default: True
+        compute_lengths : bool, default: True
             Trigger the computations for partition sizes if they're not done already.
         """
-        if not compute and (
+        if not compute_lengths and (
             self._index_cache is None
             or self._columns_cache is None
             or self._row_lengths_cache is None

--- a/modin/experimental/batch/pipeline.py
+++ b/modin/experimental/batch/pipeline.py
@@ -375,8 +375,8 @@ class PandasQueryPipeline(object):
                 partitions,
                 index,
                 columns,
-                row_lengths=tuple(map(len, internal_rows)),
-                column_widths=tuple(map(len, internal_cols)),
+                row_lengths=list(map(len, internal_rows)),
+                column_widths=list(map(len, internal_cols)),
             )
             query_compiler = PandasQueryCompiler(result_modin_frame)
             result_df = pd.DataFrame(query_compiler=query_compiler)


### PR DESCRIPTION
Signed-off-by: Vasily Litvinov <fam1ly.n4me@yandex.ru>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Allow _not_ specifying `index` and `columns` when constructing `PandasDataframe`, they would be computed on-demand when accessing `.index` and `.columns`.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4725
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
