### PR TITLE
FIX-#4993: Return `_default_to_pandas` in `df.attrs`

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -49,6 +49,7 @@ Key Features and Updates
   * FIX-#4845: Fix KeyError from `__getitem_bool` for single row dataframes (#4845)
   * FIX-#4734: Handle Series.apply when return type is a DataFrame (#4830)
   * FIX-#4983: Set `frac` to `None` in _sample when `n=0` (#4984)
+  * FIX-#4993: Return `_default_to_pandas` in `df.attrs` (#4995)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2623,7 +2623,7 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
         )
 
     @property
-    def attrs(self):  # noqa: D200
+    def attrs(self):  # noqa: RT01, D200
         """
         Return dictionary of global attributes of this dataset.
         """

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2631,7 +2631,7 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
         def attrs(df):
             return df.attrs
 
-        self._default_to_pandas(attrs)
+        return self._default_to_pandas(attrs)
 
     @property
     def style(self):  # noqa: RT01, D200

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -1210,3 +1210,9 @@ def test_setattr_axes():
     # Check that ensure_index was called
     pandas.testing.assert_index_equal(df.index, pandas.Index(["foo", "bar"]))
     pandas.testing.assert_index_equal(df.columns, pandas.Index([9, 10]))
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_attrs(data):
+    modin_df, pandas_df = create_test_dfs(data)
+    eval_general(modin_df, pandas_df, lambda df: df.attrs)


### PR DESCRIPTION
Signed-off-by: Karthik Velayutham <vkarthik@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

We forgot to return the return value from `_default_to_pandas` 🤣 

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4993 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
