### PR TITLE
FEAT-#4766: Support fsspec URLs in `read_csv` and `read_csv_glob`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -106,6 +106,7 @@ Key Features and Updates
   * FEAT-#4664: Finalize compatibility support for Python 3.6 (#4800)
   * FEAT-#4746: Sync interchange protocol with recent API changes (#4763)
   * FEAT-#4733: Support fastparquet as engine for `read_parquet` (#4807)
+  * FEAT-#4766: Support fsspec URLs in `read_csv` and `read_csv_glob` (#4898)
 
 Contributors
 ------------

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -24,13 +24,11 @@ import fsspec
 
 import pandas
 import pandas._libs.lib as lib
-from pandas.io.common import is_url
+from pandas.io.common import is_url, is_fsspec_url, stringify_path
 
 from modin.config import NPartitions
 from modin.core.io.file_dispatcher import OpenFile
 from modin.core.io.text.csv_dispatcher import CSVDispatcher
-
-_SUPPORTED_PROTOCOLS = {"s3", "S3"}
 
 
 class CSVGlobDispatcher(CSVDispatcher):
@@ -54,7 +52,7 @@ class CSVGlobDispatcher(CSVDispatcher):
             Query compiler with imported data for further processing.
         """
         # Ensures that the file is a string file path. Otherwise, default to pandas.
-        filepath_or_buffer = cls.get_path_or_buffer(filepath_or_buffer)
+        filepath_or_buffer = cls.get_path_or_buffer(stringify_path(filepath_or_buffer))
         if isinstance(filepath_or_buffer, str):
             # os.altsep == None on Linux
             is_folder = any(
@@ -331,17 +329,8 @@ class CSVGlobDispatcher(CSVDispatcher):
         bool
             True if the path is valid.
         """
-        if isinstance(file_path, str) and is_url(file_path):
-            raise NotImplementedError("`read_csv_glob` supports only s3-like paths.")
-
-        if (
-            not isinstance(file_path, str)
-            or fsspec.core.split_protocol(file_path)[0] not in _SUPPORTED_PROTOCOLS
-        ):
+        if not is_fsspec_url(file_path) and not is_url(file_path):
             return len(glob.glob(file_path)) > 0
