### PR TITLE
FIX-#4934: preserve `dtypes` in `try_cast_to_pandas`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2955,7 +2955,8 @@ class PandasDataframe(ClassLogger):
         pandas.DataFrame
         """
         df = self._partition_mgr_cls.to_pandas(self._partitions)
-        if df.empty:
+        if len(self._partitions) == 0:
+            # This constructor may overwrite `dtypes` left over from previous operations.
             df = pandas.DataFrame(columns=self.columns, index=self.index)
         else:
             for axis in [0, 1]:
@@ -2963,8 +2964,6 @@ class PandasDataframe(ClassLogger):
                     not df.axes[axis].equals(self.axes[axis]),
                     f"Internal and external indices on axis {axis} do not match.",
                 )
-            df.index = self.index
-            df.columns = self.columns
 
         return df
 

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2964,6 +2964,8 @@ class PandasDataframe(ClassLogger):
                     not df.axes[axis].equals(self.axes[axis]),
                     f"Internal and external indices on axis {axis} do not match.",
                 )
+            df.index = self.index
+            df.columns = self.columns
 
         return df
 

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2955,7 +2955,7 @@ class PandasDataframe(ClassLogger):
         pandas.DataFrame
         """
         df = self._partition_mgr_cls.to_pandas(self._partitions)
-        if len(self._partitions) == 0:
+        if len(self._partitions) == 0 or len(self._partitions.T) == 0:
             # This constructor may overwrite `dtypes` left over from previous operations.
             df = pandas.DataFrame(columns=self.columns, index=self.index)
         else:

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -657,10 +657,16 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             axis = 1
         else:
             ErrorMessage.catch_bugs_and_request_email(True)
+
+        def _empty(df):
+            # Custom function to save dtypes after previous operations.
+            # A normal function uses `or`, not `and`.
+            return len(df) == 0 and df.columns == 0
+
         df_rows = [
             pandas.concat([part for part in row], axis=axis)
             for row in retrieved_objects
-            if not all(part.empty for part in row)
+            if not all(_empty(part) for part in row)
         ]
         if len(df_rows) == 0:
             return pandas.DataFrame()

--- a/modin/test/test_utils.py
+++ b/modin/test/test_utils.py
@@ -12,10 +12,14 @@
 # governing permissions and limitations under the License.
 
 import pytest
-import modin.utils
 import json
-
 from textwrap import dedent, indent
+import numpy as np
+import pandas
+
+import modin.utils
+import modin.pandas as pd
+from modin.pandas.test.utils import df_equals
 from modin.error_message import ErrorMessage
 
 
@@ -287,3 +291,15 @@ def test_warns_that_defaulting_to_pandas():
 
     with warns_that_defaulting_to_pandas():
         ErrorMessage.default_to_pandas(message="Function name")
+
+
+def test_try_cast_to_pandas_preserve_dtypes():
+    modin_df = pd.DataFrame({"col": [1]}, dtype=np.int64)
+    pandas_df = pandas.DataFrame({"col": [1]}, dtype=np.int64)
+
+    # just to get empty frames
+    modin_df.query("col > 2", inplace=True), pandas_df.query("col > 2", inplace=True)
+
+    casted_to_pandas_df = modin.utils.try_cast_to_pandas(modin_df)
+    df_equals(casted_to_pandas_df, pandas_df)
+    df_equals(casted_to_pandas_df.dtypes, pandas_df.dtypes)


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [ ] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4934 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
