### PR TITLE
TEST-#4985: CI: Exclude .github changes that don't affect workflows/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     paths:
       # NOTE: keep these paths in sync with the paths that trigger the
       # fuzzydata Github Actions in .github/workflows/fuzzydata-test.yml
-      - .github/**
+      - .github/workflows/**
       - asv_bench/**
       - modin/**
       - requirements/**

--- a/.github/workflows/fuzzydata-test.yml
+++ b/.github/workflows/fuzzydata-test.yml
@@ -4,7 +4,7 @@ on:
     paths:
       # NOTE: keep these paths in sync with the paths that trigger the CI Github
       # Actions in .github/workflows/ci.yml
-      - .github/**
+      - .github/workflows/**
       - asv_bench/**
       - modin/**
       - requirements/**


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

TEST-#4985: CI: Exclude .github changes that don't affect workflows/

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4985
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
