### PR TITLE
FIX-#4945: Return empty `pandas.Index` instead of list in `get_indices`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -46,6 +46,7 @@ Key Features and Updates
   * FIX-#3983: FIX-#4107: Materialize 'rowid' columns when selecting rows by position (#4834)
   * FIX-#4845: Fix KeyError from `__getitem_bool` for single row dataframes (#4845)
   * FIX-#4734: Handle Series.apply when return type is a DataFrame (#4830)
+  * FIX-#4945: Return empty `pandas.Index` instead of list in `get_indices` (#4948)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -814,7 +814,7 @@ class PandasDataframe(ClassLogger):
         else:
             row_partitions_dict = {i: slice(None) for i in range(len(self._partitions))}
             new_row_lengths = self._row_lengths_cache
-            new_index = self._index_cache
+            new_index = self.index
 
         if col_positions is not None:
             sorted_col_positions = self._get_sorted_positions(col_positions)

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -867,7 +867,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         new_idx = [idx.apply(func) for idx in target[0]] if len(target) else []
         new_idx = cls.get_objects_from_partitions(new_idx)
         # TODO FIX INFORMATION LEAK!!!!1!!1!!
-        total_idx = new_idx[0].append(new_idx[1:]) if new_idx else new_idx
+        total_idx = new_idx[0].append(new_idx[1:]) if new_idx else pandas.Index([])
         return total_idx, new_idx
 
     @classmethod

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -2117,3 +2117,22 @@ def test__getitem_bool_single_row_dataframe():
     # This test case comes from
     # https://github.com/modin-project/modin/issues/4845
     eval_general(pd, pandas, lambda lib: lib.DataFrame([1])[lib.Series([True])])
+
+
+# This is a very subtle bug that comes from:
+# https://github.com/modin-project/modin/issues/4945
+def test_4945():
+    modin_df, pandas_df = create_test_dfs({"col0": [0, 1]})
+
+    def func(df):
+        df_copy = df[df["col0"] < 6].copy()
+        # The problem here is that the index is not copied over so it needs
+        # to get recomputed at some point. Our implementation of __setitem__
+        # requires us to build a mask and insert the value from the right
+        # handside into the new DataFrame. However, it's possible that we
+        # won't have any new partitions, so we will end up computing an empty
+        # index.
+        df_copy["col0"] = df_copy["col0"].apply(lambda x: x + 1)
+        return df_copy
+
+    eval_general(modin_df, pandas_df, func)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4945 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
