### PR TITLE
FEAT-#4733: Support fastparquet as engine for `read_parquet`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -93,6 +93,7 @@ Key Features and Updates
   * FEAT-#4725: Make index and columns lazy in Modin DataFrame (#4726)
   * FEAT-#4664: Finalize compatibility support for Python 3.6 (#4800)
   * FEAT-#4746: Sync interchange protocol with recent API changes (#4763)
+  * FEAT-#4733: Support fastparquet as engine for `read_parquet` (#4807)
 
 Contributors
 ------------

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -38,6 +38,7 @@ dependencies:
   - psycopg2
   - mypy
   - pandas-stubs
+  - fastparquet
   - pip:
       - xgboost>=1.6.0
       - modin-spreadsheet>=0.1.1

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -30,10 +30,9 @@ from modin.core.io.column_stores.column_store_dispatcher import ColumnStoreDispa
 from modin.utils import import_optional_dependency, _inherit_docstrings
 
 
-class ColumnStoreDataset:  # noqa : PR01
+class ColumnStoreDataset:
     """
-    Base class that encapsulates Parquet engine-specific details for
-    a given Parquet dataset.
+    Base class that encapsulates Parquet engine-specific details.
 
     This class exposes a set of functions that are commonly used in the
     `read_parquet` implementation.
@@ -60,7 +59,7 @@ class ColumnStoreDataset:  # noqa : PR01
         List that contains the full paths of the parquet files in the dataset.
     """
 
-    def __init__(self, path, storage_options):
+    def __init__(self, path, storage_options):  # noqa : PR01
         self.path = path
         self.storage_options = storage_options
         self._fs_path = None

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -563,7 +563,7 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         path : str, path object or file-like object
             The filepath of the parquet file in local filesystem or hdfs.
         engine : str
-            Parquet library to use (only 'PyArrow' is supported for now).
+            Parquet library to use (either pyarrow or fastparquet).
         columns : list
             If not None, only these columns will be read from the file.
         **kwargs : dict

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -302,12 +302,12 @@ class ParquetDispatcher(ColumnStoreDispatcher):
 
             raise ImportError(
                 "Unable to find a usable engine; "
-                "tried using: 'pyarrow', 'fastparquet'.\n"
-                "A suitable version of "
-                "pyarrow or fastparquet is required for parquet "
-                "support.\n"
-                "Trying to import the above resulted in these errors:"
-                f"{error_msgs}"
+                + "tried using: 'pyarrow', 'fastparquet'.\n"
+                + "A suitable version of "
+                + "pyarrow or fastparquet is required for parquet "
+                + "support.\n"
+                + "Trying to import the above resulted in these errors:"
+                + f"{error_msgs}"
             )
         elif engine == "pyarrow":
             return PyArrowDataset(path, storage_options)

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -203,6 +203,8 @@ class FastParquetDataset(Dataset):
     def pandas_metadata(self):
         import json
 
+        if "pandas" not in self.dataset.key_value_metadata:
+            return {}
         return json.loads(self.dataset.key_value_metadata["pandas"])
 
     @property

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -66,7 +66,7 @@ class Dataset(ABC):
         pass
 
     @abstractmethod
-    def read_table_as_pandas(columns):
+    def read_table_as_pandas(self, columns):
         """
         Return a pandas dataframe with the given columns.
 

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -563,7 +563,7 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         path : str, path object or file-like object
             The filepath of the parquet file in local filesystem or hdfs.
         engine : str
-            Parquet library to use (either pyarrow or fastparquet).
+            Parquet library to use (either PyArrow or fastparquet).
         columns : list
             If not None, only these columns will be read from the file.
         **kwargs : dict

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -690,22 +690,26 @@ class PandasParquetParser(PandasParser):
             return ParquetFile(f)[row_group_start:row_group_end].to_pandas(
                 columns=columns
             )
+        else:
+            # We shouldn't ever come to this case, so something went wrong
+            raise ValueError("engine must be one of 'pyarrow', 'fastparquet'")
 
     @staticmethod
     @doc(
         _doc_parse_func,
         parameters="""files_for_parser : list
     List of files to be read.
