### PR TITLE
PERF-#5087: use cache for widths/lengths/index/columns if possible

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -83,6 +83,7 @@ Key Features and Updates
   * PERF-#4890: `PandasDataframeAxisPartition.drain` should be serialized only once (#4891)
   * PERF-#4870: Avoid index materialization in `__getattribute__` and `__getitem__` (4911)
   * PERF-#4886: Use lazy index and columns evaluation in `query` method (#4887)
+  * PERF-#5087: Use cache for widths/lengths if possible (#5031)
   * PERF-#4866: `iloc` function that used in `partition.mask` should be serialized only once (#4901)
   * PERF-#4920: Avoid index and cache computations in `take_2d_labels_or_positional` unless they are needed (#4921)
   * PERF-#4999: don't call `apply` in virtual partition' `drain_call_queue` if `call_queue` is empty (#4975)

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -83,7 +83,6 @@ Key Features and Updates
   * PERF-#4890: `PandasDataframeAxisPartition.drain` should be serialized only once (#4891)
   * PERF-#4870: Avoid index materialization in `__getattribute__` and `__getitem__` (4911)
   * PERF-#4886: Use lazy index and columns evaluation in `query` method (#4887)
-  * PERF-#5087: Use cache for widths/lengths if possible (#5031)
   * PERF-#4866: `iloc` function that used in `partition.mask` should be serialized only once (#4901)
   * PERF-#4920: Avoid index and cache computations in `take_2d_labels_or_positional` unless they are needed (#4921)
   * PERF-#4999: don't call `apply` in virtual partition' `drain_call_queue` if `call_queue` is empty (#4975)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1172,8 +1172,8 @@ class PandasDataframe(ClassLogger):
         )
         return self.__constructor__(
             new_frame,
-            self.index,
-            self.columns,
+            self._index_cache,
+            self._columns_cache,
             self._row_lengths_cache,
             self._column_widths_cache,
             new_dtypes,
@@ -1689,8 +1689,8 @@ class PandasDataframe(ClassLogger):
             )
         return self.__constructor__(
             new_partitions,
-            self.axes[0],
-            self.axes[1],
+            self._index_cache,
+            self._columns_cache,
             self._row_lengths_cache,
             self._column_widths_cache,
             dtypes=dtypes,
@@ -1757,8 +1757,8 @@ class PandasDataframe(ClassLogger):
         )
         return self.__constructor__(
             new_partitions,
-            self.index,
-            self.columns,
+            self._index_cache,
+            self._columns_cache,
             self._row_lengths_cache,
             self._column_widths_cache,
         )
@@ -1802,8 +1802,8 @@ class PandasDataframe(ClassLogger):
         new_dtypes[col_labels] = new_cols_dtypes
         return self.__constructor__(
             self._partitions,
-            self.index,
-            self.columns,
+            self._index_cache,
+            self._columns_cache,
             self._row_lengths_cache,
             self._column_widths_cache,
             new_dtypes,
@@ -3105,8 +3105,8 @@ class PandasDataframe(ClassLogger):
             new_dtypes = None
         return self.__constructor__(
             new_partitions,
-            self.columns,
-            self.index,
+            self._columns_cache,
+            self._index_cache,
             self._column_widths_cache,
             self._row_lengths_cache,
             dtypes=new_dtypes,

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1174,8 +1174,8 @@ class PandasDataframe(ClassLogger):
             new_frame,
             self.index,
             self.columns,
-            self.row_lengths,
-            self.column_widths,
+            self._row_lengths_cache,
+            self._column_widths_cache,
             new_dtypes,
         )
 
@@ -1759,8 +1759,8 @@ class PandasDataframe(ClassLogger):
             new_partitions,
             self.index,
             self.columns,
-            self.row_lengths,
-            self.column_widths,
+            self._row_lengths_cache,
+            self._column_widths_cache,
         )
 
     def infer_objects(self) -> "PandasDataframe":
@@ -1804,8 +1804,8 @@ class PandasDataframe(ClassLogger):
             self._partitions,
             self.index,
             self.columns,
-            self.row_lengths,
-            self.column_widths,
+            self._row_lengths_cache,
+            self._column_widths_cache,
             new_dtypes,
         )
 
@@ -1910,8 +1910,8 @@ class PandasDataframe(ClassLogger):
             new_parts,
             new_index,
             new_cols,
-            self.row_lengths,
-            self.column_widths,
+            self._row_lengths_cache,
+            self._column_widths_cache,
             new_dtypes,
         )
 
@@ -3107,8 +3107,8 @@ class PandasDataframe(ClassLogger):
             new_partitions,
             self.columns,
             self.index,
-            self.column_widths,
-            self.row_lengths,
+            self._column_widths_cache,
+            self._row_lengths_cache,
             dtypes=new_dtypes,
         )
 


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5087 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
