### PR TITLE
TEST-#4760: Limit only ray memory to 1 GB.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,8 +504,8 @@ jobs:
         engine: ["python", "ray", "dask"]
         memory: ""
         include:
-          memory: [null]
-          engine: "python"
+          - memory: [null]
+            engine: "python"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: ${{matrix.memory}}
@@ -637,8 +637,8 @@ jobs:
         engine: ["python", "ray", "dask"]
         memory: [null]
         include:
-          memory: 1000000000
-          engine: "ray"
+          - memory: 1000000000
+            engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: ${{matrix.memory}}
@@ -687,8 +687,8 @@ jobs:
         engine: ["python", "ray", "dask"]
         memory: [null]
         include:
-          memory: 1000000000
-          engine: "ray"
+          - memory: 1000000000
+            engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: ${{matrix.memory}}
@@ -781,8 +781,8 @@ jobs:
         engine: ["ray", "dask"]
         memory: [null]
         include:
-          memory: 1000000000
-          engine: "ray"
+          - memory: 1000000000
+            engine: "ray"
         test-task:
           - modin/pandas/test/dataframe/test_binary.py
           - modin/pandas/test/dataframe/test_default.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if ["${{matrix.engine}}" = "ray"]; then
+          if [ "${{matrix.engine}}" = "ray" ]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2
@@ -641,7 +641,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if ["${{matrix.engine}}" = "ray"]; then
+          if [ "${{matrix.engine}}" = "ray" ]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2
@@ -691,7 +691,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if ["${{matrix.engine}}" = "ray"]; then
+          if [ "${{matrix.engine}}" = "ray" ]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2
@@ -803,7 +803,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if ["${{matrix.engine}}" = "ray"]; then
+          if [ "${{matrix.engine}}" = "ray" ]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,10 +502,10 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["python", "ray", "dask"]
-        memory: ""
+        memory: [null]
         include:
-          - memory: [null]
-            engine: "python"
+          - memory: 1000000000
+            engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: ${{matrix.memory}}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,18 +502,16 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["python", "ray", "dask"]
-        memory: [null]
-        include:
-          - memory: 1000000000
-            engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: ${{matrix.memory}}
       # Only test reading from SQL server and postgres on ubuntu for now.
       # Eventually, we should test on Windows, too, but we will have to set up
       # the servers differently.
       MODIN_TEST_READ_FROM_SQL_SERVER: true
       MODIN_TEST_READ_FROM_POSTGRES: true
