### PR TITLE
FIX-#4734: Handle `Series.apply` when return type is a `DataFrame`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -44,6 +44,7 @@ Key Features and Updates
   * FIX-#4907: Implement `radd` for Series and DataFrame (#4908)
   * FIX-#4818, PERF-#4825: Fix where by using the new n-ary operator (#4820)    
   * FIX-#4845: Fix KeyError from `__getitem_bool` for single row dataframes (#4845)
+  * FIX-#4734: Handle Series.apply when return type is a DataFrame (#4830)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -2227,7 +2227,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             - "reduce": keep result into a single cell (opposite of "expand").
             - "broadcast": broadcast result to original data shape (overwrite the existing column/row with the function result).
             - None: use "expand" strategy if Series is returned, "reduce" otherwise.
-        ret_series : bool
+        ret_series : bool, default: False
             Flag that specifies whether we have a func that returns a Series
             object and are working on a Series object.
         *args : iterable

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -2203,9 +2203,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     # UDF (apply and agg) methods
     # There is a wide range of behaviors that are supported, so a lot of the
     # logic can get a bit convoluted.
-    def apply(
-        self, func, axis, raw=False, result_type=None, ret_series=False, *args, kwargs
-    ):
+    def apply(self, func, axis, raw=False, result_type=None, *args, **kwargs):
         """
         Apply passed function across given axis.
 
@@ -2227,12 +2225,9 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             - "reduce": keep result into a single cell (opposite of "expand").
             - "broadcast": broadcast result to original data shape (overwrite the existing column/row with the function result).
             - None: use "expand" strategy if Series is returned, "reduce" otherwise.
-        ret_series : bool, default: False
-            Flag that specifies whether we have a func that returns a Series
-            object and are working on a Series object.
         *args : iterable
             Positional arguments to pass to `func`.
-        kwargs : dict
+        **kwargs : dict
             Keyword arguments to pass to `func`.
 
         Returns
@@ -2249,21 +2244,38 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             - Each element is the result of execution of `func` against
               corresponding row/column.
         """
