### PR TITLE
TEST-#4998: Add flake8 plugins to dev requirements.

### DIFF
--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -66,6 +66,8 @@ jobs:
       - run: pip install .
         if: matrix.execution == 'omnisci_on_native'
       # install test dependencies
+      # NOTE: If you are changing the set of packages installed here, make sure that
+      # the dev requirements match them.
       # TODO: remove pin when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
       - run: pip install pytest pytest-cov black "flake8<5" flake8-print flake8-no-implicit-concat
         if: matrix.execution != 'omnisci_on_native'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,6 +154,8 @@ jobs:
         with:
           python-version: "3.8.x"
           architecture: "x64"
+      # NOTE: If you are changing the set of packages installed here, make sure that
+      # the dev requirements match them.
       # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
       - run: pip install "flake8<5" flake8-print flake8-no-implicit-concat
       - run: flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py

--- a/contributing/contributing.md
+++ b/contributing/contributing.md
@@ -87,6 +87,5 @@ you should reopen your terminal to find "(base)" next to your prompt: ![](conda_
         1. Again in settings, search for "format on save" and enable the "Editor: Format on Save" option.
     2. Add a pre-commit hook:
         1. In your modin repository, copy [this pre-commit file](pre-commit) to `.git/hooks/pre-commit`
-        1. Every time you try to commit, git will run flake8 and abort the commit if it fails. This lets you make sure your commits passes flake8 before you push to GitHub.
+        1. Every time you try to commit, git will try to run flake8 and mypy, and abort the commit if either one fails. This lets you make sure your commits pass these tests before you push to GitHub.
         1. To bypass the pre-commit hook (e.g. if you don't want to create a pull request, or you already know your code will pass the tests), commit with the flag `--no-verify`.
-        1. We also recommend installing [flake8-no-implicit-concat](https://pypi.org/project/flake8-no-implicit-concat/) via `pip install flake8-no-implicit-concat` to avoid Python implicit string concatenation errors.

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -132,6 +132,7 @@ Key Features and Updates
   * FEAT-#4619: Integrate mypy static type checking (#4620)
   * FEAT-#4202: Allow dask past 2022.2.0 (#4769)
   * FEAT-#4925: Upgrade pandas to 1.4.4 (#4926)
+  * TEST-#4998: Add flake8 plugins to dev requirements (#5000)
 * New Features
   * FEAT-4463: Add experimental fuzzydata integration for testing against a randomized dataframe workflow (#4556)
   * FEAT-#4419: Extend virtual partitioning API to pandas on Dask (#4420)

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -52,6 +52,8 @@ dependencies:
       - black
       # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
       - flake8<5
+      - flake8-no-implicit-concat
+      - flake8-print
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0
       # experimental version of fuzzydata requires at least 0.0.6 to successfully resolve all dependencies

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -39,6 +39,8 @@ connectorx>=0.2.6a4
 black
 # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
 flake8<5
+flake8-no-implicit-concat
+flake8-print
 # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
 numpydoc==1.1.0
 # experimental version of fuzzydata requires at least 0.0.6 to successfully resolve all dependencies

--- a/requirements/env_omnisci.yml
+++ b/requirements/env_omnisci.yml
@@ -23,5 +23,7 @@ dependencies:
       - black
       # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
       - flake8<5
+      - flake8-no-implicit-concat
+      - flake8-print
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0

--- a/requirements/environment-py36.yml
+++ b/requirements/environment-py36.yml
@@ -49,5 +49,7 @@ dependencies:
       - black
       # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
       - flake8<5
+      - flake8-no-implicit-concat
+      - flake8-print
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -41,5 +41,7 @@ dependencies:
       - black
       # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
       - flake8<5
+      - flake8-no-implicit-concat
+      - flake8-print
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

## What do these changes do?

TEST-#4998: Add flake8 plugins to dev requirements.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4998 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