-
-        # `file_path` may start with a capital letter, which isn't supported by `fsspec.core.url_to_fs` used below.
-        file_path = file_path[0].lower() + file_path[1:]
 
         from botocore.exceptions import (
             NoCredentialsError,
@@ -384,13 +373,10 @@ class CSVGlobDispatcher(CSVDispatcher):
         list
             List of strings of absolute file paths.
         """
-        if fsspec.core.split_protocol(file_path)[0] not in _SUPPORTED_PROTOCOLS:
+        if not is_fsspec_url(file_path) and not is_url(file_path):
             relative_paths = glob.glob(file_path)
             abs_paths = [os.path.abspath(path) for path in relative_paths]
             return abs_paths
-
-        # `file_path` may start with a capital letter, which isn't supported by `fsspec.core.url_to_fs` used below.
-        file_path = file_path[0].lower() + file_path[1:]
 
         from botocore.exceptions import (
             NoCredentialsError,
@@ -402,8 +388,8 @@ class CSVGlobDispatcher(CSVDispatcher):
             file_paths = fs_handle.glob(file_path)
             if len(file_paths) == 0 and not fs_handle.exists(file_path):
                 raise FileNotFoundError(f"Path <{file_path}> isn't available.")
-            s3_addresses = [f"s3://{path}" for path in file_paths]
-            return s3_addresses
+            fs_addresses = [fs_handle.unstrip_protocol(path) for path in file_paths]
+            return fs_addresses
 
         fs, _ = fsspec.core.url_to_fs(file_path)
         try:

--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -329,7 +329,10 @@ class CSVGlobDispatcher(CSVDispatcher):
         bool
             True if the path is valid.
         """
-        if not is_fsspec_url(file_path) and not is_url(file_path):
+        if is_url(file_path):
+            raise NotImplementedError("`read_csv_glob` does not support urllib paths.")
+
+        if not is_fsspec_url(file_path):
             return len(glob.glob(file_path)) > 0
 
         from botocore.exceptions import (

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -28,6 +28,7 @@ import numpy as np
 import pandas
 import pandas._libs.lib as lib
 from pandas.core.dtypes.common import is_list_like
+from pandas.io.common import stringify_path
 
 from modin.core.io.file_dispatcher import FileDispatcher, OpenFile
 from modin.core.storage_formats.pandas.utils import compute_chunksize
@@ -963,6 +964,7 @@ class TextFileDispatcher(FileDispatcher):
         new_query_compiler : BaseQueryCompiler
             Query compiler with imported data for further processing.
         """
+        filepath_or_buffer = stringify_path(filepath_or_buffer)
         filepath_or_buffer_md = (
             cls.get_path(filepath_or_buffer)
             if isinstance(filepath_or_buffer, str)

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -28,7 +28,6 @@ import numpy as np
 import pandas
 import pandas._libs.lib as lib
 from pandas.core.dtypes.common import is_list_like
-from pandas.io.common import stringify_path
 
 from modin.core.io.file_dispatcher import FileDispatcher, OpenFile
 from modin.core.storage_formats.pandas.utils import compute_chunksize
@@ -964,7 +963,6 @@ class TextFileDispatcher(FileDispatcher):
         new_query_compiler : BaseQueryCompiler
             Query compiler with imported data for further processing.
         """
-        filepath_or_buffer = stringify_path(filepath_or_buffer)
         filepath_or_buffer_md = (
             cls.get_path(filepath_or_buffer)
             if isinstance(filepath_or_buffer, str)

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -168,7 +168,7 @@ class TestCsvGlob:
     Engine.get() != "Ray", reason="Currently only support Ray engine for glob paths."
 )
 def test_read_multiple_csv_s3():
-    path = "S3://modin-datasets/testing/multiple_csv/test_data*.csv"
+    path = "s3://modin-datasets/testing/multiple_csv/test_data*.csv"
 
     def _pandas_read_csv_glob(path, storage_options):
         pandas_dfs = [

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -164,15 +164,17 @@ class TestCsvGlob:
             df_equals(modin_df, pandas_df)
 
 
+@pytest.mark.parametrize(
+    "path",
+    [
+        "s3://modin-datasets/testing/multiple_csv/test_data*.csv",
+        "gs://modin-testing/testing/multiple_csv/test_data*.csv",
+    ],
+)
 @pytest.mark.skipif(
     Engine.get() != "Ray", reason="Currently only support Ray engine for glob paths."
 )
-def test_read_multiple_csv_cloud_store():
-    paths = [
-        "s3://modin-datasets/testing/multiple_csv/test_data*.csv",
-        "gs://modin-testing/testing/multiple_csv/test_data*.csv",
-    ]
-
+def test_read_multiple_csv_cloud_store(path):
     def _pandas_read_csv_glob(path, storage_options):
         pandas_dfs = [
             pandas.read_csv(
@@ -182,17 +184,14 @@ def test_read_multiple_csv_cloud_store():
         ]
         return pandas.concat(pandas_dfs).reset_index(drop=True)
 
-    for path in paths:
-        eval_general(
-            pd,
-            pandas,
-            lambda module, **kwargs: pd.read_csv_glob(path, **kwargs).reset_index(
-                drop=True
-            )
-            if hasattr(module, "read_csv_glob")
-            else _pandas_read_csv_glob(path, **kwargs),
-            storage_options={"anon": True},
-        )
+    eval_general(
+        pd,
+        pandas,
+        lambda module, **kwargs: pd.read_csv_glob(path, **kwargs).reset_index(drop=True)
+        if hasattr(module, "read_csv_glob")
+        else _pandas_read_csv_glob(path, **kwargs),
+        storage_options={"anon": True},
+    )
 
 
 test_default_to_pickle_filename = "test_default_to_pickle.pkl"

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -167,8 +167,11 @@ class TestCsvGlob:
 @pytest.mark.skipif(
     Engine.get() != "Ray", reason="Currently only support Ray engine for glob paths."
 )
-def test_read_multiple_csv_s3():
-    path = "s3://modin-datasets/testing/multiple_csv/test_data*.csv"
+def test_read_multiple_csv_cloud_store():
+    paths = [
+        "s3://modin-datasets/testing/multiple_csv/test_data*.csv",
+        "gs://modin-testing/testing/multiple_csv/test_data*.csv",
+    ]
 
     def _pandas_read_csv_glob(path, storage_options):
         pandas_dfs = [
@@ -179,14 +182,17 @@ def test_read_multiple_csv_s3():
         ]
         return pandas.concat(pandas_dfs).reset_index(drop=True)
 
-    eval_general(
-        pd,
-        pandas,
-        lambda module, **kwargs: pd.read_csv_glob(path, **kwargs).reset_index(drop=True)
-        if hasattr(module, "read_csv_glob")
-        else _pandas_read_csv_glob(path, **kwargs),
-        storage_options={"anon": True},
-    )
+    for path in paths:
+        eval_general(
+            pd,
+            pandas,
+            lambda module, **kwargs: pd.read_csv_glob(path, **kwargs).reset_index(
+                drop=True
+            )
+            if hasattr(module, "read_csv_glob")
+            else _pandas_read_csv_glob(path, **kwargs),
+            storage_options={"anon": True},
+        )
 
 
 test_default_to_pickle_filename = "test_default_to_pickle.pkl"

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -915,6 +915,13 @@ class TestCsv:
             dtype={"one": "int64", "two": "category"},
         )
 
+    def test_read_csv_gs(self):
+        eval_io(
+            fn_name="read_csv",
+            # read_csv kwargs
+            filepath_or_buffer="gs://modin-testing/testing/multiple_csv/test_data0.csv",
+        )
+
     @pytest.mark.parametrize("encoding", [None, "utf-8"])
     @pytest.mark.parametrize("encoding_errors", ["strict", "ignore"])
     @pytest.mark.parametrize(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -915,7 +915,7 @@ class TestCsv:
             dtype={"one": "int64", "two": "category"},
         )
 
-    def test_read_csv_gs(self):
+    def test_read_csv_google_cloud_storage(self):
         eval_io(
             fn_name="read_csv",
             # read_csv kwargs


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR adds proper support for fsspec URLs that matches pandas behavior for `read_csv`. 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4766 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