+    - env:
+      MODIN_MEMORY: 1000000000
+      if: matrix.engine == 'ray'
     name: test-ubuntu (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
       - uses: actions/checkout@v2
@@ -635,13 +633,11 @@ jobs:
       matrix:
         python-version: ["3.6"]
         engine: ["python", "ray", "dask"]
-        memory: [null]
-        include:
-          - memory: 1000000000
-            engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: ${{matrix.memory}}
+    - env:
+      MODIN_MEMORY: 1000000000
+      if: matrix.engine == 'ray'
     name: test-compat-ubuntu (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
       - uses: actions/checkout@v2
@@ -685,13 +681,11 @@ jobs:
       matrix:
         python-version: ["3.6"]
         engine: ["python", "ray", "dask"]
-        memory: [null]
-        include:
-          - memory: 1000000000
-            engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: ${{matrix.memory}}
+    - env:
+      MODIN_MEMORY: 1000000000
+      if: matrix.engine == 'ray'
     name: test-compat-win (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
       - uses: actions/checkout@v2
@@ -779,10 +773,6 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["ray", "dask"]
-        memory: [null]
-        include:
-          - memory: 1000000000
-            engine: "ray"
         test-task:
           - modin/pandas/test/dataframe/test_binary.py
           - modin/pandas/test/dataframe/test_default.py
@@ -803,7 +793,9 @@ jobs:
           - modin/pandas/test/test_io.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: ${{matrix.memory}}
+    - env:
+      MODIN_MEMORY: 1000000000
+      if: matrix.engine == 'ray'
     name: test-windows
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,10 +512,8 @@ jobs:
     name: test-ubuntu (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
       - name: Limit ray memory
-        run: |
-          if [ "${{matrix.engine}}" = "ray" ]; then
-            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
-          fi
+        run: echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+        if: matrix.engine == 'ray'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,7 +504,7 @@ jobs:
         engine: ["python", "ray", "dask"]
         memory: ""
         include:
-          memory: null
+          memory: [null]
           engine: "python"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
@@ -635,7 +635,7 @@ jobs:
       matrix:
         python-version: ["3.6"]
         engine: ["python", "ray", "dask"]
-        memory: null
+        memory: [null]
         include:
           memory: 1000000000
           engine: "ray"
@@ -685,7 +685,7 @@ jobs:
       matrix:
         python-version: ["3.6"]
         engine: ["python", "ray", "dask"]
-        memory: null
+        memory: [null]
         include:
           memory: 1000000000
           engine: "ray"
@@ -779,7 +779,7 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["ray", "dask"]
-        memory: null
+        memory: [null]
         include:
           memory: 1000000000
           engine: "ray"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -509,11 +509,12 @@ jobs:
       # the servers differently.
       MODIN_TEST_READ_FROM_SQL_SERVER: true
       MODIN_TEST_READ_FROM_POSTGRES: true
-    - env:
-      MODIN_MEMORY: 1000000000
-      if: matrix.engine == 'ray'
     name: test-ubuntu (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
+      - name: Limit ray memory
+        run: |
+          if [${{matrix.engine}} = "ray"]; then
+            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -635,11 +636,12 @@ jobs:
         engine: ["python", "ray", "dask"]
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-    - env:
-      MODIN_MEMORY: 1000000000
-      if: matrix.engine == 'ray'
     name: test-compat-ubuntu (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
+      - name: Limit ray memory
+        run: |
+          if [${{matrix.engine}} = "ray"]; then
+            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -683,11 +685,12 @@ jobs:
         engine: ["python", "ray", "dask"]
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-    - env:
-      MODIN_MEMORY: 1000000000
-      if: matrix.engine == 'ray'
     name: test-compat-win (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
+      - name: Limit ray memory
+        run: |
+          if [${{matrix.engine}} = "ray"]; then
+            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -793,11 +796,12 @@ jobs:
           - modin/pandas/test/test_io.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-    - env:
-      MODIN_MEMORY: 1000000000
-      if: matrix.engine == 'ray'
     name: test-windows
     steps:
+      - name: Limit ray memory
+        run: |
+          if [${{matrix.engine}} = "ray"]; then
+            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -513,7 +513,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if [${{matrix.engine}} = "ray"]; then
+          if ["${{matrix.engine}}" = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2
@@ -641,7 +641,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if [${{matrix.engine}} = "ray"]; then
+          if ["${{matrix.engine}}" = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2
@@ -691,7 +691,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if [${{matrix.engine}} = "ray"]; then
+          if ["${{matrix.engine}}" = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2
@@ -803,7 +803,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if [${{matrix.engine}} = "ray"]; then
+          if ["${{matrix.engine}}" = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -515,6 +515,7 @@ jobs:
         run: |
           if [${{matrix.engine}} = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -642,6 +643,7 @@ jobs:
         run: |
           if [${{matrix.engine}} = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -691,6 +693,7 @@ jobs:
         run: |
           if [${{matrix.engine}} = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -802,6 +805,7 @@ jobs:
         run: |
           if [${{matrix.engine}} = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,10 +638,8 @@ jobs:
     name: test-compat-ubuntu (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
       - name: Limit ray memory
-        run: |
-          if [ "${{matrix.engine}}" = "ray" ]; then
-            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
-          fi
+        run: echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+        if: matrix.engine == 'ray'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -688,10 +686,8 @@ jobs:
     name: test-compat-win (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
       - name: Limit ray memory
-        run: |
-          if [ "${{matrix.engine}}" = "ray" ]; then
-            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
-          fi
+        run: echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+        if: matrix.engine == 'ray'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -800,10 +796,8 @@ jobs:
     name: test-windows
     steps:
       - name: Limit ray memory
-        run: |
-          if [ "${{matrix.engine}}" = "ray" ]; then
-            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
-          fi
+        run: echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+        if: matrix.engine == 'ray'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,6 @@ jobs:
       matrix:
         execution: [BaseOnPython]
     env:
-      MODIN_MEMORY: 1000000000
       MODIN_TEST_DATASET_SIZE: "small"
     name: Test ${{ matrix.execution }} execution, Python 3.8
     steps:
@@ -503,9 +502,13 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["python", "ray", "dask"]
+        memory: ""
+        include:
+          memory: null
+          engine: "python"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: 1000000000
+      MODIN_MEMORY: ${{matrix.memory}}
       # Only test reading from SQL server and postgres on ubuntu for now.
       # Eventually, we should test on Windows, too, but we will have to set up
       # the servers differently.
@@ -590,7 +593,6 @@ jobs:
     env:
       MODIN_ENGINE: "python"
       MODIN_EXPERIMENTAL: "True"
-      MODIN_MEMORY: 1000000000
     name: test experimental
     steps:
       - uses: actions/checkout@v2
@@ -633,9 +635,13 @@ jobs:
       matrix:
         python-version: ["3.6"]
         engine: ["python", "ray", "dask"]
+        memory: null
+        include:
+          memory: 1000000000
+          engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: 1000000000
+      MODIN_MEMORY: ${{matrix.memory}}
     name: test-compat-ubuntu (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
       - uses: actions/checkout@v2
@@ -679,9 +685,13 @@ jobs:
       matrix:
         python-version: ["3.6"]
         engine: ["python", "ray", "dask"]
+        memory: null
+        include:
+          memory: 1000000000
+          engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: 1000000000
+      MODIN_MEMORY: ${{matrix.memory}}
     name: test-compat-win (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
       - uses: actions/checkout@v2
@@ -724,7 +734,6 @@ jobs:
     env:
       MODIN_ENGINE: "python"
       MODIN_EXPERIMENTAL: "True"
-      MODIN_MEMORY: 1000000000
     name: test cloud
     steps:
       - uses: actions/checkout@v2
@@ -770,6 +779,10 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["ray", "dask"]
+        memory: null
+        include:
+          memory: 1000000000
+          engine: "ray"
         test-task:
           - modin/pandas/test/dataframe/test_binary.py
           - modin/pandas/test/dataframe/test_default.py
@@ -790,7 +803,7 @@ jobs:
           - modin/pandas/test/test_io.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: 1000000000
+      MODIN_MEMORY: ${{matrix.memory}}
     name: test-windows
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -53,7 +53,6 @@ jobs:
       matrix:
         execution: [BaseOnPython]
     env:
-      MODIN_MEMORY: 1000000000
       MODIN_TEST_DATASET_SIZE: "small"
     name: Test ${{ matrix.execution }} execution, Python 3.8
     steps:
@@ -146,9 +145,13 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["python", "ray", "dask"]
+        memory: null
+        include:
+          memory: 1000000000
+          engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: 1000000000
+      MODIN_MEMORY: ${{matrix.memory}}
       # Only test reading from SQL server and postgres on ubuntu for now.
       # Eventually, we should test on Windows, too, but we will have to set up
       # the servers differently.
@@ -230,6 +233,10 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["ray", "dask"]
+        memory: null
+        include:
+          memory: 1000000000
+          engine: "ray"
         test-task:
           - modin/pandas/test/dataframe/test_binary.py
           - modin/pandas/test/dataframe/test_default.py
@@ -250,7 +257,7 @@ jobs:
           - modin/pandas/test/test_io.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: 1000000000
+      MODIN_MEMORY: ${{matrix.memory}}
     name: test-windows
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -147,8 +147,8 @@ jobs:
         engine: ["python", "ray", "dask"]
         memory: [null]
         include:
-          memory: 1000000000
-          engine: "ray"
+          - memory: 1000000000
+            engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
       MODIN_MEMORY: ${{matrix.memory}}
@@ -235,8 +235,8 @@ jobs:
         engine: ["ray", "dask"]
         memory: [null]
         include:
-          memory: 1000000000
-          engine: "ray"
+          - memory: 1000000000
+            engine: "ray"
         test-task:
           - modin/pandas/test/dataframe/test_binary.py
           - modin/pandas/test/dataframe/test_default.py

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -158,6 +158,7 @@ jobs:
         run: |
           if [${{matrix.engine}} = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -258,6 +258,7 @@ jobs:
         run: |
           if [${{matrix.engine}} = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+          fi
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -145,13 +145,11 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["python", "ray", "dask"]
-        memory: [null]
-        include:
-          - memory: 1000000000
-            engine: "ray"
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: ${{matrix.memory}}
+    - env:
+      MODIN_MEMORY: 1000000000
+      if: matrix.engine == 'ray'
       # Only test reading from SQL server and postgres on ubuntu for now.
       # Eventually, we should test on Windows, too, but we will have to set up
       # the servers differently.
@@ -233,10 +231,6 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["ray", "dask"]
-        memory: [null]
-        include:
-          - memory: 1000000000
-            engine: "ray"
         test-task:
           - modin/pandas/test/dataframe/test_binary.py
           - modin/pandas/test/dataframe/test_default.py
@@ -257,7 +251,9 @@ jobs:
           - modin/pandas/test/test_io.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-      MODIN_MEMORY: ${{matrix.memory}}
+    - env:
+      MODIN_MEMORY: 1000000000
+      if: matrix.engine == 'ray'    
     name: test-windows
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -155,10 +155,8 @@ jobs:
     name: test-ubuntu (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
       - name: Limit ray memory
-        run: |
-          if [ "${{matrix.engine}}" = "ray" ]; then
-            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
-          fi
+        run: echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+        if: matrix.engine == 'ray'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -256,10 +254,8 @@ jobs:
     name: test-windows
     steps:
       - name: Limit ray memory
-        run: |
-          if [ "${{matrix.engine}}" = "ray" ]; then
-            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
-          fi
+        run: echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
+        if: matrix.engine == 'ray'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -156,7 +156,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if [${{matrix.engine}} = "ray"]; then
+          if ["${{matrix.engine}}" = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2
@@ -257,7 +257,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if [${{matrix.engine}} = "ray"]; then
+          if ["${{matrix.engine}}" = "ray"]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -145,7 +145,7 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["python", "ray", "dask"]
-        memory: null
+        memory: [null]
         include:
           memory: 1000000000
           engine: "ray"
@@ -233,7 +233,7 @@ jobs:
       matrix:
         python-version: ["3.8"]
         engine: ["ray", "dask"]
-        memory: null
+        memory: [null]
         include:
           memory: 1000000000
           engine: "ray"

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -147,9 +147,6 @@ jobs:
         engine: ["python", "ray", "dask"]
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-    - env:
-      MODIN_MEMORY: 1000000000
-      if: matrix.engine == 'ray'
       # Only test reading from SQL server and postgres on ubuntu for now.
       # Eventually, we should test on Windows, too, but we will have to set up
       # the servers differently.
@@ -157,6 +154,10 @@ jobs:
       MODIN_TEST_READ_FROM_POSTGRES: true
     name: test-ubuntu (engine ${{matrix.engine}}, python ${{matrix.python-version}})
     steps:
+      - name: Limit ray memory
+        run: |
+          if [${{matrix.engine}} = "ray"]; then
+            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -251,11 +252,12 @@ jobs:
           - modin/pandas/test/test_io.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
-    - env:
-      MODIN_MEMORY: 1000000000
-      if: matrix.engine == 'ray'    
     name: test-windows
     steps:
+      - name: Limit ray memory
+        run: |
+          if [${{matrix.engine}} = "ray"]; then
+            echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -156,7 +156,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if ["${{matrix.engine}}" = "ray"]; then
+          if [ "${{matrix.engine}}" = "ray" ]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2
@@ -257,7 +257,7 @@ jobs:
     steps:
       - name: Limit ray memory
         run: |
-          if ["${{matrix.engine}}" = "ray"]; then
+          if [ "${{matrix.engine}}" = "ray" ]; then
             echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
           fi
       - uses: actions/checkout@v2

--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -124,7 +124,7 @@ setup_commands:
 
         pip install colorful cloudpickle
         # ray now executes "ray stop" which expects "ray" to be in $PATH
-        # so place a symlink to current "ray"binary to /usr/local/bin
+        # so place a symlink to current "ray" binary to /usr/local/bin
         sudo ln -s `which ray` /usr/local/bin/ray
         echo 'export MODIN_RAY_CLUSTER=True' >> ~/.bashrc
 

--- a/modin/experimental/cloud/ray-autoscaler.yml
+++ b/modin/experimental/cloud/ray-autoscaler.yml
@@ -124,7 +124,7 @@ setup_commands:
 
         pip install colorful cloudpickle
         # ray now executes "ray stop" which expects "ray" to be in $PATH
-        # so place a symlink to current "ray" binary to /usr/local/bin
+        # so place a symlink to current "ray"binary to /usr/local/bin
         sudo ln -s `which ray` /usr/local/bin/ray
         echo 'export MODIN_RAY_CLUSTER=True' >> ~/.bashrc
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1970,9 +1970,6 @@ class TestHdf:
             teardown_test_files([filename])
 
 
-@pytest.mark.skipif(
-    Engine.get() == "Dask", reason="Dask seems to hang forever on these tests"
-)
 class TestSql:
     @pytest.mark.xfail(
         condition="config.getoption('--simulate-cloud').lower() != 'off'",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

TEST-#4760: Limit only ray memory to 1 GB.

Since 53f38a4518996455b3cddaf31fd8fbf833aeee13, github CI has limited memory for
almost all tests to 1 GB, but that change was only meant for ray.

This change should not only deflake dask CI, but also speed it up significantly.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4760
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
