### PR TITLE
FIX-#4835: Handle Pathlike paths in `read_parquet`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -37,7 +37,7 @@ Key Features and Updates
   * FIX-#4099: Use mangled column names but keep the original when building frames from arrow (#4767)
   * FIX-#4838: Bump up modin-spreadsheet to latest master (#4839)
   * FIX-#4840: Change modin-spreadsheet version for notebook requirements (#4841)
-  * FIX-#4835: Handle `pathlib.Path` properly in `read_parquet` (#4837)
+  * FIX-#4835: Handle Pathlike paths in `read_parquet` (#4837)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -37,6 +37,7 @@ Key Features and Updates
   * FIX-#4099: Use mangled column names but keep the original when building frames from arrow (#4767)
   * FIX-#4838: Bump up modin-spreadsheet to latest master (#4839)
   * FIX-#4840: Change modin-spreadsheet version for notebook requirements (#4841)
+  * FIX-#4835: Handle `pathlib.Path` properly in `read_parquet` (#4837)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -60,7 +60,7 @@ class ColumnStoreDataset:
     """
 
     def __init__(self, path, storage_options):  # noqa : PR01
-        self.path = ColumnStoreDataset._get_path_str_or_handle(path)
+        self.path = path.__fspath__() if isinstance(path, os.PathLike) else path
         self.storage_options = storage_options
         self._fs_path = None
         self._fs = None
@@ -139,25 +139,6 @@ class ColumnStoreDataset:
             List of columns that should be read from file.
         """
         raise NotImplementedError
-
-    @staticmethod
-    def _get_path_str_or_handle(path):
-        """
-        Return string if path is a PathLike object.
-
-        Parameters
-        ----------
-        path : str, path object or file-like object
-            The filepath of the parquet file in local filesystem or hdfs.
-
-        Returns
-        -------
-        fs_path_str : str, bytes, or file-like object
-            String representation of path or file object
-        """
-        if isinstance(path, os.PathLike):
-            return path.__fspath__()
-        return path
 
     def _get_files(self, files):
         """

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -20,7 +20,6 @@ import fsspec
 from fsspec.core import url_to_fs
 from fsspec.spec import AbstractBufferedFile
 import numpy as np
-from pathlib import Path
 from packaging import version
 
 from modin.core.storage_formats.pandas.utils import compute_chunksize
@@ -61,7 +60,7 @@ class ColumnStoreDataset:
     """
 
     def __init__(self, path, storage_options):  # noqa : PR01
-        self.path = str(path) if isinstance(path, Path) else path
+        self.path = ColumnStoreDataset._get_path_str_or_handle(path)
         self.storage_options = storage_options
         self._fs_path = None
         self._fs = None
@@ -140,6 +139,25 @@ class ColumnStoreDataset:
             List of columns that should be read from file.
         """
         raise NotImplementedError
+
+    @staticmethod
+    def _get_path_str_or_handle(path):
+        """
+        Return string if path is a PathLike object.
+
+        Parameters
+        ----------
+        path : str, path object or file-like object
+            The filepath of the parquet file in local filesystem or hdfs.
+
+        Returns
+        -------
+        fs_path_str : str, bytes, or file-like object
+            String representation of path or file object
+        """
+        if isinstance(path, os.PathLike):
+            return path.__fspath__()
+        return path
 
     def _get_files(self, files):
         """

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -20,6 +20,7 @@ import fsspec
 from fsspec.core import url_to_fs
 from fsspec.spec import AbstractBufferedFile
 import numpy as np
+from pathlib import Path
 from packaging import version
 
 from modin.core.storage_formats.pandas.utils import compute_chunksize
@@ -60,7 +61,7 @@ class ColumnStoreDataset:
     """
 
     def __init__(self, path, storage_options):  # noqa : PR01
-        self.path = path
+        self.path = str(path) if isinstance(path, Path) else path
         self.storage_options = storage_options
         self._fs_path = None
         self._fs = None

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1646,26 +1646,6 @@ class TestParquet:
 
             df_equals(test_df, read_df)
 
-    @pytest.mark.xfail(
-        condition="config.getoption('--simulate-cloud').lower() != 'off'",
-        reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
-    )
-    def test_read_parquet_glob_path(self):
-        test_dfs = [
-            pandas.DataFrame(np.arange(1, 16).reshape(3, 5)).add_prefix("col")
-            for _ in range(5)
-        ]
-        pandas_df = pd.concat(test_dfs)
-
-        with tempfile.TemporaryDirectory() as directory:
-            for idx, test_df in enumerate(test_dfs):
-                test_df.to_parquet(f"{directory}/{idx}.parquet")
-
-            path = Path(directory)
-            files = list(path.glob("**/*.parquet"))
-            modin_df = pd.concat([pd.read_parquet(f) for f in files])
-            df_equals(pandas_df, modin_df)
-
 
 class TestJson:
     @pytest.mark.parametrize("lines", [False, True])

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1352,7 +1352,7 @@ class TestParquet:
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
     )
     def test_read_parquet(self, make_parquet_file, columns, row_group_size, engine):
-        unique_filename = get_unique_filename(extension="parquet")
+        unique_filename = Path(get_unique_filename(extension="parquet"))
         make_parquet_file(filename=unique_filename, row_group_size=row_group_size)
 
         eval_io(
@@ -1642,6 +1642,26 @@ class TestParquet:
             read_df = pd.read_parquet(path)
 
             df_equals(test_df, read_df)
+
+    @pytest.mark.xfail(
+        condition="config.getoption('--simulate-cloud').lower() != 'off'",
+        reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
+    )
+    def test_read_parquet_glob_path(self):
+        test_dfs = [
+            pandas.DataFrame(np.arange(1, 16).reshape(3, 5)).add_prefix("col")
+            for _ in range(5)
+        ]
+        pandas_df = pd.concat(test_dfs)
+
+        with tempfile.TemporaryDirectory() as directory:
+            for idx, test_df in enumerate(test_dfs):
+                test_df.to_parquet(f"{directory}/{idx}.parquet")
+
+            path = Path(directory)
+            files = list(path.glob("**/*.parquet"))
+            modin_df = pd.concat([pd.read_parquet(f) for f in files])
+            df_equals(pandas_df, modin_df)
 
 
 class TestJson:

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1347,12 +1347,15 @@ class TestParquet:
     @pytest.mark.parametrize("columns", [None, ["col1"]])
     @pytest.mark.parametrize("row_group_size", [None, 100, 1000, 10_000])
     @pytest.mark.parametrize("engine", ["auto", "pyarrow", "fastparquet"])
+    @pytest.mark.parametrize("path_type", [Path, str])
     @pytest.mark.xfail(
         condition="config.getoption('--simulate-cloud').lower() != 'off'",
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
     )
-    def test_read_parquet(self, make_parquet_file, columns, row_group_size, engine):
-        unique_filename = Path(get_unique_filename(extension="parquet"))
+    def test_read_parquet(
+        self, make_parquet_file, columns, row_group_size, engine, path_type
+    ):
+        unique_filename = path_type(get_unique_filename(extension="parquet"))
         make_parquet_file(filename=unique_filename, row_group_size=row_group_size)
 
         eval_io(


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4835 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
