### PR TITLE
REFACTOR-#5012: Add mypy checks for singleton files in base modin directory

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -108,6 +108,7 @@ Key Features and Updates
   * REFACTOR-#4942: Remove `call` method in favor of `register` due to duplication (4943)
   * REFACTOR-#4922: Helpers for take_2d_labels_or_positional (#4865)
   * REFACTOR-#4755: Rewrite Pandas version mismatch warning (#4965)
+  * REFACTOR-#5012: Add mypy checks for singleton files in base modin directory (#5013)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/modin/__init__.py
+++ b/modin/__init__.py
@@ -11,14 +11,24 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+from typing import Any, Optional, Tuple, Union, Type, TYPE_CHECKING
 import warnings
+
+if TYPE_CHECKING:
+    from .config import Engine, StorageFormat
 
 from ._version import get_versions
 
 
-def custom_formatwarning(msg, category, *args, **kwargs):
+def custom_formatwarning(
+    message: Union[Warning, str],
+    category: Type[Warning],
+    filename: str,
+    lineno: int,
+    line: Optional[str] = None,
+) -> str:
     # ignore everything except the message
-    return "{}: {}\n".format(category.__name__, msg)
+    return "{}: {}\n".format(category.__name__, message)
 
 
 warnings.formatwarning = custom_formatwarning
@@ -32,7 +42,9 @@ warnings.filterwarnings(
 )
 
 
-def set_execution(engine=None, storage_format=None):
+def set_execution(
+    engine: Any = None, storage_format: Any = None
+) -> Tuple["Engine", "StorageFormat"]:
     """
     Method to set the _pair_ of execution engine and storage format format simultaneously.
     This is needed because there might be cases where switching one by one would be

--- a/modin/__main__.py
+++ b/modin/__main__.py
@@ -16,7 +16,7 @@
 import argparse
 
 
-def main():
+def main() -> None:
     parser = argparse.ArgumentParser(
         "python -m modin",
         description="Drop-in pandas replacement; refer to https://modin.readthedocs.io/ for details.",

--- a/modin/_version.py
+++ b/modin/_version.py
@@ -112,14 +112,11 @@ def run_command(
         if verbose:
             print("unable to find command, tried %s" % (commands,))
         return None, None
-    stdout: str
-    stdout = p.communicate()[0].strip()  # type: ignore
-    if sys.version_info[0] >= 3:
-        stdout = stdout.decode()  # type: ignore
+    stdout = p.communicate()[0].strip().decode()
     if p.returncode != 0:
         if verbose:
-            print("unable to run %s (error)" % dispcmd)
-            print("stdout was %s" % stdout)
+            print(f"unable to run {dispcmd} (error)")
+            print(f"stdout was {stdout}")
         return None, p.returncode
     return stdout, p.returncode
 

--- a/modin/_version.py
+++ b/modin/_version.py
@@ -14,9 +14,12 @@ import os
 import re
 import subprocess
 import sys
+from typing import Any, Callable, Dict, Optional, List, Tuple
+
+VcsPieces = Dict[str, Any]
 
 
-def get_keywords():
+def get_keywords() -> Dict[str, str]:
     """Get the keywords needed to look up the version information."""
     # these strings will be replaced by git during git-archive.
     # setup.py/versioneer.py will grep for the variable names, so they must
@@ -32,8 +35,15 @@ def get_keywords():
 class VersioneerConfig:
     """Container for Versioneer configuration parameters."""
 
+    VCS: str
+    style: str
+    tag_prefix: str
+    parentdir_prefix: str
+    versionfile_source: str
+    verbose: bool
 
-def get_config():
+
+def get_config() -> VersioneerConfig:
     """Create, populate and return the VersioneerConfig() object."""
     # these strings are filled in when 'setup.py versioneer' creates
     # _version.py
@@ -51,14 +61,13 @@ class NotThisMethod(Exception):
     """Exception raised if a method is not valid for the current scenario."""
 
 
-LONG_VERSION_PY = {}
-HANDLERS = {}
+HANDLERS: Dict[str, Dict[str, Callable]] = {}
 
 
-def register_vcs_handler(vcs, method):  # decorator
+def register_vcs_handler(vcs: str, method: str) -> Callable:  # decorator
     """Decorator to mark a method as the handler for a particular VCS."""
 
-    def decorate(f):
+    def decorate(f: Callable) -> Callable:
         """Store f in HANDLERS[vcs][method]."""
         if vcs not in HANDLERS:
             HANDLERS[vcs] = {}
@@ -68,7 +77,14 @@ def register_vcs_handler(vcs, method):  # decorator
     return decorate
 
 
-def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=None):
+def run_command(
+    commands: List[str],
+    args: List[Any],
+    cwd: Optional[str] = None,
+    verbose: bool = False,
+    hide_stderr: bool = False,
+    env: Optional[Dict[str, str]] = None,
+) -> Tuple[Optional[str], Optional[int]]:
     """Call the given command(s)."""
     assert isinstance(commands, list)
     p = None
@@ -86,7 +102,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
-            if e.errno == errno.ENOENT:
+            if e.errno == errno.ENOENT:  # type: ignore
                 continue
             if verbose:
                 print("unable to run %s" % dispcmd)
@@ -96,9 +112,10 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
         if verbose:
             print("unable to find command, tried %s" % (commands,))
         return None, None
-    stdout = p.communicate()[0].strip()
+    stdout: str
+    stdout = p.communicate()[0].strip()  # type: ignore
     if sys.version_info[0] >= 3:
-        stdout = stdout.decode()
+        stdout = stdout.decode()  # type: ignore
     if p.returncode != 0:
         if verbose:
             print("unable to run %s (error)" % dispcmd)
@@ -107,7 +124,7 @@ def run_command(commands, args, cwd=None, verbose=False, hide_stderr=False, env=
     return stdout, p.returncode
 
 
-def versions_from_parentdir(parentdir_prefix, root, verbose):
+def versions_from_parentdir(parentdir_prefix: str, root: str, verbose: bool) -> Dict:
     """Try to determine the version from the parent directory name.
 
     Source tarballs conventionally unpack into a directory that includes both
