### PR TITLE
PERF: __getitem__

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -17,6 +17,7 @@ Module contains class PandasDataframe.
 PandasDataframe is a parent abstract class for any dataframe class
 for pandas storage format.
 """
+from pandas.util._decorators import cache_readonly
 from collections import OrderedDict
 import numpy as np
 import pandas
@@ -1142,6 +1143,74 @@ class PandasDataframe(ClassLogger):
             ):
                 columns.append(col)
         return columns
+
+    @cache_readonly
+    def _col_bins(self) -> np.ndarray:
+        """
+        The bins that we use for determing which partition column j is in.
+
+        To find which partition column j is in, we use `np.digitize(j, self._col_bins)`.
+
+        See also
+        --------
+        pandas.core.internals.BlockManager.blknos
+            Analogous to np.digitize(np.arange(ncols), self._col_bins)
+        """
+        widths = np.asarray(self._column_widths)
+
+        # INT_MAX to make sure we don't try to compute on partitions that don't exist.
+        bins = np.append(widths[:-1].cumsum(), np.iinfo(widths.dtype).max)
+        return bins
+
+    @cache_readonly
+    def _row_bins(self) -> np.ndarray:
+        """
+        The bins that we use for determing which partition row i is in.
+
+        To find which partition row i is in, we use `np.digitize(i, self._row_bins)`.
+
+        See also
+        --------
+        pandas.core.internals.BlockManager.blknos
+            Analogous to np.digitize(np.arange(nrows), self._row_bins)
+        """
+        lengths = np.asarray(self._row_lengths)
+
+        # INT_MAX to make sure we don't try to compute on partitions that don't exist.
+        bins = np.append(lengths[:-1].cumsum(), np.iinfo(lengths.dtype).max)
+        return bins
+
+    def _get_row_blklocs(self, x: int, blkno: int, axis: int):
+        """
+        For a row position x, we use _row_blknos to find the partition N
+        containing row x. We now want to find what row position _within_
+        partition N corresponds to row x.
+
+        See also
+        --------
+        pandas.core.internals.BlockManager.blklocs
+        """
+        # TODO: vectorize this function
+        if blkno == 0:
+            return x
+
+        if axis == 0:
+            prev = self._row_bins[blkno - 1]
+        else:
+            prev = self._col_bins[blkno - 1]
+        return x - prev
+
+    def getitem_iat(self, x, y):
+        row_blkno = np.digitize(x, self._row_bins)
+        # TODO: searchsorted is marginally faster than digitize
+        col_blkno = np.digitize(y, self._col_bins)
+
+        part = self._partitions[row_blkno, col_blkno]
+
+        row_blkloc = self._get_row_blklocs(x, row_blkno, 0)
+        col_blkloc = self._get_row_blklocs(y, col_blkno, 1)
+
+        return part.getitem_iat(row_blkloc, col_blkloc)
 
     def _get_dict_of_block_index(self, axis, indices, are_indices_sorted=False):
         """

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -322,3 +322,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
             New `PandasDataframePartition` object.
         """
         return cls.put(pandas.DataFrame(), 0, 0)
+
+    def getitem_iat(self, x: int, y: int):
+        df = self.get()
+        return df.iat[x, y]

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -342,6 +342,15 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             self._ip_cache = ray.get(self._ip_cache)
         return self._ip_cache
 
+    def getitem_iat(self, x: int, y: int):
+        res = _getitem_iat.remote(self._data, x, y)
+        return ray.get(res)
+
+
+@ray.remote(num_returns=1)
+def _getitem_iat(df, x: int, y: int):
+    return df.iat[x, y]
+
 
 @ray.remote(num_returns=2)
 def _get_index_and_columns(df):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1137,6 +1137,16 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
         output.append("")
         buf.write("\n".join(output))
 
+    def iat2(self, x: int, y: int):
+        """
+        Temporary function for profiling against `iat[x, y]`
+
+        DO NOT MERGE until this is deleted.
+        """
+        qc = self._query_compiler
+        mf = qc._modin_frame
+        return mf.getitem_iat(x, y)
+
     def insert(self, loc, column, value, allow_duplicates=False):  # noqa: PR01, D200
         """
         Insert column into ``DataFrame`` at specified location.

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -20,6 +20,8 @@ from pandas.util._validators import validate_bool_kwarg
 from pandas.core.dtypes.common import (
     is_dict_like,
     is_list_like,
+    is_integer,
+    is_scalar,
 )
 from pandas._libs.lib import no_default
 from pandas._typing import IndexKeyFunc
@@ -2413,6 +2415,18 @@ class Series(SeriesCompat, BasePandasDataset):
                     pandas.RangeIndex(len(self.index))[key]
                 )
             )
+
+        qc = self._query_compiler
+        mf = qc._modin_frame
+        index = self.index
+        if is_integer(key) and index._should_fallback_to_positional:
+            loc = key
+            return mf.getitem_iat(loc, 0)
+        elif is_scalar(key):
+            loc = index.get_loc(key)
+            if is_integer(loc):
+                return mf.getitem_iat(loc, 0)
+
         # TODO: More efficiently handle `tuple` case for `Series.__getitem__`
         if isinstance(key, tuple):
             return self._default_to_pandas(pandas.Series.__getitem__, key)


### PR DESCRIPTION
This is in proof-of-concept phase at the moment.

Goals:
1) improve performance of `Series.__getitem__`, `DataFrame.iat`, etc.
2) Make `_get_dict_of_block_index` clearer, use some of the terminology/patterns used in pandas' BlockManager for the analogous lookups

Perf comparisons `iat` vs a hypothetical implementation currently parked at `iat2`, and `Series.__getitem__`
```
import numpy as np
import modin.pandas as pd

arr = np.random.randn(20_000, 50)
df = pd.DataFrame(arr)

x = 19000
y = 40

%timeit df.iat[x, y]
4.04 ms ± 526 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
1.55 ms ± 9.43 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- iat2
11.6 µs ± 417 ns per loop (mean ± std. dev. of 7 runs, 100000 loops each)  # <- pandas

ser = df[10]
_ = ser._query_compiler.to_pandas()  # not sure why this is needed; discussed below

%timeit ser[50]
3.69 ms ± 241 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)  # <- master
1.31 ms ± 23 µs per loop (mean ± std. dev. of 7 runs, 1000 loops each)  # <- PR
1.91 µs ± 43.1 ns per loop (mean ± std. dev. of 7 runs, 1000000 loops each)  # <- pandas
```

Without the `ser._query_compiler.to_pandas()` call, `ser[50]` incorrectly returns `arr[50, 0]` instead of `arr[50, 10]`.  I have  no idea what's going on there.