### PR TITLE
REFACTOR-#4530: Unify access to physical data for any partition type

### DIFF
--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -504,19 +504,7 @@ def execute(
             return
 
         # compatibility with old Modin versions
-        blocks = [
-            block for partition in partitions for block in partition.list_of_blocks
-        ]
-        if ASV_USE_ENGINE == "ray":
-            from ray import wait
-
-            wait(blocks, num_returns=len(blocks))
-        elif ASV_USE_ENGINE == "dask":
-            from dask.distributed import wait
-
-            wait(blocks, return_when="ALL_COMPLETED")
-        elif ASV_USE_ENGINE == "python":
-            pass
+        df._query_compiler._modin_frame._partition_mgr_cls.wait_partitions(partitions)
 
     elif ASV_USE_IMPL == "pandas":
         pass

--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -29,7 +29,6 @@ from typing import Optional, Union
 from .compatibility import (
     ASV_USE_IMPL,
     ASV_DATASET_SIZE,
-    ASV_USE_ENGINE,
     ASV_USE_STORAGE_FORMAT,
 )
 from .data_shapes import RAND_LOW, RAND_HIGH

--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -504,7 +504,9 @@ def execute(
             return
 
         # compatibility with old Modin versions
-        blocks = [block for partition in partitions for block in partition.list_of_blocks]
+        blocks = [
+            block for partition in partitions for block in partition.list_of_blocks
+        ]
         if ASV_USE_ENGINE == "ray":
             from ray import wait
 
@@ -512,7 +514,7 @@ def execute(
         elif ASV_USE_ENGINE == "dask":
             from dask.distributed import wait
 
-            wait(blocks, return_when='ALL_COMPLETED')
+            wait(blocks, return_when="ALL_COMPLETED")
         elif ASV_USE_ENGINE == "python":
             pass
 

--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -504,14 +504,15 @@ def execute(
             return
 
         # compatibility with old Modin versions
+        blocks = [block for partition in partitions for block in partition.list_of_blocks]
         if ASV_USE_ENGINE == "ray":
             from ray import wait
 
-            all(map(lambda partition: wait([partition.list_of_blocks[0]]), partitions))
+            wait(blocks, num_returns=len(blocks))
         elif ASV_USE_ENGINE == "dask":
             from dask.distributed import wait
 
-            all(map(lambda partition: wait(partition.list_of_blocks[0]), partitions))
+            wait(blocks, return_when='ALL_COMPLETED')
         elif ASV_USE_ENGINE == "python":
             pass
 

--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -504,20 +504,14 @@ def execute(
             return
 
         # compatibility with old Modin versions
-        all(
-            map(
-                lambda partition: partition.drain_call_queue() or True,
-                partitions,
-            )
-        )
         if ASV_USE_ENGINE == "ray":
             from ray import wait
 
-            all(map(lambda partition: wait([partition._data]), partitions))
+            all(map(lambda partition: wait([partition.list_of_blocks[0]]), partitions))
         elif ASV_USE_ENGINE == "dask":
             from dask.distributed import wait
 
-            all(map(lambda partition: wait(partition._data), partitions))
+            all(map(lambda partition: wait(partition.list_of_blocks[0]), partitions))
         elif ASV_USE_ENGINE == "python":
             pass
 

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -31,7 +31,7 @@ Key Features and Updates
   * FIX-#4756: Correctly propagate `storage_options` in `read_parquet` (#4764)
   * FIX-#4657: Use `fsspec` for handling s3/http-like paths instead of `s3fs` (#4710)
   * FIX-#4676: drain sub-virtual-partition call queues (#4695)
-  * FIX-#4782: Exclude certain non-parquet files in `read_parquet` (#4783)    
+  * FIX-#4782: Exclude certain non-parquet files in `read_parquet` (#4783)
   * FIX-#4808: Set dtypes correctly after column rename (#4809)
   * FIX-#4811: Apply dataframe -> not_dataframe functions to virtual partitions (#4812)
   * FIX-#4099: Use mangled column names but keep the original when building frames from arrow (#4767)
@@ -68,6 +68,7 @@ Key Features and Updates
   * REFACTOR-#4722: Stop suppressing undefined name lint (#4723)
   * REFACTOR-#4832: unify `split_result_of_axis_func_pandas` (#4831)
   * REFACTOR-#4796: Introduce constant for __reduced__ column name (#4799)
+  * REFACTOR-#4530: Unify access to physical data for any partition type (#4829)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements
@@ -81,7 +82,7 @@ Key Features and Updates
   * TEST-#4550: Use much less data in test_partition_api (#4554)
   * TEST-#4610: Remove explicit installation of `black`/`flake8` for omnisci ci-notebooks (#4609)
   * TEST-#2564: Add caching and use mamba for conda setups in GH (#4607)
-  * TEST-#4557: Delete multiindex sorts instead of xfailing (#4559)  
+  * TEST-#4557: Delete multiindex sorts instead of xfailing (#4559)
   * TEST-#4698: Stop passing invalid storage_options param (#4699)
   * TEST-#4745: Pin flake8 to <5 to workaround installation conflict (#4752)
   * TEST-#4875: XFail tests failing due to file gone missing (#4876)

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -38,7 +38,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         list
             A list of physical partition objects (``ray.ObjectRef``, ``distributed.Future`` e.g.).
         """
-        # Defer draining call queue (which is hided in `partition.list_of_blocks` call) until we get the partitions.
+        # Defer draining call queue (which is hidden in `partition.list_of_blocks` call) until we get the partitions.
         # TODO Look into draining call queue at the same time as the task
         return [
             partition.list_of_blocks[0] for partition in self.list_of_block_partitions

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -28,6 +28,22 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
     Because much of the code is similar, this allows us to reuse this code.
     """
 
+    @property
+    def list_of_blocks(self):
+        """
+        Get the list of physical partition objects that compose this partition.
+
+        Returns
+        -------
+        list
+            A list of physical partition objects (``ray.ObjectRef``, ``distributed.Future`` e.g.).
+        """
+        # Defer draining call queue (which is hided in `partition.list_of_blocks` call) until we get the partitions.
+        # TODO Look into draining call queue at the same time as the task
+        return [
+            partition.list_of_blocks[0] for partition in self.list_of_block_partitions
+        ]
+
     def apply(
         self,
         func,

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -54,12 +54,12 @@ class PandasDataframePartition(ABC):  # pragma: no cover
     @property
     def list_of_blocks(self):
         """
-        Get actual physical data holded by partition.
+        Get the list of physical partition objects that compose this partition.
 
         Returns
         -------
         list
-            List of objects, specific for concrete execution ([ray.ObjectRef] e.g.)
+            A list of physical partition objects (``ray.ObjectRef``, ``distributed.Future`` e.g.).
         """
         self.drain_call_queue()
         return [self._data]

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -51,6 +51,11 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         """
         pass
 
+    @property
+    def list_of_blocks(self):
+        self.drain_call_queue()
+        return [self._data]
+
     def apply(self, func, *args, **kwargs):
         """
         Apply a function to the object wrapped by this partition.

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -53,6 +53,14 @@ class PandasDataframePartition(ABC):  # pragma: no cover
 
     @property
     def list_of_blocks(self):
+        """
+        Get actual physical data holded by partition.
+
+        Returns
+        -------
+        list
+            List of objects, specific for concrete execution ([ray.ObjectRef] e.g.)
+        """
         self.drain_call_queue()
         return [self._data]
 

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -61,6 +61,8 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         list
             A list of physical partition objects (``ray.ObjectRef``, ``distributed.Future`` e.g.).
         """
+        # Defer draining call queue until we get the partitions.
+        # TODO Look into draining call queue at the same time as the task
         self.drain_call_queue()
         return [self._data]
 

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1281,15 +1281,23 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         np.ndarray
             A NumPy array with new partitions.
         """
-        [part.drain_call_queue() for part in right.flatten()]
-
         func = cls.preprocess_func(func)
+
+        def get_right_block(row_idx, col_idx):
+            blocks = right[row_idx][col_idx].list_of_blocks
+            # TODO Resolve this assertion as a part of #4691, because the current implementation assumes
+            # that partition contains only 1 block.
+            assert (
+                len(blocks) == 1
+            ), f"Implementation assumes that partition contains only 1 block, but {len(blocks)} recieved."
+            return blocks[0]
+
         return np.array(
             [
                 [
                     part.apply(
                         func,
-                        right[row_idx][col_idx].list_of_blocks[0],
+                        get_right_block(row_idx, col_idx),
                     )
                     for col_idx, part in enumerate(left[row_idx])
                 ]

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1289,7 +1289,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 [
                     part.apply(
                         func,
-                        right[row_idx][col_idx]._data,
+                        right[row_idx][col_idx].list_of_blocks[0],
                     )
                     for col_idx, part in enumerate(left[row_idx])
                 ]

--- a/modin/core/execution/dask/implementations/pandas_on_dask/dataframe/dataframe.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/dataframe/dataframe.py
@@ -68,17 +68,19 @@ class PandasOnDaskDataframe(PandasDataframe):
             return [
                 partition.apply(
                     lambda df: len(df) if not axis else len(df.columns)
-                )._data
+                ).list_of_blocks[0]
             ]
         elif partition.axis == axis:
             return [
-                ptn.apply(lambda df: len(df) if not axis else len(df.columns))._data
+                ptn.apply(
+                    lambda df: len(df) if not axis else len(df.columns)
+                ).list_of_blocks[0]
                 for ptn in partition.list_of_block_partitions
             ]
         return [
             partition.list_of_block_partitions[0]
             .apply(lambda df: len(df) if not axis else (len(df.columns)))
-            ._data
+            .list_of_blocks[0]
         ]
 
     @property

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
@@ -39,6 +39,8 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
         """
         Get the objects wrapped by `partitions` in parallel.
 
+        This function assumes that each partition in `partitions` contains a single block.
+
         Parameters
         ----------
         partitions : np.ndarray

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
@@ -49,7 +49,9 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
-        return DaskWrapper.materialize([partition._data for partition in partitions])
+        return DaskWrapper.materialize(
+            [partition.list_of_blocks[0] for partition in partitions]
+        )
 
     @classmethod
     def wait_partitions(cls, partitions):
@@ -63,4 +65,7 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
         partitions : np.ndarray
             NumPy array with ``PandasDataframePartition``-s.
         """
-        wait([partition._data for partition in partitions], return_when="ALL_COMPLETED")
+        wait(
+            [partition.list_of_blocks[0] for partition in partitions],
+            return_when="ALL_COMPLETED",
+        )

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
@@ -49,6 +49,9 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
+        assert all(
+            [len(partition.list_of_blocks) == 1 for partition in partitions]
+        ), "Implementation assumes that each partition contains a signle block."
         return DaskWrapper.materialize(
             [partition.list_of_blocks[0] for partition in partitions]
         )
@@ -66,6 +69,6 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
             NumPy array with ``PandasDataframePartition``-s.
         """
         wait(
-            [partition.list_of_blocks[0] for partition in partitions],
+            [block for partition in partitions for block in partition.list_of_blocks],
             return_when="ALL_COMPLETED",
         )

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -116,24 +116,6 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         return self._list_of_block_partitions
 
     @property
-    def list_of_blocks(self):
-        """
-        Get the list of physical partition objects that compose this partition.
-
-        Returns
-        -------
-        List
-            A list of ``distributed.Future``.
-        """
-        # Defer draining call queue until we get the partitions
-        # TODO Look into draining call queue at the same time as the task
-        result = [None] * len(self.list_of_block_partitions)
-        for idx, partition in enumerate(self.list_of_block_partitions):
-            partition.drain_call_queue()
-            result[idx] = partition.list_of_blocks[0]
-        return result
-
-    @property
     def list_of_ips(self):
         """
         Get the IPs holding the physical objects composing this partition.

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -130,7 +130,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         result = [None] * len(self.list_of_block_partitions)
         for idx, partition in enumerate(self.list_of_block_partitions):
             partition.drain_call_queue()
-            result[idx] = partition._data
+            result[idx] = partition.list_of_blocks[0]
         return result
 
     @property

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/virtual_partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/virtual_partition.py
@@ -43,7 +43,7 @@ class PandasOnPythonDataframeAxisPartition(PandasDataframeAxisPartition):
         for obj in list_of_blocks:
             obj.drain_call_queue()
         # Unwrap from PandasDataframePartition object for ease of use
-        self.list_of_blocks = [obj._data for obj in list_of_blocks]
+        self.list_of_blocks = [obj.list_of_blocks[0] for obj in list_of_blocks]
 
     partition_type = PandasOnPythonDataframePartition
     instance_type = pandas.DataFrame

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/virtual_partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/virtual_partition.py
@@ -40,10 +40,8 @@ class PandasOnPythonDataframeAxisPartition(PandasDataframeAxisPartition):
             raise NotImplementedError(
                 "Pandas on Python execution requires full-axis partitions."
             )
-        for obj in list_of_blocks:
-            obj.drain_call_queue()
-        # Unwrap from PandasDataframePartition object for ease of use
-        self.list_of_blocks = [obj.list_of_blocks[0] for obj in list_of_blocks]
+
+        self.list_of_block_partitions = list_of_blocks
 
     partition_type = PandasOnPythonDataframePartition
     instance_type = pandas.DataFrame

--- a/modin/core/execution/ray/generic/modin_aqp.py
+++ b/modin/core/execution/ray/generic/modin_aqp.py
@@ -51,7 +51,7 @@ def call_progress_bar(result_parts, line_no):
     except AttributeError:
         return
     pbar_id = str(cell_no) + "-" + str(line_no)
-    futures = [x._data for row in result_parts for x in row]
+    futures = [x.list_of_blocks[0] for row in result_parts for x in row]
     bar_format = (
         "{l_bar}{bar}{r_bar}"
         if "DEBUG_PROGRESS_BAR" in os.environ

--- a/modin/core/execution/ray/generic/modin_aqp.py
+++ b/modin/core/execution/ray/generic/modin_aqp.py
@@ -51,7 +51,12 @@ def call_progress_bar(result_parts, line_no):
     except AttributeError:
         return
     pbar_id = str(cell_no) + "-" + str(line_no)
-    futures = [x.list_of_blocks[0] for row in result_parts for x in row]
+    futures = [
+        block
+        for row in result_parts
+        for partition in row
+        for block in partition.list_of_blocks
+    ]
     bar_format = (
         "{l_bar}{bar}{r_bar}"
         if "DEBUG_PROGRESS_BAR" in os.environ

--- a/modin/core/execution/ray/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/generic/partitioning/partition_manager.py
@@ -43,7 +43,7 @@ class GenericRayDataframePartitionManager(PandasDataframePartitionManager):
         """
         parts = ray.get(
             [
-                obj.apply(lambda df, **kwargs: df.to_numpy(**kwargs))._data
+                obj.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).list_of_blocks[0]
                 for row in partitions
                 for obj in row
             ]

--- a/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -236,7 +236,7 @@ class PandasOnRayIO(RayIO):
             max_retries=0,
         )
         # pending completion
-        ray.get([partition._data for partition in result.flatten()])
+        ray.get([partition.list_of_blocks[0] for partition in result.flatten()])
 
     @staticmethod
     def _to_parquet_check_support(kwargs):
@@ -309,4 +309,4 @@ class PandasOnRayIO(RayIO):
             lengths=None,
             enumerate_partitions=True,
         )
-        ray.get([part._data for row in result for part in row])
+        ray.get([part.list_of_blocks[0] for row in result for part in row])

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -107,7 +107,7 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
-        return ray.get([partition._data for partition in partitions])
+        return ray.get([partition.list_of_blocks[0] for partition in partitions])
 
     @classmethod
     def wait_partitions(cls, partitions):
@@ -122,7 +122,8 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
             NumPy array with ``PandasDataframePartition``-s.
         """
         ray.wait(
-            [partition._data for partition in partitions], num_returns=len(partitions)
+            [partition.list_of_blocks[0] for partition in partitions],
+            num_returns=len(partitions),
         )
 
     @classmethod

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -97,6 +97,8 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         """
         Get the objects wrapped by `partitions` in parallel.
 
+        This function assumes that each partition in `partitions` contains a single block.
+
         Parameters
         ----------
         partitions : np.ndarray

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -107,6 +107,9 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         list
             The objects wrapped by `partitions`.
         """
+        assert all(
+            [len(partition.list_of_blocks) == 1 for partition in partitions]
+        ), "Implementation assumes that each partition contains a signle block."
         return ray.get([partition.list_of_blocks[0] for partition in partitions])
 
     @classmethod
@@ -121,9 +124,12 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         partitions : np.ndarray
             NumPy array with ``PandasDataframePartition``-s.
         """
+        blocks = [
+            block for partition in partitions for block in partition.list_of_blocks
+        ]
         ray.wait(
-            [partition.list_of_blocks[0] for partition in partitions],
-            num_returns=len(partitions),
+            blocks,
+            num_returns=len(blocks),
         )
 
     @classmethod

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -129,10 +129,7 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         blocks = [
             block for partition in partitions for block in partition.list_of_blocks
         ]
-        ray.wait(
-            blocks,
-            num_returns=len(blocks),
-        )
+        ray.wait(blocks, num_returns=len(blocks))
 
     @classmethod
     @progress_bar_wrapper

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -114,24 +114,6 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         return self._list_of_block_partitions
 
     @property
-    def list_of_blocks(self):
-        """
-        Get the list of physical partition objects that compose this partition.
-
-        Returns
-        -------
-        List
-            A list of ``ray.ObjectRef``.
-        """
-        # Defer draining call queue until we get the partitions
-        # TODO Look into draining call queue at the same time as the task
-        result = [None] * len(self.list_of_block_partitions)
-        for idx, partition in enumerate(self.list_of_block_partitions):
-            partition.drain_call_queue()
-            result[idx] = partition.list_of_blocks[0]
-        return result
-
-    @property
     def list_of_ips(self):
         """
         Get the IPs holding the physical objects composing this partition.

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -128,7 +128,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         result = [None] * len(self.list_of_block_partitions)
         for idx, partition in enumerate(self.list_of_block_partitions):
             partition.drain_call_queue()
-            result[idx] = partition._data
+            result[idx] = partition.list_of_blocks[0]
         return result
 
     @property

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -56,17 +56,22 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
 
         def _unwrap_partitions():
             [p.drain_call_queue() for p in modin_frame._partitions.flatten()]
+
+            def get_block(partition):
+                blocks = partition.list_of_blocks
+                assert (
+                    len(blocks) == 1
+                ), f"Implementation assumes that partition contains a single block, but {len(blocks)} recieved."
+                return blocks[0]
+
             if get_ip:
                 return [
-                    [
-                        (partition._ip_cache, partition.list_of_blocks[0])
-                        for partition in row
-                    ]
+                    [(partition._ip_cache, get_block(partition)) for partition in row]
                     for row in modin_frame._partitions
                 ]
             else:
                 return [
-                    [partition.list_of_blocks[0] for partition in row]
+                    [get_block(partition) for partition in row]
                     for row in modin_frame._partitions
                 ]
 

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -58,12 +58,15 @@ def unwrap_partitions(api_layer_object, axis=None, get_ip=False):
             [p.drain_call_queue() for p in modin_frame._partitions.flatten()]
             if get_ip:
                 return [
-                    [(partition._ip_cache, partition._data) for partition in row]
+                    [
+                        (partition._ip_cache, partition.list_of_blocks[0])
+                        for partition in row
+                    ]
                     for row in modin_frame._partitions
                 ]
             else:
                 return [
-                    [partition._data for partition in row]
+                    [partition.list_of_blocks[0] for partition in row]
                     for row in modin_frame._partitions
                 ]
 

--- a/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/axis_partition.py
+++ b/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/axis_partition.py
@@ -36,7 +36,7 @@ class PyarrowOnRayDataframeAxisPartition(BaseDataframeAxisPartition):
 
     def __init__(self, list_of_blocks):
         # Unwrap from PandasDataframePartition object for ease of use
-        self.list_of_blocks = [obj._data for obj in list_of_blocks]
+        self.list_of_blocks = [obj.list_of_blocks[0] for obj in list_of_blocks]
 
     def apply(self, func, num_splits=None, other_axis_partition=None, **kwargs):
         """

--- a/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/axis_partition.py
+++ b/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/axis_partition.py
@@ -35,6 +35,9 @@ class PyarrowOnRayDataframeAxisPartition(BaseDataframeAxisPartition):
     """
 
     def __init__(self, list_of_blocks):
+        assert all(
+            [len(partition.list_of_blocks) == 1 for partition in list_of_blocks]
+        ), "Implementation assumes that each partition contains a signle block."
         # Unwrap from PandasDataframePartition object for ease of use
         self.list_of_blocks = [obj.list_of_blocks[0] for obj in list_of_blocks]
 

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -80,7 +80,7 @@ def test_unwrap_partitions(axis, reverse_index, reverse_columns):
         for row_idx in range(expected_partitions.shape[0]):
             for col_idx in range(expected_partitions.shape[1]):
                 df_equals(
-                    get_func(expected_partitions[row_idx][col_idx]._data),
+                    get_func(expected_partitions[row_idx][col_idx].list_of_blocks[0]),
                     get_func(actual_partitions[row_idx][col_idx]),
                 )
     else:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR adds public API for block partition class to access to actual `._data`. Now, naming between axis/block partitions to access to physical data is aligned.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4530 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
