### PR TITLE
REFACTOR-#4796: Introduce constant for __reduced__ column name

### DIFF
--- a/docs/flow/modin/core/storage_formats/index.rst
+++ b/docs/flow/modin/core/storage_formats/index.rst
@@ -54,7 +54,7 @@ whole methods can be handled at the API layer with the existing API.
 
 The query compiler is the level where Modin stops distinguishing DataFrame and Series (or column) objects.
 A Series is represented by a `1xN` query compiler, where the Series name is the column label.
-If Series is unnamed, then the label is ``"__reduced__"``. The high-level DataFrame API layer
+If Series is unnamed, then the label is ``MODIN_UNNAMED_SERIES_LABEL``. The high-level DataFrame API layer
 interprets a one-column query compiler as Series or DataFrame depending on the operation context.
 
 .. note::

--- a/docs/flow/modin/core/storage_formats/index.rst
+++ b/docs/flow/modin/core/storage_formats/index.rst
@@ -54,7 +54,7 @@ whole methods can be handled at the API layer with the existing API.
 
 The query compiler is the level where Modin stops distinguishing DataFrame and Series (or column) objects.
 A Series is represented by a `1xN` query compiler, where the Series name is the column label.
-If Series is unnamed, then the label is ``MODIN_UNNAMED_SERIES_LABEL``. The high-level DataFrame API layer
+If Series is unnamed, then the label is ``MODIN_UNNAMED_SERIES_LABEL``, which is equal to ``"__reduced__"``. The high-level DataFrame API layer
 interprets a one-column query compiler as Series or DataFrame depending on the operation context.
 
 .. note::

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -53,7 +53,7 @@ Key Features and Updates
   * REFACTOR-#4774: remove `_build_treereduce_func` call from `_compute_dtypes` (#4775)
   * REFACTOR-#4750: Delete BaseDataframeAxisPartition.shuffle (#4751)
   * REFACTOR-#4722: Stop suppressing undefined name lint (#4723)
-  * REFACTOR-#4796: Introduce constant for __reduced__ column name (#4799)  
+  * REFACTOR-#4796: Introduce constant for __reduced__ column name (#4799)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -52,6 +52,7 @@ Key Features and Updates
   * REFACTOR-#4717: Improve PartitionMgr.get_indices() usage (#4718)
   * REFACTOR-#4774: remove `_build_treereduce_func` call from `_compute_dtypes` (#4775)
   * REFACTOR-#4750: Delete BaseDataframeAxisPartition.shuffle (#4751)
+  * REFACTOR-#4796: Introduce constant for __reduced__ column name (#4799)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/modin/core/dataframe/algebra/default2pandas/default.py
+++ b/modin/core/dataframe/algebra/default2pandas/default.py
@@ -14,7 +14,7 @@
 """Module houses default functions builder class."""
 
 from modin.core.dataframe.algebra import Operator
-from modin.utils import try_cast_to_pandas
+from modin.utils import try_cast_to_pandas, MODIN_UNNAMED_SERIES_LABEL
 
 from pandas.core.dtypes.common import is_list_like
 import pandas
@@ -102,7 +102,7 @@ class DefaultMethod(Operator):
                 )
             if isinstance(result, pandas.Series):
                 if result.name is None:
-                    result.name = "__reduced__"
+                    result.name = MODIN_UNNAMED_SERIES_LABEL
                 result = result.to_frame()
 
             inplace_method = kwargs.get("inplace", False)

--- a/modin/core/dataframe/algebra/default2pandas/groupby.py
+++ b/modin/core/dataframe/algebra/default2pandas/groupby.py
@@ -18,6 +18,8 @@ from .default import DefaultMethod
 import pandas
 from pandas.core.dtypes.common import is_list_like
 
+from modin.utils import MODIN_UNNAMED_SERIES_LABEL
+
 
 # FIXME: there is no sence of keeping `GroupBy` and `GroupByDefault` logic in a different
 # classes. They should be combined.
@@ -56,7 +58,7 @@ class GroupBy:
                 df = df.squeeze(axis=1)
             if not isinstance(df, pandas.Series):
                 return df
-            if df.name == "__reduced__":
+            if df.name == MODIN_UNNAMED_SERIES_LABEL:
                 df.name = None
             return df
 
