### PR TITLE
PERF-#4890: `PandasDataframeAxisPartition.drain` should be serialized only once

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -58,6 +58,7 @@ Key Features and Updates
   * PERF-#4842: `copy` should not trigger any previous computations (#4843)
   * PERF-#4849: compute `dtypes` in `concat` also for ROW_WISE case when possible (#4850)
   * PERF-#4860: `PandasDataframeAxisPartition.deploy_axis_func` should be serialized only once (#4861)
+  * PERF-#4890: `PandasDataframeAxisPartition.drain` should be serialized only once (#4891)
   * PERF-#4886: Use lazy index and columns evaluation in `query` method (#4887)
   * PERF-#4268: Implement partition-parallel __getitem__ for bool Series masks (#4753)
 * Benchmarking enhancements

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -215,7 +215,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         return split_result_of_axis_func_pandas(axis, num_splits, result)
 
     @classmethod
-    def drain(cls, df, call_queue):
+    def drain(cls, df: pandas.DataFrame, call_queue: list):
         """
         Execute all operations stored in the call queue on the pandas object (helper function).
 

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -217,7 +217,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
     @classmethod
     def drain(cls, df, call_queue):
         """
-        Helper function for drain operation.
+        Execute all operations stored in the call queue on the pandas object (helper function).
 
         Parameters
         ----------

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -213,3 +213,22 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         # for func, we fold args into kwargs. This is a bit of a hack, but it works.
         result = func(lt_frame, rt_frame, *kwargs.pop("args", ()), **kwargs)
         return split_result_of_axis_func_pandas(axis, num_splits, result)
+
+    @classmethod
+    def drain(cls, df, call_queue):
+        """
+        Helper function for drain operation.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+        call_queue : list
+            Call queue that needs to be executed on pandas DataFrame.
+
+        Returns
+        -------
+        pandas.DataFrame
+        """
+        for func, args, kwargs in call_queue:
+            df = func(df, *args, **kwargs)
+        return df

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -26,9 +26,6 @@ from .partition import PandasOnDaskDataframePartition
 from modin.core.execution.dask.common.engine_wrapper import DaskWrapper
 
 
-_DRAIN = DaskWrapper.put(PandasDataframeAxisPartition.drain)
-
-
 class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
     """
     The class implements the interface in ``PandasDataframeAxisPartition``.
@@ -421,8 +418,12 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         num_splits : int, default: None
             The number of times to split the result object.
         """
+        # TODO: Need to check if `drain_call_queue` speeds up if helper
+        # `drain` function is serialized only once.
         drained = super(PandasOnDaskDataframeVirtualPartition, self).apply(
-            _DRAIN, num_splits=num_splits, call_queue=self.call_queue
+            PandasDataframeAxisPartition.drain,
+            num_splits=num_splits,
+            call_queue=self.call_queue,
         )
         self._list_of_block_partitions = drained
         self.call_queue = []

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -26,6 +26,9 @@ from .partition import PandasOnDaskDataframePartition
 from modin.core.execution.dask.common.engine_wrapper import DaskWrapper
 
 
+_DRAIN = DaskWrapper.put(PandasDataframeAxisPartition.drain)
+
+
 class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
     """
     The class implements the interface in ``PandasDataframeAxisPartition``.
@@ -418,14 +421,8 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         num_splits : int, default: None
             The number of times to split the result object.
         """
-
-        def drain(df):
-            for func, args, kwargs in self.call_queue:
-                df = func(df, *args, **kwargs)
-            return df
-
         drained = super(PandasOnDaskDataframeVirtualPartition, self).apply(
-            drain, num_splits=num_splits
+            _DRAIN, num_splits=num_splits, call_queue=self.call_queue
         )
         self._list_of_block_partitions = drained
         self.call_queue = []

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -25,6 +25,7 @@ from .partition import PandasOnRayDataframePartition
 
 
 _DEPLOY_AXIS_FUNC = ray.put(PandasDataframeAxisPartition.deploy_axis_func)
+_DRAIN = ray.put(PandasDataframeAxisPartition.drain)
 
 
 class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
@@ -427,14 +428,8 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         num_splits : int, default: None
             The number of times to split the result object.
         """
-
-        def drain(df):
-            for func, args, kwargs in self.call_queue:
-                df = func(df, *args, **kwargs)
-            return df
-
         drained = super(PandasOnRayDataframeVirtualPartition, self).apply(
-            drain, num_splits=num_splits
+            _DRAIN, num_splits=num_splits, call_queue=self.call_queue
         )
         self._list_of_block_partitions = drained
         self.call_queue = []


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4890 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