-        # There are some cases where a func to be applied returns a Series object and
-        # needs to be handled differently.
-        if self.is_series_like() and ret_series:
-            return SeriesDefault.register(pandas.Series.apply)(
-                self,
-                func=func,
-                *args,
-                **kwargs,
-            )
         return DataFrameDefault.register(pandas.DataFrame.apply)(
             self,
             func=func,
             axis=axis,
             raw=raw,
             result_type=result_type,
+            *args,
+            **kwargs,
+        )
+
+    def apply_on_series(self, func, *args, **kwargs):
+        """
+        Apply passed function on underlying Series.
+
+        Parameters
+        ----------
+        func : callable(pandas.Series) -> scalar, str, list or dict of such
+            The function to apply to each row.
+        *args : iterable
+            Positional arguments to pass to `func`.
+        **kwargs : dict
+            Keyword arguments to pass to `func`.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        assert self.is_series_like()
+
+        return SeriesDefault.register(pandas.Series.apply)(
+            self,
+            func=func,
             *args,
             **kwargs,
         )

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2381,13 +2381,15 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # UDF (apply and agg) methods
     # There is a wide range of behaviors that are supported, so a lot of the
     # logic can get a bit convoluted.
-    def apply(self, func, axis, is_series, *args, **kwargs):
+    def apply(self, func, axis, *args, **kwargs):
         # if any of args contain modin object, we should
         # convert it to pandas
 
         # TODO(vkarthik): currently is_series only works for callable
         # functions that return Series objects. We should handle this
         # for other cases as well.
+        is_series = kwargs.pop("is_series", False)
+
         args = try_cast_to_pandas(args)
         kwargs = try_cast_to_pandas(kwargs)
         if isinstance(func, dict):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -854,7 +854,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
             args=args,
             raw=raw,
             result_type=result_type,
-            **kwds,
+            kwargs=kwds,
         )
         return query_compiler
 
@@ -1639,7 +1639,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
             }
 
             return self.__constructor__(
-                query_compiler=self._query_compiler.apply("kurt", axis, **func_kwargs)
+                query_compiler=self._query_compiler.apply("kurt", axis, func_kwargs)
             )
 
         if numeric_only is not None and not numeric_only:

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -848,12 +848,12 @@ class BasePandasDataset(BasePandasDatasetCompat):
                     FutureWarning,
                     stacklevel=2,
                 )
+        kwds["args"] = args
+        kwds["raw"] = raw
+        kwds["result_type"] = result_type
         query_compiler = self._query_compiler.apply(
             func,
             axis,
-            args=args,
-            raw=raw,
-            result_type=result_type,
             kwargs=kwds,
         )
         return query_compiler
@@ -1639,7 +1639,9 @@ class BasePandasDataset(BasePandasDatasetCompat):
             }
 
             return self.__constructor__(
-                query_compiler=self._query_compiler.apply("kurt", axis, func_kwargs)
+                query_compiler=self._query_compiler.apply(
+                    "kurt", axis, kwargs=func_kwargs
+                )
             )
 
         if numeric_only is not None and not numeric_only:

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -848,13 +848,13 @@ class BasePandasDataset(BasePandasDatasetCompat):
                     FutureWarning,
                     stacklevel=2,
                 )
-        kwds["args"] = args
-        kwds["raw"] = raw
-        kwds["result_type"] = result_type
         query_compiler = self._query_compiler.apply(
             func,
             axis,
-            kwargs=kwds,
+            args=args,
+            raw=raw,
+            result_type=result_type,
+            **kwds,
         )
         return query_compiler
 
@@ -1639,9 +1639,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
             }
 
             return self.__constructor__(
-                query_compiler=self._query_compiler.apply(
-                    "kurt", axis, kwargs=func_kwargs
-                )
+                query_compiler=self._query_compiler.apply("kurt", axis, **func_kwargs)
             )
 
         if numeric_only is not None and not numeric_only:

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -677,9 +677,7 @@ class Series(SeriesCompat, BasePandasDataset):
                 # has to be handled by the underlying pandas.Series apply
                 # function and not our default applymap call.
                 if return_type == "DataFrame":
-                    result = self._query_compiler.apply(
-                        f, axis=1, ret_series=True, kwargs={}
-                    )
+                    result = self._query_compiler.apply_on_series(f)
                 else:
                     result = self.map(f)._query_compiler
 

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -677,7 +677,9 @@ class Series(SeriesCompat, BasePandasDataset):
                 # has to be handled by the underlying pandas.Series apply
                 # function and not our default applymap call.
                 if return_type == "DataFrame":
-                    result = self._query_compiler.apply(f, axis=1, is_series=True)
+                    result = self._query_compiler.apply(
+                        f, axis=1, ret_series=True, kwargs={}
+                    )
                 else:
                     result = self.map(f)._query_compiler
 

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -680,9 +680,10 @@ class Series(SeriesCompat, BasePandasDataset):
                     result = self._query_compiler.apply(f, axis=1, is_series=True)
                 else:
                     result = self.map(f)._query_compiler
-        from .dataframe import DataFrame
 
         if return_type == "DataFrame":
+            from .dataframe import DataFrame
+
             result = DataFrame(query_compiler=result)
         elif return_type == "Series":
             result = Series(query_compiler=result)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4713,23 +4713,13 @@ def test_peculiar_callback():
     df_equals(modin_series, pandas_series)
 
 
-def test_apply_return_df():
-    modin_series, pandas_series = create_test_series([2, 4, 6, 0, 1])
-    eval_general(
-        modin_series,
-        pandas_series,
-        lambda series: series.apply(lambda x: pandas.Series([x, x + 1])),
-    )
-
-
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-@pytest.mark.parametrize("num_columns", [4, 8, 16, 32, 64])
-def test_apply_return_df_multiple_partitions(data, num_columns):
+def test_apply_return_df(data):
     modin_series, pandas_series = create_test_series(data)
     eval_general(
         modin_series,
         pandas_series,
         lambda series: series.apply(
-            lambda x: pandas.Series([x + i for i in range(num_columns)])
+            lambda x: pandas.Series([x + i for i in range(100)])
         ),
     )

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4711,3 +4711,30 @@ def test_peculiar_callback():
     modin_series = modin_df["col"].apply(func)
 
     df_equals(modin_series, pandas_series)
+
+
+def test_apply_return_df():
+    modin_df = pd.Series(1).apply(lambda x: pandas.Series([x, x]))
+    pandas_df = pandas.Series(1).apply(lambda x: pandas.Series([x, x]))
+
+    df_equals(modin_df, pandas_df)
+
+    modin_df = pd.Series([2, 4, 6, 0, 1]).apply(lambda x: pandas.Series([x, x + 1]))
+    pandas_df = pandas.Series([2, 4, 6, 0, 1]).apply(
+        lambda x: pandas.Series([x, x + 1])
+    )
+
+    df_equals(modin_df, pandas_df)
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_apply_return_df_multiple_partitions(data):
+    modin_series, pandas_series = create_test_series(data)
+    modin_df = modin_series.apply(
+        lambda x: pandas.Series([x, x + 1, x + 2], index=["a", "b", "c"])
+    )
+    pandas_df = pandas_series.apply(
+        lambda x: pandas.Series([x, x + 1, x + 2], index=["a", "b", "c"])
+    )
+
+    df_equals(modin_df, pandas_df)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4728,22 +4728,14 @@ def test_apply_return_df():
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_apply_return_df_multiple_partitions(data):
+@pytest.mark.parametrize("num_columns", [4, 8, 16, 32, 64])
+def test_apply_return_df_multiple_partitions(data, num_columns):
     modin_series, pandas_series = create_test_series(data)
     modin_df = modin_series.apply(
-        lambda x: pandas.Series([x, x + 1, x + 2], index=["a", "b", "c"])
+        lambda x: pandas.Series([x + i for i in range(num_columns)])
     )
     pandas_df = pandas_series.apply(
-        lambda x: pandas.Series([x, x + 1, x + 2], index=["a", "b", "c"])
+        lambda x: pandas.Series([x + i for i in range(num_columns)])
     )
-
-    df_equals(modin_df, pandas_df)
-
-
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_apply_return_df_multiple_partitions_horizontal(data):
-    modin_series, pandas_series = create_test_series(data)
-    modin_df = modin_series.apply(lambda x: pandas.Series([x, x + 1, x + 2] * 30))
-    pandas_df = pandas_series.apply(lambda x: pandas.Series([x, x + 1, x + 2] * 30))
 
     df_equals(modin_df, pandas_df)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4738,3 +4738,12 @@ def test_apply_return_df_multiple_partitions(data):
     )
 
     df_equals(modin_df, pandas_df)
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_apply_return_df_multiple_partitions_horizontal(data):
+    modin_series, pandas_series = create_test_series(data)
+    modin_df = modin_series.apply(lambda x: pandas.Series([x, x + 1, x + 2] * 30))
+    pandas_df = pandas_series.apply(lambda x: pandas.Series([x, x + 1, x + 2] * 30))
+
+    df_equals(modin_df, pandas_df)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4714,28 +4714,22 @@ def test_peculiar_callback():
 
 
 def test_apply_return_df():
-    modin_df = pd.Series(1).apply(lambda x: pandas.Series([x, x]))
-    pandas_df = pandas.Series(1).apply(lambda x: pandas.Series([x, x]))
-
-    df_equals(modin_df, pandas_df)
-
-    modin_df = pd.Series([2, 4, 6, 0, 1]).apply(lambda x: pandas.Series([x, x + 1]))
-    pandas_df = pandas.Series([2, 4, 6, 0, 1]).apply(
-        lambda x: pandas.Series([x, x + 1])
+    modin_series, pandas_series = create_test_series([2, 4, 6, 0, 1])
+    eval_general(
+        modin_series,
+        pandas_series,
+        lambda series: series.apply(lambda x: pandas.Series([x, x + 1])),
     )
-
-    df_equals(modin_df, pandas_df)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("num_columns", [4, 8, 16, 32, 64])
 def test_apply_return_df_multiple_partitions(data, num_columns):
     modin_series, pandas_series = create_test_series(data)
-    modin_df = modin_series.apply(
-        lambda x: pandas.Series([x + i for i in range(num_columns)])
+    eval_general(
+        modin_series,
+        pandas_series,
+        lambda series: series.apply(
+            lambda x: pandas.Series([x + i for i in range(num_columns)])
+        ),
     )
-    pandas_df = pandas_series.apply(
-        lambda x: pandas.Series([x + i for i in range(num_columns)])
-    )
-
-    df_equals(modin_df, pandas_df)


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR addresses a bug where `Series.apply` returns the incorrect value when the return type of the function is a `DataFrame`.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4734 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
