### PR TITLE
FIX-#5032: Enable fuzzydata artifact upload on test failure also

### DIFF
--- a/.github/workflows/fuzzydata-test.yml
+++ b/.github/workflows/fuzzydata-test.yml
@@ -55,6 +55,7 @@ jobs:
         env:
           MODIN_ENGINE: ${{matrix.engine}}
       - uses: actions/upload-artifact@v3
+        if: success() || failure()
         with:
            name: fuzzydata-test-workflow-${{matrix.engine}}
            path: /tmp/fuzzydata-test-wf-${{matrix.engine}}/* # Must match output dir in test_fuzzydata.py


### PR DESCRIPTION
Signed-off-by: Suhail Rehman <suhailrehman@gmail.com>

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5032 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [ ] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
