### PR TITLE
REFACTOR-#4832: unify `split_result_of_axis_func_pandas`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -61,6 +61,7 @@ Key Features and Updates
   * REFACTOR-#4774: remove `_build_treereduce_func` call from `_compute_dtypes` (#4775)
   * REFACTOR-#4750: Delete BaseDataframeAxisPartition.shuffle (#4751)
   * REFACTOR-#4722: Stop suppressing undefined name lint (#4723)
+  * REFACTOR-#4832: unify `split_result_of_axis_func_pandas` (#4831)
   * REFACTOR-#4796: Introduce constant for __reduced__ column name (#4799)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)

--- a/modin/core/storage_formats/pandas/utils.py
+++ b/modin/core/storage_formats/pandas/utils.py
@@ -92,23 +92,16 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
 
     if length_list is not None:
         length_list.insert(0, 0)
-        sums = np.cumsum(length_list)
-        if axis == 0 or isinstance(result, pandas.Series):
-            return [result.iloc[sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
-        else:
-            return [result.iloc[:, sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
-
-    # We do this to restore block partitioning
-    chunksize = compute_chunksize(result.shape[axis], num_splits)
-    if axis == 0 or isinstance(result, pandas.Series):
-        return [
-            result.iloc[chunksize * i : chunksize * (i + 1)] for i in range(num_splits)
-        ]
     else:
-        return [
-            result.iloc[:, chunksize * i : chunksize * (i + 1)]
-            for i in range(num_splits)
-        ]
+        chunksize = compute_chunksize(result.shape[axis], num_splits)
+        length_list = np.full(num_splits + 1, chunksize)
+        length_list[0] = 0
+    sums = np.cumsum(length_list)
+    # We do this to restore block partitioning
+    if axis == 0 or isinstance(result, pandas.Series):
+        return [result.iloc[sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
+    else:
+        return [result.iloc[:, sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
 
 
 def length_fn_pandas(df):


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4832 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
