### PR TITLE
PERF-#5268: Call `get` on all partitions at once in `to_pandas`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -68,7 +68,6 @@ Key Features and Updates
   * PERF-#4727: Improve perf of `concat` operation (#4728)
   * PERF-#4705: Improve perf of arithmetic operations between `Series` objects with shared `.index` (#4689)
   * PERF-#4703: Improve performance in accessing `ser.cat.categories`, `ser.cat.ordered`, and `ser.__array_priority__` (#4704)
-  * PERF-#2814: Call `get` on all partitions at once in `to_pandas` (#4776)
   * PERF-#4305: Parallelize `read_parquet` over row groups (#4700)
   * PERF-#4773: Compute `lengths` and `widths` in `put` method of Dask partition like Ray do (#4780)
   * PERF-#4732: Avoid overwriting already-evaluated `PandasOnRayDataframePartition._length_cache` and `PandasOnRayDataframePartition._width_cache` (#4754)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -68,6 +68,7 @@ Key Features and Updates
   * PERF-#4727: Improve perf of `concat` operation (#4728)
   * PERF-#4705: Improve perf of arithmetic operations between `Series` objects with shared `.index` (#4689)
   * PERF-#4703: Improve performance in accessing `ser.cat.categories`, `ser.cat.ordered`, and `ser.__array_priority__` (#4704)
+  * PERF-#2814: Call `get` on all partitions at once in `to_pandas` (#4776)
   * PERF-#4305: Parallelize `read_parquet` over row groups (#4700)
   * PERF-#4773: Compute `lengths` and `widths` in `put` method of Dask partition like Ray do (#4780)
   * PERF-#4732: Avoid overwriting already-evaluated `PandasOnRayDataframePartition._length_cache` and `PandasOnRayDataframePartition._width_cache` (#4754)

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -643,15 +643,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         """
         retrieved_objects = cls.get_objects_from_partitions(partitions.flatten())
         if all(isinstance(obj, (pandas.DataFrame, pandas.Series)) for obj in retrieved_objects):
-            height, width = 0, 0
-            if len(partitions.shape) == 2:
-                # possible case when shape == (0,)
-                height, width = partitions.shape
-            # restore 2d array
-            retrieved_objects = [
-                [retrieved_objects[i * width + j] for j in range(width)]
-                for i in range(height)
-            ]
+            retrieved_objects = retrieved_objects.reshape(partitions.shape)
         else:
             retrieved_objects = [
                 [obj.to_pandas() for obj in part] for part in partitions

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -646,10 +646,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             isinstance(obj, (pandas.DataFrame, pandas.Series))
             for obj in retrieved_objects
         ):
-            height, width = 0, 0
-            if len(partitions.shape) == 2:
-                # possible case when shape == (0,)
-                height, width = partitions.shape
+            height, width, *_ = tuple(partitions.shape) + (0,)
             # restore 2d array
             retrieved_objects = [
                 [retrieved_objects[i * width + j] for j in range(width)]

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -646,7 +646,15 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             isinstance(obj, (pandas.DataFrame, pandas.Series))
             for obj in retrieved_objects
         ):
-            retrieved_objects = np.reshape(retrieved_objects, partitions.shape)
+            height, width = 0, 0
+            if len(partitions.shape) == 2:
+                # possible case when shape == (0,)
+                height, width = partitions.shape
+            # restore 2d array
+            retrieved_objects = [
+                [retrieved_objects[i * width + j] for j in range(width)]
+                for i in range(height)
+            ]
         else:
             retrieved_objects = [
                 [obj.to_pandas() for obj in part] for part in partitions

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -642,12 +642,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             A pandas DataFrame
         """
         retrieved_objects = cls.get_objects_from_partitions(partitions.flatten())
