### PR TITLE
REFACTOR-#4942: Remove `call` method in favor of `register` due to duplication

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -89,6 +89,7 @@ Key Features and Updates
   * REFACTOR-#3780: Remove code duplication for `PandasOnDaskDataframe` (#3781)
   * REFACTOR-#4530: Unify access to physical data for any partition type (#4829)
   * REFACTOR-#4885: De-duplicated take_2d_labels_or_positional methods (#4883)
+  * REFACTOR-#4942: Remove `call` method in favor of `register` due to duplication (4943)
   * REFACTOR-#4922: Helpers for take_2d_labels_or_positional (#4865)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)

--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -23,7 +23,7 @@ class Binary(Operator):
     """Builder class for Binary operator."""
 
     @classmethod
-    def call(cls, func, join_type="outer", labels="replace"):
+    def register(cls, func, join_type="outer", labels="replace"):
         """
         Build template binary operator.
 

--- a/modin/core/dataframe/algebra/default2pandas/any.py
+++ b/modin/core/dataframe/algebra/default2pandas/any.py
@@ -78,4 +78,4 @@ class AnyDefault(DefaultMethod):
         if obj_type is None:
             obj_type = ObjTypeDeterminer()
 
-        return cls.call(func, obj_type=obj_type, **kwargs)
+        return super().register(func, obj_type=obj_type, **kwargs)

--- a/modin/core/dataframe/algebra/default2pandas/dataframe.py
+++ b/modin/core/dataframe/algebra/default2pandas/dataframe.py
@@ -46,4 +46,4 @@ class DataFrameDefault(DefaultMethod):
         """
         if obj_type is None:
             obj_type = pandas.DataFrame
-        return cls.call(func, obj_type=obj_type, **kwargs)
+        return super().register(func, obj_type=obj_type, **kwargs)

--- a/modin/core/dataframe/algebra/default2pandas/default.py
+++ b/modin/core/dataframe/algebra/default2pandas/default.py
@@ -33,7 +33,7 @@ class DefaultMethod(Operator):
     OBJECT_TYPE = "DataFrame"
 
     @classmethod
-    def call(cls, func, obj_type=pandas.DataFrame, inplace=None, fn_name=None):
+    def register(cls, func, obj_type=pandas.DataFrame, inplace=None, fn_name=None):
         """
         Build function that do fallback to default pandas implementation for passed `func`.
 
@@ -113,28 +113,6 @@ class DefaultMethod(Operator):
             return result if not inplace_method else df
 
         return cls.build_wrapper(applyier, fn_name)
-
-    @classmethod
-    # FIXME: `register` is an alias for `call` method. One of them should be removed.
-    def register(cls, func, **kwargs):
-        """
-        Build function that do fallback to default pandas implementation for passed `func`.
-
-        Parameters
-        ----------
-        func : callable or str,
-            Function to apply to the casted to pandas frame or its property accesed
-            by ``cls.frame_wrapper``.
-        **kwargs : kwargs
-            Additional parameters that will be used for building.
-
-        Returns
-        -------
-        callable
-            Function that takes query compiler, does fallback to pandas and applies `func`
-            to the casted to pandas frame or its property accesed by ``cls.frame_wrapper``.
-        """
-        return cls.call(func, **kwargs)
 
     @classmethod
     # FIXME: this method is almost a duplicate of `cls.build_default_to_pandas`.

--- a/modin/core/dataframe/algebra/default2pandas/groupby.py
+++ b/modin/core/dataframe/algebra/default2pandas/groupby.py
@@ -541,7 +541,9 @@ class GroupByDefault(DefaultMethod):
             Functiom that takes query compiler and defaults to pandas to do GroupBy
             aggregation.
         """
-        return cls.call(GroupBy.build_groupby(func), fn_name=func.__name__, **kwargs)
+        return super().register(
+            GroupBy.build_groupby(func), fn_name=func.__name__, **kwargs
+        )
 
     # This specifies a `pandas.DataFrameGroupBy` method to pass the `agg_func` to,
     # it's based on `how` to apply it. Going by pandas documentation:

--- a/modin/core/dataframe/algebra/default2pandas/resample.py
+++ b/modin/core/dataframe/algebra/default2pandas/resample.py
@@ -79,7 +79,7 @@ class ResampleDefault(DefaultMethod):
             Function that takes query compiler and does fallback to pandas to resample
             time-series data and apply aggregation on it.
         """
-        return cls.call(
+        return super().register(
             Resampler.build_resample(func, squeeze_self),
             fn_name=func.__name__,
             **kwargs

--- a/modin/core/dataframe/algebra/default2pandas/rolling.py
+++ b/modin/core/dataframe/algebra/default2pandas/rolling.py
@@ -72,4 +72,6 @@ class RollingDefault(DefaultMethod):
             Function that takes query compiler and defaults to pandas to apply aggregation
             `func` on a rolling window.
         """
