### PR TITLE
REFACTOR-#5038: Remove unnecessary `_method` argument from resamplers

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -118,6 +118,7 @@ Key Features and Updates
   * REFACTOR-#5009: Use `RayWrapper.materialize` instead of `ray.get` (#5010)
   * REFACTOR-#4755: Rewrite Pandas version mismatch warning (#4965)
   * REFACTOR-#5012: Add mypy checks for singleton files in base modin directory (#5013)
+  * REFACTOR-#5038: Remove unnecessary _method argument from resamplers (#5039)
 * Pandas API implementations and improvements
   * FEAT-#4670: Implement convert_dtypes by mapping across partitions (#4671)
 * OmniSci enhancements

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3774,12 +3774,10 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             self, resample_kwargs, method, limit
         )
 
-    @doc_utils.doc_resample_reduce(
-        result="first element", refer_to="first", params="_method : str"
-    )
-    def resample_first(self, resample_kwargs, _method, *args, **kwargs):
+    @doc_utils.doc_resample_reduce(result="first element", refer_to="first")
+    def resample_first(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.first)(
-            self, resample_kwargs, _method, *args, **kwargs
+            self, resample_kwargs, *args, **kwargs
         )
 
     # FIXME: This function takes Modin DataFrame via `obj` parameter,
@@ -3849,44 +3847,34 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             **kwargs,
         )
 
-    @doc_utils.doc_resample_reduce(
-        result="last element", params="_method : str", refer_to="last"
-    )
-    def resample_last(self, resample_kwargs, _method, *args, **kwargs):
+    @doc_utils.doc_resample_reduce(result="last element", refer_to="last")
+    def resample_last(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.last)(
-            self, resample_kwargs, _method, *args, **kwargs
+            self, resample_kwargs, *args, **kwargs
         )
 
-    @doc_utils.doc_resample_reduce(
-        result="maximum value", params="_method : str", refer_to="max"
-    )
-    def resample_max(self, resample_kwargs, _method, *args, **kwargs):
+    @doc_utils.doc_resample_reduce(result="maximum value", refer_to="max")
+    def resample_max(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.max)(
-            self, resample_kwargs, _method, *args, **kwargs
+            self, resample_kwargs, *args, **kwargs
         )
 
-    @doc_utils.doc_resample_reduce(
-        result="mean value", params="_method : str", refer_to="mean"
-    )
-    def resample_mean(self, resample_kwargs, _method, *args, **kwargs):
+    @doc_utils.doc_resample_reduce(result="mean value", refer_to="mean")
+    def resample_mean(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.mean)(
-            self, resample_kwargs, _method, *args, **kwargs
+            self, resample_kwargs, *args, **kwargs
         )
 
-    @doc_utils.doc_resample_reduce(
-        result="median value", params="_method : str", refer_to="median"
-    )
-    def resample_median(self, resample_kwargs, _method, *args, **kwargs):
+    @doc_utils.doc_resample_reduce(result="median value", refer_to="median")
+    def resample_median(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.median)(
-            self, resample_kwargs, _method, *args, **kwargs
+            self, resample_kwargs, *args, **kwargs
         )
 
-    @doc_utils.doc_resample_reduce(
-        result="minimum value", params="_method : str", refer_to="min"
-    )
-    def resample_min(self, resample_kwargs, _method, *args, **kwargs):
+    @doc_utils.doc_resample_reduce(result="minimum value", refer_to="min")
+    def resample_min(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.min)(
-            self, resample_kwargs, _method, *args, **kwargs
+            self, resample_kwargs, *args, **kwargs
         )
 
     @doc_utils.doc_resample_fillna(method="'nearest'", refer_to="nearest")
@@ -3895,37 +3883,33 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             self, resample_kwargs, limit
         )
 
-    @doc_utils.doc_resample_reduce(
-        result="number of unique values", params="_method : str", refer_to="nunique"
-    )
-    def resample_nunique(self, resample_kwargs, _method, *args, **kwargs):
+    @doc_utils.doc_resample_reduce(result="number of unique values", refer_to="nunique")
+    def resample_nunique(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.nunique)(
-            self, resample_kwargs, _method, *args, **kwargs
+            self, resample_kwargs, *args, **kwargs
         )
 
     # FIXME: Query Compiler shouldn't care about differences between Series and DataFrame
     # so `resample_ohlc_df` and `resample_ohlc_ser` should be combined (Modin issue #3104).
     @doc_utils.doc_resample_agg(
         action="compute open, high, low and close values",
-        params="_method : str",
         output="labels of columns containing computed values",
         refer_to="ohlc",
     )
-    def resample_ohlc_df(self, resample_kwargs, _method, *args, **kwargs):
+    def resample_ohlc_df(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.ohlc)(
-            self, resample_kwargs, _method, *args, **kwargs
+            self, resample_kwargs, *args, **kwargs
         )
 
     @doc_utils.doc_resample_agg(
         action="compute open, high, low and close values",
-        params="_method : str",
         output="labels of columns containing computed values",
         refer_to="ohlc",
     )
