### PR TITLE
FIX-#4099: Use mangled column names but keep the original when building frames from arrow

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -33,7 +33,8 @@ Key Features and Updates
   * FIX-#4676: drain sub-virtual-partition call queues (#4695)
   * FIX-#4782: Exclude certain non-parquet files in `read_parquet` (#4783)    
   * FIX-#4808: Set dtypes correctly after column rename (#4809)
-  * FIX-#4811: Apply dataframe -> not_dataframe functions to virtual partitions (#4812)  
+  * FIX-#4811: Apply dataframe -> not_dataframe functions to virtual partitions (#4812)
+  * FIX-#4099: Use mangled column names but keep the original when building frames from arrow
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
@@ -2156,5 +2156,18 @@ class TestArrowExecution:
         )
 
 
+class TestNonStrCols:
+    data = {0: [1, 2, 3], "1": [3, 4, 5], 2: [6, 7, 8]}
+
+    def test_sum(self):
+        mdf = pd.DataFrame(self.data).sum()
+        pdf = pandas.DataFrame(self.data).sum()
+        df_equals(mdf, pdf)
+
+    def test_set_index(self):
+        df = pd.DataFrame(self.data)
+        df._query_compiler._modin_frame._set_index(pd.Index([1, 2, 3]))
+
+
 if __name__ == "__main__":
     pytest.main(["-v", __file__])


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The method Table.rename_columns() accepts a list of strings, but not numbers, thus, the columns must be converted to strings.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4099 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
