### PR TITLE
FIX-#4945: Fix `_take_2d_positional` that loses indexes due to filtering empty dataframes

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -42,6 +42,7 @@ Key Features and Updates
   * FIX-#4914: `base_lengths` should be computed from `base_frame` instead of `self` in `copartition` (#4915)
   * FIX-#4848: Fix rebalancing partitions when NPartitions == 1 (#4874)
   * FIX-#4907: Implement `radd` for Series and DataFrame (#4908)
+  * FIZ-#4945: Fix `_take_2d_positional` that loses indexes due to filtering empty dataframes (#4951)
   * FIX-#4818, PERF-#4825: Fix where by using the new n-ary operator (#4820)
   * FIX-#3983: FIX-#4107: Materialize 'rowid' columns when selecting rows by position (#4834)
   * FIX-#4845: Fix KeyError from `__getitem_bool` for single row dataframes (#4845)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1341,6 +1341,9 @@ class PandasDataframe(ClassLogger):
             indices = np.array(indices, dtype=np.int64)
         # Fasttrack empty numpy array
         if isinstance(indices, np.ndarray) and indices.size == 0:
+            # This will help preserve metadata stored in empty dataframes (indexes and dtypes)
+            # Otherwise, we will get an empty `new_partitions` array, from which it will
+            #  no longer be possible to obtain metadata
             return OrderedDict([(0, np.array([], dtype=np.int64))])
         negative_mask = np.less(indices, 0)
         has_negative = np.any(negative_mask)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -852,12 +852,8 @@ class PandasDataframe(ClassLogger):
                         row_internal_indices, col_internal_indices
                     )
                     for col_idx, col_internal_indices in col_partitions_dict.items()
-                    if isinstance(col_internal_indices, slice)
-                    or len(col_internal_indices) > 0
                 ]
                 for row_idx, row_internal_indices in row_partitions_dict.items()
-                if isinstance(row_internal_indices, slice)
-                or len(row_internal_indices) > 0
             ]
         )
         intermediate = self.__constructor__(
@@ -1343,6 +1339,9 @@ class PandasDataframe(ClassLogger):
         if isinstance(indices, list):
             # Converting python list to numpy for faster processing
             indices = np.array(indices, dtype=np.int64)
+        # Fasttrack empty numpy array
+        if isinstance(indices, np.ndarray) and indices.size == 0:
+            return OrderedDict([(0, np.array([], dtype=np.int64))])
         negative_mask = np.less(indices, 0)
         has_negative = np.any(negative_mask)
         if has_negative:

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1451,7 +1451,6 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                     for obj in partitions[stop]:
                         obj._length_cache = new_last_partition_size
 
-                    partition_size = ideal_partition_size
                 # The new virtual partitions are not `full_axis`, even if they
                 # happen to span all rows in the dataframe, because they are
                 # meant to be the final partitions of the dataframe. They've

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1451,6 +1451,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                     for obj in partitions[stop]:
                         obj._length_cache = new_last_partition_size
 
+                    partition_size = ideal_partition_size
                 # The new virtual partitions are not `full_axis`, even if they
                 # happen to span all rows in the dataframe, because they are
                 # meant to be the final partitions of the dataframe. They've

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -2121,7 +2121,7 @@ def test__getitem_bool_single_row_dataframe():
 
 # This is a very subtle bug that comes from:
 # https://github.com/modin-project/modin/issues/4945
-def test_4945():
+def test_lazy_eval_index():
     modin_df, pandas_df = create_test_dfs({"col0": [0, 1]})
 
     def func(df):

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -2117,3 +2117,22 @@ def test__getitem_bool_single_row_dataframe():
     # This test case comes from
     # https://github.com/modin-project/modin/issues/4845
     eval_general(pd, pandas, lambda lib: lib.DataFrame([1])[lib.Series([True])])
+
+
+# This is a very subtle bug that comes from:
+# https://github.com/modin-project/modin/issues/4945
+def test_4945():
+    modin_df, pandas_df = create_test_dfs({"col0": [0, 1]})
+
+    def func(df):
+        df_copy = df[df["col0"] < 6].copy()
+        # The problem here is that the index is not copied over so it needs
+        # to get recomputed at some point. Our implementation of __setitem__
+        # requires us to build a mask and insert the value from the right
+        # handside into the new DataFrame. However, it's possible that we
+        # won't have any new partitions, so we will end up computing an empty
+        # index.
+        df_copy["col0"] = df_copy["col0"].apply(lambda x: x + 1)
+        return df_copy
+
+    eval_general(modin_df, pandas_df, func)


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4945 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
