### PR TITLE
FIX-#4966: Fix to_timedelta to return Series instead of TimedeltaIndex

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ to be modular so we can plug in different components as they develop and improve
 - [10-min Quickstart Guide](https://modin.readthedocs.io/en/latest/getting_started/quickstart.html)
 - [Examples and Tutorials](https://modin.readthedocs.io/en/latest/getting_started/examples.html)
 - [Videos and Blogposts](https://modin.readthedocs.io/en/latest/getting_started/examples.html#talks-podcasts)
+- [Benchmarking Modin](https://modin.readthedocs.io/en/latest/usage_guide/benchmarking.html)
 
 #### Modin Community
 

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -138,6 +138,7 @@ Key Features and Updates
   * DOCS-#4668: Set light theme for readthedocs page, remove theme switcher (#4669)
   * DOCS-#4748: Apply the Triage label to new issues (#4749)
   * DOCS-#4790: Give all templates issue type and triage labels (#4791)
+  * DOCS-#4521: Document how to benchmark modin (#5020)
 * Dependencies
   * FEAT-#4598: Add support for pandas 1.4.3 (#4599)
   * FEAT-#4619: Integrate mypy static type checking (#4620)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -81,6 +81,7 @@ Key Features and Updates
   * PERF-#4920: Avoid index and cache computations in `take_2d_labels_or_positional` unless they are needed (#4921)
   * PERF-#4999: don't call `apply` in virtual partition' `drain_call_queue` if `call_queue` is empty (#4975)
   * PERF-#4268: Implement partition-parallel __getitem__ for bool Series masks (#4753)
+  * PERF-#5017: `reset_index` shouldn't trigger index materialization if possible (#5018)
   * PERF-#4963: Use partition `width/length` methods instead of `_compute_axis_labels_and_lengths` if index is already known (#4964)
   * PERF-#4940: Optimize categorical dtype check in `concatenate` (#4953)
 * Benchmarking enhancements

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -52,6 +52,7 @@ Key Features and Updates
   * FIX-#4993: Return `_default_to_pandas` in `df.attrs` (#4995)
   * FIX-#4597: Refactor Partition handling of func, args, kwargs (#4715)
   * FIX-#4996: Evaluate BenchmarkMode at each function call (#4997)
+  * FIX-#4966: Fix `to_timedelta` to return Series instead of TimedeltaIndex (#4966)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/docs/usage_guide/benchmarking.rst
+++ b/docs/usage_guide/benchmarking.rst
@@ -1,0 +1,181 @@
+Benchmarking Modin
+==================
+
+Summary
+-------
+To benchmark a single Modin function, often turning on the
+:doc:`configuration variable </flow/modin/config>` variable
+:code:`BenchmarkMode` will suffice.
+
+There is no simple way to benchmark more complex Modin workflows, though
+benchmark mode or calling ``repr`` on Modin objects may be useful. The
+:doc:`Modin logs </usage_guide/advanced_usage/modin_logging>` may help you
+identify bottlenecks in your code, and they may also help profile the execution
+of each Modin function.
+
+Modin's execution and benchmark mode
+------------------------------------
+
+Most of Modin's execution happens asynchronously, i.e. in separate processes that run
+independently of the main program flow. Some execution is also lazy, meaning that it
+doesn't start immediately once the user calls a Modin function. While Modin provides
+the same API as pandas, lazy and asynchronous execution can often make it hard to
+tell how much time each Modin function call takes, as well as to compare Modin's
+performance to pandas and other similar libraries.
+
+.. note::
+    All examples in this doc use the system specified at the bottom of this page.
+
+Consider the following ipython script:
+
+.. code-block:: python
+
+    import modin.pandas as pd
+    from modin.config import MinPartitionSize
+    import time
+    import ray
+
+    ray.init()
+    df = pd.DataFrame(list(range(MinPartitionSize.get() * 2)))
+    %time result = df.applymap(lambda x: time.sleep(0.1) or x)
+    %time print(result)
+
+
+Modin takes just 2.68 milliseconds for the ``applymap``, and 3.78 seconds to print
+the result. However, if we run this script in pandas by replacing
+:code:`import modin.pandas as pd` with :code:`import pandas as pd`, the ``applymap``
+takes 6.63 seconds, and printing the result takes just 5.53 milliseconds.
+
+Both pandas and Modin start executing the ``applymap`` as soon as the interpreter
+evalutes it. While pandas blocks until the ``applymap`` has finished, Modin just kicks
+off asynchronous functions in remote ray processes. Printing the function result
+is fairly fast in pandas and Modin, but before Modin can print the data, it has to
+wait until all the remote functions complete.
+
+To time how long Modin takes for a single operation, you should typically use
+benchmark mode. Benchmark mode will wait for all asynchronous remote execution
+to complete. You can turn on benchmark mode on at any point as follows:
+
+.. code-block:: python
+
+    from modin.config import BenchmarkMode
+    BenchmarkMode.put(True)
+
+Rerunning the script above with benchmark mode on, the Modin ``applymap`` takes
+3.59 seconds, and the ``print`` takes 183 milliseconds. These timings better
+reflect where Modin is spending its execution time.
+
+A caveat about benchmark mode
+-----------------------------
+
+While benchmark code is often good for measuring the performance of a single
+Modin function call, it can underestimate Modin's performance in cases where
+Modin's asynchronous execution improves Modin's performance. Consider the
+following script with benchmark mode on:
+
+.. code-block:: python
+
+    import numpy as np
+    import time
+    import ray
+    from io import BytesIO
+
+    import modin.pandas as pd
+    from modin.config import BenchmarkMode, MinPartitionSize
+
+    BenchmarkMode.put(True)
+
+    start = time.time()
+    df = pd.DataFrame(list(range(MinPartitionSize.get())), columns=['A'])
+    result1 = df.applymap(lambda x: time.sleep(0.2) or x + 1)
+    result2 = df.applymap(lambda x: time.sleep(0.2) or x + 2)
+    result1.to_parquet(BytesIO())
+    result2.to_parquet(BytesIO())
+    end = time.time()
+    print(f'applymap and write to parquet took {end - start} seconds.')
+
+.. code-block::python
+
+The script does two slow ``applymap`` on a dataframe and then writes each result
+to a buffer. The whole script takes 13 seconds with benchmark mode on, but
+just 7 seconds with benchmark mode off. Because Modin can run the ``applymap``
+asynchronously, it can start writing the first result to its buffer while
+it's still computing the second result. With benchmark mode on, Modin has to
+execute every function synchronously instead.
+
+How to benchmark complex workflows
+----------------------------------
+
+Typically, to benchmark Modin's overall performance on your workflow, you
+should start by looking at end-to-end performance with benchmark mode off.
+It's common for Modin worfklows to end with writing results to one or more
+files, or with printing some Modin objects to an interactive console. Such
+end points are natural ways to make sure that all of the Modin execution that
+you require is complete.
+
+To measure more fine-grained performance, it can be helpful to turn
+benchmark mode on, but beware that doing so may reduce your script's overall
+performance and thus may not reflect where Modin is normally spending execution
+time, as pointed out above.
+
+Turning on :doc:`Modin logging </usage_guide/advanced_usage/modin_logging>` and
+using the Modin logs can also help you profile your workflow. The Modin logs
+can also give a detailed break down of the performance of each Modin function
+at each Modin :doc:`layer </development/architecture>`. Log mode is more
+useful when used in conjuction with benchmark mode.
+
+Sometimes, if you don't have a natural end-point to your workflow, you can
+just call ``repr`` on the workflow's final Modin objects. That will typically
+block on any asynchronous computation. However, beware that ``repr`` can also
+be misleading, e.g. here:
+
+.. code-block:: python
+
+    import time
+    import ray
+    from io import BytesIO
+
+    import modin.pandas as pd
+    from modin.config import MinPartitionSize, NPartitions
+
+    MinPartitionSize.put(32)
+    NPartitions.put(16)
+
+    def slow_add_one(x):
+      if x == 5000:
+        time.sleep(10)
+      return x + 1
+
+    ray.init()
+    df1 = pd.DataFrame(list(range(10_000)), columns=['A'])
+    result = df1.applymap(slow_add_one)
+    %time repr(result)
+    # time.sleep(10)
+    %time result.to_parquet(BytesIO())
+.. code-block::python
+
+The ``repr`` takes only 802 milliseconds, but writing the result to a buffer
+takes 9.84 seconds. However, if you uncomment the :code:`time.sleep` before the
+:code:`to_parquet` call, the :code:`to_parquet` takes just 23.8 milliseconds!
+The problem is that the ``repr`` blocks only on getting the first few and the
+last few rows, but the slow execution is for row 5001, which Modin is
+computing asynchronously in the background even after ``repr`` finishes.
+
+.. note::
+    If you see any Modin documentation touting Modin's speed without using
+    benchmark mode or otherwise guaranteeing that Modin is finishing all asynchronous
+    and deferred computation, you should file an issue on the Modin GitHub. It's
+    not fair to compare the speed of an async Modin function call to an equivalent
+    synchronous call using another library.
+
+Appendix: System Information
+----------------------------
+The example scripts here were run on the following system:
+
+- **OS Platform and Distribution (e.g., Linux Ubuntu 16.04)**: macOS Monterey 12.4
+- **Modin version**: d6d503ac7c3028d871c34d9e99e925ddb0746df6
+- **Ray version**: 2.0.0
+- **Python version**: 3.10.4
+- **Machine**: MacBook Pro (16-inch, 2019)
+- **Processor**: 2.3 GHz 8-core Intel Core i9 processor
+- **Memory**: 16 GB 2667 MHz DDR4

--- a/docs/usage_guide/index.rst
+++ b/docs/usage_guide/index.rst
@@ -12,6 +12,7 @@ how you can further optimize the performance of your workload with Modin.
     examples/index
     advanced_usage/index
     optimization_notes/index
+    benchmarking
 
 .. meta::
     :description lang=en:

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -550,7 +550,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     if len(level) < self.index.nlevels
                     else pandas.RangeIndex(len(self.index))
                 )
-        else:
+        elif not drop:
             uniq_sorted_level = list(range(self.index.nlevels))
 
         if not drop:
@@ -627,7 +627,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         else:
             new_self = self.copy()
             new_self.index = (
-                pandas.RangeIndex(len(new_self.index))
+                # Cheaper to compute row lengths than index
+                pandas.RangeIndex(sum(new_self._modin_frame._row_lengths))
                 if new_index is None
                 else new_index
             )

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -55,7 +55,6 @@ with warnings.catch_warnings():
         DatetimeIndex,
         Timedelta,
         Timestamp,
-        to_timedelta,
         set_eng_float_format,
         options,
         set_option,
@@ -251,6 +250,7 @@ from .general import (
     crosstab,
     lreshape,
     wide_to_long,
+    to_timedelta,
 )
 
 from modin._compat.pandas_api.namespace import pivot_table

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -759,3 +759,11 @@ def _determine_name(objs: Iterable[BaseQueryCompiler], axis: Union[int, str]):
         return list(names[0]) if is_list_like(names[0]) else [names[0]]
     else:
         return None
+
+
+def to_timedelta(arg, unit=None, errors="raise"):
+    if isinstance(arg, Series):
+        arg = arg._to_pandas()
+    result = pandas.to_timedelta(arg, unit=unit, errors=errors)
+    if isinstance(result, pandas.Series):
+        return Series(result)

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -26,6 +26,7 @@ from .utils import (
     test_data_keys,
     df_equals,
     sort_index_for_equal_values,
+    eval_general,
 )
 
 
@@ -801,3 +802,9 @@ def test_empty_dataframe():
 def test_empty_series():
     s = pd.Series([])
     pd.to_numeric(s)
+
+
+def test_to_timedelta():
+    # This test case comes from
+    # https://github.com/modin-project/modin/issues/4966
+    eval_general(pd, pandas, lambda lib: lib.to_timedelta(lib.Series([1])))


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Added `to_timedelta` implementation to `general.py` instead of importing and using pandas version, which previously returned the wrong output when provided a Modin Series.

Added test to confirm functionality of `to_timedelta` on Modin Series.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
