### PR TITLE
PERF-#4777: Don't use `copy=True` parameter for `concat` calls inside `to_pandas`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -66,6 +66,7 @@ Key Features and Updates
   * PERF-#4325: Improve perf of multi-column assignment in `__setitem__` when no new column names are assigning (#4455)
   * PERF-#3844: Improve perf of `drop` operation (#4694)
   * PERF-#4727: Improve perf of `concat` operation (#4728)
+  * PERF-#4777: Don't use `copy=True` parameter for `concat` calls inside `to_pandas` (#4777)
   * PERF-#4705: Improve perf of arithmetic operations between `Series` objects with shared `.index` (#4689)
   * PERF-#4703: Improve performance in accessing `ser.cat.categories`, `ser.cat.ordered`, and `ser.__array_priority__` (#4704)
   * PERF-#4305: Parallelize `read_parquet` over row groups (#4700)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -66,7 +66,6 @@ Key Features and Updates
   * PERF-#4325: Improve perf of multi-column assignment in `__setitem__` when no new column names are assigning (#4455)
   * PERF-#3844: Improve perf of `drop` operation (#4694)
   * PERF-#4727: Improve perf of `concat` operation (#4728)
-  * PERF-#4777: Don't use `copy=True` parameter for `concat` calls inside `to_pandas` (#4777)
   * PERF-#4705: Improve perf of arithmetic operations between `Series` objects with shared `.index` (#4689)
   * PERF-#4703: Improve performance in accessing `ser.cat.categories`, `ser.cat.ordered`, and `ser.__array_priority__` (#4704)
   * PERF-#4305: Parallelize `read_parquet` over row groups (#4700)

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -755,7 +755,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             )
 
         df_rows = [
-            pandas.concat([part for part in row], axis=axis)
+            pandas.concat([part for part in row], axis=axis, copy=False)
             for row in retrieved_objects
             if not all(is_part_empty(part) for part in row)
         ]

--- a/modin/core/dataframe/pandas/utils.py
+++ b/modin/core/dataframe/pandas/utils.py
@@ -43,4 +43,4 @@ def concatenate(dfs):
             df.isetitem(
                 i, pandas.Categorical(df.iloc[:, i], categories=union.categories)
             )
-    return pandas.concat(dfs)
+    return pandas.concat(dfs, copy=False)

--- a/modin/core/dataframe/pandas/utils.py
+++ b/modin/core/dataframe/pandas/utils.py
@@ -43,4 +43,5 @@ def concatenate(dfs):
             df.isetitem(
                 i, pandas.Categorical(df.iloc[:, i], categories=union.categories)
             )
+    # `ValueError: buffer source array is read-only` if copy==False
     return pandas.concat(dfs, copy=True)

--- a/modin/core/dataframe/pandas/utils.py
+++ b/modin/core/dataframe/pandas/utils.py
@@ -43,4 +43,4 @@ def concatenate(dfs):
             df.isetitem(
                 i, pandas.Categorical(df.iloc[:, i], categories=union.categories)
             )
-    return pandas.concat(dfs, copy=False)
+    return pandas.concat(dfs, copy=True)


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4777 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
