### PR TITLE
FIX-#4996: Evaluate BenchmarkMode at each function call.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -421,7 +421,6 @@ jobs:
       - name: Install HDF5
         run: sudo apt update && sudo apt install -y libhdf5-dev
       - run: pytest modin/test/storage_formats/omnisci/test_internals.py
-      - run: MODIN_BENCHMARK_MODE=True pytest modin/pandas/test/internals/test_benchmark_mode.py
       - run: pytest modin/experimental/core/execution/native/implementations/omnisci_on_native/test/test_dataframe.py
       - run: pytest modin/pandas/test/test_io.py::TestCsv --verbose
       - run: pytest modin/test/interchange/dataframe_protocol/test_general.py

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -50,6 +50,7 @@ Key Features and Updates
   * FIX-#4734: Handle Series.apply when return type is a DataFrame (#4830)
   * FIX-#4983: Set `frac` to `None` in _sample when `n=0` (#4984)
   * FIX-#4993: Return `_default_to_pandas` in `df.attrs` (#4995)
+  * FIX-#4996: Evaluate BenchmarkMode at each function call (#4997)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -813,7 +813,6 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
     @classmethod
     def wait_partitions(cls, partitions):
-        print("calling python wait_partitions")
         """
         Wait on the objects wrapped by `partitions`, without materializing them.
 

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -51,16 +51,16 @@ def wait_computations_if_benchmark_mode(func):
     -----
     `func` should return NumPy array with partitions.
     """
-    if BenchmarkMode.get():
 
-        @wraps(func)
-        def wait(cls, *args, **kwargs):
-            """Wait for computation results."""
-            result = func(cls, *args, **kwargs)
-            if isinstance(result, tuple):
-                partitions = result[0]
-            else:
-                partitions = result
+    @wraps(func)
+    def wait(cls, *args, **kwargs):
+        """Wait for computation results."""
+        result = func(cls, *args, **kwargs)
+        if isinstance(result, tuple):
+            partitions = result[0]
+        else:
+            partitions = result
+        if BenchmarkMode.get():
             # When partitions have a deferred call queue, calling
             # partition.wait() on each partition serially will serially kick
             # off each deferred computation and wait for each partition to
@@ -73,10 +73,9 @@ def wait_computations_if_benchmark_mode(func):
             # (We can't just add a `cls` argument to this `wait` function, since doing so
             # seems to be incompatible with the way function decorators work)
             cls.wait_partitions(partitions.flatten())
-            return result
+        return result
 
-        return wait
-    return func
+    return wait
 
 
 class PandasDataframePartitionManager(ClassLogger, ABC):
@@ -814,6 +813,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
     @classmethod
     def wait_partitions(cls, partitions):
+        print("calling python wait_partitions")
         """
         Wait on the objects wrapped by `partitions`, without materializing them.
 

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -56,11 +56,11 @@ def wait_computations_if_benchmark_mode(func):
     def wait(cls, *args, **kwargs):
         """Wait for computation results."""
         result = func(cls, *args, **kwargs)
-        if isinstance(result, tuple):
-            partitions = result[0]
-        else:
-            partitions = result
         if BenchmarkMode.get():
+            if isinstance(result, tuple):
+                partitions = result[0]
+            else:
+                partitions = result
             # When partitions have a deferred call queue, calling
             # partition.wait() on each partition serially will serially kick
             # off each deferred computation and wait for each partition to

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -70,8 +70,6 @@ def wait_computations_if_benchmark_mode(func):
             [part.drain_call_queue() for part in partitions.flatten()]
             # The partition manager invokes the relevant .wait() method under
             # the hood, which should wait in parallel for all computations to finish
-            # (We can't just add a `cls` argument to this `wait` function, since doing so
-            # seems to be incompatible with the way function decorators work)
             cls.wait_partitions(partitions.flatten())
         return result
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -115,7 +115,6 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
 
     @classmethod
     def wait_partitions(cls, partitions):
-        print('calling ray wait_partitions')
         """
         Wait on the objects wrapped by `partitions` in parallel, without materializing them.
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -115,6 +115,7 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
 
     @classmethod
     def wait_partitions(cls, partitions):
