### PR TITLE
FIX-#4691: Unify `other_partition` parameter for `apply` of block/axis-partition

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -39,6 +39,7 @@ Key Features and Updates
   * FIX-#4840: Change modin-spreadsheet version for notebook requirements (#4841)
   * FIX-#4835: Handle Pathlike paths in `read_parquet` (#4837)
   * FIX-#4848: Fix rebalancing partitions when NPartitions == 1 (#4874)
+  * FIX-#4691: Unify `other_partition`` parameter for `apply`` of block/axis-partition (#4846)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/dataframe/base/partitioning/axis_partition.py
+++ b/modin/core/dataframe/base/partitioning/axis_partition.py
@@ -27,7 +27,7 @@ class BaseDataframeAxisPartition(ABC):  # pragma: no cover
         self,
         func,
         num_splits=None,
-        other_axis_partition=None,
+        other_partition=None,
         maintain_partitioning=True,
         **kwargs,
     ):
@@ -41,7 +41,7 @@ class BaseDataframeAxisPartition(ABC):  # pragma: no cover
             the corresponding `BaseDataframePartition` objects.
         num_splits : int, default: None
             The number of times to split the result object.
-        other_axis_partition : BaseDataframeAxisPartition, default: None
+        other_partition : BaseDataframeAxisPartition, default: None
             Another `BaseDataframeAxisPartition` object to be applied
             to func. This is for operations that are between two data sets.
         maintain_partitioning : bool, default: True

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -32,7 +32,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         self,
         func,
         num_splits=None,
-        other_axis_partition=None,
+        other_partition=None,
         maintain_partitioning=True,
         **kwargs,
     ):
@@ -45,7 +45,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
             The function to apply.
         num_splits : int, default: None
             The number of times to split the result object.
-        other_axis_partition : PandasDataframeAxisPartition, default: None
+        other_partition : PandasDataframeAxisPartition, default: None
             Another `PandasDataframeAxisPartition` object to be applied
             to func. This is for operations that are between two data sets.
         maintain_partitioning : bool, default: True
@@ -66,14 +66,14 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         if num_splits is None:
             num_splits = len(self.list_of_blocks)
 
-        if other_axis_partition is not None:
-            if not isinstance(other_axis_partition, list):
-                other_axis_partition = [other_axis_partition]
+        if other_partition is not None:
+            if not isinstance(other_partition, list):
+                other_partition = [other_partition]
 
             # (other_shape[i-1], other_shape[i]) will indicate slice
             # to restore i-1 axis partition
             other_shape = np.cumsum(
-                [0] + [len(o.list_of_blocks) for o in other_axis_partition]
+                [0] + [len(o.list_of_blocks) for o in other_partition]
             )
 
             return self._wrap_partitions(
@@ -87,7 +87,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
                         self.list_of_blocks
                         + [
                             part
-                            for axis_partition in other_axis_partition
+                            for axis_partition in other_partition
                             for part in axis_partition.list_of_blocks
                         ]
                     ),

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -51,7 +51,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         """
         pass
 
-    def apply(self, func, *args, **kwargs):
+    def apply(self, func, *args, other_partition=None, **kwargs):
         """
         Apply a function to the object wrapped by this partition.
 
@@ -61,6 +61,9 @@ class PandasDataframePartition(ABC):  # pragma: no cover
             Function to apply.
         *args : iterable
             Additional positional arguments to be passed in `func`.
+        other_partition : PandasDataframePartition, default: None
+            Another ``PandasDataframePartition`` object to be applied
+            to `func`. This is for operations that are between two data sets.
         **kwargs : dict
             Additional keyword arguments to be passed in `func`.
 

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1281,8 +1281,6 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         np.ndarray
             A NumPy array with new partitions.
         """
-        [part.drain_call_queue() for part in right.flatten()]
-
         func = cls.preprocess_func(func)
         return np.array(
             [

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -452,7 +452,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         # load-balance the data as well.
         kw = {
             "num_splits": num_splits,
-            "other_axis_partition": right_partitions,
+            "other_partition": right_partitions,
         }
         if lengths:
             kw["_lengths"] = lengths
@@ -1289,7 +1289,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 [
                     part.apply(
                         func,
-                        right[row_idx][col_idx]._data,
+                        other_partition=right[row_idx][col_idx],
                     )
                     for col_idx, part in enumerate(left[row_idx])
                 ]

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -267,7 +267,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         func,
         *args,
         num_splits=None,
-        other_axis_partition=None,
+        other_partition=None,
         maintain_partitioning=True,
         **kwargs,
     ):
@@ -282,7 +282,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
             Additional positional arguments to be passed in `func`.
         num_splits : int, default: None
             The number of times to split the result object.
-        other_axis_partition : PandasDataframeAxisPartition, default: None
+        other_partition : PandasDataframeAxisPartition, default: None
             Another `PandasDataframeAxisPartition` object to be applied
             to func. This is for operations that are between two data sets.
         maintain_partitioning : bool, default: True
@@ -308,7 +308,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
             self.drain_call_queue()
         kwargs["args"] = args
         result = super(PandasOnDaskDataframeVirtualPartition, self).apply(
-            func, num_splits, other_axis_partition, maintain_partitioning, **kwargs
+            func, num_splits, other_partition, maintain_partitioning, **kwargs
         )
         if self.full_axis:
             return result

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
@@ -65,7 +65,7 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
         self.drain_call_queue()
         return self._data.copy()
 
-    def apply(self, func, *args, **kwargs):
+    def apply(self, func, *args, other_partition=None, **kwargs):
         """
         Apply a function to the object wrapped by this partition.
 
