### PR TITLE
PERF-#4851: Compute `dtypes` for binary operations that can only return bool type and the right operand is not a Modin object

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -51,7 +51,7 @@ Key Features and Updates
   * PERF-#4773: Compute `lengths` and `widths` in `put` method of Dask partition like Ray do (#4780)
   * PERF-#4732: Avoid overwriting already-evaluated `PandasOnRayDataframePartition._length_cache` and `PandasOnRayDataframePartition._width_cache` (#4754)
   * PERF-#4713: Stop overriding the ray MacOS object store size limit (#4792)
-  * PERF-#4851: Compute `dtypes` for binary operations that can only return bool type (#4852)
+  * PERF-#4851: Compute `dtypes` for binary operations that can only return bool type and the right operand is not a Modin object (#4852)
   * PERF-#4842: `copy` should not trigger any previous computations (#4843)
   * PERF-#4268: Implement partition-parallel __getitem__ for bool Series masks (#4753)
 * Benchmarking enhancements

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -51,6 +51,7 @@ Key Features and Updates
   * PERF-#4773: Compute `lengths` and `widths` in `put` method of Dask partition like Ray do (#4780)
   * PERF-#4732: Avoid overwriting already-evaluated `PandasOnRayDataframePartition._length_cache` and `PandasOnRayDataframePartition._width_cache` (#4754)
   * PERF-#4713: Stop overriding the ray MacOS object store size limit (#4792)
+  * PERF-#4851: Compute `dtypes` for binary operations that can only return bool type (#4852)
   * PERF-#4842: `copy` should not trigger any previous computations (#4843)
   * PERF-#4268: Implement partition-parallel __getitem__ for bool Series masks (#4753)
 * Benchmarking enhancements

--- a/modin/core/dataframe/algebra/default2pandas/default.py
+++ b/modin/core/dataframe/algebra/default2pandas/default.py
@@ -68,7 +68,7 @@ class DefaultMethod(Operator):
         if type(fn) == property:
             fn = cls.build_property_wrapper(fn)
 
-        def applyier(df, *args, dtypes=None, **kwargs):
+        def applyier(df, *args, **kwargs):
             """
             Apply target function to the casted to pandas frame.
 
@@ -76,6 +76,8 @@ class DefaultMethod(Operator):
             function under it and processes result so it is possible to create a valid
             query compiler from it.
             """
+            # pandas default implementation does not use argument
+            kwargs.pop("dtypes", None)
             df = cls.frame_wrapper(df)
             result = fn(df, *args, **kwargs)
 

--- a/modin/core/dataframe/algebra/default2pandas/default.py
+++ b/modin/core/dataframe/algebra/default2pandas/default.py
@@ -76,7 +76,7 @@ class DefaultMethod(Operator):
             function under it and processes result so it is possible to create a valid
             query compiler from it.
             """
-            # pandas default implementation does not use argument
+            # pandas default implementation doesn't know how to handle `dtypes` keyword argument
             kwargs.pop("dtypes", None)
             df = cls.frame_wrapper(df)
             result = fn(df, *args, **kwargs)

--- a/modin/core/dataframe/algebra/default2pandas/default.py
+++ b/modin/core/dataframe/algebra/default2pandas/default.py
@@ -68,7 +68,7 @@ class DefaultMethod(Operator):
         if type(fn) == property:
             fn = cls.build_property_wrapper(fn)
 
-        def applyier(df, *args, **kwargs):
+        def applyier(df, *args, dtypes=None, **kwargs):
             """
             Apply target function to the casted to pandas frame.
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3031,13 +3031,13 @@ class BasePandasDataset(BasePandasDatasetCompat):
         operation="union", bin_op="and", right="other", **_doc_binary_op_kwargs
     )
     def __and__(self, other):
-        return self._binary_op("__and__", other, axis=0, dtypes="copy")
+        return self._binary_op("__and__", other, axis=0)
 
     @_doc_binary_op(
         operation="union", bin_op="rand", right="other", **_doc_binary_op_kwargs
     )
     def __rand__(self, other):
-        return self._binary_op("__rand__", other, axis=0, dtypes="copy")
+        return self._binary_op("__rand__", other, axis=0)
 
     def __array__(self, dtype=None):
         """
@@ -3330,7 +3330,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         **_doc_binary_op_kwargs,
     )
     def __or__(self, other):
-        return self._binary_op("__or__", other, axis=0, dtypes="copy")
+        return self._binary_op("__or__", other, axis=0)
 
     @_doc_binary_op(
         operation="disjunction",
@@ -3339,7 +3339,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         **_doc_binary_op_kwargs,
     )
     def __ror__(self, other):
-        return self._binary_op("__ror__", other, axis=0, dtypes="copy")
+        return self._binary_op("__ror__", other, axis=0)
 
     def __sizeof__(self):
         """