@@ -139,7 +156,7 @@ def versions_from_parentdir(parentdir_prefix, root, verbose):
 
 
 @register_vcs_handler("git", "get_keywords")
-def git_get_keywords(versionfile_abs):
+def git_get_keywords(versionfile_abs: str) -> Dict:
     """Extract version information from the given file."""
     # the code embedded in _version.py can just fetch the value of these
     # keywords. When used from setup.py, we don't want to import _version.py,
@@ -168,7 +185,9 @@ def git_get_keywords(versionfile_abs):
 
 
 @register_vcs_handler("git", "keywords")
-def git_versions_from_keywords(keywords, tag_prefix, verbose):
+def git_versions_from_keywords(
+    keywords: Dict[str, str], tag_prefix: str, verbose: bool
+) -> Dict:
     """Get version information from git keywords."""
     if not keywords:
         raise NotThisMethod("no keywords at all, weird")
@@ -230,7 +249,9 @@ def git_versions_from_keywords(keywords, tag_prefix, verbose):
 
 
 @register_vcs_handler("git", "pieces_from_vcs")
-def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
+def git_pieces_from_vcs(
+    tag_prefix: str, root: str, verbose: bool, run_command: Callable = run_command
+) -> Dict:
     """Get version from 'git describe' in the root of the source tree.
 
     This only gets called if the git-archive 'subst' keywords were *not*
@@ -330,14 +351,14 @@ def git_pieces_from_vcs(tag_prefix, root, verbose, run_command=run_command):
     return pieces
 
 
-def plus_or_dot(pieces):
+def plus_or_dot(pieces: VcsPieces) -> str:
     """Return a + if we don't already have one, else return a ."""
     if "+" in pieces.get("closest-tag", ""):
         return "."
     return "+"
 
 
-def render_pep440(pieces):
+def render_pep440(pieces: VcsPieces) -> str:
     """Build up version string, with post-release "local version identifier".
 
     Our goal: TAG[+DISTANCE.gHEX[.dirty]] . Note that if you
@@ -361,7 +382,7 @@ def render_pep440(pieces):
     return rendered
 
 
-def render_pep440_pre(pieces):
+def render_pep440_pre(pieces: VcsPieces) -> str:
     """TAG[.post.devDISTANCE] -- No -dirty.
 
     Exceptions:
@@ -377,7 +398,7 @@ def render_pep440_pre(pieces):
     return rendered
 
 
-def render_pep440_post(pieces):
+def render_pep440_post(pieces: VcsPieces) -> str:
     """TAG[.postDISTANCE[.dev0]+gHEX] .
 
     The ".dev0" means dirty. Note that .dev0 sorts backwards
@@ -404,7 +425,7 @@ def render_pep440_post(pieces):
     return rendered
 
 
-def render_pep440_old(pieces):
+def render_pep440_old(pieces: VcsPieces) -> str:
     """TAG[.postDISTANCE[.dev0]] .
 
     The ".dev0" means dirty.