-        return cls.call(Rolling.build_rolling(func), fn_name=func.__name__, **kwargs)
+        return super().register(
+            Rolling.build_rolling(func), fn_name=func.__name__, **kwargs
+        )

--- a/modin/core/dataframe/algebra/fold.py
+++ b/modin/core/dataframe/algebra/fold.py
@@ -20,7 +20,7 @@ class Fold(Operator):
     """Builder class for Fold functions."""
 
     @classmethod
-    def call(cls, fold_function):
+    def register(cls, fold_function):
         """
         Build Fold operator that will be performed across rows/columns.
 

--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -26,7 +26,7 @@ class GroupByReduce(TreeReduce):
     """Builder class for GroupBy aggregation functions."""
 
     @classmethod
-    def call(cls, map_func, reduce_func=None, **call_kwds):
+    def register(cls, map_func, reduce_func=None, **call_kwds):
         """
         Build template GroupBy aggregation function.
 

--- a/modin/core/dataframe/algebra/map.py
+++ b/modin/core/dataframe/algebra/map.py
@@ -20,7 +20,7 @@ class Map(Operator):
     """Builder class for Map operator."""
 
     @classmethod
-    def call(cls, function, *call_args, **call_kwds):
+    def register(cls, function, *call_args, **call_kwds):
         """
         Build Map operator that will be performed across each partition.
 

--- a/modin/core/dataframe/algebra/operator.py
+++ b/modin/core/dataframe/algebra/operator.py
@@ -27,25 +27,6 @@ class Operator(object):
         )
 
     @classmethod
-    def call(cls, func, **call_kwds):
-        """
-        Build operator that applies source function across the entire dataset.
-
-        Parameters
-        ----------
-        func : callable
-            Source function.
-        **call_kwds : kwargs
-            Kwargs that will be used for building.
-
-        Returns
-        -------
-        callable
-        """
-        raise NotImplementedError("Please implement in child class")
-
-    @classmethod
-    # FIXME: `register` is an alias for `call` method. One of them should be removed.
     def register(cls, func, **kwargs):
         """
         Build operator that applies source function across the entire dataset.
@@ -61,7 +42,7 @@ class Operator(object):
         -------
         callable
         """
-        return cls.call(func, **kwargs)
+        raise NotImplementedError("Please implement in child class")
 
     @classmethod
     def validate_axis(cls, axis: Optional[int]) -> int:

--- a/modin/core/dataframe/algebra/reduce.py
+++ b/modin/core/dataframe/algebra/reduce.py
@@ -20,7 +20,7 @@ class Reduce(Operator):
     """Builder class for Reduce operator."""
 
     @classmethod
-    def call(cls, reduce_function, axis=None):
+    def register(cls, reduce_function, axis=None):
         """
         Build Reduce operator that will be performed across rows/columns.
 

--- a/modin/core/dataframe/algebra/tree_reduce.py
+++ b/modin/core/dataframe/algebra/tree_reduce.py
@@ -20,7 +20,7 @@ class TreeReduce(Operator):
     """Builder class for TreeReduce operator."""
 
     @classmethod
-    def call(cls, map_function, reduce_function, axis=None):
+    def register(cls, map_function, reduce_function=None, axis=None):
         """
         Build TreeReduce operator.
 
@@ -28,7 +28,7 @@ class TreeReduce(Operator):
         ----------
         map_function : callable(pandas.DataFrame) -> pandas.DataFrame
             Source map function.
-        reduce_function : callable(pandas.DataFrame) -> pandas.Series
+        reduce_function : callable(pandas.DataFrame) -> pandas.Series, optional
             Source reduce function.
         axis : int, optional
             Specifies axis to apply function along.
@@ -39,6 +39,8 @@ class TreeReduce(Operator):
             Function that takes query compiler and executes passed functions
             with TreeReduce algorithm.
         """
+        if reduce_function is None:
+            reduce_function = map_function
 
         def caller(query_compiler, *args, **kwargs):
             """Execute TreeReduce function against passed query compiler."""
@@ -52,28 +54,3 @@ class TreeReduce(Operator):
             )
 
         return caller
-
-    @classmethod
-    # FIXME: `register` is an alias for `call` method. One of them should be removed.
-    def register(cls, map_function, reduce_function=None, **kwargs):
-        """
-        Build TreeReduce function.
-
-        Parameters
-        ----------
-        map_function : callable(pandas.DataFrame) -> [pandas.DataFrame, pandas.Series]
-            Source map function.
-        reduce_function : callable(pandas.DataFrame) -> pandas.Series, optional
-            Source reduce function. If not specified `map_function` will be used.
-        **kwargs : dict
-            Additional parameters to pass to the builder function.
-
-        Returns
-        -------
-        callable
-            Function that takes query compiler and executes passed functions
-            with TreeReduce algorithm.
-        """
-        if reduce_function is None:
-            reduce_function = map_function
-        return cls.call(map_function, reduce_function, **kwargs)


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4942 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