@@ -245,7 +247,7 @@ class GroupBy:
                     inplace=True,
                 )
 
-            if result.index.name == "__reduced__":
+            if result.index.name == MODIN_UNNAMED_SERIES_LABEL:
                 result.index.name = None
 
             return result
@@ -465,7 +467,9 @@ class GroupBy:
             internal_by_cols = pandas.Index(internal_by_cols)
 
         internal_by_cols = (
-            internal_by_cols[~internal_by_cols.str.startswith("__reduced__", na=False)]
+            internal_by_cols[
+                ~internal_by_cols.str.startswith(MODIN_UNNAMED_SERIES_LABEL, na=False)
+            ]
             if hasattr(internal_by_cols, "str")
             else internal_by_cols
         )

--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -18,7 +18,7 @@ import pandas
 
 from .tree_reduce import TreeReduce
 from .default2pandas.groupby import GroupBy
-from modin.utils import try_cast_to_pandas, hashable
+from modin.utils import try_cast_to_pandas, hashable, MODIN_UNNAMED_SERIES_LABEL
 from modin.error_message import ErrorMessage
 
 
@@ -350,7 +350,7 @@ class GroupByReduce(TreeReduce):
         )
 
         result = query_compiler.__constructor__(new_modin_frame)
-        if result.index.name == "__reduced__":
+        if result.index.name == MODIN_UNNAMED_SERIES_LABEL:
             result.index.name = None
         return result
 

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -39,6 +39,7 @@ from modin.core.dataframe.base.dataframe.utils import (
 from modin.pandas.indexing import is_range_like
 from modin.pandas.utils import is_full_grab_slice, check_both_not_none
 from modin.logging import ClassLogger
+from modin.utils import MODIN_UNNAMED_SERIES_LABEL
 
 
 def lazy_metadata_decorator(apply_axis=None, axis_arg=-1, transpose=False):
@@ -1414,11 +1415,11 @@ class PandasDataframe(ClassLogger):
                 # line up with the index of the data based on how pandas creates a
                 # DataFrame from a Series.
                 result = pandas.DataFrame(series_result).T
-                result.index = ["__reduced__"]
+                result.index = [MODIN_UNNAMED_SERIES_LABEL]
             else:
                 result = pandas.DataFrame(series_result)
                 if isinstance(series_result, pandas.Series):
-                    result.columns = ["__reduced__"]
+                    result.columns = [MODIN_UNNAMED_SERIES_LABEL]
             return result
 
         return _tree_reduce_func
@@ -1441,7 +1442,7 @@ class PandasDataframe(ClassLogger):
         """
         new_axes, new_axes_lengths = [0, 0], [0, 0]
 
-        new_axes[axis] = ["__reduced__"]
+        new_axes[axis] = [MODIN_UNNAMED_SERIES_LABEL]
         new_axes[axis ^ 1] = self.axes[axis ^ 1]
 
         new_axes_lengths[axis] = [1]

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -322,7 +322,7 @@ class PandasDataframe(ClassLogger):
             )
         else:
             dtypes = pandas.Series([])
-        # reset name to None because we use "__reduced__" internally
+        # reset name to None because we use MODIN_UNNAMED_SERIES_LABEL internally
         dtypes.name = None
         return dtypes
 

--- a/modin/core/dataframe/pandas/exchange/dataframe_protocol/column.py
+++ b/modin/core/dataframe/pandas/exchange/dataframe_protocol/column.py
@@ -241,7 +241,7 @@ class PandasProtocolColumn(ProtocolColumn):
 
         intermediate_df = self._col.tree_reduce(0, map_func, reduce_func)
         # Set ``pandas.RangeIndex(1)`` to index and column labels because
-        # 1) We internally use '__reduced__' for labels of a reduced axis
+        # 1) We internally use `MODIN_UNNAMED_SERIES_LABEL` for labels of a reduced axis
         # 2) The return value of `reduce_func` is a pandas DataFrame with
         # index and column labels set to ``pandas.RangeIndex(1)``
         # 3) We further use `to_pandas().squeeze()` to get an integer value of the null count.

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -2218,7 +2218,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             - Index of the specified axis contains: the names of the passed functions if multiple
               functions are passed, otherwise: indices of the `func` result if "expand" strategy
               is used, indices of the original frame if "broadcast" strategy is used, a single
-              label "__reduced__" if "reduce" strategy is used.
+              label `MODIN_UNNAMED_SERIES_LABEL` if "reduce" strategy is used.
             - Labels of the opposite axis are preserved.
             - Each element is the result of execution of `func` against
               corresponding row/column.

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -33,6 +33,7 @@ from modin.core.dataframe.algebra.default2pandas import (
 from modin.error_message import ErrorMessage
 from . import doc_utils
 from modin.logging import ClassLogger
+from modin.utils import MODIN_UNNAMED_SERIES_LABEL
 
 from pandas.core.dtypes.common import is_scalar
 import pandas.core.resample
@@ -898,7 +899,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             Transposed new QueryCompiler or self.
         """
         if len(self.columns) != 1 or (
-            len(self.index) == 1 and self.index[0] == "__reduced__"
+            len(self.index) == 1 and self.index[0] == MODIN_UNNAMED_SERIES_LABEL
         ):
             return self.transpose()
         return self

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -42,6 +42,7 @@ from modin.utils import (
     wrap_udf_function,
     hashable,
     _inherit_docstrings,
+    MODIN_UNNAMED_SERIES_LABEL,
 )
 from modin.core.dataframe.algebra import (
     Fold,
@@ -246,7 +247,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         result = pandas_op(self.to_pandas(), *args, **kwargs)
         if isinstance(result, pandas.Series):
             if result.name is None:
-                result.name = "__reduced__"
+                result.name = MODIN_UNNAMED_SERIES_LABEL
             result = result.to_frame()
         if isinstance(result, pandas.DataFrame):
             return self.from_pandas(result, type(self._modin_frame))
@@ -674,7 +675,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     def columnarize(self):
         if len(self.columns) != 1 or (
-            len(self.index) == 1 and self.index[0] == "__reduced__"
+            len(self.index) == 1 and self.index[0] == MODIN_UNNAMED_SERIES_LABEL
         ):
             return self.transpose()
         return self
@@ -1015,7 +1016,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
         )
 
     def resample_size(self, resample_kwargs):
-        return self._resample_func(resample_kwargs, "size", new_columns=["__reduced__"])
+        return self._resample_func(
+            resample_kwargs, "size", new_columns=[MODIN_UNNAMED_SERIES_LABEL]
+        )
 
     def resample_sem(self, resample_kwargs, _method, *args, **kwargs):
         return self._resample_func(
@@ -1178,7 +1181,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             and len(level) == self.index.nlevels
         ):
             axis = 1
-            new_columns = ["__reduced__"]
+            new_columns = [MODIN_UNNAMED_SERIES_LABEL]
             need_reindex = True
         else:
             axis = 0
@@ -1331,7 +1334,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             and is_list_like(level)
             and len(level) == self.columns.nlevels
         ):
