### PR TITLE
FIX-#4907: Implement `radd` for Series and DataFrame

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -40,6 +40,7 @@ Key Features and Updates
   * FIX-#4835: Handle Pathlike paths in `read_parquet` (#4837)
   * FIX-#4872: Stop checking the private ray mac memory limit (#4873)
   * FIX-#4848: Fix rebalancing partitions when NPartitions == 1 (#4874)
+  * FIX-#4907: Implement `radd` for Series and DataFrame (#4908)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -600,6 +600,12 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     def pow(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.pow)(self, other=other, **kwargs)
 
+    @doc_utils.doc_binary_method(operation="addition", sign="+", self_on_right=True)
+    def radd(self, other, **kwargs):  # noqa: PR02
+        return BinaryDefault.register(pandas.DataFrame.radd)(
+            self, other=other, **kwargs
+        )
+
     @doc_utils.doc_binary_method(
         operation="integer division", sign="//", self_on_right=True
     )

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -381,6 +381,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     mul = Binary.register(pandas.DataFrame.mul)
     ne = Binary.register(pandas.DataFrame.ne)
     pow = Binary.register(pandas.DataFrame.pow)
+    radd = Binary.register(pandas.DataFrame.radd)
     rfloordiv = Binary.register(pandas.DataFrame.rfloordiv)
     rmod = Binary.register(pandas.DataFrame.rmod)
     rpow = Binary.register(pandas.DataFrame.rpow)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1953,8 +1953,6 @@ class BasePandasDataset(BasePandasDatasetCompat):
             "pow", other, axis=axis, level=level, fill_value=fill_value
         )
 
-    radd = add
-
     def quantile(
         self, q=0.5, axis=0, numeric_only=True, interpolation="linear"
     ):  # noqa: PR01, RT01, D200
@@ -2261,6 +2259,16 @@ class BasePandasDataset(BasePandasDatasetCompat):
                 col_fill=col_fill,
             )
         return self._create_or_update_from_compiler(new_query_compiler, inplace)
+
+    def radd(
+        self, other, axis="columns", level=None, fill_value=None
+    ):  # noqa: PR01, RT01, D200
+        """
+        Return addition of `BasePandasDataset` and `other`, element-wise (binary operator `radd`).
+        """
+        return self._binary_op(
+            "radd", other, axis=axis, level=level, fill_value=fill_value
+        )
 
     def rfloordiv(
         self, other, axis="columns", level=None, fill_value=None

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1697,7 +1697,6 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
         )
 
     product = DataFrameCompat.prod
-    radd = add
 
     def query(self, expr, inplace=False, **kwargs):  # noqa: PR01, RT01, D200
         """
@@ -1789,6 +1788,21 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
         """
         return self._binary_op(
             "rfloordiv",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
+        )
+
+    def radd(
+        self, other, axis="columns", level=None, fill_value=None
+    ):  # noqa: PR01, RT01, D200
+        """
+        Get addition of ``DataFrame`` and `other`, element-wise (binary operator `radd`).
+        """
+        return self._binary_op(
+            "radd",
             other,
             axis=axis,
             level=level,

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -170,9 +170,9 @@ class Series(SeriesCompat, BasePandasDataset):
     def __add__(self, right):
         return self.add(right)
 
-    @_doc_binary_op(operation="addition", bin_op="add", right="left")
+    @_doc_binary_op(operation="addition", bin_op="radd", right="left")
     def __radd__(self, left):
-        return self.add(left)
+        return self.radd(left)
 
     @_doc_binary_op(operation="union", bin_op="and", right="other")
     def __and__(self, other):
@@ -492,6 +492,17 @@ class Series(SeriesCompat, BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).add(
+            new_other, level=level, fill_value=fill_value, axis=axis
+        )
+
+    def radd(
+        self, other, level=None, fill_value=None, axis=0
+    ):  # noqa: PR01, RT01, D200
+        """
+        Return Addition of series and other, element-wise (binary operator radd).
+        """
+        new_self, new_other = self._prepare_inter_op(other)
+        return super(Series, new_self).radd(
             new_other, level=level, fill_value=fill_value, axis=axis
         )
 
@@ -1441,7 +1452,6 @@ class Series(SeriesCompat, BasePandasDataset):
         )
 
     product = SeriesCompat.prod
-    radd = add
 
     def ravel(self, order="C"):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -288,10 +288,7 @@ def test_empty_df(empty_operand):
     df_equals(modin_res, pandas_res)
 
 
-def test_concat_string_to_df():
-    modin_df, pandas_df = create_test_dfs({"a": ["a", "b", "c", "d"]})
-
-    modin_df = "random_string" + modin_df
-    pandas_df = "random_string" + pandas_df
-
-    df_equals(modin_df, pandas_df)
+def test_add_string_to_df():
+    modin_df, pandas_df = create_test_dfs(["a", "b"])
+    eval_general(modin_df, pandas_df, lambda df: "string" + df)
+    eval_general(modin_df, pandas_df, lambda df: df + "string")

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -286,3 +286,12 @@ def test_empty_df(empty_operand):
         pandas_res = pandas_df_empty + pandas_df_empty
 
     df_equals(modin_res, pandas_res)
+
+
+def test_concat_string_to_df():
+    modin_df, pandas_df = create_test_dfs({"a": ["a", "b", "c", "d"]})
+
+    modin_df = "random_string" + modin_df
+    pandas_df = "random_string" + pandas_df
+
+    df_equals(modin_df, pandas_df)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4540,6 +4540,16 @@ def test_encode(data, encoding_type):
         df_equals(modin_result, pandas_result)
 
 
+@pytest.mark.parametrize("data", test_string_data_values, ids=test_string_data_keys)
+def test_concat_string_to_series(data):
+    modin_series, pandas_series = create_test_series(data)
+
+    modin_series = "random_string" + modin_series
+    pandas_series = "random_string" + pandas_series
+
+    df_equals(modin_series, pandas_series)
+
+
 @pytest.mark.parametrize(
     "is_sparse_data", [True, False], ids=["is_sparse", "is_not_sparse"]
 )

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4541,13 +4541,9 @@ def test_encode(data, encoding_type):
 
 
 @pytest.mark.parametrize("data", test_string_data_values, ids=test_string_data_keys)
-def test_concat_string_to_series(data):
-    modin_series, pandas_series = create_test_series(data)
-
-    modin_series = "random_string" + modin_series
-    pandas_series = "random_string" + pandas_series
-
-    df_equals(modin_series, pandas_series)
+def test_add_string_to_series(data):
+    eval_general(*create_test_series(data), lambda s: "string" + s)
+    eval_general(*create_test_series(data), lambda s: s + "string")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR implements a proper implementation for `radd` which is needed for string concatenation on DataFrames and Series objects.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4907 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
