### PR TITLE
PERF-#4743: avoid `partition.length()` in the parquet dispatcher

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -77,6 +77,7 @@ Key Features and Updates
   * PERF-#4870: Avoid index materialization in `__getattribute__` and `__getitem__` (4911)
   * PERF-#4886: Use lazy index and columns evaluation in `query` method (#4887)
   * PERF-#4866: `iloc` function that used in `partition.mask` should be serialized only once (#4901)
+  * PERF-#4743: Avoid `partition.length()` in the parquet dispatcher (#4960)
   * PERF-#4920: Avoid index and cache computations in `take_2d_labels_or_positional` unless they are needed (#4921)
   * PERF-#4999: don't call `apply` in virtual partition' `drain_call_queue` if `call_queue` is empty (#4975)
   * PERF-#4268: Implement partition-parallel __getitem__ for bool Series masks (#4753)

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -559,15 +559,10 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         )
         index, sync_index = cls.build_index(dataset, partition_ids, index_columns)
         remote_parts = cls.build_partition(partition_ids, column_widths)
-        if len(partition_ids) > 0:
-            row_lengths = [part.length() for part in remote_parts.T[0]]
-        else:
-            row_lengths = None
         frame = cls.frame_cls(
             remote_parts,
             index,
             columns,
-            row_lengths=row_lengths,
             column_widths=column_widths,
             dtypes=None,
         )


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4743 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
