### PR TITLE
FIX-#4756: Correctly propagate `storage_options` in `read_parquet`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -26,7 +26,8 @@ Key Features and Updates
   * FIX-#4658: Expand exception handling for `read_*` functions from s3 storages (#4659)
   * FIX-#4672: Fix incorrect warning when setting `frame.index` or `frame.columns` (#4721)
   * FIX-#4686: Propagate metadata and drain call queue in unwrap_partitions (#4697)
-  * FIX-#4652: Support categorical data in `from_dataframe` (#4737) 
+  * FIX-#4652: Support categorical data in `from_dataframe` (#4737)
+  * FIX-#4756: Correctly propagate `storage_options` in `read_parquet` (#4764)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -96,9 +96,9 @@ class ParquetDispatcher(ColumnStoreDispatcher):
 
         Returns
         -------
-        filesystem: Any
+        filesystem : Any
             Protocol implementation of registry.
-        fs_path: list
+        fs_path : list
             Filesystem's specific path.
         """
         return (

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -83,7 +83,28 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         ]
 
     @classmethod
-    def call_deploy(cls, fname, col_partitions, **kwargs):
+    def _get_fs_and_fs_path(cls, path, storage_options):
+        """
+        Retrieve filesystem interface and filesystem-specific path.
+
+        Parameters
+        ----------
+        path : str, path object or file-like object
+            Path to dataset.
+        storage_options : dict
+            Parameters for specific storage engine.
+
+        Returns
+        -------
+        filesystem: Any
+            Protocol implementation of registry.
+        fs_path: list
+            Filesystem's specific path.
+        """
+        return url_to_fs(path, storage_options) if is_fsspec_url(path) else (None, path)
+
+    @classmethod
+    def call_deploy(cls, fname, col_partitions, storage_options, **kwargs):
         """
         Deploy remote tasks to the workers with passed parameters.
 
@@ -94,6 +115,8 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         col_partitions : list
             List of arrays with columns names that should be read
             by each partition.
+        storage_options : dict
+            Parameters for specific storage engine.
         **kwargs : dict
             Parameters of deploying read_* function.
 
@@ -109,8 +132,6 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         # set of references.
         if len(col_partitions) == 0:
             return []
-
-        storage_options = kwargs.pop("storage_options", {}) or {}
 
         filesystem, parquet_files = cls.get_fsspec_files(fname, storage_options)
 
@@ -230,7 +251,7 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         )
 
     @classmethod
-    def build_index(cls, path, partition_ids, index_columns):
+    def build_index(cls, path, partition_ids, index_columns, storage_options):
         """
         Compute index and its split sizes of resulting Modin DataFrame.
 
@@ -242,6 +263,8 @@ class ParquetDispatcher(ColumnStoreDispatcher):
             Array with references to the partitions data.
         index_columns : list
             List of index columns specified by pandas metadata.
+        storage_options : dict
+            Parameters for specific storage engine.
 
         Returns
         -------
@@ -273,8 +296,11 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         # For the second check, let us consider the case where we have an empty dataframe,
         # that has a valid index.
         if range_index or (len(partition_ids) == 0 and len(column_names_to_read) != 0):
+            fs, fs_path = cls._get_fs_and_fs_path(path, storage_options)
             complete_index = (
-                read_table(path, columns=column_names_to_read).to_pandas().index
+                read_table(fs_path, columns=column_names_to_read, filesystem=fs)
+                .to_pandas()
+                .index
             )
         # Empty DataFrame case
         elif len(partition_ids) == 0:
@@ -306,9 +332,12 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         new_query_compiler : BaseQueryCompiler
             Query compiler with imported data for further processing.
         """
+        storage_options = kwargs.pop("storage_options", {}) or {}
         col_partitions, column_widths = cls.build_columns(columns)
-        partition_ids = cls.call_deploy(path, col_partitions, **kwargs)
-        index, sync_index = cls.build_index(path, partition_ids, index_columns)
+        partition_ids = cls.call_deploy(path, col_partitions, storage_options, **kwargs)
+        index, sync_index = cls.build_index(
+            path, partition_ids, index_columns, storage_options
+        )
         remote_parts = cls.build_partition(partition_ids, column_widths)
         if len(partition_ids) > 0:
             row_lengths = [part.length() for part in remote_parts.T[0]]
@@ -383,11 +412,7 @@ class ParquetDispatcher(ColumnStoreDispatcher):
                     **kwargs,
                 )
         # url_to_fs returns the fs and path formatted for the specific fs
-        fs, fs_path = (
-            url_to_fs(path, **(kwargs.get("storage_options") or {}))
-            if is_fsspec_url(path)
-            else (None, path)
-        )
+        fs, fs_path = cls._get_fs_and_fs_path(path, kwargs.get("storage_options") or {})
         dataset = ParquetDataset(fs_path, filesystem=fs, use_legacy_dataset=False)
         index_columns = (
             dataset.schema.pandas_metadata.get("index_columns", [])

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -101,7 +101,9 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         fs_path: list
             Filesystem's specific path.
         """
-        return url_to_fs(path, storage_options) if is_fsspec_url(path) else (None, path)
+        return (
+            url_to_fs(path, **storage_options) if is_fsspec_url(path) else (None, path)
+        )
 
     @classmethod
     def call_deploy(cls, fname, col_partitions, storage_options, **kwargs):


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR addresses a bug where we do not propagate `storage_options` to the `read_table` call in `build_index`. This wasn't caught by any of our CI tests since we didn't stringently check for the options pass in for `read_parquet`. I'm working on getting access to a bucket so we can make sure that this works accordingly. 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #4756 
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