-            new_columns = ["__reduced__"]
+            new_columns = [MODIN_UNNAMED_SERIES_LABEL]
         else:
             new_columns = None
 
@@ -1730,15 +1733,17 @@ class PandasQueryCompiler(BaseQueryCompiler):
         num_cols = other.shape[1] if len(other.shape) > 1 else 1
         if len(self.columns) == 1:
             new_index = (
-                ["__reduced__"]
+                [MODIN_UNNAMED_SERIES_LABEL]
                 if (len(self.index) == 1 or squeeze_self) and num_cols == 1
                 else None
             )
-            new_columns = ["__reduced__"] if squeeze_self and num_cols == 1 else None
+            new_columns = (
+                [MODIN_UNNAMED_SERIES_LABEL] if squeeze_self and num_cols == 1 else None
+            )
             axis = 0
         else:
             new_index = self.index
-            new_columns = ["__reduced__"] if num_cols == 1 else None
+            new_columns = [MODIN_UNNAMED_SERIES_LABEL] if num_cols == 1 else None
             axis = 1
 
         new_modin_frame = self._modin_frame.apply_full_axis(
@@ -1785,7 +1790,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             )
 
         if columns is None:
-            new_columns = ["__reduced__"]
+            new_columns = [MODIN_UNNAMED_SERIES_LABEL]
         else:
             new_columns = self.columns
 
