### PR TITLE
FEAT-#4202: Allow dask versions past 2022.2.0.

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -72,13 +72,13 @@ Key Features and Updates
 * Dependencies
   * FEAT-#4598: Add support for pandas 1.4.3 (#4599)
   * FEAT-#4619: Integrate mypy static type checking (#4620)
+  * FEAT-#4202: Allow dask past 2022.2.0 (#4769)
 * New Features
   * FEAT-4463: Add experimental fuzzydata integration for testing against a randomized dataframe workflow (#4556)
   * FEAT-#4419: Extend virtual partitioning API to pandas on Dask (#4420)
   * FEAT-#4147: Add partial compatibility with Python 3.6 and pandas 1.1 (#4301)
   * FEAT-#4569: Add error message when `read_` function defaults to pandas (#4647)
   * FEAT-#4725: Make index and columns lazy in Modin DataFrame (#4726)
-  * FEAT-#4202: Allow dask past 2022.2.0 (#4769)
 
 Contributors
 ------------

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -78,6 +78,7 @@ Key Features and Updates
   * FEAT-#4147: Add partial compatibility with Python 3.6 and pandas 1.1 (#4301)
   * FEAT-#4569: Add error message when `read_` function defaults to pandas (#4647)
   * FEAT-#4725: Make index and columns lazy in Modin DataFrame (#4726)
+  * FEAT-#4202: Allow dask past 2022-2-0 (#4769)
 
 Contributors
 ------------

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -78,7 +78,7 @@ Key Features and Updates
   * FEAT-#4147: Add partial compatibility with Python 3.6 and pandas 1.1 (#4301)
   * FEAT-#4569: Add error message when `read_` function defaults to pandas (#4647)
   * FEAT-#4725: Make index and columns lazy in Modin DataFrame (#4726)
-  * FEAT-#4202: Allow dask past 2022-2-0 (#4769)
+  * FEAT-#4202: Allow dask past 2022.2.0 (#4769)
 
 Contributors
 ------------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,8 +5,8 @@ dependencies:
   - pandas==1.4.3
   - numpy>=1.18.5
   - pyarrow>=4.0.1
-  - dask[complete]>=2.22.0,<2022.2.0
-  - distributed>=2.22.0,<2022.2.0
+  - dask[complete]>=2.22.0
+  - distributed>=2.22.0
   - fsspec
   - xarray
   - Jinja2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
 pandas==1.4.3
 numpy>=1.18.5
 pyarrow>=4.0.1
-dask[complete]>=2.22.0,<2022.2.0
-distributed>=2.22.0,<2022.2.0
+dask[complete]>=2.22.0
+distributed>=2.22.0
 ray[default]>=1.4.0
 redis>=3.5.0,<4.0.0
 psutil

--- a/requirements/requirements-py36.txt
+++ b/requirements/requirements-py36.txt
@@ -1,8 +1,8 @@
 pandas==1.1.5
 numpy>=1.18.5
 pyarrow>=4.0.1
-dask[complete]>=2.22.0,<2022.2.0
-distributed>=2.22.0,<2022.2.0
+dask[complete]>=2.22.0
+distributed>=2.22.0
 ray[default]>=1.4.0
 redis>=3.5.0,<4.0.0
 psutil

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ PANDAS_VERSION = "1.4.3" if sys.version_info >= (3, 8) else "1.1.5"
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
-dask_deps = ["dask>=2.22.0,<2022.2.0", "distributed>=2.22.0,<2022.2.0"]
+dask_deps = ["dask>=2.22.0", "distributed>=2.22.0"]
 if sys.version_info < (3, 8):
     dask_deps.append("pickle5")
 


### PR DESCRIPTION
## What do these changes do?

FEAT-#4202: Allow dask past 2022-2-0. Increasing the dask memory limit in #4768 should prevent the memory failures that caused dask to get stuck in #4202.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4202
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