@@ -426,7 +447,7 @@ def render_pep440_old(pieces):
     return rendered
 
 
-def render_git_describe(pieces):
+def render_git_describe(pieces: VcsPieces) -> str:
     """TAG[-DISTANCE-gHEX][-dirty].
 
     Like 'git describe --tags --dirty --always'.
@@ -446,7 +467,7 @@ def render_git_describe(pieces):
     return rendered
 
 
-def render_git_describe_long(pieces):
+def render_git_describe_long(pieces: VcsPieces) -> str:
     """TAG-DISTANCE-gHEX[-dirty].
 
     Like 'git describe --tags --dirty --always -long'.
@@ -466,7 +487,7 @@ def render_git_describe_long(pieces):
     return rendered
 
 
-def render(pieces, style):
+def render(pieces: VcsPieces, style: str) -> Dict[str, Optional[str]]:
     """Render the given version pieces into the requested style."""
     if pieces["error"]:
         return {
@@ -504,7 +525,7 @@ def render(pieces, style):
     }
 
 
-def get_versions():
+def get_versions() -> Dict[str, Optional[str]]:
     """Get version information or return default if unable to do so."""
     # I am in _version.py, which lives at ROOT/VERSIONFILE_SOURCE. If we have
     # __file__, we can work backwards from there to the root. Some