+engine : str
+    Parquet library to use (either pyarrow or fastparquet).
 """,
     )
-    def parse(files_for_parser, **kwargs):
+    def parse(files_for_parser, engine, **kwargs):
         columns = kwargs.get("columns", None)
         storage_options = kwargs.pop("storage_options", {}) or {}
-        engine = kwargs.pop("engine")
         chunks = []
         # `single_worker_read` just passes in a string path
         if isinstance(files_for_parser, str):
-            return pandas.read_parquet(files_for_parser, **kwargs)
+            return pandas.read_parquet(files_for_parser, engine=engine, **kwargs)
 
         for file_for_parser in files_for_parser:
             if isinstance(file_for_parser.path, IOBase):

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -664,7 +664,9 @@ class ParquetFileToRead(NamedTuple):
 @doc(_doc_pandas_parser_class, data_type="PARQUET data")
 class PandasParquetParser(PandasParser):
     @staticmethod
-    def read_row_group_chunk(f, row_group_start, row_group_end, columns, engine):
+    def read_row_group_chunk(
+        f, row_group_start, row_group_end, columns, engine
+    ):  # noqa: GL08
         if engine == "pyarrow":
             from pyarrow.parquet import ParquetFile
 

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -664,7 +664,7 @@ class ParquetFileToRead(NamedTuple):
 @doc(_doc_pandas_parser_class, data_type="PARQUET data")
 class PandasParquetParser(PandasParser):
     @staticmethod
-    def read_row_group_chunk(
+    def _read_row_group_chunk(
         f, row_group_start, row_group_end, columns, engine
     ):  # noqa: GL08
         if engine == "pyarrow":
@@ -717,7 +717,7 @@ engine : str
             else:
                 context = fsspec.open(file_for_parser.path, **storage_options)
             with context as f:
-                chunk = PandasParquetParser.read_row_group_chunk(
+                chunk = PandasParquetParser._read_row_group_chunk(
                     f,
                     file_for_parser.row_group_start,
                     file_for_parser.row_group_end,

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -700,7 +700,7 @@ class PandasParquetParser(PandasParser):
         parameters="""files_for_parser : list
     List of files to be read.
 engine : str
-    Parquet library to use (either pyarrow or fastparquet).
+    Parquet library to use (either PyArrow or fastparquet).
 """,
     )
     def parse(files_for_parser, engine, **kwargs):

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -673,11 +673,9 @@ class PandasParquetParser(PandasParser):
             return (
                 ParquetFile(f)
                 .read_row_groups(
-                    list(
-                        range(
-                            row_group_start,
-                            row_group_end,
-                        )
+                    range(
+                        row_group_start,
+                        row_group_end,
                     ),
                     columns=columns,
                     use_pandas_metadata=True,
@@ -692,7 +690,9 @@ class PandasParquetParser(PandasParser):
             )
         else:
             # We shouldn't ever come to this case, so something went wrong
-            raise ValueError("engine must be one of 'pyarrow', 'fastparquet'")
+            raise ValueError(
+                f"engine must be one of 'pyarrow', 'fastparquet', got: {engine}"
+            )
 
     @staticmethod
     @doc(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -44,3 +44,4 @@ numpydoc==1.1.0
 fuzzydata>=0.0.6
 mypy
 pandas-stubs
+fastparquet

--- a/requirements/environment-py36.yml
+++ b/requirements/environment-py36.yml
@@ -38,6 +38,7 @@ dependencies:
   - pymssql
   - psycopg2
   - jupyter>=1.0.0 # modin-spreadsheet needs that, but it won't install on Windows on Py36 via pip
+  - fastparquet
   - pip:
       - modin-spreadsheet>=0.1.1
       - tqdm

--- a/requirements/requirements-py36.txt
+++ b/requirements/requirements-py36.txt
@@ -25,3 +25,4 @@ scikit-learn
 pickle5
 tqdm
 modin-spreadsheet>=0.1.1
+fastparquet


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR adds `fastparquet` as a supported engine for `read_parquet`. I took the liberty to abstract some details of the underlying engine in a way I thought best fit. Please drop suggestions for code cleanup. 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4733 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
