### PR TITLE
TEST-#4879: Use pandas `ensure_clean()` in place of `io_tests_data`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -38,6 +38,7 @@ Key Features and Updates
   * FIX-#4838: Bump up modin-spreadsheet to latest master (#4839)
   * FIX-#4840: Change modin-spreadsheet version for notebook requirements (#4841)
   * FIX-#4835: Handle Pathlike paths in `read_parquet` (#4837)
+  * TEST-#4879: Cleanup `io_tests_data` after pytests finish (#4881)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -85,7 +85,7 @@ Key Features and Updates
   * TEST-#4698: Stop passing invalid storage_options param (#4699)
   * TEST-#4745: Pin flake8 to <5 to workaround installation conflict (#4752)
   * TEST-#4875: XFail tests failing due to file gone missing (#4876)
-  * TEST-#4879: Cleanup `io_tests_data` after pytests finish (#4881)
+  * TEST-#4879: Use pandas `ensure_clean()` in place of `io_tests_data` (#4881)
 * Documentation improvements
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
   * DOCS-#4628: Add to_parquet partial support notes (#4648)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -38,7 +38,6 @@ Key Features and Updates
   * FIX-#4838: Bump up modin-spreadsheet to latest master (#4839)
   * FIX-#4840: Change modin-spreadsheet version for notebook requirements (#4841)
   * FIX-#4835: Handle Pathlike paths in `read_parquet` (#4837)
-  * TEST-#4879: Cleanup `io_tests_data` after pytests finish (#4881)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)
@@ -86,6 +85,7 @@ Key Features and Updates
   * TEST-#4698: Stop passing invalid storage_options param (#4699)
   * TEST-#4745: Pin flake8 to <5 to workaround installation conflict (#4752)
   * TEST-#4875: XFail tests failing due to file gone missing (#4876)
+  * TEST-#4879: Cleanup `io_tests_data` after pytests finish (#4881)
 * Documentation improvements
   * DOCS-#4552: Change default sphinx language to en to fix sphinx >= 5.0.0 build (#4553)
   * DOCS-#4628: Add to_parquet partial support notes (#4648)

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -60,7 +60,6 @@ from modin.pandas.test.utils import (  # noqa: E402
     make_default_file,
     teardown_test_files,
     NROWS,
-    IO_OPS_DATA_DIR,
 )
 
 
@@ -541,10 +540,6 @@ ray_client_server = None
 
 
 def pytest_sessionstart(session):
-    # create test data dir if it is not exists yet
-    if not os.path.exists(IO_OPS_DATA_DIR):
-        os.mkdir(IO_OPS_DATA_DIR)
-
     if TestRayClient.get():
         import ray
         import ray.util.client.server.server as ray_server
@@ -556,10 +551,6 @@ def pytest_sessionstart(session):
 
 
 def pytest_sessionfinish(session, exitstatus):
-    # Cleanup io_tests_data
-    if os.path.exists(IO_OPS_DATA_DIR):
-        shutil.rmtree(IO_OPS_DATA_DIR)
-
     if TestRayClient.get():
         import ray
 

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -557,7 +557,8 @@ def pytest_sessionstart(session):
 
 def pytest_sessionfinish(session, exitstatus):
     # Cleanup io_tests_data
-    shutil.rmtree(IO_OPS_DATA_DIR)
+    if os.path.exists(IO_OPS_DATA_DIR):
+        shutil.rmtree(IO_OPS_DATA_DIR)
 
     if TestRayClient.get():
         import ray

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -63,10 +63,6 @@ from modin.pandas.test.utils import (  # noqa: E402
     IO_OPS_DATA_DIR,
 )
 
-# create test data dir if it is not exists yet
-if not os.path.exists(IO_OPS_DATA_DIR):
-    os.mkdir(IO_OPS_DATA_DIR)
-
 
 def pytest_addoption(parser):
     parser.addoption(
@@ -545,6 +541,10 @@ ray_client_server = None
 
 
 def pytest_sessionstart(session):
+    # create test data dir if it is not exists yet
+    if not os.path.exists(IO_OPS_DATA_DIR):
+        os.mkdir(IO_OPS_DATA_DIR)
+
     if TestRayClient.get():
         import ray
         import ray.util.client.server.server as ray_server
@@ -556,6 +556,9 @@ def pytest_sessionstart(session):
 
 
 def pytest_sessionfinish(session, exitstatus):
+    # Cleanup io_tests_data
+    shutil.rmtree(IO_OPS_DATA_DIR)
+
     if TestRayClient.get():
         import ray
 

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -511,9 +511,6 @@ def make_sql_connection():
 
     yield _sql_connection
 
-    # Teardown the fixture
-    teardown_test_files(filenames)
-
 
 @pytest.fixture(scope="class")
 def TestReadGlobCSVFixture():

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -62,8 +62,8 @@ def test_from_sql_distributed(make_sql_connection):  # noqa: F811
                 max_sessions=2,
             )
 
