### PR TITLE
PERF-#4849: compute `dtypes` in `concat` also for ROW_WISE when possible

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -52,6 +52,7 @@ Key Features and Updates
   * PERF-#4732: Avoid overwriting already-evaluated `PandasOnRayDataframePartition._length_cache` and `PandasOnRayDataframePartition._width_cache` (#4754)
   * PERF-#4713: Stop overriding the ray MacOS object store size limit (#4792)
   * PERF-#4842: `copy` should not trigger any previous computations (#4843)
+  * PERF-#4849: compute `dtypes` in `concat` also for ROW_WISE case when possible (#4850)
   * PERF-#4268: Implement partition-parallel __getitem__ for bool Series masks (#4753)
 * Benchmarking enhancements
   * FEAT-#4706: Add Modin ClassLogger to PandasDataframePartitionManager (#4707)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2653,11 +2653,16 @@ class PandasDataframe(ClassLogger):
         if axis == Axis.ROW_WISE:
             new_index = self.index.append([other.index for other in others])
             new_columns = joined_index
-            all_dtypes = [frame._dtypes for frame in [self] + others]
-            if all(dtypes is not None for dtypes in all_dtypes):
-                new_dtypes = pandas.concat(all_dtypes, axis=1).apply(
-                    lambda col: find_common_type(col.values), axis=1
-                )
+            try:
+                all_dtypes = [frame._dtypes for frame in [self] + others]
+                if all(dtypes is not None for dtypes in all_dtypes):
+                    new_dtypes = pandas.concat(all_dtypes, axis=1).apply(
+                        lambda col: find_common_type(col.values), axis=1
+                    )
+            except TypeError:
+                # Cannot interpret 'nan' as a data type;
+                # Case when not all dtypes in a frame are defined
+                pass
             # If we have already cached the length of each row in at least one
             # of the row's partitions, we can build new_lengths for the new
             # frame. Typically, if we know the length for any partition in a

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2658,7 +2658,7 @@ class PandasDataframe(ClassLogger):
                 new_dtypes = pandas.concat(all_dtypes, axis=1)
                 # nan value will be placed in a row if column isn't exist in all partitions;
                 # this value is np.float64 type, need an explicit conversion
-                new_dtypes = new_dtypes.fillna(np.dtype("float64"))
+                new_dtypes.fillna(np.dtype("float64"), inplace=True)
                 new_dtypes = new_dtypes.apply(
                     lambda row: find_common_type(row.values), axis=1
                 )

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2657,7 +2657,7 @@ class PandasDataframe(ClassLogger):
                 all_dtypes = [frame._dtypes for frame in [self] + others]
                 if all(dtypes is not None for dtypes in all_dtypes):
                     new_dtypes = pandas.concat(all_dtypes, axis=1).apply(
-                        lambda col: find_common_type(col.values), axis=1
+                        lambda row: find_common_type(row.values), axis=1
                     )
             except TypeError:
                 # Cannot interpret 'nan' as a data type;

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2656,8 +2656,8 @@ class PandasDataframe(ClassLogger):
             all_dtypes = [frame._dtypes for frame in [self] + others]
             if all(dtypes is not None for dtypes in all_dtypes):
                 new_dtypes = pandas.concat(all_dtypes, axis=1)
-                # nan value will be placed in a row if column isn't exist in all partitions;
-                # this value is np.float64 type, need an explicit conversion
+                # 'nan' value will be placed in a row if a column doesn't exist in all frames;
+                # this value is np.float64 type so we need an explicit conversion
                 new_dtypes.fillna(np.dtype("float64"), inplace=True)
                 new_dtypes = new_dtypes.apply(
                     lambda row: find_common_type(row.values), axis=1


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4849 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
