### PR TITLE
FIX-#4016, FIX-#4086, FIX-#4039: Fall back to pandas in case of duplicate column names

### DIFF
--- a/modin/_compat/pandas_api/latest/base.py
+++ b/modin/_compat/pandas_api/latest/base.py
@@ -333,11 +333,15 @@ class LatestCompatibleBasePandasDataset(BaseCompatibleBasePandasDataset):
     def set_axis(self, labels, axis=0, inplace=no_default, *, copy=no_default):
         if inplace is True and copy is True:
             raise ValueError("Cannot specify both inplace=True and copy=True")
+        if inplace is no_default:
+            inplace = False
+        if copy is no_default:
+            copy = not inplace
         return self._set_axis(
             labels=labels,
             axis=axis,
-            inplace=False if inplace is no_default else inplace,
-            copy=True if copy is no_default else copy,
+            inplace=inplace,
+            copy=copy,
         )
 
     def sem(

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -323,7 +323,11 @@ class HdkOnNativeDataframe(PandasDataframe):
                 new_columns = base.columns[col_positions]
             exprs = self._index_exprs()
             for col in new_columns:
-                exprs[col] = base.ref(col)
+                expr = base.ref(col)
+                if exprs.setdefault(col, expr) is not expr:
+                    raise NotImplementedError(
+                        "duplicate column names are not supported"
+                    )
             dtypes = self._dtypes_for_exprs(exprs)
             base = self.__constructor__(
                 columns=new_columns,
@@ -2030,7 +2034,9 @@ class HdkOnNativeDataframe(PandasDataframe):
         """
         exprs = self._index_exprs()
         for old, new in zip(self.columns, new_columns):
-            exprs[new] = self.ref(old)
+            expr = self.ref(old)
+            if exprs.setdefault(new, expr) is not expr:
+                raise NotImplementedError("duplicate column names are not supported")
         return self.__constructor__(
             columns=new_columns,
             dtypes=self._dtypes.tolist(),

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -178,7 +178,17 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
 
             try:
                 at = pyarrow.Table.from_pandas(obj, preserve_index=False)
-            except (pyarrow.lib.ArrowTypeError, pyarrow.lib.ArrowInvalid) as err:
+            except (
+                pyarrow.lib.ArrowTypeError,
+                pyarrow.lib.ArrowInvalid,
+                ValueError,
+            ) as err:
+                # The ValueError is raised by pyarrow in case of duplicate columns.
+                # We catch and handle this error here. If there are no duplicates
+                # (is_unique is True), then the error is caused by something different
+                # and we just rethrow it.
+                if (type(err) == ValueError) and obj.columns.is_unique:
+                    raise err
                 regex = r"Conversion failed for column ([^\W]*)"
                 unsupported_cols = []
                 for msg in err.args:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -23,6 +23,7 @@ from modin.pandas.test.utils import (
     io_ops_bad_exc,
     default_to_pandas_ignore_string,
     random_state,
+    test_data,
 )
 from .utils import eval_io, ForceHdkImport, set_execution_mode, run_and_compare
 from pandas.core.dtypes.common import is_list_like
@@ -2245,6 +2246,71 @@ class TestCompare:
             data2=data2,
             constructor_kwargs={"columns": columns},
             force_lazy=False,
+        )
+
+
+class TestDuplicateColumns:
+    def test_init(self):
+        def init(df, **kwargs):
+            return df
+
+        data = [
+            [1, 2, 3, 4],
+            [5, 6, 7, 8],
+            [9, 10, 11, 12],
+            [13, 14, 15, 16],
+            [17, 18, 19, 20],
+        ]
+        columns = ["c1", "c2", "c1", "c3"]
+        run_and_compare(
+            fn=init,
+            data=data,
+            force_lazy=False,
+            constructor_kwargs={"columns": columns},
+        )
+
+    def test_loc(self):
+        def loc(df, **kwargs):
+            return df.loc[:, ["col1", "col3", "col3"]]
+
+        run_and_compare(
+            fn=loc,
+            data=test_data_values[0],
+            force_lazy=False,
+        )
+
+    def test_set_columns(self):
+        def set_cols(df, **kwargs):
+            df.columns = ["col1", "col3", "col3"]
+            return df
+
+        run_and_compare(
+            fn=set_cols,
+            data=[[1, 2, 3], [4, 5, 6], [7, 8, 9]],
+            force_lazy=False,
+        )
+
+    def test_set_axis(self):
+        def set_axis(df, **kwargs):
+            sort_index = df.axes[1]
+            labels = [
+                np.nan if i % 2 == 0 else sort_index[i] for i in range(len(sort_index))
+            ]
+            inplace = kwargs["set_axis_inplace"]
+            res = df.set_axis(labels, axis=1, inplace=inplace)
+            return df if inplace else res
+
+        run_and_compare(
+            fn=set_axis,
+            data=test_data["float_nan_data"],
+            force_lazy=False,
+            set_axis_inplace=True,
+        )
+        run_and_compare(
+            fn=set_axis,
+            data=test_data["float_nan_data"],
+            force_lazy=False,
+            set_axis_inplace=False,
         )
 
 

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/utils.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/utils.py
@@ -329,7 +329,8 @@ def run_and_compare(
             new_schema = {}
             for col in exp_res.columns:
                 if (
-                    internal_dtypes[col] == "category"
+                    not isinstance(internal_dtypes[col], pandas.Series)
+                    and internal_dtypes[col] == "category"
                     and external_dtypes[col] != "category"
                 ):
                     new_schema[col] = external_dtypes[col]

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -510,7 +510,11 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         if self._modin_frame._has_unsupported_data:
             default_axis_setter(1)(self, columns)
         else:
-            self._modin_frame = self._modin_frame._set_columns(columns)
+            try:
+                self._modin_frame = self._modin_frame._set_columns(columns)
+            except NotImplementedError:
+                default_axis_setter(1)(self, columns)
+                self._modin_frame._has_unsupported_data = True
 
     def fillna(
         self,


### PR DESCRIPTION
Signed-off-by: Andrey Pavlenko <andrey.a.pavlenko@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Duplicate column names are not supported by the omnisci backend. To workaround this issue - fall back to pandas in case of duplicates.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4016 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
