### PR TITLE
DOCS-#4790: Give all templates issue type and triage labels.

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -2,7 +2,7 @@
 name: Bug report
 about: You ran into a behavior that doesn't match pandas
 title: ''
-labels: 'Triage 🩹'
+labels: 'bug 🦗, Triage 🩹'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -2,7 +2,7 @@
 name: Feature request
 about: Request a new API or feature implementation
 title: ''
-labels: 'new feature/request :speech_balloon:'
+labels: 'new feature/request 💬, Triage 🩹'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -2,7 +2,7 @@
 name: Question
 about: You want to ask a question
 title: ''
-labels: 'question :question:'
+labels: 'question ❓, Triage 🩹'
 assignees: ''
 
 ---

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -73,6 +73,7 @@ Key Features and Updates
   * DOCS-#4628: Add to_parquet partial support notes (#4648)
   * DOCS-#4668: Set light theme for readthedocs page, remove theme switcher (#4669)
   * DOCS-#4748: Apply the Triage label to new issues.   
+  * DOCS-#4790: Give all templates issue type and triage labels (#4791)
 * Dependencies
   * FEAT-#4598: Add support for pandas 1.4.3 (#4599)
   * FEAT-#4619: Integrate mypy static type checking (#4620)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -72,7 +72,7 @@ Key Features and Updates
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
   * DOCS-#4628: Add to_parquet partial support notes (#4648)
   * DOCS-#4668: Set light theme for readthedocs page, remove theme switcher (#4669)
-  * DOCS-#4748: Apply the Triage label to new issues.   
+  * DOCS-#4748: Apply the Triage label to new issues (#4749)
   * DOCS-#4790: Give all templates issue type and triage labels (#4791)
 * Dependencies
   * FEAT-#4598: Add support for pandas 1.4.3 (#4599)


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

DOCS-#4790: Give all templates issue type and triage labels.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4790
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