@@ -75,6 +75,9 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
             Function to apply.
         *args : iterable
             Additional positional arguments to be passed in `func`.
+        other_partition : PandasDataframePartition, default: None
+            Another ``PandasDataframePartition`` object to be applied
+            to `func`. This is for operations that are between two data sets.
         **kwargs : dict
             Additional keyword arguments to be passed in `func`.
 
@@ -110,6 +113,10 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
 
         self._data = call_queue_closure(self._data, self.call_queue)
         self.call_queue = []
+
+        if other_partition is not None:
+            args = (other_partition._data,) + args
+
         return PandasOnPythonDataframePartition(
             func(self._data.copy(), *args, **kwargs)
         )

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
@@ -115,6 +115,7 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
         self.call_queue = []
 
         if other_partition is not None:
+            other_partition.drain_call_queue()
             args = (other_partition._data,) + args
 
         return PandasOnPythonDataframePartition(

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -81,7 +81,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         logger.debug(f"EXIT::Partition.get::{self._identity}")
         return result
 
-    def apply(self, func, *args, **kwargs):
+    def apply(self, func, *args, other_partition=None, **kwargs):
         """
         Apply a function to the object wrapped by this partition.
 
@@ -91,6 +91,9 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             A function to apply.
         *args : iterable
             Additional positional arguments to be passed in `func`.
+        other_partition : PandasDataframePartition, default: None
+            Another ``PandasDataframePartition`` object to be applied
+            to `func`. This is for operations that are between two data sets.
         **kwargs : dict
             Additional keyword arguments to be passed in `func`.
 
@@ -107,6 +110,11 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         logger = get_logger()
         logger.debug(f"ENTER::Partition.apply::{self._identity}")
         data = self._data
+
+        if other_partition is not None:
+            other_partition.drain_call_queue()
+            args = (other_partition._data,) + args
+
         call_queue = self.call_queue + [(func, args, kwargs)]
         if len(call_queue) > 1:
             logger.debug(f"SUBMIT::_apply_list_of_funcs::{self._identity}")

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -269,7 +269,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         func,
         *args,
         num_splits=None,
-        other_axis_partition=None,
+        other_partition=None,
         maintain_partitioning=True,
         **kwargs,
     ):
@@ -284,7 +284,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             Additional positional arguments to be passed in `func`.
         num_splits : int, default: None
             The number of times to split the result object.
-        other_axis_partition : PandasDataframeAxisPartition, default: None
+        other_partition : PandasDataframeAxisPartition, default: None
             Another `PandasDataframeAxisPartition` object to be applied
             to func. This is for operations that are between two data sets.
         maintain_partitioning : bool, default: True
@@ -312,7 +312,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         result = super(PandasOnRayDataframeVirtualPartition, self).apply(
             func,
             num_splits,
-            other_axis_partition,
+            other_partition,
             maintain_partitioning,
             **kwargs,
         )

--- a/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/axis_partition.py
+++ b/modin/experimental/core/execution/ray/implementations/pyarrow_on_ray/partitioning/axis_partition.py
@@ -38,7 +38,7 @@ class PyarrowOnRayDataframeAxisPartition(BaseDataframeAxisPartition):
         # Unwrap from PandasDataframePartition object for ease of use
         self.list_of_blocks = [obj._data for obj in list_of_blocks]
 
-    def apply(self, func, num_splits=None, other_axis_partition=None, **kwargs):
+    def apply(self, func, num_splits=None, other_partition=None, **kwargs):
         """
         Apply func to the object in the Plasma store.
 
@@ -48,7 +48,7 @@ class PyarrowOnRayDataframeAxisPartition(BaseDataframeAxisPartition):
             The function to apply.
         num_splits : int, optional
             The number of times to split the resulting object.
-        other_axis_partition : PyarrowOnRayDataframeAxisPartition, optional
+        other_partition : PyarrowOnRayDataframeAxisPartition, optional
             Another ``PyarrowOnRayDataframeAxisPartition`` object to apply to
             `func` with this one.
         **kwargs : dict
@@ -66,7 +66,7 @@ class PyarrowOnRayDataframeAxisPartition(BaseDataframeAxisPartition):
         if num_splits is None:
             num_splits = len(self.list_of_blocks)
 
-        if other_axis_partition is not None:
+        if other_partition is not None:
             return [
                 PyarrowOnRayDataframePartition(obj)
                 for obj in deploy_ray_func_between_two_axis_partitions.options(
@@ -77,7 +77,7 @@ class PyarrowOnRayDataframeAxisPartition(BaseDataframeAxisPartition):
                     num_splits,
                     len(self.list_of_blocks),
                     kwargs,
-                    *(self.list_of_blocks + other_axis_partition.list_of_blocks),
+                    *(self.list_of_blocks + other_partition.list_of_blocks),
                 )
             ]
 

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -286,3 +286,11 @@ def test_empty_df(empty_operand):
         pandas_res = pandas_df_empty + pandas_df_empty
 
     df_equals(modin_res, pandas_res)
+
+
+@pytest.mark.parametrize("size", [1, 25, 50])
+def test_virtual_partitions(size):
+    pd_df = pandas.concat([pandas.DataFrame([i]) for i in range(size)])
+    md_df = pd.concat([pd.DataFrame([i]) for i in range(size)])
+
+    df_equals(pd_df + pd_df, md_df + md_df)


### PR DESCRIPTION
Signed-off-by: Alexey Prutskov <lehaprutskov@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4691  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