-            df_equals(modin_df_from_query, pandas_df)
-            df_equals(modin_df_from_table, pandas_df)
+        df_equals(modin_df_from_query, pandas_df)
+        df_equals(modin_df_from_table, pandas_df)
 
 
 @pytest.mark.skipif(
@@ -83,8 +83,8 @@ def test_from_sql_defaults(make_sql_connection):  # noqa: F811
         with pytest.warns(UserWarning):
             modin_df_from_table = pd.read_sql(table, conn)
 
-        df_equals(modin_df_from_query, pandas_df)
-        df_equals(modin_df_from_table, pandas_df)
+    df_equals(modin_df_from_query, pandas_df)
+    df_equals(modin_df_from_table, pandas_df)
 
 
 @pytest.mark.usefixtures("TestReadGlobCSVFixture")
@@ -292,7 +292,7 @@ def test_read_custom_json_text():
         df2 = pd.read_json(filename, lines=True)[["col0", "col1", "col3"]].rename(
             columns={"col0": "testID"}
         )
-        df_equals(df1, df2)
+    df_equals(df1, df2)
 
 
 @pytest.mark.skipif(
@@ -342,4 +342,4 @@ def test_read_evaluated_dict():
         df2 = pd.read_custom_text(
             filename, columns=columns_callback, custom_parser=_custom_parser
         )
-        df_equals(df1, df2)
+    df_equals(df1, df2)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -26,6 +26,7 @@ from modin.pandas.test.utils import (
     df_equals,
     arg_keys,
     name_contains,
+    get_unique_filename,
     test_data,
     test_data_values,
     test_data_keys,
@@ -1894,7 +1895,7 @@ def test___setitem__partitions_aligning():
 
 
 def test___setitem__with_mismatched_partitions():
-    fname = "200kx99.csv"
+    fname = get_unique_filename(extension=".csv")
     np.savetxt(fname, np.random.randint(0, 100, size=(200_000, 99)), delimiter=",")
     modin_df = pd.read_csv(fname)
     pandas_df = pandas.read_csv(fname)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -15,6 +15,7 @@ import pytest
 import numpy as np
 import pandas
 from pandas.testing import assert_index_equal
+from pandas._testing import ensure_clean
 import matplotlib
 import modin.pandas as pd
 import sys
@@ -26,7 +27,6 @@ from modin.pandas.test.utils import (
     df_equals,
     arg_keys,
     name_contains,
-    get_unique_filename,
     test_data,
     test_data_values,
     test_data_keys,
@@ -1895,13 +1895,13 @@ def test___setitem__partitions_aligning():
 
 
 def test___setitem__with_mismatched_partitions():
-    fname = get_unique_filename(extension="csv")
-    np.savetxt(fname, np.random.randint(0, 100, size=(200_000, 99)), delimiter=",")
-    modin_df = pd.read_csv(fname)
-    pandas_df = pandas.read_csv(fname)
-    modin_df["new"] = pd.Series(list(range(len(modin_df))))
-    pandas_df["new"] = pandas.Series(list(range(len(pandas_df))))
-    df_equals(modin_df, pandas_df)
+    with ensure_clean(".csv") as fname:
+        np.savetxt(fname, np.random.randint(0, 100, size=(200_000, 99)), delimiter=",")
+        modin_df = pd.read_csv(fname)
+        pandas_df = pandas.read_csv(fname)
+        modin_df["new"] = pd.Series(list(range(len(modin_df))))
+        pandas_df["new"] = pandas.Series(list(range(len(pandas_df))))
+        df_equals(modin_df, pandas_df)
 
 
 def test___setitem__mask():

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1895,7 +1895,7 @@ def test___setitem__partitions_aligning():
 
 
 def test___setitem__with_mismatched_partitions():
-    fname = get_unique_filename(extension=".csv")
+    fname = get_unique_filename(extension="csv")
     np.savetxt(fname, np.random.randint(0, 100, size=(200_000, 99)), delimiter=",")
     modin_df = pd.read_csv(fname)
     pandas_df = pandas.read_csv(fname)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1385,8 +1385,8 @@ class TestParquet:
             make_parquet_file(filename=unique_filename, nrows=nrows)
 
             parquet_df = pd.read_parquet(unique_filename)
-            for col in parquet_df.columns:
-                parquet_df[col]
+        for col in parquet_df.columns:
+            parquet_df[col]
 
     @pytest.mark.parametrize("columns", [None, ["col1"]])
     @pytest.mark.parametrize("row_group_size", [None, 100, 1000, 10_000])

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -55,9 +55,6 @@ NGROUPS = 10
 RAND_LOW = 0
 RAND_HIGH = 100
 
-# Directory for storing I/O operations test data
-IO_OPS_DATA_DIR = os.path.join(os.path.dirname(__file__), "io_tests_data")
-
 # Input data and functions for the tests
 # The test data that we will test our code against
 test_data = {
@@ -978,7 +975,7 @@ def get_unique_filename(
     test_name: str = "test",
     kwargs: dict = {},
     extension: str = "csv",
-    data_dir: str = IO_OPS_DATA_DIR,
+    data_dir: str = "",
     suffix: str = "",
     debug_mode=False,
 ):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR does some test cleanup to ensure that `io_tests_data` gets cleaned up after pytests finish. There was also another lingering file from another test that was changed to use the `get_unique_filename` method.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4879 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