--- a/modin/_version.py
+++ b/modin/_version.py
@@ -102,7 +102,7 @@ def run_command(
             break
         except EnvironmentError:
             e = sys.exc_info()[1]
-            if e.errno == errno.ENOENT:  # type: ignore
+            if e.errno == errno.ENOENT:  # type: ignore[union-attr]
                 continue
             if verbose:
                 print("unable to run %s" % dispcmd)

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -11,6 +11,9 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+# We turn off mypy type checks in this file because it's not imported anywhere
+# type: ignore
+
 import os
 import sys
 import pytest

--- a/modin/db_conn.py
+++ b/modin/db_conn.py
@@ -23,6 +23,8 @@ make a db connection. It can make and provide a connection whenever the Modin
 driver or a worker wants one.
 """
 
+from typing import Any, Sequence, Dict, Optional
+
 _PSYCOPG_LIB_NAME = "psycopg2"
 _SQLALCHEMY_LIB_NAME = "sqlalchemy"
 
@@ -47,7 +49,12 @@ class ModinDatabaseConnection:
         Keyword arguments to pass when creating the connection.
     """
 
-    def __init__(self, lib, *args, **kwargs):
+    lib: str
+    args: Sequence
+    kwargs: Dict
+    _dialect_is_microsoft_sql_cache: Optional[bool]
+
+    def __init__(self, lib: str, *args: Any, **kwargs: Any) -> None:
         lib = lib.lower()
         if lib not in (_PSYCOPG_LIB_NAME, _SQLALCHEMY_LIB_NAME):
             raise UnsupportedDatabaseException(f"Unsupported database library {lib}")
@@ -56,7 +63,7 @@ class ModinDatabaseConnection:
         self.kwargs = kwargs
         self._dialect_is_microsoft_sql_cache = None
 
-    def _dialect_is_microsoft_sql(self):
+    def _dialect_is_microsoft_sql(self) -> bool:
         """
         Tell whether this connection requires Microsoft SQL dialect.
 
@@ -66,7 +73,7 @@ class ModinDatabaseConnection:
 
         Returns
         -------
-        Boolean
+        bool
         """
         if self._dialect_is_microsoft_sql_cache is None:
             self._dialect_is_microsoft_sql_cache = False
@@ -79,7 +86,7 @@ class ModinDatabaseConnection:
 
         return self._dialect_is_microsoft_sql_cache
 
-    def get_connection(self):
+    def get_connection(self) -> Any:
         """
         Make the database connection and get it.
 
@@ -104,7 +111,7 @@ class ModinDatabaseConnection:
 
         raise UnsupportedDatabaseException("Unsupported database library")
 
-    def get_string(self):
+    def get_string(self) -> str:
         """
         Get input connection string.
 
@@ -114,7 +121,7 @@ class ModinDatabaseConnection:
         """
         return self.args[0]
 
-    def column_names_query(self, query):
+    def column_names_query(self, query: str) -> str:
         """
         Get a query that gives the names of columns that `query` would produce.
 
@@ -131,7 +138,7 @@ class ModinDatabaseConnection:
         # SQL, which doesn't let you use a "limit" clause to select 0 rows.
         return f"SELECT * FROM ({query}) AS _ WHERE 1 = 0"
 
-    def row_count_query(self, query):
+    def row_count_query(self, query: str) -> str:
         """
         Get a query that gives the names of rows that `query` would produce.
 
@@ -146,7 +153,7 @@ class ModinDatabaseConnection:
         """
         return f"SELECT COUNT(*) FROM ({query}) AS _"
 
-    def partition_query(self, query, limit, offset):
+    def partition_query(self, query: str, limit: int, offset: int) -> str:
         """
         Get a query that partitions the original `query`.
 

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -19,7 +19,7 @@ from modin.utils import get_current_execution
 
 class ErrorMessage(object):
     # Only print full ``default to pandas`` warning one time.
-    printed_default_to_pandas: bool = False
+    printed_default_to_pandas = False
     printed_warnings: Set[int] = set()  # Set of hashes of printed warnings
 
     @classmethod

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+from typing import NoReturn, Set
 import warnings
 from modin.logging import get_logger
 from modin.utils import get_current_execution
@@ -18,11 +19,11 @@ from modin.utils import get_current_execution
 
 class ErrorMessage(object):
     # Only print full ``default to pandas`` warning one time.
-    printed_default_to_pandas = False
-    printed_warnings = set()
+    printed_default_to_pandas: bool = False
+    printed_warnings: Set[int] = set()  # Set of hashes of printed warnings
 
     @classmethod
-    def not_implemented(cls, message=""):
+    def not_implemented(cls, message: str = "") -> NoReturn:
         if message == "":
             message = "This functionality is not yet available in Modin."
         get_logger().info(f"Modin Error: NotImplementedError: {message}")
@@ -34,7 +35,7 @@ class ErrorMessage(object):
         )
 
     @classmethod
-    def single_warning(cls, message):
+    def single_warning(cls, message: str) -> None:
         message_hash = hash(message)
         logger = get_logger()
         if message_hash in cls.printed_warnings:
@@ -48,7 +49,7 @@ class ErrorMessage(object):
         cls.printed_warnings.add(message_hash)
 
     @classmethod
-    def default_to_pandas(cls, message="", reason=""):
+    def default_to_pandas(cls, message: str = "", reason: str = "") -> None:
         if message != "":
             execution_str = get_current_execution()
             message = (
@@ -71,7 +72,9 @@ class ErrorMessage(object):
         warnings.warn(message)
 
     @classmethod
-    def catch_bugs_and_request_email(cls, failure_condition, extra_log=""):
+    def catch_bugs_and_request_email(
+        cls, failure_condition: bool, extra_log: str = ""
+    ) -> None:
         if failure_condition:
             get_logger().info(f"Modin Error: Internal Error: {extra_log}")
             raise Exception(
@@ -83,7 +86,7 @@ class ErrorMessage(object):
             )
 
     @classmethod
-    def non_verified_udf(cls):
+    def non_verified_udf(cls) -> None:
         get_logger().debug("Modin Warning: Non Verified UDF")
         warnings.warn(
             "User-defined function verification is still under development in Modin. "
@@ -91,7 +94,7 @@ class ErrorMessage(object):
         )
 
     @classmethod
-    def missmatch_with_pandas(cls, operation, message):
+    def missmatch_with_pandas(cls, operation: str, message: str) -> None:
         get_logger().debug(
             f"Modin Warning: {operation} mismatch with pandas: {message}"
         )
@@ -100,7 +103,7 @@ class ErrorMessage(object):
         )
 
     @classmethod
-    def not_initialized(cls, engine, code):
+    def not_initialized(cls, engine: str, code: str) -> None:
         get_logger().debug(f"Modin Warning: Not Initialized: {engine}")
         warnings.warn(
             f"{engine} execution environment not yet initialized. Initializing...\n"

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -316,7 +316,7 @@ def _replace_doc(
     ):
         apilink_l = [apilink] if not isinstance(apilink, list) and apilink else apilink
         links = []
-        for i, link in enumerate(apilink_l):
+        for link in apilink_l:
             if attr_name:
                 token = f"{link}.{attr_name}"
             else:

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -29,7 +29,7 @@ import sys
 import json
 import codecs
 
-if sys.version_info < (3, 7):
+if sys.version_info < (3, 8):
     from typing_extensions import Protocol, runtime_checkable
 else:
     from typing import Protocol, runtime_checkable
@@ -299,8 +299,6 @@ def _replace_doc(
     target_doc = target_obj.__doc__ or ""
     overwrite = overwrite or not target_doc
     doc = source_doc if overwrite else target_doc
-    apilink_l: Optional[List[str]]
-    apilink_l = [apilink] if not isinstance(apilink, list) and apilink else apilink  # type: ignore
 
     if parent_cls and not attr_name:
         if isinstance(target_obj, property):
@@ -312,10 +310,11 @@ def _replace_doc(
 
     if (
         source_doc.strip()
-        and apilink_l
+        and apilink
         and "pandas API documentation for " not in target_doc
         and (not (attr_name or "").startswith("_"))
     ):
+        apilink_l = [apilink] if not isinstance(apilink, list) and apilink else apilink
         links = []
         for i, link in enumerate(apilink_l):
             if attr_name:

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -18,7 +18,6 @@ import types
 from typing import (
     Any,
     Callable,
-    Dict,
     List,
     Mapping,
     Optional,

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -41,7 +41,7 @@ import pandas
 import numpy as np
 
 from pandas.util._decorators import Appender
-from pandas.util._print_versions import _get_sys_info, _get_dependency_info  # type: ignore
+from pandas.util._print_versions import _get_sys_info, _get_dependency_info  # type: ignore[attr-defined]
 from pandas._typing import JSONSerializable
 
 from modin.config import Engine, StorageFormat, IsExperimental
@@ -302,11 +302,11 @@ def _replace_doc(
 
     if parent_cls and not attr_name:
         if isinstance(target_obj, property):
-            attr_name = target_obj.fget.__name__  # type: ignore
+            attr_name = target_obj.fget.__name__  # type: ignore[union-attr]
         elif isinstance(target_obj, (staticmethod, classmethod)):
             attr_name = target_obj.__func__.__name__
         else:
-            attr_name = target_obj.__name__  # type: ignore
+            attr_name = target_obj.__name__  # type: ignore[attr-defined]
 
     if (
         source_doc.strip()
@@ -337,7 +337,7 @@ def _replace_doc(
 
     if parent_cls and isinstance(target_obj, property):
         if overwrite:
-            target_obj.fget.__doc_inherited__ = True  # type: ignore
+            target_obj.fget.__doc_inherited__ = True  # type: ignore[union-attr]
         assert attr_name is not None
         setattr(
             parent_cls,
@@ -346,7 +346,7 @@ def _replace_doc(
         )
     else:
         if overwrite:
-            target_obj.__doc_inherited__ = True  # type: ignore
+            target_obj.__doc_inherited__ = True  # type: ignore[attr-defined]
         target_obj.__doc__ = doc
 
 
@@ -403,7 +403,7 @@ def _inherit_docstrings(
 
         if not isinstance(cls_or_func, types.FunctionType):
             seen = set()
-            for base in cls_or_func.__mro__:  # type: ignore
+            for base in cls_or_func.__mro__:  # type: ignore[attr-defined]
                 if base is object:
                     continue
                 for attr, obj in base.__dict__.items():

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -24,13 +24,16 @@ from typing import (
     Optional,
     Union,
     TypeVar,
-    Protocol,
-    runtime_checkable,
 )
 import re
 import sys
 import json
 import codecs
+
+if sys.version_info < (3, 7):
+    from typing_extensions import Protocol, runtime_checkable
+else:
+    from typing import Protocol, runtime_checkable
 
 from textwrap import dedent, indent
 from packaging import version

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -15,24 +15,58 @@
 
 import importlib
 import types
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Mapping,
+    Optional,
+    Union,
+    TypeVar,
+    Protocol,
+    runtime_checkable,
+)
 import re
 import sys
 import json
 import codecs
 
 from textwrap import dedent, indent
-from typing import Union
 from packaging import version
 
 import pandas
 import numpy as np
 
 from pandas.util._decorators import Appender
-from pandas.util._print_versions import _get_sys_info, _get_dependency_info
+from pandas.util._print_versions import _get_sys_info, _get_dependency_info  # type: ignore
 from pandas._typing import JSONSerializable
 
 from modin.config import Engine, StorageFormat, IsExperimental
 from modin._version import get_versions
+
+T = TypeVar("T")
+"""Generic type parameter"""
+
+Fn = TypeVar("Fn", bound=Callable)
+"""Function type parameter (used in decorators that don't change a function's signature)"""
+
+
+@runtime_checkable
+class SupportsPrivateToPandas(Protocol):
+    """Structural type for objects with a ``_to_pandas`` method (note the leading underscore)."""
+
+    def _to_pandas(self) -> Any:  # TODO add proper return type
+        pass
+
+
+@runtime_checkable
+class SupportsPublicToPandas(Protocol):
+    """Structural type for objects with a ``to_pandas`` method (without a leading underscore)."""
+
+    def to_pandas(self) -> Any:
+        pass
+
 
 MIN_RAY_VERSION = version.parse("1.4.0")
 MIN_DASK_VERSION = version.parse("2.22.0")
@@ -47,7 +81,7 @@ distinguish between an N-element series and 1xN dataframe.
 """
 
 
-def _make_api_url(token):
+def _make_api_url(token: str) -> str:
     """
     Generate the link to pandas documentation.
 
@@ -116,7 +150,7 @@ def _get_indents(source: Union[list, str]) -> list:
     return indents
 
 
-def format_string(template: str, **kwargs) -> str:
+def format_string(template: str, **kwargs: str) -> str:
     """
     Insert passed values at the corresponding placeholders of the specified template.
 
@@ -200,7 +234,7 @@ def align_indents(source: str, target: str) -> str:
     return indent(target, " " * source_indent)
 
 
-def append_to_docstring(message: str):
+def append_to_docstring(message: str) -> Callable[[Fn], Fn]:
     """
     Create a decorator which appends passed message to the function's docstring.
 
@@ -214,7 +248,7 @@ def append_to_docstring(message: str):
     callable
     """
 
-    def decorator(func):
+    def decorator(func: Fn) -> Fn:
         to_append = align_indents(func.__doc__ or "", message)
         return Appender(to_append)(func)
 
@@ -222,8 +256,13 @@ def append_to_docstring(message: str):
 
 
 def _replace_doc(
-    source_obj, target_obj, overwrite, apilink, parent_cls=None, attr_name=None
-):
+    source_obj: object,
+    target_obj: object,
+    overwrite: bool,
+    apilink: Optional[Union[str, List[str]]],
+    parent_cls: Optional[Fn] = None,
+    attr_name: Optional[str] = None,
+) -> None:
     """
     Replace docstring in `target_obj`, possibly taking from `source_obj` and augmenting.
 
@@ -238,8 +277,8 @@ def _replace_doc(
     overwrite : bool
         Forces replacing the docstring with the one from `source_obj` even
         if `target_obj` has its own non-empty docstring.
-    apilink : str
-        If non-empty, insert the link to pandas API documentation.
+    apilink : str | List[str], optional
+        If non-empty, insert the link(s) to pandas API documentation.
         Should be the prefix part in the URL template, e.g. "pandas.DataFrame".
     parent_cls : class, optional
         If `target_obj` is an attribute of a class, `parent_cls` should be that class.
@@ -258,30 +297,31 @@ def _replace_doc(
     target_doc = target_obj.__doc__ or ""
     overwrite = overwrite or not target_doc
     doc = source_doc if overwrite else target_doc
-    apilink = [apilink] if not isinstance(apilink, list) and apilink else apilink
+    apilink_l: Optional[List[str]]
+    apilink_l = [apilink] if not isinstance(apilink, list) and apilink else apilink  # type: ignore
 
     if parent_cls and not attr_name:
         if isinstance(target_obj, property):
-            attr_name = target_obj.fget.__name__
+            attr_name = target_obj.fget.__name__  # type: ignore
         elif isinstance(target_obj, (staticmethod, classmethod)):
             attr_name = target_obj.__func__.__name__
         else:
-            attr_name = target_obj.__name__
+            attr_name = target_obj.__name__  # type: ignore
 
     if (
         source_doc.strip()
-        and apilink
+        and apilink_l
         and "pandas API documentation for " not in target_doc
         and (not (attr_name or "").startswith("_"))
     ):
-        links = [None] * len(apilink)
-        for i, link in enumerate(apilink):
+        links = []
+        for i, link in enumerate(apilink_l):
             if attr_name:
                 token = f"{link}.{attr_name}"
             else:
                 token = link
             url = _make_api_url(token)
-            links[i] = f"`{token} <{url}>`_"
+            links.append(f"`{token} <{url}>`_")
 
         indent_line = " " * _get_indent(doc)
         notes_section = f"\n{indent_line}Notes\n{indent_line}-----\n"
@@ -296,7 +336,8 @@ def _replace_doc(
 
     if parent_cls and isinstance(target_obj, property):
         if overwrite:
-            target_obj.fget.__doc_inherited__ = True
+            target_obj.fget.__doc_inherited__ = True  # type: ignore
+        assert attr_name is not None
         setattr(
             parent_cls,
             attr_name,
@@ -304,11 +345,16 @@ def _replace_doc(
         )
     else:
         if overwrite:
-            target_obj.__doc_inherited__ = True
+            target_obj.__doc_inherited__ = True  # type: ignore
         target_obj.__doc__ = doc
 
 
-def _inherit_docstrings(parent, excluded=[], overwrite_existing=False, apilink=None):
+def _inherit_docstrings(
+    parent: object,
+    excluded: List[object] = [],
+    overwrite_existing: bool = False,
+    apilink: Optional[Union[str, List[str]]] = None,
+) -> Callable[[Fn], Fn]:
     """
     Create a decorator which overwrites decorated object docstring(s).
 
