### PR TITLE
TEST-#4802: Pin mindsdb-sql to workaround install issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -577,7 +577,7 @@ jobs:
       - run: ./.github/workflows/sql_server/set_up_sql_server.sh
       - run: python -m pytest modin/pandas/test/test_io.py --verbose
       - run: python -m pytest modin/experimental/pandas/test/test_io_exp.py
-      - run: pip install "dfsql>=0.4.2" "pyparsing<=2.4.7" && pytest modin/experimental/sql/test/test_sql.py
+      - run: pip install "dfsql>=0.4.2" "pyparsing<=2.4.7" "mindsdb-sql<0.3.11" && pytest modin/experimental/sql/test/test_sql.py
       - run: pytest modin/test/exchange/dataframe_protocol/test_general.py
       - run: pytest modin/test/exchange/dataframe_protocol/pandas/test_protocol.py
       - uses: codecov/codecov-action@v2

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -72,6 +72,7 @@ Key Features and Updates
   * TEST-#4557: Delete multiindex sorts instead of xfailing (#4559)  
   * TEST-#4698: Stop passing invalid storage_options param (#4699)
   * TEST-#4745: Pin flake8 to <5 to workaround installation conflict (#4752)
+  * TEST-#4802: Pin mindsdb-sql to workaround install issues (#4803)
 * Documentation improvements
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
   * DOCS-#4628: Add to_parquet partial support notes (#4648)

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,8 @@ ray_deps = [
 ]
 remote_deps = ["rpyc==4.1.5", "cloudpickle", "boto3"]
 spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]
-sql_deps = ["dfsql>=0.4.2", "pyparsing<=2.4.7"]
+# pin mindsdb-sql to workaround https://github.com/modin-project/modin/issues/4802
+sql_deps = ["dfsql>=0.4.2", "pyparsing<=2.4.7", "mindsdb-sql<0.3.11"]
 all_deps = dask_deps + ray_deps + remote_deps + spreadsheet_deps
 
 # Distribute 'modin-autoimport-pandas.pth' along with binary and source distributions.


### PR DESCRIPTION
Signed-off-by: Vasily Litvinov <fam1ly.n4me@yandex.ru>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Pin upper bound of `mindsb-sql` to workaround its install issues.
Should be reverted when the upstream is fixed.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4802
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