@@ -1810,7 +1815,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
         )
         if isinstance(empty_eval, pandas.Series):
             new_columns = (
-                [empty_eval.name] if empty_eval.name is not None else ["__reduced__"]
+                [empty_eval.name]
+                if empty_eval.name is not None
+                else [MODIN_UNNAMED_SERIES_LABEL]
             )
         else:
             new_columns = empty_eval.columns
@@ -2584,7 +2591,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             default_to_pandas_func=lambda grp: grp.size(),
         )
         if groupby_kwargs.get("as_index", True):
-            result.columns = ["__reduced__"]
+            result.columns = [MODIN_UNNAMED_SERIES_LABEL]
         elif isinstance(result.columns, pandas.MultiIndex):
             # Dropping one extra-level which was added because of renaming aggregation
             result.columns = (
@@ -2835,7 +2842,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     result = pandas.DataFrame(index=grouped_df.size().index)
                 if isinstance(result, pandas.Series):
                     result = result.to_frame(
-                        result.name if result.name is not None else "__reduced__"
+                        result.name
+                        if result.name is not None
+                        else MODIN_UNNAMED_SERIES_LABEL
                     )
 
                 selection = agg_func.keys() if isinstance(agg_func, dict) else None
@@ -2866,7 +2875,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 else:
                     new_index_names = tuple(
                         None
-                        if isinstance(name, str) and name.startswith("__reduced__")
+                        if isinstance(name, str)
+                        and name.startswith(MODIN_UNNAMED_SERIES_LABEL)
                         else name
                         for name in result.index.names
                     )

--- a/modin/experimental/core/execution/native/implementations/omnisci_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/omnisci_on_native/dataframe/dataframe.py
@@ -24,6 +24,7 @@ from pandas.core.indexes.api import ensure_index, Index, MultiIndex, RangeIndex
 from pandas.core.dtypes.common import get_dtype, is_list_like, is_bool_dtype
 from modin.error_message import ErrorMessage
 from modin.pandas.indexing import is_range_like
+from modin.utils import MODIN_UNNAMED_SERIES_LABEL
 import pandas as pd
 from typing import List, Hashable, Optional, Tuple, Union
 
@@ -2320,7 +2321,7 @@ class OmnisciOnNativeDataframe(PandasDataframe):
         match = re.search("__index__\\d+_(.*)", col)
         if match:
             name = match.group(1)
-            if name in ("__None__", "__reduced__"):
+            if name in ("__None__", MODIN_UNNAMED_SERIES_LABEL):
                 return None
             return name
 

--- a/modin/experimental/core/storage_formats/omnisci/query_compiler.py
+++ b/modin/experimental/core/storage_formats/omnisci/query_compiler.py
@@ -23,7 +23,7 @@ from modin.core.storage_formats.base.query_compiler import (
     _get_axis as default_axis_getter,
 )
 from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
-from modin.utils import _inherit_docstrings
+from modin.utils import _inherit_docstrings, MODIN_UNNAMED_SERIES_LABEL
 from modin.error_message import ErrorMessage
 import pandas
 
@@ -315,7 +315,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         )
         if as_index:
             shape_hint = "column"
-            new_frame = new_frame._set_columns(["__reduced__"])
+            new_frame = new_frame._set_columns([MODIN_UNNAMED_SERIES_LABEL])
         else:
             shape_hint = None
             new_frame = new_frame._set_columns(["size"]).reset_index(drop=False)
@@ -445,7 +445,9 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
         new_frame = self._modin_frame.agg(agg)
         new_frame = new_frame._set_index(
-            pandas.Index.__new__(pandas.Index, data=["__reduced__"], dtype="O")
+            pandas.Index.__new__(
+                pandas.Index, data=[MODIN_UNNAMED_SERIES_LABEL], dtype="O"
+            )
         )
         return self.__constructor__(new_frame, shape_hint="row")
 
@@ -718,7 +720,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             return self.transpose()
 
         if len(self.columns) != 1 or (
-            len(self.index) == 1 and self.index[0] == "__reduced__"
+            len(self.index) == 1 and self.index[0] == MODIN_UNNAMED_SERIES_LABEL
         ):
             res = self.transpose()
             res._shape_hint = "column"

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -36,7 +36,13 @@ import warnings
 
 from modin.pandas import Categorical
 from modin.error_message import ErrorMessage
