### PR TITLE
REFACTOR-#4755: Rewrite Pandas version mismatch warning

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -102,6 +102,7 @@ Key Features and Updates
   * REFACTOR-#4885: De-duplicated take_2d_labels_or_positional methods (#4883)
   * REFACTOR-#4942: Remove `call` method in favor of `register` due to duplication (4943)
   * REFACTOR-#4922: Helpers for take_2d_labels_or_positional (#4865)
+  * REFACTOR-#4755: Rewrite Pandas version mismatch warning (#4965)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -21,8 +21,8 @@ if PandasCompatVersion.CURRENT == PandasCompatVersion.PY36:
 
     if pandas.__version__ != __pandas_version__:
         warnings.warn(
-            f"The pandas version installed {pandas.__version__} does not match the supported pandas version in"
-            + f" Modin {__pandas_version__} compatibility mode. This may cause undesired side effects!"
+            f"The pandas version installed ({pandas.__version__}) does not match the pandas version"
+            + f" Modin supports ({__pandas_version__}). This may cause undesired side effects!"
         )
     else:
         warnings.warn(
@@ -33,8 +33,8 @@ elif PandasCompatVersion.CURRENT == PandasCompatVersion.LATEST:
 
     if pandas.__version__ != __pandas_version__:
         warnings.warn(
-            f"The pandas version installed {pandas.__version__} does not match the supported pandas version in"
-            + f" Modin {__pandas_version__}. This may cause undesired side effects!"
+            f"The pandas version installed ({pandas.__version__}) does not match the pandas version"
+            + f" Modin supports ({__pandas_version__}). This may cause undesired side effects!"
         )
 
 with warnings.catch_warnings():

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -22,7 +22,7 @@ if PandasCompatVersion.CURRENT == PandasCompatVersion.PY36:
     if pandas.__version__ != __pandas_version__:
         warnings.warn(
             f"The pandas version installed ({pandas.__version__}) does not match the pandas version"
-            + f" Modin supports ({__pandas_version__}). This may cause undesired side effects!"
+            + f" Modin supports ({__pandas_version__}) in Python 3.6 legacy compatibility mode. This may cause undesired side effects!"
         )
     else:
         warnings.warn(

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -22,7 +22,8 @@ if PandasCompatVersion.CURRENT == PandasCompatVersion.PY36:
     if pandas.__version__ != __pandas_version__:
         warnings.warn(
             f"The pandas version installed ({pandas.__version__}) does not match the pandas version"
-            + f" Modin supports ({__pandas_version__}) in Python 3.6 legacy compatibility mode. This may cause undesired side effects!"
+            + f" Modin supports ({__pandas_version__}) in Python 3.6 legacy compatibility mode."
+            + " This may cause undesired side effects!"
         )
     else:
         warnings.warn(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
This PR makes the warning message for pandas version mismatch less confusing.

Should this be categorized as a FEAT? I'll change the commit message + PR title once I know how to categorize this.

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4755
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
