### PR TITLE
FIX-#4872: Stop checking the private ray mac memory limit.

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -38,6 +38,7 @@ Key Features and Updates
   * FIX-#4838: Bump up modin-spreadsheet to latest master (#4839)
   * FIX-#4840: Change modin-spreadsheet version for notebook requirements (#4841)
   * FIX-#4835: Handle Pathlike paths in `read_parquet` (#4837)
+  * FIX-#4872: Stop checking the private ray mac memory limit (#4873)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -36,6 +36,10 @@ from modin.config import (
 from modin.error_message import ErrorMessage
 
 _OBJECT_STORE_TO_SYSTEM_MEMORY_RATIO = 0.6
+# This constant should be in sync with the limit in ray, which is private,
+# not exposed to users, and not documented:
+# https://github.com/ray-project/ray/blob/4692e8d8023e789120d3f22b41ffb136b50f70ea/python/ray/_private/ray_constants.py#L57-L62
+_MAC_OBJECT_STORE_LIMIT_BYTES = 2 * 2**30
 
 ObjectIDType = ray.ObjectRef
 if version.parse(ray.__version__) >= version.parse("1.2.0"):
@@ -187,18 +191,11 @@ def _get_object_store_memory() -> Optional[int]:
     )
     if object_store_memory == 0:
         return None
-    # Versions of ray with MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT don't allow us
-    # to initialize ray with object store size larger than that constant.
+    # Newer versions of ray don't allow us to initialize ray with object store
+    # size larger than that _MAC_OBJECT_STORE_LIMIT_BYTES.
     # For background see https://github.com/ray-project/ray/issues/20388
-    mac_size_limit = getattr(
-        ray.ray_constants, "MAC_DEGRADED_PERF_MMAP_SIZE_LIMIT", None
-    )
-    if (
-        sys.platform == "darwin"
-        and mac_size_limit is not None
-        and object_store_memory > mac_size_limit
-    ):
-        object_store_memory = mac_size_limit
+    if sys.platform == "darwin":
+        object_store_memory = min(object_store_memory, _MAC_OBJECT_STORE_LIMIT_BYTES)
     return object_store_memory
 
 

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -192,9 +192,17 @@ def _get_object_store_memory() -> Optional[int]:
     if object_store_memory == 0:
         return None
     # Newer versions of ray don't allow us to initialize ray with object store
-    # size larger than that _MAC_OBJECT_STORE_LIMIT_BYTES.
-    # For background see https://github.com/ray-project/ray/issues/20388
-    if sys.platform == "darwin":
+    # size larger than that _MAC_OBJECT_STORE_LIMIT_BYTES. It seems that
+    # object store > the limit is too slow even on ray 1.0.0. However, limiting
+    # the object store to _MAC_OBJECT_STORE_LIMIT_BYTES only seems to start
+    # helping at ray version 1.3.0. So if ray version is at least 1.3.0, cap
+    # the object store at _MAC_OBJECT_STORE_LIMIT_BYTES.
+    # For background on the ray bug see:
+    # - https://github.com/ray-project/ray/issues/20388
+    # - https://github.com/modin-project/modin/issues/4872
+    if sys.platform == "darwin" and version.parse(ray.__version__) >= version.parse(
+        "1.3.0"
+    ):
         object_store_memory = min(object_store_memory, _MAC_OBJECT_STORE_LIMIT_BYTES)
     return object_store_memory
 


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

Stop checking the private ray mac memory limit.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4872
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