-from modin.utils import _inherit_docstrings, to_pandas, hashable, append_to_docstring
+from modin.utils import (
+    _inherit_docstrings,
+    to_pandas,
+    hashable,
+    append_to_docstring,
+    MODIN_UNNAMED_SERIES_LABEL,
+)
 from modin.config import Engine, IsExperimental, PersistentPickle
 from .utils import (
     from_pandas,
@@ -385,7 +391,7 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
         # the 'else' branch also handles 'result_type == "expand"' since it makes the output type
         # depend on the `func` result (Series for a scalar, DataFrame for list-like)
         else:
-            reduced_index = pandas.Index(["__reduced__"])
+            reduced_index = pandas.Index([MODIN_UNNAMED_SERIES_LABEL])
             if query_compiler.get_axis(axis).equals(
                 reduced_index
             ) or query_compiler.get_axis(axis ^ 1).equals(reduced_index):

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -29,6 +29,7 @@ from modin.utils import (
     wrap_udf_function,
     hashable,
     wrap_into_list,
+    MODIN_UNNAMED_SERIES_LABEL,
 )
 from modin.core.storage_formats.base.query_compiler import BaseQueryCompiler
 from modin.core.dataframe.algebra.default2pandas.groupby import GroupBy
@@ -678,8 +679,8 @@ class DataFrameGroupBy(ClassLogger):
         if not self._kwargs.get("as_index") and not isinstance(result, Series):
             result = result.rename(columns={0: "size"})
             result = (
-                result.rename(columns={"__reduced__": "index"})
-                if "__reduced__" in result.columns
+                result.rename(columns={MODIN_UNNAMED_SERIES_LABEL: "index"})
+                if MODIN_UNNAMED_SERIES_LABEL in result.columns
                 else result
             )
         elif isinstance(self._df, Series):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -26,7 +26,12 @@ from pandas._typing import IndexKeyFunc
 from typing import Union, Optional
 import warnings
 
-from modin.utils import _inherit_docstrings, to_pandas, Engine
+from modin.utils import (
+    _inherit_docstrings,
+    to_pandas,
+    Engine,
+    MODIN_UNNAMED_SERIES_LABEL,
+)
 from modin.config import IsExperimental, PersistentPickle
 from .base import BasePandasDataset, _ATTRS_NO_LOOKUP
 from .iterator import PartitionIterator
@@ -101,7 +106,7 @@ class Series(SeriesCompat, BasePandasDataset):
                 "Distributing {} object. This may take some time.".format(type(data))
             )
             if name is None:
-                name = "__reduced__"
+                name = MODIN_UNNAMED_SERIES_LABEL
                 if isinstance(data, pandas.Series) and data.name is not None:
                     name = data.name
 
@@ -131,7 +136,7 @@ class Series(SeriesCompat, BasePandasDataset):
         hashable
         """
         name = self._query_compiler.columns[0]
-        if name == "__reduced__":
+        if name == MODIN_UNNAMED_SERIES_LABEL:
             return None
         return name
 
@@ -145,7 +150,7 @@ class Series(SeriesCompat, BasePandasDataset):
             Name value to set.
         """
         if name is None:
-            name = "__reduced__"
+            name = MODIN_UNNAMED_SERIES_LABEL
         self._query_compiler.columns = [name]
 
     name = property(_get_name, _set_name)
@@ -942,7 +947,8 @@ class Series(SeriesCompat, BasePandasDataset):
         Transform each element of a list-like to a row.
         """
         return super(Series, self).explode(
-            "__reduced__" if self.name is None else self.name, ignore_index=ignore_index
+            MODIN_UNNAMED_SERIES_LABEL if self.name is None else self.name,
+            ignore_index=ignore_index,
         )
 
     def factorize(self, sort=False, na_sentinel=-1):  # noqa: PR01, RT01, D200
@@ -2159,7 +2165,7 @@ class Series(SeriesCompat, BasePandasDataset):
         """
         df = self._query_compiler.to_pandas()
         series = df[df.columns[0]]
-        if self._query_compiler.columns[0] == "__reduced__":
+        if self._query_compiler.columns[0] == MODIN_UNNAMED_SERIES_LABEL:
             series.name = None
         return series
 
@@ -2372,7 +2378,7 @@ class Series(SeriesCompat, BasePandasDataset):
             if self.name == other.name:
                 new_self.name = new_other.name = self.name
             else:
