### PR TITLE
FIX-#4782: Exclude certain non-parquet files in `read_parquet`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -29,7 +29,8 @@ Key Features and Updates
   * FIX-#4652: Support categorical data in `from_dataframe` (#4737)
   * FIX-#4756: Correctly propagate `storage_options` in `read_parquet` (#4764)
   * FIX-#4657: Use `fsspec` for handling s3/http-like paths instead of `s3fs` (#4710)
-  * FIX-#4676: drain sub-virtual-partition call queues (#4695)    
+  * FIX-#4676: drain sub-virtual-partition call queues (#4695)
+  * FIX-#4782: Exclude certain non-parquet files in `read_parquet` (#4783)    
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1403,6 +1403,14 @@ class TestParquet:
             )
             start_row = end_row
         path = make_parquet_dir(dfs_by_filename, row_group_size)
+
+        # There are specific files that PyArrow will try to ignore by default
+        # in a parquet directory. One example is files that start with '_'. Our
+        # previous implementation tried to read all files in a parquet directory,
+        # but we now make use of PyArrow to ensure the directory is valid.
+        with open(os.path.join(path, "_committed_file"), "w+") as f:
+            f.write("testingtesting")
+
         eval_io(
             fn_name="read_parquet",
             # read_parquet kwargs

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1405,7 +1405,7 @@ class TestParquet:
         path = make_parquet_dir(dfs_by_filename, row_group_size)
 
         # There are specific files that PyArrow will try to ignore by default
-        # in a parquet directory. One example is files that start with '_'. Our
+        # in a parquet directory. One example are files that start with '_'. Our
         # previous implementation tried to read all files in a parquet directory,
         # but we now make use of PyArrow to ensure the directory is valid.
         with open(os.path.join(path, "_committed_file"), "w+") as f:


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR fixes a bug where `read_parquet` would not ignore certain metadata files that are normally ignored by `pyarrow`.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4782 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