@@ -3368,7 +3368,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         **_doc_binary_op_kwargs,
     )
     def __xor__(self, other):
-        return self._binary_op("__xor__", other, axis=0, dtypes="copy")
+        return self._binary_op("__xor__", other, axis=0)
 
     @_doc_binary_op(
         operation="exclusive disjunction",
@@ -3377,7 +3377,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         **_doc_binary_op_kwargs,
     )
     def __rxor__(self, other):
-        return self._binary_op("__rxor__", other, axis=0, dtypes="copy")
+        return self._binary_op("__rxor__", other, axis=0)
 
     @property
     def size(self):  # noqa: RT01, D200

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1329,7 +1329,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         Get equality of `BasePandasDataset` and `other`, element-wise (binary operator `eq`).
         """
-        return self._binary_op("eq", other, axis=axis, level=level)
+        return self._binary_op("eq", other, axis=axis, level=level, dtypes=np.bool_)
 
     def explode(self, column, ignore_index: bool = False):  # noqa: PR01, RT01, D200
         """
@@ -1521,7 +1521,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         Get greater than or equal comparison of `BasePandasDataset` and `other`, element-wise (binary operator `ge`).
         """
-        return self._binary_op("ge", other, axis=axis, level=level)
+        return self._binary_op("ge", other, axis=axis, level=level, dtypes=np.bool_)
 
     def get(self, key, default=None):  # noqa: PR01, RT01, D200
         """
@@ -1536,7 +1536,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         Get greater than comparison of `BasePandasDataset` and `other`, element-wise (binary operator `gt`).
         """
-        return self._binary_op("gt", other, axis=axis, level=level)
+        return self._binary_op("gt", other, axis=axis, level=level, dtypes=np.bool_)
 
     def head(self, n=5):  # noqa: PR01, RT01, D200
         """
@@ -1679,13 +1679,13 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         Get less than or equal comparison of `BasePandasDataset` and `other`, element-wise (binary operator `le`).
         """
-        return self._binary_op("le", other, axis=axis, level=level)
+        return self._binary_op("le", other, axis=axis, level=level, dtypes=np.bool_)
 
     def lt(self, other, axis="columns", level=None):  # noqa: PR01, RT01, D200
         """
         Get less than comparison of `BasePandasDataset` and `other`, element-wise (binary operator `lt`).
         """
-        return self._binary_op("lt", other, axis=axis, level=level)
+        return self._binary_op("lt", other, axis=axis, level=level, dtypes=np.bool_)
 
     @property
     def loc(self):  # noqa: RT01, D200
@@ -1895,7 +1895,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         Get Not equal comparison of `BasePandasDataset` and `other`, element-wise (binary operator `ne`).
         """
-        return self._binary_op("ne", other, axis=axis, level=level)
+        return self._binary_op("ne", other, axis=axis, level=level, dtypes=np.bool_)
 
     def notna(self):  # noqa: RT01, D200
         """
@@ -3031,13 +3031,13 @@ class BasePandasDataset(BasePandasDatasetCompat):
         operation="union", bin_op="and", right="other", **_doc_binary_op_kwargs
     )
     def __and__(self, other):
-        return self._binary_op("__and__", other, axis=0)
+        return self._binary_op("__and__", other, axis=0, dtypes="copy")
 
     @_doc_binary_op(
         operation="union", bin_op="rand", right="other", **_doc_binary_op_kwargs
     )
     def __rand__(self, other):
-        return self._binary_op("__rand__", other, axis=0)
+        return self._binary_op("__rand__", other, axis=0, dtypes="copy")
 
     def __array__(self, dtype=None):
         """
@@ -3330,7 +3330,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         **_doc_binary_op_kwargs,
     )
     def __or__(self, other):
-        return self._binary_op("__or__", other, axis=0)
+        return self._binary_op("__or__", other, axis=0, dtypes="copy")
 
     @_doc_binary_op(
         operation="disjunction",
@@ -3339,7 +3339,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         **_doc_binary_op_kwargs,
     )
     def __ror__(self, other):
-        return self._binary_op("__ror__", other, axis=0)
+        return self._binary_op("__ror__", other, axis=0, dtypes="copy")
 
     def __sizeof__(self):
         """
@@ -3368,7 +3368,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         **_doc_binary_op_kwargs,
     )
     def __xor__(self, other):
-        return self._binary_op("__xor__", other, axis=0)
+        return self._binary_op("__xor__", other, axis=0, dtypes="copy")
 
     @_doc_binary_op(
         operation="exclusive disjunction",
@@ -3377,7 +3377,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         **_doc_binary_op_kwargs,
     )
     def __rxor__(self, other):
-        return self._binary_op("__rxor__", other, axis=0)
+        return self._binary_op("__rxor__", other, axis=0, dtypes="copy")
 
     @property
     def size(self):  # noqa: RT01, D200


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4851 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