-                new_self.name = new_other.name = "__reduced__"
+                new_self.name = new_other.name = MODIN_UNNAMED_SERIES_LABEL
         else:
             new_self = self
             new_other = other

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1985,7 +1985,7 @@ def test_validate_by():
             df_equals(obj1, obj2)
 
     # This emulates situation when the Series's query compiler being passed as a 'by':
-    #   1. The Series at the QC level is represented as a single-column frame with the "__reduced__" columns.
+    #   1. The Series at the QC level is represented as a single-column frame with the `MODIN_UNNAMED_SERIES_LABEL` columns.
     #   2. The valid representation of such QC is an unnamed Series.
     reduced_frame = pandas.DataFrame({MODIN_UNNAMED_SERIES_LABEL: [1, 2, 3]})
     series_result = GroupBy.validate_by(reduced_frame)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -20,7 +20,12 @@ from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
 import modin.pandas as pd
-from modin.utils import try_cast_to_pandas, get_current_execution, hashable
+from modin.utils import (
+    try_cast_to_pandas,
+    get_current_execution,
+    hashable,
+    MODIN_UNNAMED_SERIES_LABEL,
+)
 from modin.core.dataframe.algebra.default2pandas.groupby import GroupBy
 from modin.pandas.utils import from_pandas, is_scalar
 from .utils import (
@@ -1982,7 +1987,7 @@ def test_validate_by():
     # This emulates situation when the Series's query compiler being passed as a 'by':
     #   1. The Series at the QC level is represented as a single-column frame with the "__reduced__" columns.
     #   2. The valid representation of such QC is an unnamed Series.
-    reduced_frame = pandas.DataFrame({"__reduced__": [1, 2, 3]})
+    reduced_frame = pandas.DataFrame({MODIN_UNNAMED_SERIES_LABEL: [1, 2, 3]})
     series_result = GroupBy.validate_by(reduced_frame)
     series_reference = [pandas.Series([1, 2, 3], name=None)]
     compare(series_reference, series_result)
@@ -1997,7 +2002,7 @@ def test_validate_by():
     compare(splited_df, splited_df_result)
 
     # This emulates situation of mixed by (two column names and an external Series):
-    by = ["col1", "col2", pandas.DataFrame({"__reduced__": [1, 2, 3]})]
+    by = ["col1", "col2", pandas.DataFrame({MODIN_UNNAMED_SERIES_LABEL: [1, 2, 3]})]
     result_by = GroupBy.validate_by(by)
     reference_by = ["col1", "col2", pandas.Series([1, 2, 3], name=None)]
     compare(reference_by, result_by)

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -39,6 +39,8 @@ MIN_DASK_VERSION = version.parse("2.22.0")
 
 PANDAS_API_URL_TEMPLATE = f"https://pandas.pydata.org/pandas-docs/version/{pandas.__version__}/reference/api/{{}}.html"
 
+MODIN_UNNAMED_SERIES_LABEL = "__reduced__"
+
 
 def _make_api_url(token):
     """
@@ -445,7 +447,7 @@ def try_cast_to_pandas(obj, squeeze=False):
         # Query compiler case, it doesn't have logic about convertion to Series
         if (
             isinstance(getattr(result, "name", None), str)
-            and result.name == "__reduced__"
+            and result.name == MODIN_UNNAMED_SERIES_LABEL
         ):
             result.name = None
         return result

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -40,6 +40,11 @@ MIN_DASK_VERSION = version.parse("2.22.0")
 PANDAS_API_URL_TEMPLATE = f"https://pandas.pydata.org/pandas-docs/version/{pandas.__version__}/reference/api/{{}}.html"
 
 MODIN_UNNAMED_SERIES_LABEL = "__reduced__"
+"""
+The '__reduced__' name is used internally by the query compiler as a column name to
+represent pandas Series objects that are not explicitly assigned a name, so as to
+distinguish between an N-element series and 1xN dataframe.
+"""
 
 
 def _make_api_url(token):


### PR DESCRIPTION
Signed-off-by: Jonathan Shi <jhshi@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Adds the `MODIN_UNNAMED_SERIES_LABEL` to replace hardcoded instances of `"__reduced__" found throughout the codebase.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4796 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