+        print('calling ray wait_partitions')
         """
         Wait on the objects wrapped by `partitions` in parallel, without materializing them.
 

--- a/modin/pandas/test/internals/test_benchmark_mode.py
+++ b/modin/pandas/test/internals/test_benchmark_mode.py
@@ -16,7 +16,6 @@ import unittest.mock as mock
 import modin.pandas as pd
 from modin.pandas.test.utils import test_data_values
 from modin.config import BenchmarkMode, Engine
-from modin.test.test_utils import warns_that_defaulting_to_pandas
 
 
 engine = Engine.get()
@@ -43,8 +42,7 @@ else:
 
 def test_from_environment_variable():
     assert BenchmarkMode.get()
-    # On Omnisci storage, transpose() defaults to Pandas.
-    with warns_that_defaulting_to_pandas(), mock.patch(wait_method) as wait:
+    with mock.patch(wait_method) as wait:
         pd.DataFrame(test_data_values[0]).mean()
 
     wait.assert_called()

--- a/modin/pandas/test/internals/test_benchmark_mode.py
+++ b/modin/pandas/test/internals/test_benchmark_mode.py
@@ -11,12 +11,11 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from contextlib import nullcontext
 import unittest.mock as mock
 
 import modin.pandas as pd
 from modin.pandas.test.utils import test_data_values
-from modin.config import BenchmarkMode, StorageFormat, Engine
+from modin.config import BenchmarkMode, Engine
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 
 
@@ -45,12 +44,9 @@ else:
 def test_from_environment_variable():
     assert BenchmarkMode.get()
     # On Omnisci storage, transpose() defaults to Pandas.
-    with (
-        warns_that_defaulting_to_pandas()
-        if StorageFormat.get() == "Omnisci"
-        else nullcontext()
-    ), mock.patch(wait_method) as wait:
+    with warns_that_defaulting_to_pandas(), mock.patch(wait_method) as wait:
         pd.DataFrame(test_data_values[0]).mean()
+
     wait.assert_called()
 
 

--- a/modin/pandas/test/internals/test_benchmark_mode.py
+++ b/modin/pandas/test/internals/test_benchmark_mode.py
@@ -24,11 +24,22 @@ engine = Engine.get()
 
 # We have to explicitly mock subclass implementations of wait_partitions.
 if engine == "Ray":
-    wait_method = "modin.core.execution.ray.implementations.pandas_on_ray.partitioning.partition_manager.PandasOnRayDataframePartitionManager.wait_partitions"
+    wait_method = (
+        "modin.core.execution.ray.implementations.pandas_on_ray."
+        + "partitioning.partition_manager."
+        + "PandasOnRayDataframePartitionManager.wait_partitions"
+    )
 elif engine == "Dask":
-    wait_method = "modin.core.execution.dask.implementations.pandas_on_dask.partitioning.partition_manager.PandasOnDaskDataframePartitionManager.wait_partitions"
+    wait_method = (
+        "modin.core.execution.dask.implementations."
+        + "pandas_on_dask.partitioning.partition_manager."
+        + "PandasOnDaskDataframePartitionManager.wait_partitions"
+    )
 else:
-    wait_method = "modin.core.dataframe.pandas.partitioning.partition_manager.PandasDataframePartitionManager.wait_partitions"
+    wait_method = (
+        "modin.core.dataframe.pandas.partitioning."
+        + "partition_manager.PandasDataframePartitionManager.wait_partitions"
+    )
 
 
 def test_from_environment_variable():

--- a/modin/pandas/test/internals/test_benchmark_mode.py
+++ b/modin/pandas/test/internals/test_benchmark_mode.py
@@ -11,21 +11,50 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-# test BenchmarkMode == True
-
 from contextlib import nullcontext
+import unittest.mock as mock
+
 import modin.pandas as pd
 from modin.pandas.test.utils import test_data_values
-from modin.config import BenchmarkMode, StorageFormat
+from modin.config import BenchmarkMode, StorageFormat, Engine
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 
 
-def test_syncronous_mode():
+engine = Engine.get()
+
+# We have to explicitly mock subclass implementations of wait_partitions.
+if engine == "Ray":
+    wait_method = "modin.core.execution.ray.implementations.pandas_on_ray.partitioning.partition_manager.PandasOnRayDataframePartitionManager.wait_partitions"
+elif engine == "Dask":
+    wait_method = "modin.core.execution.dask.implementations.pandas_on_dask.partitioning.partition_manager.PandasOnDaskDataframePartitionManager.wait_partitions"
+else:
+    wait_method = "modin.core.dataframe.pandas.partitioning.partition_manager.PandasDataframePartitionManager.wait_partitions"
+
+
+def test_from_environment_variable():
     assert BenchmarkMode.get()
     # On Omnisci storage, transpose() defaults to Pandas.
     with (
         warns_that_defaulting_to_pandas()
         if StorageFormat.get() == "Omnisci"
         else nullcontext()
-    ):
+    ), mock.patch(wait_method) as wait:
         pd.DataFrame(test_data_values[0]).mean()
+    wait.assert_called()
+
+
+def test_turn_off():
+    df = pd.DataFrame([0])
+    BenchmarkMode.put(False)
+    with mock.patch(wait_method) as wait:
+        df.dropna()
+    wait.assert_not_called()
+
+
+def test_turn_on():
+    BenchmarkMode.put(False)
+    df = pd.DataFrame([0])
+    BenchmarkMode.put(True)
+    with mock.patch(wait_method) as wait:
+        df.dropna()
+    wait.assert_called()


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

FIX-#4996: Evalute BenchmarkMode at each function call.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4996
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