-    def resample_ohlc_ser(self, resample_kwargs, _method, *args, **kwargs):
+    def resample_ohlc_ser(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(
             pandas.core.resample.Resampler.ohlc, squeeze_self=True
-        )(self, resample_kwargs, _method, *args, **kwargs)
+        )(self, resample_kwargs, *args, **kwargs)
 
     @doc_utils.doc_resample_fillna(method="'pad'", refer_to="pad")
     def resample_pad(self, resample_kwargs, limit):
@@ -3966,14 +3950,12 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     @doc_utils.doc_resample_reduce(
         result="product",
-        params="""
-        _method : str
-        min_count : int""",
+        params="min_count : int",
         refer_to="prod",
     )
-    def resample_prod(self, resample_kwargs, _method, min_count, *args, **kwargs):
+    def resample_prod(self, resample_kwargs, min_count, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.prod)(
-            self, resample_kwargs, _method, min_count, *args, **kwargs
+            self, resample_kwargs, min_count, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduce(
@@ -3986,12 +3968,11 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     @doc_utils.doc_resample_reduce(
         result="standard error of the mean",
-        params="ddof : int, default: 1",
         refer_to="sem",
     )
-    def resample_sem(self, resample_kwargs, ddof=1, *args, **kwargs):
+    def resample_sem(self, resample_kwargs, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.sem)(
-            self, resample_kwargs, ddof, *args, **kwargs
+            self, resample_kwargs, *args, **kwargs
         )
 
     @doc_utils.doc_resample_reduce(
@@ -4012,14 +3993,12 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     @doc_utils.doc_resample_reduce(
         result="sum",
-        params="""
-        _method : str
-        min_count : int""",
+        params="min_count : int",
         refer_to="sum",
     )
-    def resample_sum(self, resample_kwargs, _method, min_count, *args, **kwargs):
+    def resample_sum(self, resample_kwargs, min_count, *args, **kwargs):
         return ResampleDefault.register(pandas.core.resample.Resampler.sum)(
-            self, resample_kwargs, _method, min_count, *args, **kwargs
+            self, resample_kwargs, min_count, *args, **kwargs
         )
 
     def resample_transform(self, resample_kwargs, arg, *args, **kwargs):

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -965,61 +965,43 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def resample_count(self, resample_kwargs):
         return self._resample_func(resample_kwargs, "count")
 
-    def resample_nunique(self, resample_kwargs, _method, *args, **kwargs):
-        return self._resample_func(
-            resample_kwargs, "nunique", _method=_method, *args, **kwargs
-        )
+    def resample_nunique(self, resample_kwargs, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "nunique", *args, **kwargs)
 
-    def resample_first(self, resample_kwargs, _method, *args, **kwargs):
-        return self._resample_func(
-            resample_kwargs, "first", _method=_method, *args, **kwargs
-        )
+    def resample_first(self, resample_kwargs, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "first", *args, **kwargs)
 
-    def resample_last(self, resample_kwargs, _method, *args, **kwargs):
-        return self._resample_func(
-            resample_kwargs, "last", _method=_method, *args, **kwargs
-        )
+    def resample_last(self, resample_kwargs, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "last", *args, **kwargs)
 
-    def resample_max(self, resample_kwargs, _method, *args, **kwargs):
-        return self._resample_func(
-            resample_kwargs, "max", _method=_method, *args, **kwargs
-        )
+    def resample_max(self, resample_kwargs, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "max", *args, **kwargs)
 
-    def resample_mean(self, resample_kwargs, _method, *args, **kwargs):
-        return self._resample_func(
-            resample_kwargs, "median", _method=_method, *args, **kwargs
-        )
+    def resample_mean(self, resample_kwargs, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "median", *args, **kwargs)
 
-    def resample_median(self, resample_kwargs, _method, *args, **kwargs):
-        return self._resample_func(
-            resample_kwargs, "median", _method=_method, *args, **kwargs
-        )
+    def resample_median(self, resample_kwargs, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "median", *args, **kwargs)
 
-    def resample_min(self, resample_kwargs, _method, *args, **kwargs):
-        return self._resample_func(
-            resample_kwargs, "min", _method=_method, *args, **kwargs
-        )
+    def resample_min(self, resample_kwargs, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "min", *args, **kwargs)
 
-    def resample_ohlc_ser(self, resample_kwargs, _method, *args, **kwargs):
+    def resample_ohlc_ser(self, resample_kwargs, *args, **kwargs):
         return self._resample_func(
             resample_kwargs,
             "ohlc",
             df_op=lambda df: df.squeeze(axis=1),
-            _method=_method,
             *args,
             **kwargs,
         )
 
-    def resample_ohlc_df(self, resample_kwargs, _method, *args, **kwargs):
-        return self._resample_func(
-            resample_kwargs, "ohlc", _method=_method, *args, **kwargs
-        )
+    def resample_ohlc_df(self, resample_kwargs, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "ohlc", *args, **kwargs)
 
-    def resample_prod(self, resample_kwargs, _method, min_count, *args, **kwargs):
+    def resample_prod(self, resample_kwargs, min_count, *args, **kwargs):
         return self._resample_func(
             resample_kwargs,
             "prod",
-            _method=_method,
             min_count=min_count,
             *args,
             **kwargs,
@@ -1030,19 +1012,16 @@ class PandasQueryCompiler(BaseQueryCompiler):
             resample_kwargs, "size", new_columns=[MODIN_UNNAMED_SERIES_LABEL]
         )
 
-    def resample_sem(self, resample_kwargs, _method, *args, **kwargs):
-        return self._resample_func(
-            resample_kwargs, "sem", _method=_method, *args, **kwargs
-        )
+    def resample_sem(self, resample_kwargs, *args, **kwargs):
+        return self._resample_func(resample_kwargs, "sem", *args, **kwargs)
 
     def resample_std(self, resample_kwargs, ddof, *args, **kwargs):
         return self._resample_func(resample_kwargs, "std", ddof=ddof, *args, **kwargs)
 
-    def resample_sum(self, resample_kwargs, _method, min_count, *args, **kwargs):
+    def resample_sum(self, resample_kwargs, min_count, *args, **kwargs):
         return self._resample_func(
             resample_kwargs,
             "sum",
-            _method=_method,
             min_count=min_count,
             *args,
             **kwargs,

--- a/modin/pandas/resample.py
+++ b/modin/pandas/resample.py
@@ -294,81 +294,74 @@ class Resampler(ClassLogger):
             query_compiler=self._query_compiler.resample_count(self.resample_kwargs)
         )
 
-    def nunique(self, _method="nunique", *args, **kwargs):
+    def nunique(self, *args, **kwargs):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.resample_nunique(
-                self.resample_kwargs, _method, *args, **kwargs
+                self.resample_kwargs, *args, **kwargs
             )
         )
 
-    def first(self, _method="first", *args, **kwargs):
+    def first(self, *args, **kwargs):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.resample_first(
                 self.resample_kwargs,
-                _method,
                 *args,
                 **kwargs,
             )
         )
 
-    def last(self, _method="last", *args, **kwargs):
+    def last(self, *args, **kwargs):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.resample_last(
                 self.resample_kwargs,
-                _method,
                 *args,
                 **kwargs,
             )
         )
 
