### PR TITLE
PERF-#4944: avoid default_to_pandas

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -73,7 +73,7 @@ Key Features and Updates
   * PERF-#4268: Implement partition-parallel __getitem__ for bool Series masks (#4753)
 * Benchmarking enhancements
   * FEAT-#4706: Add Modin ClassLogger to PandasDataframePartitionManager (#4707)
-  * PERF-#4944: Avoid default_to_pandas (#4833)
+  * PERF-#4944: Avoid default_to_pandas in ``Series.cat.codes``, ``Series.dt.tz``, and ``Series.dt.to_pytimedelta`` (#4833)
 * Refactor Codebase
   * REFACTOR-#4530: Standardize access to physical data in partitions (#4563)
   * REFACTOR-#4534: Replace logging meta class with class decorator (#4535)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -90,6 +90,7 @@ Key Features and Updates
   * REFACTOR-#4530: Unify access to physical data for any partition type (#4829)
   * REFACTOR-#4885: De-duplicated take_2d_labels_or_positional methods (#4883)
   * REFACTOR-#4922: Helpers for take_2d_labels_or_positional (#4865)
+  * REFACTOR-#0000: Avoid default_to_pandas (#4833)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -73,6 +73,7 @@ Key Features and Updates
   * PERF-#4268: Implement partition-parallel __getitem__ for bool Series masks (#4753)
 * Benchmarking enhancements
   * FEAT-#4706: Add Modin ClassLogger to PandasDataframePartitionManager (#4707)
+  * PERF-#4944: Avoid default_to_pandas (#4833)
 * Refactor Codebase
   * REFACTOR-#4530: Standardize access to physical data in partitions (#4563)
   * REFACTOR-#4534: Replace logging meta class with class decorator (#4535)
@@ -90,7 +91,6 @@ Key Features and Updates
   * REFACTOR-#4530: Unify access to physical data for any partition type (#4829)
   * REFACTOR-#4885: De-duplicated take_2d_labels_or_positional methods (#4883)
   * REFACTOR-#4922: Helpers for take_2d_labels_or_positional (#4865)
-  * REFACTOR-#0000: Avoid default_to_pandas (#4833)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/modin/core/dataframe/algebra/default2pandas/default.py
+++ b/modin/core/dataframe/algebra/default2pandas/default.py
@@ -87,14 +87,18 @@ class DefaultMethod(Operator):
                 and func != "to_numpy"
                 and func != pandas.DataFrame.to_numpy
             ):
