### PR TITLE
FIX-#4100: Fall back to Pandas on row drop

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -2145,6 +2145,28 @@ class TestArrowExecution:
             force_arrow_execute=True,
         )
 
+    def test_drop_row(self):
+        def drop_row(df, **kwargs):
+            return df.drop(1)
+
+        run_and_compare(
+            drop_row,
+            data=self.data1,
+            force_lazy=False,
+        )
+
+    def test_series_pop(self):
+        def pop(df, **kwargs):
+            col = df["a"]
+            col.pop(0)
+            return col
+
+        run_and_compare(
+            pop,
+            data=self.data1,
+            force_lazy=False,
+        )
+
     def test_empty_transform(self):
         def apply(df, **kwargs):
             return df + 1

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -2147,7 +2147,7 @@ class TestArrowExecution:
 
     def test_drop_row(self):
         def drop_row(df, **kwargs):
-            return df.drop(1)
+            return df.drop(labels=1)
 
         run_and_compare(
             drop_row,

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -556,7 +556,8 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         return self.__constructor__(new_modin_frame)
 
     def drop(self, index=None, columns=None):
-        assert index is None, "Only column drop is supported"
+        if index is not None:
+            raise NotImplementedError("Row drop")
         return self.__constructor__(
             self._modin_frame.take_2d_labels_or_positional(
                 row_labels=index, col_labels=self.columns.drop(columns)


### PR DESCRIPTION
Signed-off-by: Andrey Pavlenko <andrey.a.pavlenko@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Only column drop is currently supported by the omnisci engine.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4100 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