@@ -320,14 +366,14 @@ def _inherit_docstrings(parent, excluded=[], overwrite_existing=False, apilink=N
     ----------
     parent : object
         Parent object from which the decorated object inherits __doc__.
-    excluded : list, optional
+    excluded : list, default: []
         List of parent objects from which the class does not
         inherit docstrings.
     overwrite_existing : bool, default: False
         Allow overwriting docstrings that already exist in
         the decorated class.
-    apilink : str, default: None
-        If non-empty, insert the link to pandas API documentation.
+    apilink : str | List[str], optional
+        If non-empty, insert the link(s) to pandas API documentation.
         Should be the prefix part in the URL template, e.g. "pandas.DataFrame".
 
     Returns
@@ -342,21 +388,21 @@ def _inherit_docstrings(parent, excluded=[], overwrite_existing=False, apilink=N
     which means that ancestor class attribute docstrings could also change.
     """
 
-    def _documentable_obj(obj):
+    def _documentable_obj(obj: object) -> bool:
         """Check if `obj` docstring could be patched."""
-        return (
+        return bool(
             callable(obj)
             or (isinstance(obj, property) and obj.fget)
             or (isinstance(obj, (staticmethod, classmethod)) and obj.__func__)
         )
 
-    def decorator(cls_or_func):
+    def decorator(cls_or_func: Fn) -> Fn:
         if parent not in excluded:
             _replace_doc(parent, cls_or_func, overwrite_existing, apilink)
 
         if not isinstance(cls_or_func, types.FunctionType):
             seen = set()
-            for base in cls_or_func.__mro__:
+            for base in cls_or_func.__mro__:  # type: ignore
                 if base is object:
                     continue
                 for attr, obj in base.__dict__.items():
@@ -385,7 +431,8 @@ def _inherit_docstrings(parent, excluded=[], overwrite_existing=False, apilink=N
     return decorator
 
 
-def to_pandas(modin_obj):
+# TODO add proper type annotation
+def to_pandas(modin_obj: SupportsPrivateToPandas) -> Any:
     """
     Convert a Modin DataFrame/Series to a pandas DataFrame/Series.
 
@@ -402,7 +449,7 @@ def to_pandas(modin_obj):
     return modin_obj._to_pandas()
 
 
-def hashable(obj):
+def hashable(obj: bool) -> bool:
     """
     Return whether the `obj` is hashable.
 
@@ -415,6 +462,11 @@ def hashable(obj):
     -------
     bool
     """
+    # Happy path: if there's no __hash__ method, the object definitely isn't hashable
+    if not hasattr(obj, "__hash__"):
+        return False
+    # Otherwise, we may still need to check for type errors, as in the case of `hash(([],))`.
+    # (e.g. an unhashable object inside a tuple)
     try:
         hash(obj)
     except TypeError:
@@ -422,7 +474,7 @@ def hashable(obj):
     return True
 
 
-def try_cast_to_pandas(obj, squeeze=False):
+def try_cast_to_pandas(obj: Any, squeeze: bool = False) -> Any:
     """
     Convert `obj` and all nested objects from Modin to pandas if it is possible.
 
@@ -440,12 +492,12 @@ def try_cast_to_pandas(obj, squeeze=False):
     object
         Converted object.
     """
-    if hasattr(obj, "_to_pandas"):
+    if isinstance(obj, SupportsPrivateToPandas):
         result = obj._to_pandas()
         if squeeze:
             result = result.squeeze(axis=1)
         return result
-    if hasattr(obj, "to_pandas"):
+    if isinstance(obj, SupportsPublicToPandas):
         result = obj.to_pandas()
         if squeeze:
             result = result.squeeze(axis=1)
@@ -472,7 +524,7 @@ def try_cast_to_pandas(obj, squeeze=False):
     return obj
 
 
-def wrap_into_list(*args, skipna=True):
+def wrap_into_list(*args: Any, skipna: bool = True) -> List[Any]:
     """
     Wrap a sequence of passed values in a flattened list.
 
@@ -492,7 +544,7 @@ def wrap_into_list(*args, skipna=True):
         Passed values wrapped in a list.
     """
 
-    def isnan(o):
+    def isnan(o: Any) -> bool:
         return o is None or (isinstance(o, float) and np.isnan(o))
 
     res = []
@@ -506,7 +558,7 @@ def wrap_into_list(*args, skipna=True):
     return res
 
 
-def wrap_udf_function(func):
+def wrap_udf_function(func: Callable) -> Callable:
     """
     Create a decorator that makes `func` return pandas objects instead of Modin.
 
@@ -520,7 +572,7 @@ def wrap_udf_function(func):
     callable
     """
 
-    def wrapper(*args, **kwargs):
+    def wrapper(*args: Any, **kwargs: Any) -> Any:
         result = func(*args, **kwargs)
         # if user accidently returns modin DataFrame or Series
         # casting it back to pandas to properly process
@@ -530,7 +582,7 @@ def wrap_udf_function(func):
     return wrapper
 
 
-def get_current_execution():
+def get_current_execution() -> str:
     """
     Return current execution name as a string.
 
@@ -542,7 +594,7 @@ def get_current_execution():
     return f"{'Experimental' if IsExperimental.get() else ''}{StorageFormat.get()}On{Engine.get()}"
 
 
-def instancer(_class):
+def instancer(_class: Callable[[], T]) -> T:
     """
     Create a dummy instance each time this is imported.
 
@@ -561,7 +613,7 @@ def instancer(_class):
     return _class()
 
 
-def import_optional_dependency(name, message):
+def import_optional_dependency(name: str, message: str) -> types.ModuleType:
     """
     Import an optional dependecy.
 
@@ -586,13 +638,13 @@ def import_optional_dependency(name, message):
         ) from None
 
 
-def _get_modin_deps_info() -> "dict[str, JSONSerializable]":
+def _get_modin_deps_info() -> Mapping[str, Optional[JSONSerializable]]:
     """
     Return Modin-specific dependencies information as a JSON serializable dictionary.
 
     Returns
     -------
-    dict[str, JSONSerializable]
+    Mapping[str, Optional[pandas.JSONSerializable]]
         The dictionary of Modin dependencies and their versions.
     """
     import modin  # delayed import so modin.__init__ is fully initialized

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -55,18 +55,19 @@ Fn = TypeVar("Fn", bound=Callable)
 
 
 @runtime_checkable
-class SupportsPrivateToPandas(Protocol):
+class SupportsPrivateToPandas(Protocol):  # noqa: PR01
     """Structural type for objects with a ``_to_pandas`` method (note the leading underscore)."""
 
-    def _to_pandas(self) -> Any:  # TODO add proper return type
+    def _to_pandas(self) -> Any:  # noqa: GL08
+        # TODO add proper return type
         pass
 
 
 @runtime_checkable
-class SupportsPublicToPandas(Protocol):
+class SupportsPublicToPandas(Protocol):  # noqa: PR01
     """Structural type for objects with a ``to_pandas`` method (without a leading underscore)."""
 
-    def to_pandas(self) -> Any:
+    def to_pandas(self) -> Any:  # noqa: GL08
         pass
 
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -17,5 +17,11 @@ disallow_any_generics=False
 warn_unreachable=True
 
 # We will add more files over time to increase coverage
-; files = **/modin/*.py
-files = **/modin/config/*.py, **/modin/logging/*.py
+; files = modin/*.py
+files = 
+        modin/config/*.py,
+        modin/logging/*.py,
+        modin/_version.py,
+        modin/db_conn.py,
+        modin/error_message.py,
+        modin/utils.py

--- a/mypy.ini
+++ b/mypy.ini
@@ -21,7 +21,4 @@ warn_unreachable=True
 files = 
         modin/config/*.py,
         modin/logging/*.py,
-        modin/_version.py,
-        modin/db_conn.py,
-        modin/error_message.py,
-        modin/utils.py
+        modin/*.py


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
This PR adds type annotations to `modin/{_version,db_conn,error_message,utils}.py` in anticipation of adding more annotations to the rest of the codebase.

A few notes:
- In cases where the same variable is reassigned to a different type (like assigning `s = [s]` to convert a string to list of strings), mypy's preferred solution is to create a new variable for the new type.
- mypy supports [structural subtyping](https://mypy.readthedocs.io/en/stable/protocols.html), which lets us define what are essentially placeholder classes to perform `isinstance` checks on in cases where we would otherwise use `hasattr` for duck-typed function calls/field accesses.
- In some situations where the origin of a property is not obvious, or is hard to convey to the type checker via annotations, I threw in a `# type: ignore` annotation on the offending line.


- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5012
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
