### PR TITLE
FIX-#4808: Set dtypes correctly after column rename.

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -32,6 +32,7 @@ Key Features and Updates
   * FIX-#4657: Use `fsspec` for handling s3/http-like paths instead of `s3fs` (#4710)
   * FIX-#4676: drain sub-virtual-partition call queues (#4695)
   * FIX-#4782: Exclude certain non-parquet files in `read_parquet` (#4783)    
+  * FIX-#4808: Set dtypes correctly after column rename (TODO(mvashishtha): add PR number)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -32,7 +32,7 @@ Key Features and Updates
   * FIX-#4657: Use `fsspec` for handling s3/http-like paths instead of `s3fs` (#4710)
   * FIX-#4676: drain sub-virtual-partition call queues (#4695)
   * FIX-#4782: Exclude certain non-parquet files in `read_parquet` (#4783)    
-  * FIX-#4808: Set dtypes correctly after column rename (TODO(mvashishtha): add PR number)
+  * FIX-#4808: Set dtypes correctly after column rename (#4809)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1754,9 +1754,7 @@ class PandasDataframe(ClassLogger):
             return df.rename(index=new_row_labels, columns=new_col_labels, level=level)
 
         new_parts = self._partition_mgr_cls.map_partitions(self._partitions, map_fn)
-
         new_dtypes = None if self._dtypes is None else self._dtypes.set_axis(new_cols)
-
         return self.__constructor__(
             new_parts,
             new_index,

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1755,10 +1755,7 @@ class PandasDataframe(ClassLogger):
 
         new_parts = self._partition_mgr_cls.map_partitions(self._partitions, map_fn)
 
-        if self._dtypes is None:
-            new_dtypes = None
-        else:
-            new_dtypes = self._dtypes.set_axis(new_cols)
+        new_dtypes = None if self._dtypes is None else self._dtypes.set_axis(new_cols)
 
         return self.__constructor__(
             new_parts,

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1754,13 +1754,19 @@ class PandasDataframe(ClassLogger):
             return df.rename(index=new_row_labels, columns=new_col_labels, level=level)
 
         new_parts = self._partition_mgr_cls.map_partitions(self._partitions, map_fn)
+
+        if self._dtypes is None:
+            new_dtypes = None
+        else:
+            new_dtypes = self._dtypes.set_axis(new_cols)
+
         return self.__constructor__(
             new_parts,
             new_index,
             new_cols,
             self._row_lengths,
             self._column_widths,
-            self._dtypes,
+            new_dtypes,
         )
 
     def sort_by(

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -205,6 +205,9 @@ def test_add_prefix(data):
     new_modin_df = modin_df.add_prefix(test_prefix)
     new_pandas_df = pandas_df.add_prefix(test_prefix)
     df_equals(new_modin_df.columns, new_pandas_df.columns)
+    # TODO(https://github.com/modin-project/modin/issues/3804):
+    # make df_equals always check dtypes.
+    df_equals(new_modin_df.dtypes, new_pandas_df.dtypes)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2660,8 +2660,6 @@ def test_reindex_like():
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_rename(data):
-    # TODO(https://github.com/modin-project/modin/issues/3804):
-    # make df_equals always check dtypes.
     modin_series, pandas_series = create_test_series(data)
     new_name = "NEW_NAME"
     df_equals(modin_series.rename(new_name), pandas_series.rename(new_name))

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2660,6 +2660,8 @@ def test_reindex_like():
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_rename(data):
+    # TODO(https://github.com/modin-project/modin/issues/3804):
+    # make df_equals always check dtypes.
     modin_series, pandas_series = create_test_series(data)
     new_name = "NEW_NAME"
     df_equals(modin_series.rename(new_name), pandas_series.rename(new_name))


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4808
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
