### PR TITLE
PERF-#4866: `iloc` function that used in `partition.mask` should be serialized only once

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -59,6 +59,7 @@ Key Features and Updates
   * PERF-#4849: compute `dtypes` in `concat` also for ROW_WISE case when possible (#4850)
   * PERF-#4860: `PandasDataframeAxisPartition.deploy_axis_func` should be serialized only once (#4861)
   * PERF-#4886: Use lazy index and columns evaluation in `query` method (#4887)
+  * PERF-#4866: `iloc` function that used in `partition.mask` should be serialized only once (#4901)
   * PERF-#4268: Implement partition-parallel __getitem__ for bool Series masks (#4753)
 * Benchmarking enhancements
   * FEAT-#4706: Add Modin ClassLogger to PandasDataframePartitionManager (#4707)

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -162,6 +162,12 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         """
         return self.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).get()
 
+    _iloc = (
+        lambda df, row_labels, col_labels: df.iloc[  # noqa: E731 (lambda assignment)
+            row_labels, col_labels
+        ]
+    )
+
     def mask(self, row_labels, col_labels):
         """
         Lazily create a mask that extracts the indices provided.
@@ -200,7 +206,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         ):
             return copy(self)
 
-        new_obj = self.add_to_apply_calls(lambda df: df.iloc[row_labels, col_labels])
+        new_obj = self.add_to_apply_calls(self._iloc, row_labels, col_labels)
 
         def try_recompute_cache(indices, previous_cache):
             """Compute new axis-length cache for the masked frame based on its previous cache."""

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -162,12 +162,9 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         """
         return self.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).get()
 
-    _iloc = staticmethod(
-        lambda df, row_labels, col_labels: df.iloc[  # noqa: E731 (lambda assignment)
-            row_labels, col_labels
-        ]
-    )
-
+    @staticmethod
+    def _iloc(df, row_labels, col_labels):
+        return df.iloc[row_labels, col_labels]
     def mask(self, row_labels, col_labels):
         """
         Lazily create a mask that extracts the indices provided.

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -163,8 +163,10 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         return self.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).get()
 
     @staticmethod
-    def _iloc(df, row_labels, col_labels):
+    def _iloc(df, row_labels, col_labels):  # noqa: RT01, PR01
+        """Perform `iloc` on dataframes wrapped in partitions (helper function)."""
         return df.iloc[row_labels, col_labels]
+
     def mask(self, row_labels, col_labels):
         """
         Lazily create a mask that extracts the indices provided.

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -162,7 +162,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         """
         return self.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).get()
 
-    _iloc = (
+    _iloc = staticmethod(
         lambda df, row_labels, col_labels: df.iloc[  # noqa: E731 (lambda assignment)
             row_labels, col_labels
         ]

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -206,6 +206,8 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             call_queue=self.call_queue,
         )
 
+    _iloc = ray.put(lambda df, row_labels, col_labels: df.iloc[row_labels, col_labels])
+
     def mask(self, row_labels, col_labels):
         """
         Lazily create a mask that extracts the indices provided.

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -206,7 +206,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             call_queue=self.call_queue,
         )
 
-    _iloc = ray.put(lambda df, row_labels, col_labels: df.iloc[row_labels, col_labels])
+    _iloc = ray.put(PandasDataframePartition._iloc)
 
     def mask(self, row_labels, col_labels):
         """


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4866 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