-    def max(self, _method="max", *args, **kwargs):
+    def max(self, *args, **kwargs):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.resample_max(
                 self.resample_kwargs,
-                _method,
                 *args,
                 **kwargs,
             )
         )
 
-    def mean(self, _method="mean", *args, **kwargs):
+    def mean(self, *args, **kwargs):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.resample_mean(
                 self.resample_kwargs,
-                _method,
                 *args,
                 **kwargs,
             )
         )
 
-    def median(self, _method="median", *args, **kwargs):
+    def median(self, *args, **kwargs):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.resample_median(
                 self.resample_kwargs,
-                _method,
                 *args,
                 **kwargs,
             )
         )
 
-    def min(self, _method="min", *args, **kwargs):
+    def min(self, *args, **kwargs):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.resample_min(
                 self.resample_kwargs,
-                _method,
                 *args,
                 **kwargs,
             )
         )
 
-    def ohlc(self, _method="ohlc", *args, **kwargs):
+    def ohlc(self, *args, **kwargs):
         from .dataframe import DataFrame
 
         if isinstance(self._dataframe, DataFrame):
             return DataFrame(
                 query_compiler=self._query_compiler.resample_ohlc_df(
                     self.resample_kwargs,
-                    _method,
                     *args,
                     **kwargs,
                 )
@@ -377,13 +370,12 @@ class Resampler(ClassLogger):
             return DataFrame(
                 query_compiler=self._query_compiler.resample_ohlc_ser(
                     self.resample_kwargs,
-                    _method,
                     *args,
                     **kwargs,
                 )
             )
 
-    def prod(self, _method="prod", min_count=0, *args, **kwargs):
+    def prod(self, min_count=0, *args, **kwargs):
         if self.resample_kwargs["axis"] == 0:
             result = self.__groups.prod(min_count=min_count, *args, **kwargs)
         else:
@@ -397,11 +389,10 @@ class Resampler(ClassLogger):
             query_compiler=self._query_compiler.resample_size(self.resample_kwargs)
         )
 
-    def sem(self, _method="sem", *args, **kwargs):
+    def sem(self, *args, **kwargs):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.resample_sem(
                 self.resample_kwargs,
-                _method,
                 *args,
                 **kwargs,
             )
@@ -414,7 +405,7 @@ class Resampler(ClassLogger):
             )
         )
 
-    def sum(self, _method="sum", min_count=0, *args, **kwargs):
+    def sum(self, min_count=0, *args, **kwargs):
         if self.resample_kwargs["axis"] == 0:
             result = self.__groups.sum(min_count=min_count, *args, **kwargs)
         else:


### PR DESCRIPTION
Signed-off-by: Vasily Litvinov <fam1ly.n4me@yandex.ru>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5038
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
