### PR TITLE
FIX-#4966: Fix `to_timedelta` to return Series instead of TimedeltaIndex

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -55,7 +55,7 @@ Key Features and Updates
   * FIX-#4996: Evaluate BenchmarkMode at each function call (#4997)
   * FIX-#4022: Fixed empty data frame with index (#4910)
   * FIX-#4090: Fixed check if the index is trivial (#4936)
-  * FIX-#4966: Fix `to_timedelta` to return Series instead of TimedeltaIndex (#4966)
+  * FIX-#4966: Fix `to_timedelta` to return Series instead of TimedeltaIndex (#5028)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -55,6 +55,7 @@ Key Features and Updates
   * FIX-#4996: Evaluate BenchmarkMode at each function call (#4997)
   * FIX-#4022: Fixed empty data frame with index (#4910)
   * FIX-#4090: Fixed check if the index is trivial (#4936)
+  * FIX-#4966: Fix `to_timedelta` to return Series instead of TimedeltaIndex (#4966)
 * Performance enhancements
   * PERF-#4182: Add cell-wise execution for binary ops, fix bin ops for empty dataframes (#4391)
   * PERF-#4288: Improve perf of `groupby.mean` for narrow data (#4591)

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1322,7 +1322,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     @doc_utils.add_one_column_warning
     @doc_utils.add_refer_to("to_timedelta")
-    def to_timedelta(self, unit="ns", errors="raise", *args, **kwargs):  # noqa: PR02
+    def to_timedelta(self, unit="ns", errors="raise"):  # noqa: PR02
         """
         Convert argument to timedelta.
 
@@ -1331,10 +1331,6 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         unit : str, default: "ns"
             Denotes the unit of the arg for numeric arg. Defaults to "ns".
         errors : {"ignore", "raise", "coerce"}, default: "raise"
-        *args : iterable
-            Serves the compatibility purpose. Does not affect the result.
-        **kwargs : dict
-            Serves the compatibility purpose. Does not affect the result.
 
         Returns
         -------
@@ -1342,7 +1338,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             New QueryCompiler with converted to timedelta values.
         """
         return SeriesDefault.register(pandas.to_timedelta)(
-            self, unit=unit, errors=errors, *args, **kwargs
+            self, unit=unit, errors=errors
         )
 
     # FIXME: get rid of `**kwargs` parameter (Modin issue #3108).

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1322,7 +1322,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     @doc_utils.add_one_column_warning
     @doc_utils.add_refer_to("to_timedelta")
-    def to_timedelta(self, *args, **kwargs):  # noqa: PR02
+    def to_timedelta(self, unit="ns", errors="raise", *args, **kwargs):  # noqa: PR02
         """
         Convert argument to timedelta.
 
@@ -1341,7 +1341,9 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         BaseQueryCompiler
             New QueryCompiler with converted to timedelta values.
         """
-        return SeriesDefault.register(pandas.to_timedelta)(self, *args, **kwargs)
+        return SeriesDefault.register(pandas.to_timedelta)(
+            self, unit=unit, errors=errors, *args, **kwargs
+        )
 
     # FIXME: get rid of `**kwargs` parameter (Modin issue #3108).
     @doc_utils.add_one_column_warning

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1328,9 +1328,9 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
         Parameters
         ----------
-        unit : str
+        unit : str, default: "ns"
             Denotes the unit of the arg for numeric arg. Defaults to "ns".
-        errors : {"ignore", "raise", "coerce"}
+        errors : {"ignore", "raise", "coerce"}, default: "raise"
         *args : iterable
             Serves the compatibility purpose. Does not affect the result.
         **kwargs : dict

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1322,7 +1322,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     @doc_utils.add_one_column_warning
     @doc_utils.add_refer_to("to_timedelta")
-    def to_timedelta(self, *args, **kwargs):
+    def to_timedelta(self, *args, **kwargs):  # noqa: PR02
         """
         Convert argument to timedelta.
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1320,6 +1320,29 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         """
         return SeriesDefault.register(pandas.to_numeric)(self, *args, **kwargs)
 
