### PR TITLE
TEST-#4745: Pin flake8 to <5 to workaround installation conflict

### DIFF
--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -26,12 +26,25 @@ jobs:
           python-version: "3.8.x"
           architecture: "x64"
         if: matrix.execution != 'omnisci_on_native'
+      - name: Cache conda
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/conda_pkgs_dir
+            ~/.cache/pip
+          key:
+            ${{ runner.os }}-conda-${{ hashFiles('requirements/env_omnisci.yml') }}
+        if: matrix.execution == 'omnisci_on_native'
       - uses: conda-incubator/setup-miniconda@v2
         with:
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
           activate-environment: modin_on_omnisci
           environment-file: requirements/env_omnisci.yml
           python-version: 3.8
           channel-priority: strict
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
         if: matrix.execution == 'omnisci_on_native'
       - name: Cache datasets
         uses: actions/cache@v2
@@ -50,9 +63,10 @@ jobs:
       - run: pip install .
         if: matrix.execution == 'omnisci_on_native'
       # install test dependencies
-      - run: pip install pytest pytest-cov black flake8 flake8-print flake8-no-implicit-concat
+      # TODO: remove pin when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
+      - run: pip install pytest pytest-cov black "flake8<5" flake8-print flake8-no-implicit-concat
         if: matrix.execution != 'omnisci_on_native'
-      - run: conda install flake8-print jupyter nbformat nbconvert -c conda-forge
+      - run: pip install flake8-print jupyter nbformat nbconvert
         if: matrix.execution == 'omnisci_on_native'
       - run: pip list
         if: matrix.execution != 'omnisci_on_native'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,7 +154,8 @@ jobs:
         with:
           python-version: "3.8.x"
           architecture: "x64"
-      - run: pip install flake8 flake8-print flake8-no-implicit-concat
+      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
+      - run: pip install "flake8<5" flake8-print flake8-no-implicit-concat
       - run: flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py
 
   test-api:

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -58,6 +58,7 @@ Key Features and Updates
   * TEST-#2564: Add caching and use mamba for conda setups in GH (#4607)
   * TEST-#4557: Delete multiindex sorts instead of xfailing (#4559)  
   * TEST-#4698: Stop passing invalid storage_options param (#4699)
+  * TEST-#4745: Pin flake8 to <5 to workaround installation conflict (#4752)
 * Documentation improvements
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
   * DOCS-#4628: Add to_parquet partial support notes (#4648)

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -48,7 +48,8 @@ dependencies:
       # TODO: remove when resolving GH#4398
       - redis>=3.5.0,<4.0.0
       - black
-      - flake8
+      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
+      - flake8<5
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0
       # experimental version of fuzzydata requires at least 0.0.6 to successfully resolve all dependencies

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -36,7 +36,8 @@ pymssql
 psycopg2
 connectorx>=0.2.6a4
 black
-flake8
+# TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
+flake8<5
 # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
 numpydoc==1.1.0
 # experimental version of fuzzydata requires at least 0.0.6 to successfully resolve all dependencies

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -21,6 +21,7 @@ dependencies:
   - scipy
   - pip:
       - black
-      - flake8
+      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
+      - flake8<5
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0

--- a/requirements/environment-py36.yml
+++ b/requirements/environment-py36.yml
@@ -45,6 +45,7 @@ dependencies:
       # TODO: remove when resolving GH#4398
       - redis>=3.5.0,<4.0.0
       - black
-      - flake8
+      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
+      - flake8<5
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -38,6 +38,7 @@ dependencies:
       # TODO: remove when resolving GH#4398
       - redis>=3.5.0,<4.0.0
       - black
-      - flake8
+      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
+      - flake8<5
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0


### PR DESCRIPTION
Signed-off-by: Vasily Litvinov <fam1ly.n4me@yandex.ru>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
1. Pin `flake8` to be `<5` everywhere, as `5.0.x` seems to be in flux release process right now (and missing in `conda-forge` whatsoever leading to issues like #4745).
2. Use `pip install` for omnisci notebook test, so we _always_ install `flake8` and its plugins from `pip` (this was the only exclusion)

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4745
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
