### PR TITLE
FIX-#4090: Fixed check if the index is trivial

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -54,6 +54,7 @@ Key Features and Updates
   * FIX-#4597: Refactor Partition handling of func, args, kwargs (#4715)
   * FIX-#4996: Evaluate BenchmarkMode at each function call (#4997)
   * FIX-#4022: Fixed empty data frame with index (#4910)
+  * FIX-#4090: Fixed check if the index is trivial (#4936)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -2538,7 +2538,7 @@ class HdkOnNativeDataframe(PandasDataframe):
             return False
         return (
             index.is_monotonic_increasing
-            and index.unique
-            and index.min == 0
-            and index.max == len(index) - 1
+            and index.is_unique
+            and index.min() == 0
+            and index.max() == len(index) - 1
         )

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -19,13 +19,12 @@ import pytest
 import re
 
 from modin.config import StorageFormat
-from modin.pandas.test.utils import io_ops_bad_exc, default_to_pandas_ignore_string
-from .utils import eval_io, ForceHdkImport, set_execution_mode, run_and_compare
 from modin.pandas.test.utils import (
     io_ops_bad_exc,
     default_to_pandas_ignore_string,
     random_state,
 )
+from .utils import eval_io, ForceHdkImport, set_execution_mode, run_and_compare
 from pandas.core.dtypes.common import is_list_like
 
 StorageFormat.put("hdk")

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -21,6 +21,11 @@ import re
 from modin.config import StorageFormat
 from modin.pandas.test.utils import io_ops_bad_exc, default_to_pandas_ignore_string
 from .utils import eval_io, ForceHdkImport, set_execution_mode, run_and_compare
+from modin.pandas.test.utils import (
+    io_ops_bad_exc,
+    default_to_pandas_ignore_string,
+    random_state,
+)
 from pandas.core.dtypes.common import is_list_like
 
 StorageFormat.put("hdk")
@@ -452,7 +457,7 @@ class TestMultiIndex:
                 names=["l1", "l2", "l3"],
             )
             if is_multiindex
-            else pandas.Index(np.arange(len(self.data["a"])), name="index")
+            else pandas.Index(np.arange(1, len(self.data["a"]) + 1), name="index")
         )
         columns = pandas.MultiIndex.from_tuples(
             [("a", "b"), ("b", "c")], names=column_names
@@ -2222,6 +2227,24 @@ class TestStr:
             fn=run_cols,
             data=None,
             constructor_kwargs={"index": range(5)},
+            force_lazy=False,
+        )
+
+
+class TestCompare:
+    def test_compare_float(self):
+        def run_compare(df1, df2, **kwargs):
+            return df1.compare(df2, align_axis="columns", keep_shape=False)
+
+        data1 = random_state.randn(100, 10)
+        data2 = random_state.randn(100, 10)
+        columns = list("abcdefghij")
+
+        run_and_compare(
+            run_compare,
+            data=data1,
+            data2=data2,
+            constructor_kwargs={"columns": columns},
             force_lazy=False,
         )
 


### PR DESCRIPTION
Signed-off-by: Andrey Pavlenko <andrey.a.pavlenko@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
  * Fixed HdkOnNativeDataframe._is_trivial_index()
  * Do not preserve a trivial index in the underlying arrow table

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4090 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