+    @doc_utils.add_one_column_warning
+    @doc_utils.add_refer_to("to_timedelta")
+    def to_timedelta(self, *args, **kwargs):
+        """
+        Convert argument to timedelta.
+
+        Parameters
+        ----------
+        unit : str
+            Denotes the unit of the arg for numeric arg. Defaults to "ns".
+        errors : {"ignore", "raise", "coerce"}
+        *args : iterable
+            Serves the compatibility purpose. Does not affect the result.
+        **kwargs : dict
+            Serves the compatibility purpose. Does not affect the result.
+
+        Returns
+        -------
+        BaseQueryCompiler
+            New QueryCompiler with converted to timedelta values.
+        """
+        return SeriesDefault.register(pandas.to_timedelta)(self, *args, **kwargs)
+
     # FIXME: get rid of `**kwargs` parameter (Modin issue #3108).
     @doc_utils.add_one_column_warning
     @doc_utils.add_refer_to("Series.unique")

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1363,7 +1363,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
     to_timedelta = Map.register(
         lambda s, *args, **kwargs: pandas.to_timedelta(
             s.squeeze(1), *args, **kwargs
-        ).to_frame()
+        ).to_frame(),
+        dtypes="timedelta64[ns]",
     )
 
     # END Map partitions operations

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1360,6 +1360,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
             pandas.to_numeric(df.squeeze(axis=1), *args, **kwargs)
         )
     )
+    to_timedelta = Map.register(
+        lambda s, *args, **kwargs: pandas.to_timedelta(
+            s.squeeze(1), *args, **kwargs
+        ).to_frame()
+    )
 
     # END Map partitions operations
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1362,7 +1362,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     )
     to_timedelta = Map.register(
         lambda s, *args, **kwargs: pandas.to_timedelta(
-            s.squeeze(1), *args, **kwargs
+            s.squeeze(axis=1), *args, **kwargs
         ).to_frame(),
         dtypes="timedelta64[ns]",
     )

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -55,7 +55,6 @@ with warnings.catch_warnings():
         DatetimeIndex,
         Timedelta,
         Timestamp,
-        to_timedelta,
         set_eng_float_format,
         options,
         set_option,
@@ -251,6 +250,7 @@ from .general import (
     crosstab,
     lreshape,
     wide_to_long,
+    to_timedelta,
 )
 
 from modin._compat.pandas_api.namespace import pivot_table

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -763,7 +763,7 @@ def _determine_name(objs: Iterable[BaseQueryCompiler], axis: Union[int, str]):
 
 @_inherit_docstrings(pandas.to_datetime, apilink="pandas.to_timedelta")
 @enable_logging
-def to_timedelta(arg, unit=None, errors="raise"):
+def to_timedelta(arg, unit=None, errors="raise"):  # noqa: PR01, RT01, D200
     """
     Convert argument to timedelta.
     """

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -770,4 +770,7 @@ def to_timedelta(arg, unit=None, errors="raise"):  # noqa: PR01, RT01, D200
     if isinstance(arg, Series):
         query_compiler = arg._query_compiler.to_timedelta(unit=unit, errors=errors)
         return Series(query_compiler=query_compiler)
-    return pandas.to_timedelta(arg, unit=unit, errors=errors)
+    result = pandas.to_timedelta(arg, unit=unit, errors=errors)
+    if isinstance(result, pandas.Series):
+        return Series(result)
+    return result

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -759,3 +759,10 @@ def _determine_name(objs: Iterable[BaseQueryCompiler], axis: Union[int, str]):
         return list(names[0]) if is_list_like(names[0]) else [names[0]]
     else:
         return None
+
+
+def to_timedelta(arg, unit=None, errors="raise"):
+    if isinstance(arg, Series):
+        query_compiler = arg._query_compiler.to_timedelta(unit=unit, errors=errors)
+        return Series(query_compiler=query_compiler)
+    return pandas.to_timedelta(arg, unit=unit, errors=errors)

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -761,6 +761,8 @@ def _determine_name(objs: Iterable[BaseQueryCompiler], axis: Union[int, str]):
         return None
 
 
+@_inherit_docstrings(pandas.to_datetime, apilink="pandas.to_timedelta")
+@enable_logging
 def to_timedelta(arg, unit=None, errors="raise"):
     """
     Convert argument to timedelta.

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -770,7 +770,4 @@ def to_timedelta(arg, unit=None, errors="raise"):  # noqa: PR01, RT01, D200
     if isinstance(arg, Series):
         query_compiler = arg._query_compiler.to_timedelta(unit=unit, errors=errors)
         return Series(query_compiler=query_compiler)
-    result = pandas.to_timedelta(arg, unit=unit, errors=errors)
-    if isinstance(result, pandas.Series):
-        return Series(result)
-    return result
+    return pandas.to_timedelta(arg, unit=unit, errors=errors)

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -762,6 +762,9 @@ def _determine_name(objs: Iterable[BaseQueryCompiler], axis: Union[int, str]):
 
 
 def to_timedelta(arg, unit=None, errors="raise"):
+    """
+    Convert argument to timedelta.
+    """
     if isinstance(arg, Series):
         query_compiler = arg._query_compiler.to_timedelta(unit=unit, errors=errors)
         return Series(query_compiler=query_compiler)

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -766,6 +766,9 @@ def _determine_name(objs: Iterable[BaseQueryCompiler], axis: Union[int, str]):
 def to_timedelta(arg, unit=None, errors="raise"):  # noqa: PR01, RT01, D200
     """
     Convert argument to timedelta.
