### PR TITLE
PERF-#4772: Remove `df.copy` call from `from_pandas` since it is not needed for Ray and Dask

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -33,6 +33,7 @@ Key Features and Updates
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)
+  * PERF-#4772: Remove `df.copy` call from `from_pandas` since it is not needed for Ray and Dask (#4781)
   * PERF-#4325: Improve perf of multi-column assignment in `__setitem__` when no new column names are assigning (#4455)
   * PERF-#3844: Improve perf of `drop` operation (#4694)
   * PERF-#4727: Improve perf of `concat` operation (#4728)

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -741,9 +741,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             [
                 update_bar(
                     pbar,
-                    put_func(
-                        df.iloc[i : i + row_chunksize, j : j + col_chunksize].copy()
-                    ),
+                    put_func(df.iloc[i : i + row_chunksize, j : j + col_chunksize]),
                 )
                 for j in range(0, len(df.columns), col_chunksize)
             ]

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
@@ -166,7 +166,7 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
         PandasOnPythonDataframePartition
             New ``PandasOnPythonDataframePartition`` object.
         """
-        return cls(obj)
+        return cls(obj.copy())
 
     @classmethod
     def preprocess_func(cls, func):

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/partitioning/partition.py
@@ -112,7 +112,7 @@ class OmnisciOnNativeDataframePartition(PandasDataframePartition):
             The new partition.
         """
         return OmnisciOnNativeDataframePartition(
-            pandas_df=obj, length=len(obj.index), width=len(obj.columns)
+            pandas_df=obj.copy(), length=len(obj.index), width=len(obj.columns)
         )
 
     def wait(self):


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4772 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
