### PR TITLE
PERF-#4862: Don't call `compute_sliced_len.remote` when `row_labels/col_labels == slice(None)`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -50,6 +50,7 @@ Key Features and Updates
   * PERF-#4305: Parallelize `read_parquet` over row groups (#4700)
   * PERF-#4773: Compute `lengths` and `widths` in `put` method of Dask partition like Ray do (#4780)
   * PERF-#4732: Avoid overwriting already-evaluated `PandasOnRayDataframePartition._length_cache` and `PandasOnRayDataframePartition._width_cache` (#4754)
+  * PERF-#4862: Don't call `compute_sliced_len.remote` when `row_labels/col_labels == slice(None)` (#4863)
   * PERF-#4713: Stop overriding the ray MacOS object store size limit (#4792)
   * PERF-#4842: `copy` should not trigger any previous computations (#4843)
   * PERF-#4849: compute `dtypes` in `concat` also for ROW_WISE case when possible (#4850)

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
@@ -188,7 +188,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         new_obj = super().mask(row_labels, col_labels)
         if isinstance(row_labels, slice) and isinstance(self._length_cache, Future):
             if row_labels == slice(None):
-                # more faster way
+                # fast path - full axis take
                 new_obj._length_cache = self._length_cache
             else:
                 new_obj._length_cache = DaskWrapper.deploy(
@@ -196,7 +196,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
                 )
         if isinstance(col_labels, slice) and isinstance(self._width_cache, Future):
             if col_labels == slice(None):
-                # more faster way
+                # fast path - full axis take
                 new_obj._width_cache = self._width_cache
             else:
                 new_obj._width_cache = DaskWrapper.deploy(

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
@@ -187,13 +187,21 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         """
         new_obj = super().mask(row_labels, col_labels)
         if isinstance(row_labels, slice) and isinstance(self._length_cache, Future):
-            new_obj._length_cache = DaskWrapper.deploy(
-                compute_sliced_len, row_labels, self._length_cache
-            )
+            if row_labels == slice(None):
+                # more faster way
+                new_obj._length_cache = self._length_cache
+            else:
+                new_obj._length_cache = DaskWrapper.deploy(
+                    compute_sliced_len, row_labels, self._length_cache
+                )
         if isinstance(col_labels, slice) and isinstance(self._width_cache, Future):
-            new_obj._width_cache = DaskWrapper.deploy(
-                compute_sliced_len, col_labels, self._width_cache
-            )
+            if col_labels == slice(None):
+                # more faster way
+                new_obj._width_cache = self._width_cache
+            else:
+                new_obj._width_cache = DaskWrapper.deploy(
+                    compute_sliced_len, col_labels, self._width_cache
+                )
         return new_obj
 
     def __copy__(self):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -229,7 +229,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             self._length_cache, ObjectIDType
         ):
             if row_labels == slice(None):
-                # more faster way
+                # fast path - full axis take
                 new_obj._length_cache = self._length_cache
             else:
                 new_obj._length_cache = compute_sliced_len.remote(
@@ -239,7 +239,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             self._width_cache, ObjectIDType
         ):
             if col_labels == slice(None):
-                # more faster way
+                # fast path - full axis take
                 new_obj._width_cache = self._width_cache
             else:
                 new_obj._width_cache = compute_sliced_len.remote(

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -228,15 +228,23 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         if isinstance(row_labels, slice) and isinstance(
             self._length_cache, ObjectIDType
         ):
-            new_obj._length_cache = compute_sliced_len.remote(
-                row_labels, self._length_cache
-            )
+            if row_labels == slice(None):
+                # more faster way
+                new_obj._length_cache = self._length_cache
+            else:
+                new_obj._length_cache = compute_sliced_len.remote(
+                    row_labels, self._length_cache
+                )
         if isinstance(col_labels, slice) and isinstance(
             self._width_cache, ObjectIDType
         ):
-            new_obj._width_cache = compute_sliced_len.remote(
-                col_labels, self._width_cache
-            )
+            if col_labels == slice(None):
+                # more faster way
+                new_obj._width_cache = self._width_cache
+            else:
+                new_obj._width_cache = compute_sliced_len.remote(
+                    col_labels, self._width_cache
+                )
         logger.debug(f"EXIT::Partition.mask::{self._identity}")
         return new_obj
 


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4862  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