-        if all(
-            map(
-                lambda obj: isinstance(obj, (pandas.DataFrame, pandas.Series)),
-                retrieved_objects,
-            )
-        ):
+        if all(isinstance(obj, (pandas.DataFrame, pandas.Series)) for obj in retrieved_objects):
             height, width = 0, 0
             if len(partitions.shape) == 2:
                 # possible case when shape == (0,)

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -641,13 +641,23 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         pandas.DataFrame
             A pandas DataFrame
         """
-        old_shape = partitions.shape
         retrieved_objects = cls.get_objects_from_partitions(partitions.flatten())
-        # restore 2d array
-        retrieved_objects = [
-            [retrieved_objects[i * old_shape[1] + j] for j in range(old_shape[1])]
-            for i in range(old_shape[0])
-        ]
+        if all(
+            map(
+                lambda obj: isinstance(obj, (pandas.DataFrame, pandas.Series)),
+                retrieved_objects,
+            )
+        ):
+            old_shape = partitions.shape
+            # restore 2d array
+            retrieved_objects = [
+                [retrieved_objects[i * old_shape[1] + j] for j in range(old_shape[1])]
+                for i in range(old_shape[0])
+            ]
+        else:
+            retrieved_objects = [
+                [obj.to_pandas() for obj in part] for part in partitions
+            ]
         if all(
             isinstance(part, pandas.Series) for row in retrieved_objects for part in row
         ):

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -653,6 +653,9 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 for i in range(height)
             ]
         else:
+            # Partitions do not always contain pandas objects, for example, hdk uses pyarrow tables.
+            # This implementation comes from the fact that calling `partition.get`
+            # function is not always equivalent to `partition.to_pandas`.
             retrieved_objects = [
                 [obj.to_pandas() for obj in part] for part in partitions
             ]

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -648,7 +648,10 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 retrieved_objects,
             )
         ):
-            height, width = partitions.shape
+            height, width = 0, 0
+            if len(partitions.shape) == 2:
+                # possible case when shape == (0,)
+                height, width = partitions.shape
             # restore 2d array
             retrieved_objects = [
                 [retrieved_objects[i * width + j] for j in range(width)]

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -648,9 +648,9 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         ):
             height, width, *_ = tuple(partitions.shape) + (0,)
             # restore 2d array
+            objs = iter(retrieved_objects)
             retrieved_objects = [
-                [retrieved_objects[i * width + j] for j in range(width)]
-                for i in range(height)
+                [next(objs) for _ in range(width)] for __ in range(height)
             ]
         else:
             # Partitions do not always contain pandas objects, for example, hdk uses pyarrow tables.

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -648,11 +648,11 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 retrieved_objects,
             )
         ):
-            old_shape = partitions.shape
+            height, width = partitions.shape
             # restore 2d array
             retrieved_objects = [
-                [retrieved_objects[i * old_shape[1] + j] for j in range(old_shape[1])]
-                for i in range(old_shape[0])
+                [retrieved_objects[i * width + j] for j in range(width)]
+                for i in range(height)
             ]
         else:
             retrieved_objects = [

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -646,7 +646,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             isinstance(obj, (pandas.DataFrame, pandas.Series))
             for obj in retrieved_objects
         ):
-            retrieved_objects = retrieved_objects.reshape(partitions.shape)
+            retrieved_objects = np.reshape(retrieved_objects, partitions.shape)
         else:
             retrieved_objects = [
                 [obj.to_pandas() for obj in part] for part in partitions

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -642,7 +642,10 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             A pandas DataFrame
         """
         retrieved_objects = cls.get_objects_from_partitions(partitions.flatten())
-        if all(isinstance(obj, (pandas.DataFrame, pandas.Series)) for obj in retrieved_objects):
+        if all(
+            isinstance(obj, (pandas.DataFrame, pandas.Series))
+            for obj in retrieved_objects
+        ):
             retrieved_objects = retrieved_objects.reshape(partitions.shape)
         else:
             retrieved_objects = [

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -641,7 +641,13 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         pandas.DataFrame
             A pandas DataFrame
         """
-        retrieved_objects = [[obj.to_pandas() for obj in part] for part in partitions]
+        old_shape = partitions.shape
+        retrieved_objects = cls.get_objects_from_partitions(partitions.flatten())
+        # restore 2d array
+        retrieved_objects = [
+            [retrieved_objects[i * old_shape[1] + j] for j in range(old_shape[1])]
+            for i in range(old_shape[0])
+        ]
         if all(
             isinstance(part, pandas.Series) for row in retrieved_objects for part in row
         ):

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
@@ -51,6 +51,9 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
+        for idx in range(len(partitions)):
+            if hasattr(partitions[idx], "force_materialization"):
+                partitions[idx] = partitions[idx].force_materialization()
         assert all(
             [len(partition.list_of_blocks) == 1 for partition in partitions]
         ), "Implementation assumes that each partition contains a signle block."

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
@@ -51,9 +51,9 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
-        for idx in range(len(partitions)):
-            if hasattr(partitions[idx], "force_materialization"):
-                partitions[idx] = partitions[idx].force_materialization()
+        for idx, part in enumerate(partitions):
+            if hasattr(part, "force_materialization"):
+                partitions[idx] = part.force_materialization()
         assert all(
             [len(partition.list_of_blocks) == 1 for partition in partitions]
         ), "Implementation assumes that each partition contains a signle block."

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -108,9 +108,9 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
-        for idx in range(len(partitions)):
-            if hasattr(partitions[idx], "force_materialization"):
-                partitions[idx] = partitions[idx].force_materialization()
+        for idx, part in enumerate(partitions):
+            if hasattr(part, "force_materialization"):
+                partitions[idx] = part.force_materialization()
         assert all(
             [len(partition.list_of_blocks) == 1 for partition in partitions]
         ), "Implementation assumes that each partition contains a signle block."

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -108,6 +108,9 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
+        for idx in range(len(partitions)):
+            if hasattr(partitions[idx], "force_materialization"):
+                partitions[idx] = partitions[idx].force_materialization()
         assert all(
             [len(partition.list_of_blocks) == 1 for partition in partitions]
         ), "Implementation assumes that each partition contains a signle block."


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5268 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