+
+    Accepts str, timedelta, list-like or Series for arg parameter.
+    Returns a Series if and only if arg is provided as a Series.
     """
     if isinstance(arg, Series):
         query_compiler = arg._query_compiler.to_timedelta(unit=unit, errors=errors)

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -22,7 +22,6 @@ from modin.test.test_utils import warns_that_defaulting_to_pandas
 from pandas.testing import assert_frame_equal
 
 from .utils import (
-    eval_general,
     test_data_values,
     test_data_keys,
     df_equals,

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -817,16 +817,10 @@ def test_to_timedelta(arg):
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_series_to_timedelta(data):
-    if isinstance(data, dict):
-        modin_series = pd.Series(data[next(iter(data.keys()))])
-        pandas_series = pandas.Series(data[next(iter(data.keys()))])
-    else:
-        modin_series = pd.Series(data)
-        pandas_series = pandas.Series(data)
+    def make_frame(lib):
+        series = lib.Series(
+            next(iter(data.values())) if isinstance(data, dict) else data
+        )
+        return lib.to_timedelta(series).to_frame(name="timedelta")
 
-    modin_series = pd.to_timedelta(modin_series)
-    pandas_series = pandas.to_timedelta(pandas_series)
-    df_equals(
-        modin_series.to_frame(name="timedelta"),
-        pandas_series.to_frame(name="timedelta"),
-    )
+    eval_general(pd, pandas, make_frame)

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -804,7 +804,20 @@ def test_empty_series():
     pd.to_numeric(s)
 
 
-def test_to_timedelta():
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_to_timedelta(data):
     # This test case comes from
     # https://github.com/modin-project/modin/issues/4966
-    eval_general(pd, pandas, lambda lib: lib.to_timedelta(lib.Series([1])))
+    if isinstance(data, dict):
+        modin_series = pd.Series(data[next(iter(data.keys()))])
+        pandas_series = pandas.Series(data[next(iter(data.keys()))])
+    else:
+        modin_series = pd.Series(data)
+        pandas_series = pandas.Series(data)
+
+    modin_series = pd.to_timedelta(modin_series)
+    pandas_series = pandas.to_timedelta(pandas_series)
+    df_equals(
+        modin_series.to_frame(name="timedelta"),
+        pandas_series.to_frame(name="timedelta"),
+    )

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -22,6 +22,7 @@ from modin.test.test_utils import warns_that_defaulting_to_pandas
 from pandas.testing import assert_frame_equal
 
 from .utils import (
+    eval_general,
     test_data_values,
     test_data_keys,
     df_equals,
@@ -801,3 +802,9 @@ def test_empty_dataframe():
 def test_empty_series():
     s = pd.Series([])
     pd.to_numeric(s)
+
+
+def test_to_timedelta():
+    # This test case comes from
+    # https://github.com/modin-project/modin/issues/4966
+    eval_general(pd, pandas, lambda lib: lib.to_timedelta(lib.Series([1])))

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -26,6 +26,7 @@ from .utils import (
     test_data_keys,
     df_equals,
     sort_index_for_equal_values,
+    eval_general,
 )
 
 
@@ -803,10 +804,19 @@ def test_empty_series():
     pd.to_numeric(s)
 
 
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_to_timedelta(data):
+@pytest.mark.parametrize(
+    "arg",
+    [[1, 2], ["a"], 1, "a"],
+    ids=["list_of_ints", "list_of_invalid_strings", "scalar", "invalid_scalar"],
+)
+def test_to_timedelta(arg):
     # This test case comes from
     # https://github.com/modin-project/modin/issues/4966
+    eval_general(pd, pandas, lambda lib: lib.to_timedelta(arg))
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_series_to_timedelta(data):
     if isinstance(data, dict):
         modin_series = pd.Series(data[next(iter(data.keys()))])
         pandas_series = pandas.Series(data[next(iter(data.keys()))])


### PR DESCRIPTION
Signed-off-by: Bill Wang <billiam@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Added implementation for `to_timedelta` instead of using pandas version. Previously returned incorrect output when using a Modin Series as input.

Added tests for `to_timedelta` with Modin Series.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
