### PR TITLE
REF: de-duplicate take_2d_labels_or_positional methods

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -75,6 +75,7 @@ Key Features and Updates
   * REFACTOR-#4832: unify `split_result_of_axis_func_pandas` (#4831)
   * REFACTOR-#4796: Introduce constant for __reduced__ column name (#4799)
   * REFACTOR-#4530: Unify access to physical data for any partition type (#4829)
+  * REFACTOR-#4885: De-duplicated take_2d_labels_or_positional methods (#4883)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -674,6 +674,9 @@ class PandasDataframe(ClassLogger):
             and row_positions is None
         ):
             return self.copy()
+
+        sorted_row_positions = sorted_col_positions = None
+
         # Get numpy array of positions of values from `row_labels`
         if row_labels is not None:
             row_positions = self.index.get_indexer_for(row_labels)
@@ -798,6 +801,42 @@ class PandasDataframe(ClassLogger):
             new_col_widths,
             new_dtypes,
         )
+
+        return self._maybe_reorder_labels(
+            intermediate,
+            row_positions,
+            sorted_row_positions,
+            col_positions,
+            sorted_col_positions,
+        )
+
+    def _maybe_reorder_labels(
+        self,
+        intermediate: "PandasDataframe",
+        row_positions,
+        sorted_row_positions,
+        col_positions,
+        sorted_col_positions,
+    ) -> "PandasDataframe":
+        """
+        Call re-order labels on take_2d_labels_or_positional result if necessary.
+
+        Parameters
+        ----------
+        intermediate : PandasDataFrame
+        row_positions : list-like of ints, optional
+            The row positions to extract.
+        sorted_row_positions : list-like of ints, optional
+            Sorted version of row_positions.
+        col_positions : list-like of ints, optional
+            The column positions to extract.
+        sorted_col_positions : list-like of ints, optional
+            Sorted version of col_positions.
+
+        Returns
+        -------
+        PandasDataframe
+        """
         # Check if monotonically increasing, return if it is. Fast track code path for
         # common case to keep it fast.
         if (
@@ -814,6 +853,7 @@ class PandasDataframe(ClassLogger):
             or np.all(col_positions[1:] >= col_positions[:-1])
         ):
             return intermediate
+
         # The new labels are often smaller than the old labels, so we can't reuse the
         # original order values because those were mapped to the original data. We have
         # to reorder here based on the expected order from within the data.

--- a/modin/core/execution/ray/implementations/cudf_on_ray/dataframe/dataframe.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/dataframe/dataframe.py
@@ -273,40 +273,17 @@ class cuDFOnRayDataframe(PandasOnRayDataframe):
             new_col_widths,
             new_dtypes,
         )
-        # Check if monotonically increasing, return if it is. Fast track code path for
-        # common case to keep it fast.
-        if (
-            row_positions is None
-            or isinstance(row_positions, slice)
-            or len(row_positions) == 1
-            or np.all(row_positions[1:] >= row_positions[:-1])
-        ) and (
-            col_positions is None
-            or isinstance(col_positions, slice)
-            or len(col_positions) == 1
-            or np.all(col_positions[1:] >= col_positions[:-1])
-        ):
-            return intermediate
-        # The new labels are often smaller than the old labels, so we can't reuse the
-        # original order values because those were mapped to the original data. We have
-        # to reorder here based on the expected order from within the data.
-        # We create a dictionary mapping the position of the numeric index with respect
-        # to all others, then recreate that order by mapping the new order values from
-        # the old. This information is sent to `_reorder_labels`.
+
+        sorted_row_positions = sorted_col_positions = None
         if row_positions is not None:
-            row_order_mapping = dict(
-                zip(sorted(row_positions), range(len(row_positions)))
-            )
-            new_row_order = [row_order_mapping[idx] for idx in row_positions]
-        else:
-            new_row_order = None
+            sorted_row_positions = sorted(row_positions)
         if col_positions is not None:
-            col_order_mapping = dict(
-                zip(sorted(col_positions), range(len(col_positions)))
-            )
-            new_col_order = [col_order_mapping[idx] for idx in col_positions]
-        else:
-            new_col_order = None
-        return intermediate._reorder_labels(
-            row_positions=new_row_order, col_positions=new_col_order
+            sorted_col_positions = sorted(col_positions)
+
+        return self._maybe_reorder_labels(
+            intermediate,
+            row_positions,
+            sorted_row_positions,
+            col_positions,
+            sorted_col_positions,
         )


### PR DESCRIPTION
There's a ton in the cuDFOnRayDataframe method that looks like it should be the same as the parent method but just was never updated.  If I'm right about this, this is a textbook reason why the code should be shared.

Not bothering with opening a dummy issue or formatting the commit because I'm a cranky old man.