### PR TITLE
PERF-#4727: Improve perf of `concat` operation

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -32,6 +32,7 @@ Key Features and Updates
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)
   * PERF-#4325: Improve perf of multi-column assignment in `__setitem__` when no new column names are assigning (#4455)
   * PERF-#3844: Improve perf of `drop` operation (#4694)
+  * PERF-#4727: Improve perf of `concat` operation (#4728)
   * PERF-#4705: Improve perf of arithmetic operations between `Series` objects with shared `.index` (#4689)
   * PERF-#4703: Improve performance in accessing `ser.cat.categories`, `ser.cat.ordered`, and `ser.__array_priority__` (#4704)
   * PERF-#4305: Parallelize `read_parquet` over row groups (#4700)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2582,6 +2582,17 @@ class PandasDataframe(ClassLogger):
         """
         axis = Axis(axis)
         new_widths = None
+
+        def compute_new_width():
+            new_width = None
+            if self._column_widths_cache is not None and all(
+                o._column_widths_cache is not None for o in others
+            ):
+                new_width = self._column_widths_cache + [
+                    width for o in others for width in o._column_widths_cache
+                ]
+            return new_width
+
         # Fast path for equivalent columns and partitioning
         if (
             axis == Axis.ROW_WISE
@@ -2601,11 +2612,8 @@ class PandasDataframe(ClassLogger):
             left_parts = self._partitions
             right_parts = [o._partitions for o in others]
             new_lengths = self._row_lengths_cache
-            other_widths = [width for o in others for width in o._column_widths_cache]
-            if self._column_widths_cache is not None and all(
-                width is not None for width in other_widths
-            ):
-                new_widths = self._column_widths_cache + other_widths
+            # we can only do this for COL_WISE because `concat` might rebalance partitions for ROW_WISE
+            new_widths = compute_new_width()
         else:
             (
                 left_parts,
@@ -2617,6 +2625,7 @@ class PandasDataframe(ClassLogger):
             )
             if axis == Axis.COL_WISE:
                 new_lengths = partition_sizes_along_axis
+                new_widths = compute_new_width()
             else:
                 new_widths = partition_sizes_along_axis
         new_partitions = self._partition_mgr_cls.concat(

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2613,7 +2613,7 @@ class PandasDataframe(ClassLogger):
             right_parts = [o._partitions for o in others]
             new_lengths = self._row_lengths_cache
             # we can only do this for COL_WISE because `concat` might rebalance partitions for ROW_WISE
-            new_widths = _compute_new_width()
+            new_widths = _compute_new_widths()
         else:
             (
                 left_parts,
@@ -2625,7 +2625,7 @@ class PandasDataframe(ClassLogger):
             )
             if axis == Axis.COL_WISE:
                 new_lengths = partition_sizes_along_axis
-                new_widths = _compute_new_width()
+                new_widths = _compute_new_widths()
             else:
                 new_widths = partition_sizes_along_axis
         new_partitions = self._partition_mgr_cls.concat(

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2583,15 +2583,15 @@ class PandasDataframe(ClassLogger):
         axis = Axis(axis)
         new_widths = None
 
-        def compute_new_width():
-            new_width = None
+        def _compute_new_widths():
+            widths = None
             if self._column_widths_cache is not None and all(
                 o._column_widths_cache is not None for o in others
             ):
-                new_width = self._column_widths_cache + [
+                widths = self._column_widths_cache + [
                     width for o in others for width in o._column_widths_cache
                 ]
-            return new_width
+            return widths
 
         # Fast path for equivalent columns and partitioning
         if (
@@ -2613,7 +2613,7 @@ class PandasDataframe(ClassLogger):
             right_parts = [o._partitions for o in others]
             new_lengths = self._row_lengths_cache
             # we can only do this for COL_WISE because `concat` might rebalance partitions for ROW_WISE
-            new_widths = compute_new_width()
+            new_widths = _compute_new_width()
         else:
             (
                 left_parts,
@@ -2625,7 +2625,7 @@ class PandasDataframe(ClassLogger):
             )
             if axis == Axis.COL_WISE:
                 new_lengths = partition_sizes_along_axis
-                new_widths = compute_new_width()
+                new_widths = _compute_new_width()
             else:
                 new_widths = partition_sizes_along_axis
         new_partitions = self._partition_mgr_cls.concat(


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4727 <!-- issue must be created for each patch -->
- [x] tests ~added~ and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->

Results for [the benchmark](https://github.com/modin-project/modin/issues/4727#issue-1320028513) (Benchmark mode should be disabled):

| Pandas | Modin master | The PR |
|-|:-:|-|
| 0.89 sec | 4.5 sec | 0.0 sec