-                # When applying a DatetimeProperties function, if we don't
-                # specify the dtype for the DataFrame, the frame might get the
-                # wrong dtype, e.g. for to_pydatetime in
+                # When applying a DatetimeProperties or TimedeltaProperties function,
+                # if we don't specify the dtype for the DataFrame, the frame might
+                # get the wrong dtype, e.g. for to_pydatetime in
                 # https://github.com/modin-project/modin/issues/4436
                 astype_kwargs = {}
                 dtype = getattr(result, "dtype", None)
                 if dtype and isinstance(
-                    df, pandas.core.indexes.accessors.DatetimeProperties
+                    df,
+                    (
+                        pandas.core.indexes.accessors.DatetimeProperties,
+                        pandas.core.indexes.accessors.TimedeltaProperties,
+                    ),
                 ):
                     astype_kwargs["dtype"] = dtype
                 result = (

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3253,7 +3253,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # Cat operations
     def cat_codes(self):
         def func(df) -> np.ndarray:
-            # equiv: df.iloc[:, 0]
+            # equiv: df.iloc[:, 0] but slightly more performant
             ser = df._ixs(0, axis=1)
             return ser.cat.codes
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3252,7 +3252,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # Cat operations
     def cat_codes(self):
-
         def func(df) -> np.ndarray:
             # equiv: df.iloc[:, 0]
             ser = df._ixs(0, axis=1)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3253,8 +3253,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # Cat operations
     def cat_codes(self):
         def func(df) -> np.ndarray:
-            # equiv: df.iloc[:, 0] but slightly more performant
-            ser = df._ixs(0, axis=1)
+            ser = df.iloc[:, 0]
             return ser.cat.codes
 
         res = self._modin_frame.apply_full_axis(axis=0, func=func)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3252,7 +3252,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # Cat operations
     def cat_codes(self):
-        return self.default_to_pandas(lambda df: df[df.columns[0]].cat.codes)
+
+        def func(df) -> np.ndarray:
+            # equiv: df.iloc[:, 0]
+            ser = df._ixs(0, axis=1)
+            return ser.cat.codes
+
+        res = self._modin_frame.apply_full_axis(axis=0, func=func)
+        return self.__constructor__(res)
 
     # END Cat operations
 

--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -569,7 +569,7 @@ class DatetimeProperties(ClassLogger):
         return Series(query_compiler=self._query_compiler.dt_days_in_month())
 
     @property
-    def tz(self) -> "tzinfo" | None:
+    def tz(self) -> "tzinfo | None":
         dtype = self._series.dtype
         if isinstance(dtype, np.dtype):
             return None

--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -20,7 +20,6 @@ from typing import TYPE_CHECKING
 import sys
 import numpy as np
 import pandas
-from pandas._typing import npt
 from modin.logging import ClassLogger
 from modin.utils import _inherit_docstrings
 from .series import Series
@@ -34,6 +33,7 @@ else:
 
 if TYPE_CHECKING:
     from datetime import tzinfo
+    from pandas._typing import npt
 
 
 @_inherit_docstrings(pandas.core.arrays.categorical.CategoricalAccessor)

--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -16,8 +16,6 @@ Implement Series's accessors public API as pandas does.
 
 Accessors: `Series.cat`, `Series.str`, `Series.dt`
 """
-from __future__ import annotations
-
 from typing import TYPE_CHECKING
 import sys
 import numpy as np
@@ -625,7 +623,7 @@ class DatetimeProperties(ClassLogger):
             query_compiler=self._query_compiler.dt_total_seconds(*args, **kwargs)
         )
 
-    def to_pytimedelta(self) -> npt.NDArray[np.object_]:
+    def to_pytimedelta(self) -> "npt.NDArray[np.object_]":
         res = self._query_compiler.dt_to_pytimedelta()
         return res.to_numpy()[:, 0]
 

--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -569,7 +569,7 @@ class DatetimeProperties(ClassLogger):
         return Series(query_compiler=self._query_compiler.dt_days_in_month())
 
     @property
-    def tz(self) -> tzinfo | None:
+    def tz(self) -> "tzinfo" | None:
         dtype = self._series.dtype
         if isinstance(dtype, np.dtype):
             return None

--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -16,7 +16,9 @@ Implement Series's accessors public API as pandas does.
 
 Accessors: `Series.cat`, `Series.str`, `Series.dt`
 """
+from __future__ import annotations
 
+from typing import TYPE_CHECKING
 import sys
 import numpy as np
 import pandas
@@ -31,6 +33,9 @@ if sys.version_info[0] == 3 and sys.version_info[1] >= 7:
 else:
     # Python <= 3.6
     from re import _pattern_type
+
+if TYPE_CHECKING:
+    from datetime import tzinfo
 
 
 @_inherit_docstrings(pandas.core.arrays.categorical.CategoricalAccessor)
@@ -566,8 +571,11 @@ class DatetimeProperties(ClassLogger):
         return Series(query_compiler=self._query_compiler.dt_days_in_month())
 
     @property
-    def tz(self):
-        return self._query_compiler.dt_tz().to_pandas().squeeze()
+    def tz(self) -> tzinfo | None:
+        dtype = self._series.dtype
+        if isinstance(dtype, np.dtype):
+            return None
+        return dtype.tz
 
     @property
     def freq(self):

--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -20,6 +20,7 @@ Accessors: `Series.cat`, `Series.str`, `Series.dt`
 import sys
 import numpy as np
 import pandas
+from pandas._typing import npt
 from modin.logging import ClassLogger
 from modin.utils import _inherit_docstrings
 from .series import Series
@@ -616,10 +617,9 @@ class DatetimeProperties(ClassLogger):
             query_compiler=self._query_compiler.dt_total_seconds(*args, **kwargs)
         )
 
-    def to_pytimedelta(self):
-        return self._query_compiler.default_to_pandas(
-            lambda df: pandas.Series.dt.to_pytimedelta(df.squeeze(axis=1).dt)
-        )
+    def to_pytimedelta(self) -> npt.NDArray[np.object_]:
+        res = self._query_compiler.dt_to_pytimedelta()
+        return res.to_numpy()[:, 0]
 
     @property
     def seconds(self):


### PR DESCRIPTION
- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4944 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
