### PR TITLE
PERF-#4940: Optimize categorical dtype check in `concatenate`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -74,6 +74,7 @@ Key Features and Updates
   * PERF-#4866: `iloc` function that used in `partition.mask` should be serialized only once (#4901)
   * PERF-#4920: Avoid index and cache computations in `take_2d_labels_or_positional` unless they are needed (#4921)
   * PERF-#4268: Implement partition-parallel __getitem__ for bool Series masks (#4753)
+  * PERF-#4940: Optimize categorical dtype check in `concatenate` (#4953)
 * Benchmarking enhancements
   * FEAT-#4706: Add Modin ClassLogger to PandasDataframePartitionManager (#4707)
 * Refactor Codebase

--- a/modin/core/dataframe/pandas/utils.py
+++ b/modin/core/dataframe/pandas/utils.py
@@ -36,9 +36,7 @@ def concatenate(dfs):
     """
     for df in dfs:
         assert df.columns.equals(dfs[0].columns)
-    for i in range(len(dfs[0].columns)):
-        if dfs[0].dtypes.iloc[i].name != "category":
-            continue
+    for i in df.columns.get_indexer_for(df.select_dtypes("category").columns):
         columns = [df.iloc[:, i] for df in dfs]
         union = union_categoricals(columns)
         for df in dfs:

--- a/modin/core/dataframe/pandas/utils.py
+++ b/modin/core/dataframe/pandas/utils.py
@@ -36,7 +36,7 @@ def concatenate(dfs):
     """
     for df in dfs:
         assert df.columns.equals(dfs[0].columns)
-    for i in df.columns.get_indexer_for(df.select_dtypes("category").columns):
+    for i in dfs[0].columns.get_indexer_for(dfs[0].select_dtypes("category").columns):
         columns = [df.iloc[:, i] for df in dfs]
         union = union_categoricals(columns)
         for df in dfs:


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4940 
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
