### PR TITLE
 FIX-#4848: Fix rebalancing partitions when NPartitions == 1.

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -38,6 +38,7 @@ Key Features and Updates
   * FIX-#4838: Bump up modin-spreadsheet to latest master (#4839)
   * FIX-#4840: Change modin-spreadsheet version for notebook requirements (#4841)
   * FIX-#4835: Handle Pathlike paths in `read_parquet` (#4837)
+  * FIX-#4848: Fix rebalancing partitions when NPartitions == 1 (#4874)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1422,6 +1422,12 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                         for obj in partitions[stop]
                     ]
                     partition_size = ideal_partition_size
+                # The new virtual partitions are not `full_axis`, even if they
+                # happen to span all rows in the dataframe, because they are
+                # meant to be the final partitions of the dataframe. They've
+                # already been split up correctly along axis 0, but using the
+                # default full_axis=True would cause partition.apply() to split
+                # its result along axis 0.
                 new_partitions.append(
                     cls.column_partitions(
                         (partitions[start : stop + 1]), full_axis=False

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1429,9 +1429,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 # default full_axis=True would cause partition.apply() to split
                 # its result along axis 0.
                 new_partitions.append(
-                    cls.column_partitions(
-                        partitions[start : stop + 1], full_axis=False
-                    )
+                    cls.column_partitions(partitions[start : stop + 1], full_axis=False)
                 )
                 start = stop + 1
             return np.array(new_partitions)

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1424,8 +1424,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                     partition_size = ideal_partition_size
                 new_partitions.append(
                     cls.column_partitions(
-                        (partitions[start : stop + 1]),
-                        full_axis=partition_size == total_rows,
+                        (partitions[start : stop + 1]), full_axis=False
                     )
                 )
                 start = stop + 1

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1430,7 +1430,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 # its result along axis 0.
                 new_partitions.append(
                     cls.column_partitions(
-                        (partitions[start : stop + 1]), full_axis=False
+                        partitions[start : stop + 1], full_axis=False
                     )
                 )
                 start = stop + 1


### PR DESCRIPTION
## What do these changes do?

 FIX-#4848: Fix rebalancing partitions when NPartitions == 1. Each partition after rebalancing partitions should always have `full_axis=False`.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4848
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
