### PR TITLE
FIX-#4838: Bump up modin-spreadsheet to latest master

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -34,7 +34,8 @@ Key Features and Updates
   * FIX-#4782: Exclude certain non-parquet files in `read_parquet` (#4783)    
   * FIX-#4808: Set dtypes correctly after column rename (#4809)
   * FIX-#4811: Apply dataframe -> not_dataframe functions to virtual partitions (#4812)
-  * FIX-#4099: Use mangled column names but keep the original when building frames from arrow
+  * FIX-#4099: Use mangled column names but keep the original when building frames from arrow (#4767)
+  * FIX-#4838: Bump up modin-spreadsheet to latest master (#4839)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -11,6 +11,8 @@ sphinx
 sphinx-click
 ray[default]>=1.4.0
 git+https://github.com/modin-project/modin.git@master#egg=modin[all]
+# Override to latest version of modin-spreadsheet
+git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
 sphinxcontrib_plantuml
 sphinx-issues
 xgboost

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -41,7 +41,8 @@ dependencies:
   - fastparquet
   - pip:
       - xgboost>=1.6.0
-      - modin-spreadsheet>=0.1.1
+      # Fixes breaking ipywidgets changes, but didn't release yet.
+      - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - tqdm
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
       - ray[default]>=1.4.0

--- a/examples/spreadsheet/requirements.txt
+++ b/examples/spreadsheet/requirements.txt
@@ -1,3 +1,3 @@
 ray==1.1.0
 git+https://github.com/modin-project/modin
-modin-spreadsheet
+git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,7 +31,8 @@ scikit-learn
 git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
 xgboost>=1.6.0
 tqdm
-modin-spreadsheet>=0.1.1
+# Latest modin-spreadsheet with widget fix
+git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
 pymssql
 psycopg2
 connectorx>=0.2.6a4

--- a/requirements/environment-py36.yml
+++ b/requirements/environment-py36.yml
@@ -40,7 +40,8 @@ dependencies:
   - jupyter>=1.0.0 # modin-spreadsheet needs that, but it won't install on Windows on Py36 via pip
   - fastparquet
   - pip:
-      - modin-spreadsheet>=0.1.1
+      # Fixes breaking ipywidgets changes, but didn't release yet.
+      - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - tqdm
       - ray[default]>=1.4.0
       # TODO: remove when resolving GH#4398

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -31,7 +31,8 @@ dependencies:
   - boto3
   - pip:
       - xgboost>=1.6.0
-      - modin-spreadsheet>=0.1.1
+      # Fixes breaking ipywidgets changes, but didn't release yet.
+      - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - tqdm
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
       - connectorx>=0.2.6a4

--- a/requirements/requirements-py36.txt
+++ b/requirements/requirements-py36.txt
@@ -24,5 +24,6 @@ cloudpickle
 scikit-learn
 pickle5
 tqdm
-modin-spreadsheet>=0.1.1
+# Fixes breaking ipywidgets changes, but didn't release yet.
+git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
 fastparquet


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4838 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
