### PR TITLE
FEAT-#5053: Add pandas on unidist execution with MPI backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,8 +517,8 @@ jobs:
           path: asv_bench/benchmarks.log
         if: failure()
 
-  # This should be migrated to push-to-master.yml before merging!!!
   test-all-unidist:
+    needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -547,7 +547,7 @@ jobs:
             ~/conda_pkgs_dir
             ~/.cache/pip
           key:
-            ${{ runner.os }}-conda-${{ hashFiles('requirements/env_hdk.yml') }}
+            ${{ runner.os }}-conda-${{ hashFiles('requirements/env_unidist.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
           miniforge-variant: Mambaforge

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,6 +517,74 @@ jobs:
           path: asv_bench/benchmarks.log
         if: failure()
 
+  # This should be migrated to push-to-master.yml before merging!!!
+  test-all-unidist:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        python-version: ["3.8"]
+        unidist-backend: ["mpi"]
+    env:
+      MODIN_ENGINE: "Unidist"
+      UNIDIST_BACKEND: ${{matrix.unidist-backend}}
+      # Only test reading from SQL server and postgres on ubuntu for now.
+      # Eventually, we should test on Windows, too, but we will have to set up
+      # the servers differently.
+      MODIN_TEST_READ_FROM_SQL_SERVER: true
+      MODIN_TEST_READ_FROM_POSTGRES: true
+    name: test-ubuntu (engine unidist ${{matrix.unidist-backend}}, python ${{matrix.python-version}})
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 2
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          activate-environment: modin
+          environment-file: requirements/env_unidist.yml
+          python-version: ${{matrix.python-version}}
+          channel-priority: strict
+          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+      - name: Conda environment
+        run: |
+          conda info
+          conda list
+      - name: Install HDF5
+        run: sudo apt update && sudo apt install -y libhdf5-dev
+      - name: Set up postgres
+        # Locally, specifying port 2345:5432 works, but 2345:2345 and 5432:5432 do not. This solution is from
+        # https://stackoverflow.com/questions/36415654/cant-connect-docker-postgresql-9-3
+        run: |
+          sudo docker pull postgres
+          sudo docker run --name some-postgres -e POSTGRES_USER=sa -e POSTGRES_PASSWORD=Strong.Pwd-123 -e POSTGRES_DB=postgres -d -p 2345:5432 postgres
+      - run: MODIN_BENCHMARK_MODE=True mpiexec -n 1 python -m pytest modin/pandas/test/internals/test_benchmark_mode.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/dataframe/test_binary.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/dataframe/test_default.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/dataframe/test_indexing.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/dataframe/test_iter.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/dataframe/test_join_sort.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/dataframe/test_map_metadata.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/dataframe/test_reduce.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/dataframe/test_udf.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/dataframe/test_window.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/dataframe/test_pickle.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/test_series.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/test_rolling.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/test_concat.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/test_groupby.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/test_reshape.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/test_general.py
+      - run: chmod +x ./.github/workflows/sql_server/set_up_sql_server.sh
+      - run: ./.github/workflows/sql_server/set_up_sql_server.sh
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/test_io.py --verbose
+      - run: mpiexec -n 1 python -m pytest modin/experimental/pandas/test/test_io_exp.py
+      - run: pip install "dfsql>=0.4.2" "pyparsing<=2.4.7" && mpiexec -n 1 python -m pytest modin/experimental/sql/test/test_sql.py
+      - run: mpiexec -n 1 python -m pytest modin/test/interchange/dataframe_protocol/test_general.py
+      - run: mpiexec -n 1 python -m pytest modin/test/interchange/dataframe_protocol/pandas/test_protocol.py
+      - uses: codecov/codecov-action@v2
+
   test-all:
     needs: [lint-flake8, lint-black, lint-mypy, test-api, test-headers]
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -557,7 +557,9 @@ jobs:
           environment-file: requirements/env_unidist.yml
           python-version: ${{matrix.python-version}}
           channel-priority: strict
-          use-only-tar-bz2: true # IMPORTANT: This needs to be set for caching to work properly!
+          # we set use-only-tar-bz2 to false in order for conda to properly find new packages to be installed
+          # for more info see https://github.com/conda-incubator/setup-miniconda/issues/264
+          use-only-tar-bz2: false
       - name: Conda environment
         run: |
           conda info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,9 +540,20 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
+      - name: Cache conda
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/conda_pkgs_dir
+            ~/.cache/pip
+          key:
+            ${{ runner.os }}-conda-${{ hashFiles('requirements/env_hdk.yml') }}
       - uses: conda-incubator/setup-miniconda@v2
         with:
-          activate-environment: modin
+          miniforge-variant: Mambaforge
+          miniforge-version: latest
+          use-mamba: true
+          activate-environment: modin_on_unidist
           environment-file: requirements/env_unidist.yml
           python-version: ${{matrix.python-version}}
           channel-priority: strict

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -77,7 +77,7 @@ class Engine(EnvironmentVariable, type=str):
     """Distribution engine to run queries by."""
 
     varname = "MODIN_ENGINE"
-    choices = ("Ray", "Dask", "Python", "Native")
+    choices = ("Ray", "Dask", "Python", "Native", "Unidist")
 
     NOINIT_ENGINES = {
         "Python",
@@ -95,6 +95,7 @@ class Engine(EnvironmentVariable, type=str):
         from modin.utils import (
             MIN_RAY_VERSION,
             MIN_DASK_VERSION,
+            MIN_UNIDIST_VERSION,
         )
 
         if IsDebug.get():
@@ -137,6 +138,19 @@ class Engine(EnvironmentVariable, type=str):
             pass
         else:
             return "Native"
+        try:
+            import unidist
+
+        except ImportError:
+            pass
+        else:
+            if version.parse(unidist.__version__) < MIN_UNIDIST_VERSION:
+                raise ImportError(
+                    "Please `pip install unidist[mpi]` to install compatible unidist on MPI "
+                    + "version "
+                    + f"(>={MIN_UNIDIST_VERSION})."
+                )
+            return "Unidist"
         raise ImportError(
             "Please refer to installation documentation page to install an engine"
         )

--- a/modin/core/execution/dispatching/factories/factories.py
+++ b/modin/core/execution/dispatching/factories/factories.py
@@ -474,29 +474,30 @@ class ExperimentalBaseFactory(BaseFactory):
     @classmethod
     @_inherit_docstrings(BaseFactory._read_sql)
     def _read_sql(cls, **kwargs):
-        if Engine.get() not in ("Ray", "Unidist"):
+        supported_engines = ("Ray", "Unidist")
+        if Engine.get() not in supported_engines:
             if "partition_column" in kwargs:
                 if kwargs["partition_column"] is not None:
                     warnings.warn(
-                        "Distributed read_sql() was only implemented for Ray and Unidist engines."
+                        f"Distributed read_sql() was only implemented for {', '.join(supported_engines)} engines."
                     )
                 del kwargs["partition_column"]
             if "lower_bound" in kwargs:
                 if kwargs["lower_bound"] is not None:
                     warnings.warn(
-                        "Distributed read_sql() was only implemented for Ray and Unidist engines."
+                        f"Distributed read_sql() was only implemented for {', '.join(supported_engines)} engines."
                     )
                 del kwargs["lower_bound"]
             if "upper_bound" in kwargs:
                 if kwargs["upper_bound"] is not None:
                     warnings.warn(
-                        "Distributed read_sql() was only implemented for Ray and Unidist engines."
+                        f"Distributed read_sql() was only implemented for {', '.join(supported_engines)} engines."
                     )
                 del kwargs["upper_bound"]
             if "max_sessions" in kwargs:
                 if kwargs["max_sessions"] is not None:
                     warnings.warn(
-                        "Distributed read_sql() was only implemented for Ray and Unidist engines."
+                        f"Distributed read_sql() was only implemented for {', '.join(supported_engines)} engines."
                     )
                 del kwargs["max_sessions"]
         return cls.io_cls.read_sql(**kwargs)

--- a/modin/core/execution/unidist/__init__.py
+++ b/modin/core/execution/unidist/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Modin's functionality related to unidist execution engine."""

--- a/modin/core/execution/unidist/common/__init__.py
+++ b/modin/core/execution/unidist/common/__init__.py
@@ -1,0 +1,23 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Common utilities for unidist execution engine."""
+
+from .engine_wrapper import UnidistWrapper, SignalActor
+from .utils import initialize_unidist
+
+__all__ = [
+    "initialize_unidist",
+    "UnidistWrapper",
+    "SignalActor",
+]

--- a/modin/core/execution/unidist/common/engine_wrapper.py
+++ b/modin/core/execution/unidist/common/engine_wrapper.py
@@ -37,7 +37,7 @@ def _deploy_unidist_func(func, *args, **kwargs):  # pragma: no cover
 
     Returns
     -------
-    unidist.ObjectRef or list
+    unidist.ObjectRef or list[unidist.ObjectRef]
         Unidist identifier of the result being put to object store.
     """
     return func(*args, **kwargs)
@@ -96,12 +96,14 @@ class SignalActor:  # pragma: no cover
     """
     Help synchronize across tasks and actors on cluster.
 
-    For details see: https://docs.ray.io/en/latest/advanced.html?highlight=signalactor#multi-node-synchronization-using-an-actor
-
     Parameters
     ----------
     event_count : int
         Number of events required for synchronization.
+
+    Notes
+    -----
+    For details see: https://docs.ray.io/en/latest/advanced.html?highlight=signalactor#multi-node-synchronization-using-an-actor.
     """
 
     def __init__(self, event_count: int):

--- a/modin/core/execution/unidist/common/engine_wrapper.py
+++ b/modin/core/execution/unidist/common/engine_wrapper.py
@@ -1,0 +1,142 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""
+The module with helper mixin for executing functions remotely.
+
+To be used as a piece of building a unidist-based engine.
+"""
+
+import asyncio
+import unidist
+
+
+@unidist.remote
+def _deploy_unidist_func(func, *args, **kwargs):  # pragma: no cover
+    """
+    Wrap `func` to ease calling it remotely.
+
+    Parameters
+    ----------
+    func : callable
+        A local function that we want to call remotely.
+    *args : iterable
+        Positional arguments to pass to `func` when calling remotely.
+    **kwargs : dict
+        Keyword arguments to pass to `func` when calling remotely.
+
+    Returns
+    -------
+    unidist.ObjectRef or list
+        Unidist identifier of the result being put to object store.
+    """
+    return func(*args, **kwargs)
+
+
+class UnidistWrapper:
+    """Mixin that provides means of running functions remotely and getting local results."""
+
+    @classmethod
+    def deploy(cls, func, f_args=None, f_kwargs=None, num_returns=1):
+        """
+        Run local `func` remotely.
+
+        Parameters
+        ----------
+        func : callable
+            The function to perform.
+        f_args : list or tuple, optional
+            Positional arguments to pass to ``func``.
+        f_kwargs : dict, optional
+            Keyword arguments to pass to ``func``.
+        num_returns : int, default: 1
+            Amount of return values expected from `func`.
+
+        Returns
+        -------
+        unidist.ObjectRef or list
+            Unidist identifier of the result being put to object store.
+        """
+        args = [] if f_args is None else f_args
+        kwargs = {} if f_kwargs is None else f_kwargs
+        return _deploy_unidist_func.options(num_returns=num_returns).remote(
+            func, *args, **kwargs
+        )
+
+    @classmethod
+    def materialize(cls, obj_id):
+        """
+        Get the value of object from the object store.
+
+        Parameters
+        ----------
+        obj_id : unidist.ObjectRef
+            Unidist object identifier to get the value by.
+
+        Returns
+        -------
+        object
+            Whatever was identified by `obj_id`.
+        """
+        return unidist.get(obj_id)
+
+
+@unidist.remote
+class SignalActor:  # pragma: no cover
+    """
+    Help synchronize across tasks and actors on cluster.
+
+    For details see: https://docs.ray.io/en/latest/advanced.html?highlight=signalactor#multi-node-synchronization-using-an-actor
+
+    Parameters
+    ----------
+    event_count : int
+        Number of events required for synchronization.
+    """
+
+    def __init__(self, event_count: int):
+        self.events = [asyncio.Event() for _ in range(event_count)]
+
+    def send(self, event_idx: int):
+        """
+        Indicate that event with `event_idx` has occured.
+
+        Parameters
+        ----------
+        event_idx : int
+        """
+        self.events[event_idx].set()
+
+    async def wait(self, event_idx: int):
+        """
+        Wait until event with `event_idx` has occured.
+
+        Parameters
+        ----------
+        event_idx : int
+        """
+        await self.events[event_idx].wait()
+
+    def is_set(self, event_idx: int) -> bool:
+        """
+        Check that event with `event_idx` had occured or not.
+
+        Parameters
+        ----------
+        event_idx : int
+
+        Returns
+        -------
+        bool
+        """
+        return self.events[event_idx].is_set()

--- a/modin/core/execution/unidist/common/engine_wrapper.py
+++ b/modin/core/execution/unidist/common/engine_wrapper.py
@@ -126,17 +126,3 @@ class SignalActor:  # pragma: no cover
         event_idx : int
         """
         await self.events[event_idx].wait()
-
-    def is_set(self, event_idx: int) -> bool:
-        """
-        Check that event with `event_idx` had occured or not.
-
-        Parameters
-        ----------
-        event_idx : int
-
-        Returns
-        -------
-        bool
-        """
-        return self.events[event_idx].is_set()

--- a/modin/core/execution/unidist/common/utils.py
+++ b/modin/core/execution/unidist/common/utils.py
@@ -1,0 +1,91 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""The module holds utility and initialization routines for Modin on unidist."""
+
+import unidist
+import unidist.config as unidist_cfg
+
+from modin.config import (
+    NPartitions,
+)
+from modin.error_message import ErrorMessage
+from .engine_wrapper import UnidistWrapper
+
+
+def initialize_unidist():
+    """
+    Initialize unidist based on ``unidist.config`` variables and internal defaults.
+    """
+
+    if unidist_cfg.Backend.get() != "mpi":
+        raise RuntimeError(
+            f"Modin only supports unidist on MPI for now, got unidist backend '{unidist_cfg.Backend.get()}'"
+        )
+
+    if not unidist.is_initialized():
+        # This string is intentionally formatted this way. We want it indented in
+        # the warning message.
+        ErrorMessage.not_initialized(
+            "unidist",
+            """
+            import unidist
+            unidist.init()
+            """,
+        )
+
+        unidist.init()
+
+    num_cpus = [v["CPU"] for v in unidist.cluster_resources().values()]
+    num_cpus = sum(num_cpus)
+    NPartitions._put(num_cpus)
+
+
+def deserialize(obj):
+    """
+    Deserialize a unidist object.
+
+    Parameters
+    ----------
+    obj : unidist.ObjectRef, iterable of unidist.ObjectRef, or mapping of keys to unidist.ObjectRef
+        Object(s) to deserialize.
+
+    Returns
+    -------
+    obj
+        The deserialized object.
+    """
+    if unidist.is_object_ref(obj):
+        return UnidistWrapper.materialize(obj)
+    elif isinstance(obj, (tuple, list)):
+        # Unidist will error if any elements are not ObjectRef, but we still want unidist to
+        # perform batch deserialization for us -- thus, we must submit only the list elements
+        # that are ObjectRef, deserialize them, and restore them to their correct list index
+        ref_indices, refs = [], []
+        for i, unidist_ref in enumerate(obj):
+            if unidist.is_object_ref(unidist_ref):
+                ref_indices.append(i)
+                refs.append(unidist_ref)
+        unidist_result = UnidistWrapper.materialize(refs)
+        new_lst = list(obj[:])
+        for i, deser_item in zip(ref_indices, unidist_result):
+            new_lst[i] = deser_item
+        # Check that all objects have been deserialized
+        assert not any([unidist.is_object_ref(o) for o in new_lst])
+        return new_lst
+    elif isinstance(obj, dict) and any(
+        unidist.is_object_ref(val) for val in obj.values()
+    ):
+        return dict(zip(obj.keys(), UnidistWrapper.materialize(list(obj.values()))))
+    else:
+        return obj

--- a/modin/core/execution/unidist/common/utils.py
+++ b/modin/core/execution/unidist/common/utils.py
@@ -89,3 +89,26 @@ def deserialize(obj):
         return dict(zip(obj.keys(), UnidistWrapper.materialize(list(obj.values()))))
     else:
         return obj
+
+
+def wait(obj_refs):
+    """
+    Wrap ``unidist.wait`` to handle duplicate object references.
+
+    ``ray.wait`` assumes a list of unique object references: see
+    https://github.com/modin-project/modin/issues/5045
+
+    Parameters
+    ----------
+    obj_refs : List[unidist.ObjectRef]
+        The object IDs to wait on.
+
+    Returns
+    -------
+    Tuple[List[ObjectRef], List[ObjectRef]]
+        A list of object refs that are ready, and a list of object refs remaining (this
+        is the same as for ``ray.wait``). Unlike ``ray.wait``, the order of these refs is not
+        guaranteed.
+    """
+    unique_refs = list(set(obj_refs))
+    return unidist.wait(unique_refs, num_returns=len(unique_refs))

--- a/modin/core/execution/unidist/common/utils.py
+++ b/modin/core/execution/unidist/common/utils.py
@@ -84,7 +84,7 @@ def deserialize(obj):
     elif isinstance(obj, dict) and any(
         unidist.is_object_ref(val) for val in obj.values()
     ):
-        return dict(zip(obj.keys(), UnidistWrapper.materialize(list(obj.values()))))
+        return dict(zip(obj.keys(), deserialize(tuple(obj.values()))))
     else:
         return obj
 

--- a/modin/core/execution/unidist/common/utils.py
+++ b/modin/core/execution/unidist/common/utils.py
@@ -32,7 +32,9 @@ def initialize_unidist():
         )
 
     if not unidist.is_initialized():
-        unidist_cfg.CpuCount.put(modin_cfg.CpuCount.get())
+        modin_cfg.CpuCount.subscribe(
+            lambda cpu_count: unidist_cfg.CpuCount.put(cpu_count.get())
+        )
         # This string is intentionally formatted this way. We want it indented in
         # the warning message.
         ErrorMessage.not_initialized(

--- a/modin/core/execution/unidist/generic/__init__.py
+++ b/modin/core/execution/unidist/generic/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Generic functionality for unidist execution engine."""

--- a/modin/core/execution/unidist/generic/io/__init__.py
+++ b/modin/core/execution/unidist/generic/io/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Generic IO functionality for unidist execution engine."""
+
+from .io import UnidistIO
+
+__all__ = ["UnidistIO"]

--- a/modin/core/execution/unidist/generic/io/io.py
+++ b/modin/core/execution/unidist/generic/io/io.py
@@ -1,0 +1,20 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""The module holds base class implementing required I/O over unidist."""
+
+from modin.core.io import BaseIO
+
+
+class UnidistIO(BaseIO):
+    """Base class for doing I/O operations over unidist."""

--- a/modin/core/execution/unidist/generic/modin_aqp.py
+++ b/modin/core/execution/unidist/generic/modin_aqp.py
@@ -1,0 +1,119 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""The module for working with displaying progress bars for unidist engine."""
+
+import unidist
+import os
+import time
+import threading
+import warnings
+
+progress_bars = {}
+bar_lock = threading.Lock()
+
+
+def call_progress_bar(result_parts, line_no):
+    """
+    Attach a progress bar to given `result_parts`.
+
+    The progress bar is expected to be shown in a Jupyter Notebook cell.
+
+    Parameters
+    ----------
+    result_parts : list of list of unidist.ObjectRef
+        Objects which are being computed for which progress is requested.
+    line_no : int
+        Line number in the call stack which we're displaying progress for.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        try:
+            from tqdm.autonotebook import tqdm as tqdm_notebook
+        except ImportError:
+            raise ImportError("Please pip install tqdm to use the progress bar")
+        from IPython import get_ipython
+
+    try:
+        cell_no = get_ipython().execution_count
+    # This happens if we are not in ipython or jupyter.
+    # No progress bar is supported in that case.
+    except AttributeError:
+        return
+    pbar_id = str(cell_no) + "-" + str(line_no)
+    futures = [
+        block
+        for row in result_parts
+        for partition in row
+        for block in partition.list_of_blocks
+    ]
+    bar_format = (
+        "{l_bar}{bar}{r_bar}"
+        if "DEBUG_PROGRESS_BAR" in os.environ
+        and os.environ["DEBUG_PROGRESS_BAR"] == "True"
+        else "{desc}: {percentage:3.0f}%{bar} Elapsed time: {elapsed}, estimated remaining time: {remaining}"
+    )
+    bar_lock.acquire()
+    if pbar_id in progress_bars:
+        if hasattr(progress_bars[pbar_id], "container"):
+            if hasattr(progress_bars[pbar_id].container.children[0], "max"):
+                index = 0
+            else:
+                index = 1
+            progress_bars[pbar_id].container.children[index].max = progress_bars[
+                pbar_id
+            ].container.children[index].max + len(futures)
+        progress_bars[pbar_id].total = progress_bars[pbar_id].total + len(futures)
+        progress_bars[pbar_id].refresh()
+    else:
+        progress_bars[pbar_id] = tqdm_notebook(
+            total=len(futures),
+            desc="Estimated completion of line " + str(line_no),
+            bar_format=bar_format,
+        )
+    bar_lock.release()
+
+    threading.Thread(target=_show_time_updates, args=(progress_bars[pbar_id],)).start()
+    for i in range(1, len(futures) + 1):
+        unidist.wait(futures, num_returns=i)
+        progress_bars[pbar_id].update(1)
+        progress_bars[pbar_id].refresh()
+    if progress_bars[pbar_id].n == progress_bars[pbar_id].total:
+        progress_bars[pbar_id].close()
+
+
+def display_time_updates(bar):
+    """
+    Start displaying the progress `bar` in a notebook.
+
+    Parameters
+    ----------
+    bar : tqdm.tqdm
+        The progress bar wrapper to display in a notebook cell.
+    """
+    threading.Thread(target=_show_time_updates, args=(bar,)).start()
+
+
+def _show_time_updates(p_bar):
+    """
+    Refresh displayed progress bar `p_bar` periodically until it is complete.
+
+    Parameters
+    ----------
+    p_bar : tqdm.tqdm
+        The progress bar wrapper being displayed to refresh.
+    """
+    while p_bar.total > p_bar.n:
+        time.sleep(1)
+        if p_bar.total > p_bar.n:
+            p_bar.refresh()

--- a/modin/core/execution/unidist/generic/partitioning/__init__.py
+++ b/modin/core/execution/unidist/generic/partitioning/__init__.py
@@ -1,0 +1,20 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Generic partitioning functionality for unidist execution engine."""
+
+from .partition_manager import GenericUnidistDataframePartitionManager
+
+__all__ = [
+    "GenericUnidistDataframePartitionManager",
+]

--- a/modin/core/execution/unidist/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/generic/partitioning/partition_manager.py
@@ -47,8 +47,6 @@ class GenericUnidistDataframePartitionManager(PandasDataframePartitionManager):
                 for obj in row
             ]
         )
-        n = partitions.shape[1]
-        parts = [parts[i * n : (i + 1) * n] for i in list(range(partitions.shape[0]))]
-
-        arr = np.block(parts)
-        return arr
+        rows, cols = partitions.shape
+        parts = [parts[i * cols : (i + 1) * cols] for i in range(rows)]
+        return np.block(parts)

--- a/modin/core/execution/unidist/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/generic/partitioning/partition_manager.py
@@ -1,0 +1,54 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""The module holds Modin partition manager implemented for unidist."""
+
+import numpy as np
+
+from modin.core.dataframe.pandas.partitioning.partition_manager import (
+    PandasDataframePartitionManager,
+)
+from modin.core.execution.unidist.common import UnidistWrapper
+
+
+class GenericUnidistDataframePartitionManager(PandasDataframePartitionManager):
+    """The class implements the interface in `PandasDataframePartitionManager`."""
+
+    @classmethod
+    def to_numpy(cls, partitions, **kwargs):
+        """
+        Convert `partitions` into a NumPy array.
+
+        Parameters
+        ----------
+        partitions : NumPy array
+            A 2-D array of partitions to convert to local NumPy array.
+        **kwargs : dict
+            Keyword arguments to pass to each partition ``.to_numpy()`` call.
+
+        Returns
+        -------
+        NumPy array
+        """
+        parts = UnidistWrapper.materialize(
+            [
+                obj.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).list_of_blocks[0]
+                for row in partitions
+                for obj in row
+            ]
+        )
+        n = partitions.shape[1]
+        parts = [parts[i * n : (i + 1) * n] for i in list(range(partitions.shape[0]))]
+
+        arr = np.block(parts)
+        return arr

--- a/modin/core/execution/unidist/implementations/__init__.py
+++ b/modin/core/execution/unidist/implementations/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Experimental Modin's functionality related to unidist execution engine and optimized for specific storage formats."""

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/__init__.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Modin's functionality related to unidist execution engine and optimized for pandas storage format."""

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/dataframe/__init__.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/dataframe/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Base Modin Dataframe class optimized for pandas on unidist execution."""
+
+from .dataframe import PandasOnUnidistDataframe
+
+__all__ = ["PandasOnUnidistDataframe"]

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/dataframe/dataframe.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/dataframe/dataframe.py
@@ -1,0 +1,42 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Module houses class that implements ``PandasDataframe`` using unidist."""
+
+from ..partitioning.partition_manager import PandasOnUnidistDataframePartitionManager
+from modin.core.dataframe.pandas.dataframe.dataframe import PandasDataframe
+
+
+class PandasOnUnidistDataframe(PandasDataframe):
+    """
+    The class implements the interface in ``PandasDataframe`` using unidist.
+
+    Parameters
+    ----------
+    partitions : np.ndarray
+        A 2D NumPy array of partitions.
+    index : sequence
+        The index for the dataframe. Converted to a ``pandas.Index``.
+    columns : sequence
+        The columns object for the dataframe. Converted to a ``pandas.Index``.
+    row_lengths : list, optional
+        The length of each partition in the rows. The "height" of
+        each of the block partitions. Is computed if not provided.
+    column_widths : list, optional
+        The width of each partition in the columns. The "width" of
+        each of the block partitions. Is computed if not provided.
+    dtypes : pandas.Series, optional
+        The data types for the dataframe columns.
+    """
+
+    _partition_mgr_cls = PandasOnUnidistDataframePartitionManager

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/io/__init__.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/io/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Base IO classes optimized for pandas on unidist execution."""
+
+from .io import PandasOnUnidistIO
+
+__all__ = ["PandasOnUnidistIO"]

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -29,7 +29,7 @@ from modin.core.io import (
     SQLDispatcher,
     ExcelDispatcher,
 )
-from modin._compat.core.pd_common import get_handle as pd_get_handle
+from modin._compat.core.pandas_common import get_handle as pd_get_handle
 from modin.core.storage_formats.pandas.parsers import (
     PandasCSVParser,
     PandasFWFParser,

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -1,0 +1,323 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""The module holds the factory which performs I/O using pandas on unidist."""
+
+import io
+import os
+
+import pandas
+
+from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
+from modin.core.execution.unidist.generic.io import UnidistIO
+from modin.core.io import (
+    CSVDispatcher,
+    FWFDispatcher,
+    JSONDispatcher,
+    ParquetDispatcher,
+    FeatherDispatcher,
+    SQLDispatcher,
+    ExcelDispatcher,
+)
+from modin._compat.core.pd_common import get_handle as pd_get_handle
+from modin.core.storage_formats.pandas.parsers import (
+    PandasCSVParser,
+    PandasFWFParser,
+    PandasJSONParser,
+    PandasParquetParser,
+    PandasFeatherParser,
+    PandasSQLParser,
+    PandasExcelParser,
+)
+from modin.core.execution.unidist.common import UnidistWrapper, SignalActor
+from ..dataframe import PandasOnUnidistDataframe
+from ..partitioning import PandasOnUnidistDataframePartition
+
+
+class PandasOnUnidistIO(UnidistIO):
+    """Factory providing methods for performing I/O operations using pandas as storage format on unidist as engine."""
+
+    frame_cls = PandasOnUnidistDataframe
+    query_compiler_cls = PandasQueryCompiler
+    build_args = dict(
+        frame_partition_cls=PandasOnUnidistDataframePartition,
+        query_compiler_cls=PandasQueryCompiler,
+        frame_cls=PandasOnUnidistDataframe,
+    )
+    read_csv = type(
+        "", (UnidistWrapper, PandasCSVParser, CSVDispatcher), build_args
+    ).read
+    read_fwf = type(
+        "", (UnidistWrapper, PandasFWFParser, FWFDispatcher), build_args
+    ).read
+    read_json = type(
+        "", (UnidistWrapper, PandasJSONParser, JSONDispatcher), build_args
+    ).read
+    read_parquet = type(
+        "", (UnidistWrapper, PandasParquetParser, ParquetDispatcher), build_args
+    ).read
+    # Blocked on pandas-dev/pandas#12236. It is faster to default to pandas.
+    # read_hdf = type("", (UnidistWrapper, PandasHDFParser, HDFReader), build_args).read
+    read_feather = type(
+        "", (UnidistWrapper, PandasFeatherParser, FeatherDispatcher), build_args
+    ).read
+    read_sql = type(
+        "", (UnidistWrapper, PandasSQLParser, SQLDispatcher), build_args
+    ).read
+    read_excel = type(
+        "", (UnidistWrapper, PandasExcelParser, ExcelDispatcher), build_args
+    ).read
+
+    @classmethod
+    def to_sql(cls, qc, **kwargs):
+        """
+        Write records stored in the `qc` to a SQL database.
+
+        Parameters
+        ----------
+        qc : BaseQueryCompiler
+            The query compiler of the Modin dataframe that we want to run ``to_sql`` on.
+        **kwargs : dict
+            Parameters for ``pandas.to_sql(**kwargs)``.
+        """
+        # we first insert an empty DF in order to create the full table in the database
+        # This also helps to validate the input against pandas
+        # we would like to_sql() to complete only when all rows have been inserted into the database
+        # since the mapping operation is non-blocking, each partition will return an empty DF
+        # so at the end, the blocking operation will be this empty DF to_pandas
+
+        empty_df = qc.getitem_row_array([0]).to_pandas().head(0)
+        empty_df.to_sql(**kwargs)
+        # so each partition will append its respective DF
+        kwargs["if_exists"] = "append"
+        columns = qc.columns
+
+        def func(df):
+            """
+            Override column names in the wrapped dataframe and convert it to SQL.
+
+            Notes
+            -----
+            This function returns an empty ``pandas.DataFrame`` because ``apply_full_axis``
+            expects a Frame object as a result of operation (and ``to_sql`` has no dataframe result).
+            """
+            df.columns = columns
+            df.to_sql(**kwargs)
+            return pandas.DataFrame()
+
+        # Ensure that the metadata is syncrhonized
+        qc._modin_frame._propagate_index_objs(axis=None)
+        result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
+        # FIXME: we should be waiting for completion less expensievely, maybe use _modin_frame.materialize()?
+        result.to_pandas()  # blocking operation
+
+    @staticmethod
+    def _to_csv_check_support(kwargs):
+        """
+        Check if parallel version of ``to_csv`` could be used.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Keyword arguments passed to ``.to_csv()``.
+
+        Returns
+        -------
+        bool
+            Whether parallel version of ``to_csv`` is applicable.
+        """
+        path_or_buf = kwargs["path_or_buf"]
+        compression = kwargs["compression"]
+        if not isinstance(path_or_buf, str):
+            return False
+        # case when the pointer is placed at the beginning of the file.
+        if "r" in kwargs["mode"] and "+" in kwargs["mode"]:
+            return False
+        # encodings with BOM don't support;
+        # instead of one mark in result bytes we will have them by the number of partitions
+        # so we should fallback in pandas for `utf-16`, `utf-32` with all aliases, in instance
+        # (`utf_32_be`, `utf_16_le` and so on)
+        if kwargs["encoding"] is not None:
+            encoding = kwargs["encoding"].lower()
+            if "u" in encoding or "utf" in encoding:
+                if "16" in encoding or "32" in encoding:
+                    return False
+        if compression is None or not compression == "infer":
+            return False
+        if any((path_or_buf.endswith(ext) for ext in [".gz", ".bz2", ".zip", ".xz"])):
+            return False
+        return True
+
+    @classmethod
+    def to_csv(cls, qc, **kwargs):
+        """
+        Write records stored in the `qc` to a CSV file.
+
+        Parameters
+        ----------
+        qc : BaseQueryCompiler
+            The query compiler of the Modin dataframe that we want to run ``to_csv`` on.
+        **kwargs : dict
+            Parameters for ``pandas.to_csv(**kwargs)``.
+        """
+        if not cls._to_csv_check_support(kwargs):
+            return UnidistIO.to_csv(qc, **kwargs)
+
+        signals = SignalActor.remote(len(qc._modin_frame._partitions) + 1)
+
+        def func(df, **kw):
+            """
+            Dump a chunk of rows as csv, then save them to target maintaining order.
+
+            Parameters
+            ----------
+            df : pandas.DataFrame
+                A chunk of rows to write to a CSV file.
+            **kw : dict
+                Arguments to pass to ``pandas.to_csv(**kw)`` plus an extra argument
+                `partition_idx` serving as chunk index to maintain rows order.
+            """
+            partition_idx = kw["partition_idx"]
+            # the copy is made to not implicitly change the input parameters;
+            # to write to an intermediate buffer, we need to change `path_or_buf` in kwargs
+            csv_kwargs = kwargs.copy()
+            if partition_idx != 0:
+                # we need to create a new file only for first recording
+                # all the rest should be recorded in appending mode
+                if "w" in csv_kwargs["mode"]:
+                    csv_kwargs["mode"] = csv_kwargs["mode"].replace("w", "a")
+                # It is enough to write the header for the first partition
+                csv_kwargs["header"] = False
+
+            # for parallelization purposes, each partition is written to an intermediate buffer
+            path_or_buf = csv_kwargs["path_or_buf"]
+            is_binary = "b" in csv_kwargs["mode"]
+            csv_kwargs["path_or_buf"] = io.BytesIO() if is_binary else io.StringIO()
+            df.to_csv(**csv_kwargs)
+            content = csv_kwargs["path_or_buf"].getvalue()
+            csv_kwargs["path_or_buf"].close()
+
+            # each process waits for its turn to write to a file
+            UnidistWrapper.materialize(signals.wait.remote(partition_idx))
+
+            # preparing to write data from the buffer to a file
+            with pd_get_handle(
+                path_or_buf,
+                # in case when using URL in implicit text mode
+                # pandas try to open `path_or_buf` in binary mode
+                csv_kwargs["mode"] if is_binary else csv_kwargs["mode"] + "t",
+                encoding=kwargs["encoding"],
+                errors=kwargs["errors"],
+                compression=kwargs["compression"],
+                storage_options=kwargs.get("storage_options", None),
+                is_text=not is_binary,
+            ) as handles:
+                handles.handle.write(content)
+
+            # signal that the next process can start writing to the file
+            UnidistWrapper.materialize(signals.send.remote(partition_idx + 1))
+            # used for synchronization purposes
+            return pandas.DataFrame()
+
+        # signaling that the partition with id==0 can be written to the file
+        UnidistWrapper.materialize(signals.send.remote(0))
+        # Ensure that the metadata is syncrhonized
+        qc._modin_frame._propagate_index_objs(axis=None)
+        result = qc._modin_frame._partition_mgr_cls.map_axis_partitions(
+            axis=1,
+            partitions=qc._modin_frame._partitions,
+            map_func=func,
+            keep_partitioning=True,
+            lengths=None,
+            enumerate_partitions=True,
+            max_retries=0,
+        )
+        # pending completion
+        UnidistWrapper.materialize(
+            [partition.list_of_blocks[0] for partition in result.flatten()]
+        )
+
+    @staticmethod
+    def _to_parquet_check_support(kwargs):
+        """
+        Check if parallel version of `to_parquet` could be used.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Keyword arguments passed to `.to_parquet()`.
+
+        Returns
+        -------
+        bool
+            Whether parallel version of `to_parquet` is applicable.
+        """
+        path = kwargs["path"]
+        compression = kwargs["compression"]
+        if not isinstance(path, str):
+            return False
+        if any((path.endswith(ext) for ext in [".gz", ".bz2", ".zip", ".xz"])):
+            return False
+        if compression is None or not compression == "snappy":
+            return False
+        return True
+
+    @classmethod
+    def to_parquet(cls, qc, **kwargs):
+        """
+        Write a ``DataFrame`` to the binary parquet format.
+
+        Parameters
+        ----------
+        qc : BaseQueryCompiler
+            The query compiler of the Modin dataframe that we want to run `to_parquet` on.
+        **kwargs : dict
+            Parameters for `pandas.to_parquet(**kwargs)`.
+        """
+        if not cls._to_parquet_check_support(kwargs):
+            return UnidistIO.to_parquet(qc, **kwargs)
+
+        output_path = kwargs["path"]
+        os.makedirs(output_path, exist_ok=True)
+
+        def func(df, **kw):
+            """
+            Dump a chunk of rows as parquet, then save them to target maintaining order.
+
+            Parameters
+            ----------
+            df : pandas.DataFrame
+                A chunk of rows to write to a parquet file.
+            **kw : dict
+                Arguments to pass to ``pandas.to_parquet(**kwargs)`` plus an extra argument
+                `partition_idx` serving as chunk index to maintain rows order.
+            """
+            compression = kwargs["compression"]
+            partition_idx = kw["partition_idx"]
+            kwargs[
+                "path"
+            ] = f"{output_path}/part-{partition_idx:04d}.{compression}.parquet"
+            df.to_parquet(**kwargs)
+            return pandas.DataFrame()
+
+        result = qc._modin_frame._partition_mgr_cls.map_axis_partitions(
+            axis=1,
+            partitions=qc._modin_frame._partitions,
+            map_func=func,
+            keep_partitioning=True,
+            lengths=None,
+            enumerate_partitions=True,
+        )
+        UnidistWrapper.materialize(
+            [part.list_of_blocks[0] for row in result for part in row]
+        )

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/__init__.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/__init__.py
@@ -1,0 +1,24 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Base Modin Dataframe classes related to its partitioning and optimized for pandas on unidist execution."""
+
+from .partition_manager import PandasOnUnidistDataframePartitionManager
+from .virtual_partition import PandasOnUnidistDataframeVirtualPartition
+from .partition import PandasOnUnidistDataframePartition
+
+__all__ = [
+    "PandasOnUnidistDataframePartitionManager",
+    "PandasOnUnidistDataframeVirtualPartition",
+    "PandasOnUnidistDataframePartition",
+]

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -193,23 +193,8 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
         self.drain_call_queue()
         wait([self._data])
 
-    def __copy__(self):
-        """
-        Create a copy of this partition.
-
-        Returns
-        -------
-        PandasOnUnidistDataframePartition
-            A copy of this partition.
-        """
-        return PandasOnUnidistDataframePartition(
-            self._data,
-            length=self._length_cache,
-            width=self._width_cache,
-            ip=self._ip_cache,
-            call_queue=self.call_queue,
-        )
-
+    # If unidist has not been initialized yet by Modin,
+    # unidist itself handles initialization when calling `unidist.put`.
     _iloc = unidist.put(PandasDataframePartition._iloc)
 
     def mask(self, row_labels, col_labels):

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -16,8 +16,8 @@
 import unidist
 import uuid
 
-from modin.core.execution.unidist.common.utils import deserialize
 from modin.core.execution.unidist.common import UnidistWrapper
+from modin.core.execution.unidist.common.utils import deserialize, wait
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from modin.pandas.indexing import compute_sliced_len
 from modin.logging import get_logger
@@ -196,7 +196,7 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
     def wait(self):
         """Wait completing computations on the object wrapped by the partition."""
         self.drain_call_queue()
-        unidist.wait([self._data])
+        wait([self._data])
 
     def __copy__(self):
         """

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -1,0 +1,460 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Module houses class that wraps data (block partition) and its metadata."""
+
+import unidist
+import uuid
+
+from modin.core.execution.unidist.common.utils import deserialize
+from modin.core.execution.unidist.common import UnidistWrapper
+from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
+from modin.pandas.indexing import compute_sliced_len
+from modin.logging import get_logger
+
+compute_sliced_len = unidist.remote(compute_sliced_len)
+
+
+class PandasOnUnidistDataframePartition(PandasDataframePartition):
+    """
+    The class implements the interface in ``PandasDataframePartition``.
+
+    Parameters
+    ----------
+    data : unidist.ObjectRef
+        A reference to ``pandas.DataFrame`` that need to be wrapped with this class.
+    length : unidist.ObjectRef or int, optional
+        Length or reference to it of wrapped ``pandas.DataFrame``.
+    width : unidist.ObjectRef or int, optional
+        Width or reference to it of wrapped ``pandas.DataFrame``.
+    ip : unidist.ObjectRef or str, optional
+        Node IP address or reference to it that holds wrapped ``pandas.DataFrame``.
+    call_queue : list
+        Call queue that needs to be executed on wrapped ``pandas.DataFrame``.
+    """
+
+    def __init__(self, data, length=None, width=None, ip=None, call_queue=None):
+        assert unidist.is_object_ref(data)
+        self._data = data
+        if call_queue is None:
+            call_queue = []
+        self.call_queue = call_queue
+        self._length_cache = length
+        self._width_cache = width
+        self._ip_cache = ip
+        self._identity = uuid.uuid4().hex
+
+        logger = get_logger()
+        logger.debug(
+            "Partition ID: {}, Height: {}, Width: {}, Node IP: {}".format(
+                self._identity,
+                str(self._length_cache),
+                str(self._width_cache),
+                str(self._ip_cache),
+            )
+        )
+
+    def get(self):
+        """
+        Get the object wrapped by this partition out of the object store.
+
+        Returns
+        -------
+        pandas.DataFrame
+            The object from the object store.
+        """
+        logger = get_logger()
+        logger.debug(f"ENTER::Partition.get::{self._identity}")
+        if len(self.call_queue):
+            self.drain_call_queue()
+        result = UnidistWrapper.materialize(self._data)
+        logger.debug(f"EXIT::Partition.get::{self._identity}")
+        return result
+
+    def apply(self, func, *args, **kwargs):
+        """
+        Apply a function to the object wrapped by this partition.
+
+        Parameters
+        ----------
+        func : callable or unidist.ObjectRef
+            A function to apply.
+        *args : iterable
+            Additional positional arguments to be passed in `func`.
+        **kwargs : dict
+            Additional keyword arguments to be passed in `func`.
+
+        Returns
+        -------
+        PandasOnUnidistDataframePartition
+            A new ``PandasOnUnidistDataframePartition`` object.
+
+        Notes
+        -----
+        It does not matter if `func` is callable or an ``unidist.ObjectRef``. Unidist will
+        handle it correctly either way. The keyword arguments are sent as a dictionary.
+        """
+        logger = get_logger()
+        logger.debug(f"ENTER::Partition.apply::{self._identity}")
+        data = self._data
+        call_queue = self.call_queue + [[func, args, kwargs]]
+        if len(call_queue) > 1:
+            logger.debug(f"SUBMIT::_apply_list_of_funcs::{self._identity}")
+            result, length, width, ip = _apply_list_of_funcs.remote(call_queue, data)
+        else:
+            # We handle `len(call_queue) == 1` in a different way because
+            # this dramatically improves performance.
+            func, f_args, f_kwargs = call_queue[0]
+            result, length, width, ip = _apply_func.remote(
+                data, func, *f_args, **f_kwargs
+            )
+            logger.debug(f"SUBMIT::_apply_func::{self._identity}")
+        logger.debug(f"EXIT::Partition.apply::{self._identity}")
+        return PandasOnUnidistDataframePartition(result, length, width, ip)
+
+    def add_to_apply_calls(self, func, *args, length=None, width=None, **kwargs):
+        """
+        Add a function to the call queue.
+
+        Parameters
+        ----------
+        func : callable or unidist.ObjectRef
+            Function to be added to the call queue.
+        *args : iterable
+            Additional positional arguments to be passed in `func`.
+        length : unidist.ObjectRef or int, optional
+            Length, or reference to length, of wrapped ``pandas.DataFrame``.
+        width : unidist.ObjectRef or int, optional
+            Width, or reference to width, of wrapped ``pandas.DataFrame``.
+        **kwargs : dict
+            Additional keyword arguments to be passed in `func`.
+
+        Returns
+        -------
+        PandasOnUnidistDataframePartition
+            A new ``PandasOnUnidistDataframePartition`` object.
+
+        Notes
+        -----
+        It does not matter if `func` is callable or an ``unidist.ObjectRef``. Unidist will
+        handle it correctly either way. The keyword arguments are sent as a dictionary.
+        """
+        return PandasOnUnidistDataframePartition(
+            self._data,
+            call_queue=self.call_queue + [[func, args, kwargs]],
+            length=length,
+            width=width,
+        )
+
+    def drain_call_queue(self):
+        """Execute all operations stored in the call queue on the object wrapped by this partition."""
+        logger = get_logger()
+        logger.debug(f"ENTER::Partition.drain_call_queue::{self._identity}")
+        if len(self.call_queue) == 0:
+            return
+        data = self._data
+        call_queue = self.call_queue
+        if len(call_queue) > 1:
+            logger.debug(f"SUBMIT::_apply_list_of_funcs::{self._identity}")
+            (
+                self._data,
+                new_length,
+                new_width,
+                self._ip_cache,
+            ) = _apply_list_of_funcs.remote(call_queue, data)
+        else:
+            # We handle `len(call_queue) == 1` in a different way because
+            # this dramatically improves performance.
+            func, f_args, f_kwargs = call_queue[0]
+            logger.debug(f"SUBMIT::_apply_func::{self._identity}")
+            (
+                self._data,
+                new_length,
+                new_width,
+                self._ip_cache,
+            ) = _apply_func.remote(data, func, *f_args, **f_kwargs)
+        logger.debug(f"EXIT::Partition.drain_call_queue::{self._identity}")
+        self.call_queue = []
+
+        # GH#4732 if we already have evaluated width/length cached as ints,
+        #  don't overwrite that cache with non-evaluated values.
+        if not isinstance(self._length_cache, int):
+            self._length_cache = new_length
+        if not isinstance(self._width_cache, int):
+            self._width_cache = new_width
+
+    def wait(self):
+        """Wait completing computations on the object wrapped by the partition."""
+        self.drain_call_queue()
+        unidist.wait([self._data])
+
+    def __copy__(self):
+        """
+        Create a copy of this partition.
+
+        Returns
+        -------
+        PandasOnUnidistDataframePartition
+            A copy of this partition.
+        """
+        return PandasOnUnidistDataframePartition(
+            self._data,
+            length=self._length_cache,
+            width=self._width_cache,
+            ip=self._ip_cache,
+            call_queue=self.call_queue,
+        )
+
+    _iloc = unidist.put(PandasDataframePartition._iloc)
+
+    def mask(self, row_labels, col_labels):
+        """
+        Lazily create a mask that extracts the indices provided.
+
+        Parameters
+        ----------
+        row_labels : list-like, slice or label
+            The row labels for the rows to extract.
+        col_labels : list-like, slice or label
+            The column labels for the columns to extract.
+
+        Returns
+        -------
+        PandasOnUnidistDataframePartition
+            A new ``PandasOnUnidistDataframePartition`` object.
+        """
+        logger = get_logger()
+        logger.debug(f"ENTER::Partition.mask::{self._identity}")
+        new_obj = super().mask(row_labels, col_labels)
+        if isinstance(row_labels, slice) and unidist.is_object_ref(self._length_cache):
+            if row_labels == slice(None):
+                # fast path - full axis take
+                new_obj._length_cache = self._length_cache
+            else:
+                new_obj._length_cache = compute_sliced_len.remote(
+                    row_labels, self._length_cache
+                )
+        if isinstance(col_labels, slice) and unidist.is_object_ref(self._width_cache):
+            if col_labels == slice(None):
+                # fast path - full axis take
+                new_obj._width_cache = self._width_cache
+            else:
+                new_obj._width_cache = compute_sliced_len.remote(
+                    col_labels, self._width_cache
+                )
+        logger.debug(f"EXIT::Partition.mask::{self._identity}")
+        return new_obj
+
+    @classmethod
+    def put(cls, obj):
+        """
+        Put an object into object store and wrap it with partition object.
+
+        Parameters
+        ----------
+        obj : any
+            An object to be put.
+
+        Returns
+        -------
+        PandasOnUnidistDataframePartition
+            A new ``PandasOnUnidistDataframePartition`` object.
+        """
+        return PandasOnUnidistDataframePartition(
+            unidist.put(obj), len(obj.index), len(obj.columns)
+        )
+
+    @classmethod
+    def preprocess_func(cls, func):
+        """
+        Put a function into the object store to use in ``apply``.
+
+        Parameters
+        ----------
+        func : callable
+            A function to preprocess.
+
+        Returns
+        -------
+        unidist.ObjectRef
+            A reference to `func`.
+        """
+        return unidist.put(func)
+
+    def length(self):
+        """
+        Get the length of the object wrapped by this partition.
+
+        Returns
+        -------
+        int
+            The length of the object.
+        """
+        if self._length_cache is None:
+            if len(self.call_queue):
+                self.drain_call_queue()
+            else:
+                self._length_cache, self._width_cache = _get_index_and_columns.remote(
+                    self._data
+                )
+        if unidist.is_object_ref(self._length_cache):
+            self._length_cache = UnidistWrapper.materialize(self._length_cache)
+        return self._length_cache
+
+    def width(self):
+        """
+        Get the width of the object wrapped by the partition.
+
+        Returns
+        -------
+        int
+            The width of the object.
+        """
+        if self._width_cache is None:
+            if len(self.call_queue):
+                self.drain_call_queue()
+            else:
+                self._length_cache, self._width_cache = _get_index_and_columns.remote(
+                    self._data
+                )
+        if unidist.is_object_ref(self._width_cache):
+            self._width_cache = UnidistWrapper.materialize(self._width_cache)
+        return self._width_cache
+
+    def ip(self):
+        """
+        Get the node IP address of the object wrapped by this partition.
+
+        Returns
+        -------
+        str
+            IP address of the node that holds the data.
+        """
+        if self._ip_cache is None:
+            if len(self.call_queue):
+                self.drain_call_queue()
+            else:
+                self._ip_cache = self.apply(lambda df: df)._ip_cache
+        if unidist.is_object_ref(self._ip_cache):
+            self._ip_cache = UnidistWrapper.materialize(self._ip_cache)
+        return self._ip_cache
+
+
+@unidist.remote(num_returns=2)
+def _get_index_and_columns(df):
+    """
+    Get the number of rows and columns of a pandas DataFrame.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        A pandas DataFrame which dimensions are needed.
+
+    Returns
+    -------
+    int
+        The number of rows.
+    int
+        The number of columns.
+    """
+    return len(df.index), len(df.columns)
+
+
+@unidist.remote(num_returns=4)
+def _apply_func(partition, func, *args, **kwargs):  # pragma: no cover
+    """
+    Execute a function on the partition in a worker process.
+
+    Parameters
+    ----------
+    partition : pandas.DataFrame
+        A pandas DataFrame the function needs to be executed on.
+    func : callable
+        The function to perform on the partition.
+    *args : list
+        Positional arguments to pass to ``func``.
+    **kwargs : dict
+        Keyword arguments to pass to ``func``.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The resulting pandas DataFrame.
+    int
+        The number of rows of the resulting pandas DataFrame.
+    int
+        The number of columns of the resulting pandas DataFrame.
+    str
+        The node IP address of the worker process.
+
+    Notes
+    -----
+    Directly passing a call queue entry (i.e. a list of [func, args, kwargs]) instead of
+    destructuring it causes a performance penalty.
+    """
+    try:
+        result = func(partition, *args, **kwargs)
+    # Sometimes Arrow forces us to make a copy of an object before we operate on it. We
+    # don't want the error to propagate to the user, and we want to avoid copying unless
+    # we absolutely have to.
+    except ValueError:
+        result = func(partition.copy(), *args, **kwargs)
+    return (
+        result,
+        len(result) if hasattr(result, "__len__") else 0,
+        len(result.columns) if hasattr(result, "columns") else 0,
+        unidist.get_ip(),
+    )
+
+
+@unidist.remote(num_returns=4)
+def _apply_list_of_funcs(call_queue, partition):  # pragma: no cover
+    """
+    Execute all operations stored in the call queue on the partition in a worker process.
+
+    Parameters
+    ----------
+    call_queue : list
+        A call queue that needs to be executed on the partition.
+    partition : pandas.DataFrame
+        A pandas DataFrame the call queue needs to be executed on.
+
+    Returns
+    -------
+    pandas.DataFrame
+        The resulting pandas DataFrame.
+    int
+        The number of rows of the resulting pandas DataFrame.
+    int
+        The number of columns of the resulting pandas DataFrame.
+    str
+        The node IP address of the worker process.
+    """
+    for func, f_args, f_kwargs in call_queue:
+        func = deserialize(func)
+        args = deserialize(f_args)
+        kwargs = deserialize(f_kwargs)
+        try:
+            partition = func(partition, *args, **kwargs)
+        # Sometimes Arrow forces us to make a copy of an object before we operate on it. We
+        # don't want the error to propagate to the user, and we want to avoid copying unless
+        # we absolutely have to.
+        except ValueError:
+            partition = func(partition.copy(), *args, **kwargs)
+
+    return (
+        partition,
+        len(partition) if hasattr(partition, "__len__") else 0,
+        len(partition.columns) if hasattr(partition, "columns") else 0,
+        unidist.get_ip(),
+    )

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
@@ -16,13 +16,12 @@
 import inspect
 import threading
 
-import unidist
-
 from modin.config import ProgressBar
 from modin.core.execution.unidist.generic.partitioning import (
     GenericUnidistDataframePartitionManager,
 )
 from modin.core.execution.unidist.common import UnidistWrapper
+from modin.core.execution.unidist.common.utils import wait
 from .virtual_partition import (
     PandasOnUnidistDataframeColumnPartition,
     PandasOnUnidistDataframeRowPartition,
@@ -131,7 +130,7 @@ class PandasOnUnidistDataframePartitionManager(GenericUnidistDataframePartitionM
         blocks = [
             block for partition in partitions for block in partition.list_of_blocks
         ]
-        unidist.wait(blocks, num_returns=len(blocks))
+        wait(blocks)
 
 
 def _make_wrapped_method(name: str):

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
@@ -1,0 +1,172 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Module houses class that implements ``GenericUnidistDataframePartitionManager`` using Unidist."""
+
+import inspect
+import threading
+
+import unidist
+
+from modin.config import ProgressBar
+from modin.core.execution.unidist.generic.partitioning import (
+    GenericUnidistDataframePartitionManager,
+)
+from modin.core.execution.unidist.common import UnidistWrapper
+from .virtual_partition import (
+    PandasOnUnidistDataframeColumnPartition,
+    PandasOnUnidistDataframeRowPartition,
+)
+from .partition import PandasOnUnidistDataframePartition
+from modin.core.execution.unidist.generic.modin_aqp import call_progress_bar
+
+
+def progress_bar_wrapper(f):
+    """
+    Wrap computation function inside a progress bar.
+
+    Spawns another thread which displays a progress bar showing
+    estimated completion time.
+
+    Parameters
+    ----------
+    f : callable
+        The name of the function to be wrapped.
+
+    Returns
+    -------
+    callable
+        Decorated version of `f` which reports progress.
+    """
+    from functools import wraps
+
+    @wraps(f)
+    def magic(*args, **kwargs):
+        result_parts = f(*args, **kwargs)
+        if ProgressBar.get():
+            current_frame = inspect.currentframe()
+            function_name = None
+            while function_name != "<module>":
+                (
+                    filename,
+                    line_number,
+                    function_name,
+                    lines,
+                    index,
+                ) = inspect.getframeinfo(current_frame)
+                current_frame = current_frame.f_back
+            t = threading.Thread(
+                target=call_progress_bar,
+                args=(result_parts, line_number),
+            )
+            t.start()
+            # We need to know whether or not we are in a jupyter notebook
+            from IPython import get_ipython
+
+            try:
+                ipy_str = str(type(get_ipython()))
+                if "zmqshell" not in ipy_str:
+                    t.join()
+            except Exception:
+                pass
+        return result_parts
+
+    return magic
+
+
+class PandasOnUnidistDataframePartitionManager(GenericUnidistDataframePartitionManager):
+    """The class implements the interface in `PandasDataframePartitionManager`."""
+
+    # This object uses UnidistRemotePartition objects as the underlying store.
+    _partition_class = PandasOnUnidistDataframePartition
+    _column_partitions_class = PandasOnUnidistDataframeColumnPartition
+    _row_partition_class = PandasOnUnidistDataframeRowPartition
+
+    @classmethod
+    def get_objects_from_partitions(cls, partitions):
+        """
+        Get the objects wrapped by `partitions` in parallel.
+
+        This function assumes that each partition in `partitions` contains a single block.
+
+        Parameters
+        ----------
+        partitions : np.ndarray
+            NumPy array with ``PandasDataframePartition``-s.
+
+        Returns
+        -------
+        list
+            The objects wrapped by `partitions`.
+        """
+        assert all(
+            [len(partition.list_of_blocks) == 1 for partition in partitions]
+        ), "Implementation assumes that each partition contains a signle block."
+        return UnidistWrapper.materialize(
+            [partition.list_of_blocks[0] for partition in partitions]
+        )
+
+    @classmethod
+    def wait_partitions(cls, partitions):
+        """
+        Wait on the objects wrapped by `partitions` in parallel, without materializing them.
+
+        This method will block until all computations in the list have completed.
+
+        Parameters
+        ----------
+        partitions : np.ndarray
+            NumPy array with ``PandasDataframePartition``-s.
+        """
+        blocks = [
+            block for partition in partitions for block in partition.list_of_blocks
+        ]
+        unidist.wait(blocks, num_returns=len(blocks))
+
+
+def _make_wrapped_method(name: str):
+    """
+    Define new attribute that should work with progress bar.
+
+    Parameters
+    ----------
+    name : str
+        Name of `GenericUnidistDataframePartitionManager` attribute that should be reused.
+
+    Notes
+    -----
+    - `classmethod` decorator shouldn't be applied twice, so we refer to `__func__` attribute.
+    - New attribute is defined for `PandasOnUnidistDataframePartitionManager`.
+    """
+    setattr(
+        PandasOnUnidistDataframePartitionManager,
+        name,
+        classmethod(
+            progress_bar_wrapper(
+                getattr(GenericUnidistDataframePartitionManager, name).__func__
+            )
+        ),
+    )
+
+
+for method in (
+    "map_partitions",
+    "lazy_map_partitions",
+    "map_axis_partitions",
+    "_apply_func_to_list_of_partitions",
+    "apply_func_to_select_indices",
+    "apply_func_to_select_indices_along_full_axis",
+    "apply_func_to_indices_both_axis",
+    "n_ary_operation",
+):
+    _make_wrapped_method(method)

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
@@ -86,7 +86,7 @@ def progress_bar_wrapper(f):
 class PandasOnUnidistDataframePartitionManager(GenericUnidistDataframePartitionManager):
     """The class implements the interface in `PandasDataframePartitionManager`."""
 
-    # This object uses UnidistRemotePartition objects as the underlying store.
+    # This object uses PandasOnUnidistDataframePartition objects as the underlying store.
     _partition_class = PandasOnUnidistDataframePartition
     _column_partitions_class = PandasOnUnidistDataframeColumnPartition
     _row_partition_class = PandasOnUnidistDataframeRowPartition

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
@@ -108,6 +108,9 @@ class PandasOnUnidistDataframePartitionManager(GenericUnidistDataframePartitionM
         list
             The objects wrapped by `partitions`.
         """
+        for idx, part in enumerate(partitions):
+            if hasattr(part, "force_materialization"):
+                partitions[idx] = part.force_materialization()
         assert all(
             [len(partition.list_of_blocks) == 1 for partition in partitions]
         ), "Implementation assumes that each partition contains a signle block."

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -322,13 +322,6 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         -------
         list
             A list of `PandasOnUnidistDataframeVirtualPartition` objects.
-
-        Notes
-        -----
-        In older versions of Modin, ``args`` was passed internally as ``kwargs["args"]``, and
-        deserialization was handled in a special case in ``deploy_unidist_func``, making control flow
-        difficult to follow. All deserialization is still handled in ``deploy_unidist_func``, but
-        in a more direct fashion.
         """
         if not self.full_axis:
             # If this is not a full axis partition, it already contains a subset of

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -101,7 +101,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         """
         if self._list_of_block_partitions is not None:
             return self._list_of_block_partitions
-        self._list_of_block_partitions = []
+        list_of_block_partitions = []
         # Extract block partitions from the block and virtual partitions that
         # constitute this partition.
         for partition in self._list_of_constituent_partitions:
@@ -114,9 +114,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
                     # applied to the entire `partition` before we execute any
                     # further operations on its block parittions.
                     partition.drain_call_queue()
-                    self._list_of_block_partitions.extend(
-                        partition.list_of_block_partitions
-                    )
+                    list_of_block_partitions.extend(partition.list_of_block_partitions)
                 else:
                     # If this virtual partition is made of virtual partitions
                     # for the other axes, squeeze such partitions into a single
@@ -124,11 +122,12 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
                     # list of blocks. We could change this implementation to
                     # hold a 2-d list of blocks, but that would complicate the
                     # code quite a bit.
-                    self._list_of_block_partitions.append(
+                    list_of_block_partitions.append(
                         partition.force_materialization().list_of_block_partitions[0]
                     )
             else:
-                self._list_of_block_partitions.append(partition)
+                list_of_block_partitions.append(partition)
+        self._list_of_block_partitions = list_of_block_partitions
         return self._list_of_block_partitions
 
     @property

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -19,7 +19,7 @@ import unidist
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
-from modin.core.execution.unidist.common.utils import deserialize
+from modin.core.execution.unidist.common.utils import deserialize, wait
 from .partition import PandasOnUnidistDataframePartition
 from modin.utils import _inherit_docstrings
 
@@ -468,7 +468,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         """Wait completing computations on the object wrapped by the partition."""
         self.drain_call_queue()
         futures = self.list_of_blocks
-        unidist.wait(futures, num_returns=len(futures))
+        wait(futures)
 
     def add_to_apply_calls(self, func, *args, length=None, width=None, **kwargs):
         """

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -1,0 +1,566 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Module houses classes responsible for storing a virtual partition and applying a function to it."""
+
+import pandas
+import unidist
+
+from modin.core.dataframe.pandas.partitioning.axis_partition import (
+    PandasDataframeAxisPartition,
+)
+from modin.core.execution.unidist.common.utils import deserialize
+from .partition import PandasOnUnidistDataframePartition
+from modin.utils import _inherit_docstrings
+
+
+_DEPLOY_AXIS_FUNC = unidist.put(PandasDataframeAxisPartition.deploy_axis_func)
+_DRAIN = unidist.put(PandasDataframeAxisPartition.drain)
+
+
+class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
+    """
+    The class implements the interface in ``PandasDataframeAxisPartition``.
+
+    Parameters
+    ----------
+    list_of_partitions : Union[list, PandasOnUnidistDataframePartition]
+        List of ``PandasOnUnidistDataframePartition`` and
+        ``PandasOnUnidistDataframeVirtualPartition`` objects, or a single
+        ``PandasOnUnidistDataframePartition``.
+    get_ip : bool, default: False
+        Whether to get node IP addresses to conforming partitions or not.
+    full_axis : bool, default: True
+        Whether or not the virtual partition encompasses the whole axis.
+    call_queue : list, optional
+        A list of tuples (callable, args, kwargs) that contains deferred calls.
+    length : unidist.ObjectRef or int, optional
+        Length, or reference to length, of wrapped ``pandas.DataFrame``.
+    width : unidist.ObjectRef or int, optional
+        Width, or reference to width, of wrapped ``pandas.DataFrame``.
+    """
+
+    partition_type = PandasOnUnidistDataframePartition
+    instance_type = unidist.core.base.object_ref.ObjectRef
+    axis = None
+
+    def __init__(
+        self,
+        list_of_partitions,
+        get_ip=False,
+        full_axis=True,
+        call_queue=None,
+        length=None,
+        width=None,
+    ):
+        if isinstance(list_of_partitions, PandasOnUnidistDataframePartition):
+            list_of_partitions = [list_of_partitions]
+        self.full_axis = full_axis
+        self.call_queue = call_queue or []
+        self._length_cache = length
+        self._width_cache = width
+        # Check that all virtual partition axes are the same in `list_of_partitions`
+        # We should never have mismatching axis in the current implementation. We add this
+        # defensive assertion to ensure that undefined behavior does not happen.
+        assert (
+            len(
+                set(
+                    obj.axis
+                    for obj in list_of_partitions
+                    if isinstance(obj, PandasOnUnidistDataframeVirtualPartition)
+                )
+            )
+            <= 1
+        )
+        self._list_of_constituent_partitions = list_of_partitions
+        # Defer computing _list_of_block_partitions because we might need to
+        # drain call queues for that.
+        self._list_of_block_partitions = None
+
+    @property
+    def list_of_block_partitions(self) -> list:
+        """
+        Get the list of block partitions that compose this partition.
+
+        Returns
+        -------
+        List
+            A list of ``PandasOnUnidistDataframePartition``.
+        """
+        if self._list_of_block_partitions is not None:
+            return self._list_of_block_partitions
+        self._list_of_block_partitions = []
+        # Extract block partitions from the block and virtual partitions that
+        # constitute this partition.
+        for partition in self._list_of_constituent_partitions:
+            if isinstance(partition, PandasOnUnidistDataframeVirtualPartition):
+                if partition.axis == self.axis:
+                    # We are building a virtual partition out of another
+                    # virtual partition `partition` that contains its own list
+                    # of block partitions, partition.list_of_block_partitions.
+                    # `partition` may have its own call queue, which has to be
+                    # applied to the entire `partition` before we execute any
+                    # further operations on its block parittions.
+                    partition.drain_call_queue()
+                    self._list_of_block_partitions.extend(
+                        partition.list_of_block_partitions
+                    )
+                else:
+                    # If this virtual partition is made of virtual partitions
+                    # for the other axes, squeeze such partitions into a single
+                    # block so that this partition only holds a one-dimensional
+                    # list of blocks. We could change this implementation to
+                    # hold a 2-d list of blocks, but that would complicate the
+                    # code quite a bit.
+                    self._list_of_block_partitions.append(
+                        partition.force_materialization().list_of_block_partitions[0]
+                    )
+            else:
+                self._list_of_block_partitions.append(partition)
+        return self._list_of_block_partitions
+
+    @property
+    def list_of_ips(self):
+        """
+        Get the IPs holding the physical objects composing this partition.
+
+        Returns
+        -------
+        List
+            A list of IPs as ``unidist.ObjectRef`` or str.
+        """
+        # Defer draining call queue until we get the ip address
+        result = [None] * len(self.list_of_block_partitions)
+        for idx, partition in enumerate(self.list_of_block_partitions):
+            partition.drain_call_queue()
+            result[idx] = partition._ip_cache
+        return result
+
+    @classmethod
+    def deploy_axis_func(
+        cls,
+        axis,
+        func,
+        f_args,
+        f_kwargs,
+        num_splits,
+        maintain_partitioning,
+        *partitions,
+        lengths=None,
+        manual_partition=False,
+        max_retries=None,
+    ):
+        """
+        Deploy a function along a full axis.
+
+        Parameters
+        ----------
+        axis : {0, 1}
+            The axis to perform the function along.
+        func : callable
+            The function to perform.
+        f_args : list or tuple
+            Positional arguments to pass to ``func``.
+        f_kwargs : dict
+            Keyword arguments to pass to ``func``.
+        num_splits : int
+            The number of splits to return (see ``split_result_of_axis_func_pandas``).
+        maintain_partitioning : bool
+            If True, keep the old partitioning if possible.
+            If False, create a new partition layout.
+        *partitions : iterable
+            All partitions that make up the full axis (row or column).
+        lengths : list, optional
+            The list of lengths to shuffle the object.
+        manual_partition : bool, default: False
+            If True, partition the result with `lengths`.
+        max_retries : int, default: None
+            The max number of times to retry the func.
+
+        Returns
+        -------
+        list
+            A list of ``unidist.ObjectRef``-s.
+        """
+        return deploy_unidist_func.options(
+            num_returns=(num_splits if lengths is None else len(lengths)) * 4,
+            **({"max_retries": max_retries} if max_retries is not None else {}),
+        ).remote(
+            _DEPLOY_AXIS_FUNC,
+            axis,
+            func,
+            f_args,
+            f_kwargs,
+            num_splits,
+            maintain_partitioning,
+            *partitions,
+            manual_partition=manual_partition,
+            lengths=lengths,
+        )
+
+    @classmethod
+    def deploy_func_between_two_axis_partitions(
+        cls,
+        axis,
+        func,
+        f_args,
+        f_kwargs,
+        num_splits,
+        len_of_left,
+        other_shape,
+        *partitions,
+    ):
+        """
+        Deploy a function along a full axis between two data sets.
+
+        Parameters
+        ----------
+        axis : {0, 1}
+            The axis to perform the function along.
+        func : callable
+            The function to perform.
+        f_args : list or tuple
+            Positional arguments to pass to ``func``.
+        f_kwargs : dict
+            Keyword arguments to pass to ``func``.
+        num_splits : int
+            The number of splits to return (see ``split_result_of_axis_func_pandas``).
+        len_of_left : int
+            The number of values in `partitions` that belong to the left data set.
+        other_shape : np.ndarray
+            The shape of right frame in terms of partitions, i.e.
+            (other_shape[i-1], other_shape[i]) will indicate slice to restore i-1 axis partition.
+        *partitions : iterable
+            All partitions that make up the full axis (row or column) for both data sets.
+
+        Returns
+        -------
+        list
+            A list of ``unidist.ObjectRef``-s.
+        """
+        return deploy_unidist_func.options(num_returns=num_splits * 4).remote(
+            PandasDataframeAxisPartition.deploy_func_between_two_axis_partitions,
+            axis,
+            func,
+            f_args,
+            f_kwargs,
+            num_splits,
+            len_of_left,
+            other_shape,
+            *partitions,
+        )
+
+    def _wrap_partitions(self, partitions):
+        """
+        Wrap partitions passed as a list of ``unidist.ObjectRef`` with ``PandasOnUnidistDataframePartition`` class.
+
+        Parameters
+        ----------
+        partitions : list
+            List of ``unidist.ObjectRef``.
+
+        Returns
+        -------
+        list
+            List of ``PandasOnUnidistDataframePartition`` objects.
+        """
+        return [
+            self.partition_type(object_id, length, width, ip)
+            for (object_id, length, width, ip) in zip(*[iter(partitions)] * 4)
+        ]
+
+    def apply(
+        self,
+        func,
+        *args,
+        num_splits=None,
+        other_axis_partition=None,
+        maintain_partitioning=True,
+        lengths=None,
+        manual_partition=False,
+        **kwargs,
+    ):
+        """
+        Apply a function to this axis partition along full axis.
+
+        Parameters
+        ----------
+        func : callable
+            The function to apply.
+        *args : iterable
+            Additional positional arguments to be passed in `func`.
+        num_splits : int, default: None
+            The number of times to split the result object.
+        other_axis_partition : PandasDataframeAxisPartition, default: None
+            Another `PandasDataframeAxisPartition` object to be applied
+            to func. This is for operations that are between two data sets.
+        maintain_partitioning : bool, default: True
+            Whether to keep the partitioning in the same
+            orientation as it was previously or not. This is important because we may be
+            operating on an individual AxisPartition and not touching the rest.
+            In this case, we have to return the partitioning to its previous
+            orientation (the lengths will remain the same). This is ignored between
+            two axis partitions.
+        lengths : list, optional
+            The list of lengths to shuffle the object.
+        manual_partition : bool, default: False
+            If True, partition the result with `lengths`.
+        **kwargs : dict
+            Additional keywords arguments to be passed in `func`.
+
+        Returns
+        -------
+        list
+            A list of `PandasOnUnidistDataframeVirtualPartition` objects.
+
+        Notes
+        -----
+        In older versions of Modin, ``args`` was passed internally as ``kwargs["args"]``, and
+        deserialization was handled in a special case in ``deploy_unidist_func``, making control flow
+        difficult to follow. All deserialization is still handled in ``deploy_unidist_func``, but
+        in a more direct fashion.
+        """
+        if not self.full_axis:
+            # If this is not a full axis partition, it already contains a subset of
+            # the full axis, so we shouldn't split the result further.
+            num_splits = 1
+        if len(self.call_queue) > 0:
+            self.drain_call_queue()
+        result = super(PandasOnUnidistDataframeVirtualPartition, self).apply(
+            func,
+            *args,
+            num_splits=num_splits,
+            other_axis_partition=other_axis_partition,
+            maintain_partitioning=maintain_partitioning,
+            lengths=lengths,
+            manual_partition=manual_partition,
+            **kwargs,
+        )
+        if self.full_axis:
+            return result
+        else:
+            # If this is a full axis partition, just take out the single split in the result.
+            return result[0]
+
+    def force_materialization(self, get_ip=False):
+        """
+        Materialize partitions into a single partition.
+
+        Parameters
+        ----------
+        get_ip : bool, default: False
+            Whether to get node ip address to a single partition or not.
+
+        Returns
+        -------
+        PandasOnUnidistDataframeVirtualPartition
+            An axis partition containing only a single materialized partition.
+        """
+        materialized = super(
+            PandasOnUnidistDataframeVirtualPartition, self
+        ).force_materialization(get_ip=get_ip)
+        self._list_of_block_partitions = materialized.list_of_block_partitions
+        return materialized
+
+    def mask(self, row_indices, col_indices):
+        """
+        Create (synchronously) a mask that extracts the indices provided.
+
+        Parameters
+        ----------
+        row_indices : list-like, slice or label
+            The row labels for the rows to extract.
+        col_indices : list-like, slice or label
+            The column labels for the columns to extract.
+
+        Returns
+        -------
+        PandasOnUnidistDataframeVirtualPartition
+            A new ``PandasOnUnidistDataframeVirtualPartition`` object,
+            materialized.
+        """
+        return (
+            self.force_materialization()
+            .list_of_block_partitions[0]
+            .mask(row_indices, col_indices)
+        )
+
+    def to_pandas(self):
+        """
+        Convert the data in this partition to a ``pandas.DataFrame``.
+
+        Returns
+        -------
+        pandas DataFrame.
+        """
+        return self.force_materialization().list_of_block_partitions[0].to_pandas()
+
+    _length_cache = None
+
+    def length(self):
+        """
+        Get the length of this partition.
+
+        Returns
+        -------
+        int
+            The length of the partition.
+        """
+        if self._length_cache is None:
+            if self.axis == 0:
+                self._length_cache = sum(
+                    obj.length() for obj in self.list_of_block_partitions
+                )
+            else:
+                self._length_cache = self.list_of_block_partitions[0].length()
+        return self._length_cache
+
+    _width_cache = None
+
+    def width(self):
+        """
+        Get the width of this partition.
+
+        Returns
+        -------
+        int
+            The width of the partition.
+        """
+        if self._width_cache is None:
+            if self.axis == 1:
+                self._width_cache = sum(
+                    obj.width() for obj in self.list_of_block_partitions
+                )
+            else:
+                self._width_cache = self.list_of_block_partitions[0].width()
+        return self._width_cache
+
+    def drain_call_queue(self, num_splits=None):
+        """
+        Execute all operations stored in this partition's call queue.
+
+        Parameters
+        ----------
+        num_splits : int, default: None
+            The number of times to split the result object.
+        """
+        if len(self.call_queue) == 0:
+            # this implicitly calls `drain_call_queue`
+            _ = self.list_of_blocks
+            return
+        drained = super(PandasOnUnidistDataframeVirtualPartition, self).apply(
+            _DRAIN, num_splits=num_splits, call_queue=self.call_queue
+        )
+        self._list_of_block_partitions = drained
+        self.call_queue = []
+
+    def wait(self):
+        """Wait completing computations on the object wrapped by the partition."""
+        self.drain_call_queue()
+        futures = self.list_of_blocks
+        unidist.wait(futures, num_returns=len(futures))
+
+    def add_to_apply_calls(self, func, *args, length=None, width=None, **kwargs):
+        """
+        Add a function to the call queue.
+
+        Parameters
+        ----------
+        func : callable or unidist.ObjectRef
+            Function to be added to the call queue.
+        *args : iterable
+            Additional positional arguments to be passed in `func`.
+        length : unidist.ObjectRef or int, optional
+            Length, or reference to it, of wrapped ``pandas.DataFrame``.
+        width : unidist.ObjectRef or int, optional
+            Width, or reference to it, of wrapped ``pandas.DataFrame``.
+        **kwargs : dict
+            Additional keyword arguments to be passed in `func`.
+
+        Returns
+        -------
+        PandasOnUnidistDataframeVirtualPartition
+            A new ``PandasOnUnidistDataframeVirtualPartition`` object.
+
+        Notes
+        -----
+        It does not matter if `func` is callable or an ``unidist.ObjectRef``. Unidist will
+        handle it correctly either way. The keyword arguments are sent as a dictionary.
+        """
+        return type(self)(
+            self.list_of_block_partitions,
+            full_axis=self.full_axis,
+            call_queue=self.call_queue + [[func, args, kwargs]],
+            length=length,
+            width=width,
+        )
+
+
+@_inherit_docstrings(PandasOnUnidistDataframeVirtualPartition.__init__)
+class PandasOnUnidistDataframeColumnPartition(PandasOnUnidistDataframeVirtualPartition):
+    axis = 0
+
+
+@_inherit_docstrings(PandasOnUnidistDataframeVirtualPartition.__init__)
+class PandasOnUnidistDataframeRowPartition(PandasOnUnidistDataframeVirtualPartition):
+    axis = 1
+
+
+@unidist.remote
+def deploy_unidist_func(
+    deployer, axis, f_to_deploy, f_args, f_kwargs, *args, **kwargs
+):  # pragma: no cover
+    """
+    Execute a function on an axis partition in a worker process.
+
+    This is ALWAYS called on either ``PandasDataframeAxisPartition.deploy_axis_func``
+    or ``PandasDataframeAxisPartition.deploy_func_between_two_axis_partitions``, which both
+    serve to deploy another dataframe function on a unidist worker process. The provided ``f_args``
+    is thus are deserialized here (on the unidist worker) before the function is called (``f_kwargs``
+    will never contain more unidist objects, and thus does not require deserialization).
+
+    Parameters
+    ----------
+    deployer : callable
+        A `PandasDataFrameAxisPartition.deploy_*` method that will call ``f_to_deploy``.
+    axis : {0, 1}
+        The axis to perform the function along.
+    f_to_deploy : callable or unidist.ObjectRef
+        The function to deploy.
+    f_args : list or tuple
+        Positional arguments to pass to ``f_to_deploy``.
+    f_kwargs : dict
+        Keyword arguments to pass to ``f_to_deploy``.
+    *args : list
+        Positional arguments to pass to ``deployer``.
+    **kwargs : dict
+        Keyword arguments to pass to ``deployer``.
+
+    Returns
+    -------
+    list : Union[tuple, list]
+        The result of the function call, and metadata for it.
+
+    Notes
+    -----
+    Unidist functions are not detected by codecov (thus pragma: no cover).
+    """
+    f_args = deserialize(f_args)
+    result = deployer(axis, f_to_deploy, f_args, f_kwargs, *args, **kwargs)
+    ip = unidist.get_ip()
+    if isinstance(result, pandas.DataFrame):
+        return result, len(result), len(result.columns), ip
+    elif all(isinstance(r, pandas.DataFrame) for r in result):
+        return [i for r in result for i in [r, len(r), len(r.columns), ip]]
+    else:
+        return [i for r in result for i in [r, None, None, ip]]

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -48,7 +48,7 @@ from pandas.core.dtypes.cast import find_common_type
 from pandas.core.dtypes.concat import union_categoricals
 from pandas.io.common import infer_compression
 from pandas.util._decorators import doc
-from typing import Any
+from typing import Any, NamedTuple
 import warnings
 
 from modin.core.io.file_dispatcher import OpenFile
@@ -642,7 +642,7 @@ class PandasJSONParser(PandasParser):
         ]
 
 
-class ParquetFileToRead:
+class ParquetFileToRead(NamedTuple):
     """
     Class to store path and row group information for parquet reads.
 
@@ -656,10 +656,9 @@ class ParquetFileToRead:
         Row group to stop read.
     """
 
-    def __init__(self, path: Any, row_group_start: int, row_group_end: int):
-        self.path: Any = path
-        self.row_group_start: int = row_group_start
-        self.row_group_end: int = row_group_end
+    path: Any
+    row_group_start: int
+    row_group_end: int
 
 
 @doc(_doc_pandas_parser_class, data_type="PARQUET data")

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -48,7 +48,7 @@ from pandas.core.dtypes.cast import find_common_type
 from pandas.core.dtypes.concat import union_categoricals
 from pandas.io.common import infer_compression
 from pandas.util._decorators import doc
-from typing import Any, NamedTuple
+from typing import Any
 import warnings
 
 from modin.core.io.file_dispatcher import OpenFile
@@ -642,7 +642,7 @@ class PandasJSONParser(PandasParser):
         ]
 
 
-class ParquetFileToRead(NamedTuple):
+class ParquetFileToRead:
     """
     Class to store path and row group information for parquet reads.
 
@@ -656,9 +656,10 @@ class ParquetFileToRead(NamedTuple):
         Row group to stop read.
     """
 
-    path: Any
-    row_group_start: int
-    row_group_end: int
+    def __init__(self, path: Any, row_group_start: int, row_group_end: int):
+        self.path: Any = path
+        self.row_group_start: int = row_group_start
+        self.row_group_end: int = row_group_end
 
 
 @doc(_doc_pandas_parser_class, data_type="PARQUET data")

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -27,9 +27,14 @@ if TYPE_CHECKING:
     from modin.core.execution.dask.implementations.pandas_on_dask.partitioning.partition import (
         PandasOnDaskDataframePartition,
     )
+    from modin.core.execution.unidist.implementations.pandas_on_unidist.partitioning.partition import (
+        PandasOnUnidistDataframePartition,
+    )
 
     PartitionUnionType = Union[
-        PandasOnRayDataframePartition, PandasOnDaskDataframePartition
+        PandasOnRayDataframePartition,
+        PandasOnDaskDataframePartition,
+        PandasOnUnidistDataframePartition,
     ]
 else:
     from typing import Any
@@ -101,6 +106,7 @@ def unwrap_partitions(
         if actual_engine in (
             "PandasOnRayDataframePartition",
             "PandasOnDaskDataframePartition",
+            "PandasOnUnidistDataframePartition",
         ):
             return _unwrap_partitions()
         raise ValueError(

--- a/modin/experimental/core/execution/unidist/__init__.py
+++ b/modin/experimental/core/execution/unidist/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Experimental Modin's functionality related to unidist execution engine."""

--- a/modin/experimental/core/execution/unidist/implementations/__init__.py
+++ b/modin/experimental/core/execution/unidist/implementations/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Experimental Modin's functionality related to unidist execution engine and optimized for specific storage formats."""

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/__init__.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/__init__.py
@@ -1,0 +1,14 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Experimental functionality related to unidist execution engine and optimized for pandas storage format."""

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/__init__.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Experimental Base IO classes optimized for pandas on unidist execution."""
+
+from .io import ExperimentalPandasOnUnidistIO
+
+__all__ = ["ExperimentalPandasOnUnidistIO"]

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -1,0 +1,333 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""
+Module houses experimental IO classes and parser functions needed for these classes.
+
+Any function or class can be considered experimental API if it is not strictly replicating existent
+Query Compiler API, even if it is only extending the API.
+"""
+
+import numpy as np
+import pandas
+import warnings
+
+from modin.core.storage_formats.pandas.parsers import (
+    _split_result_for_readers,
+    PandasCSVGlobParser,
+    PandasPickleExperimentalParser,
+    CustomTextExperimentalParser,
+)
+from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
+from modin.core.execution.unidist.implementations.pandas_on_unidist.io import (
+    PandasOnUnidistIO,
+)
+from modin.core.io import (
+    CSVGlobDispatcher,
+    PickleExperimentalDispatcher,
+    CustomTextExperimentalDispatcher,
+)
+from modin.core.execution.unidist.implementations.pandas_on_unidist.dataframe import (
+    PandasOnUnidistDataframe,
+)
+from modin.core.execution.unidist.implementations.pandas_on_unidist.partitioning import (
+    PandasOnUnidistDataframePartition,
+)
+from modin.core.execution.unidist.common import UnidistWrapper
+from modin.config import NPartitions
+
+import unidist
+
+
+class ExperimentalPandasOnUnidistIO(PandasOnUnidistIO):
+    """
+    Class for handling experimental IO functionality with pandas storage format and unidist engine.
+
+    ``ExperimentalPandasOnUnidistIO`` inherits some util functions and unmodified IO functions
+    from ``PandasOnUnidistIO`` class.
+    """
+
+    build_args = dict(
+        frame_partition_cls=PandasOnUnidistDataframePartition,
+        query_compiler_cls=PandasQueryCompiler,
+        frame_cls=PandasOnUnidistDataframe,
+    )
+    read_csv_glob = type(
+        "", (UnidistWrapper, PandasCSVGlobParser, CSVGlobDispatcher), build_args
+    )._read
+    read_pickle_distributed = type(
+        "",
+        (UnidistWrapper, PandasPickleExperimentalParser, PickleExperimentalDispatcher),
+        build_args,
+    )._read
+
+    read_custom_text = type(
+        "",
+        (
+            UnidistWrapper,
+            CustomTextExperimentalParser,
+            CustomTextExperimentalDispatcher,
+        ),
+        build_args,
+    )._read
+
+    @classmethod
+    def read_sql(
+        cls,
+        sql,
+        con,
+        index_col=None,
+        coerce_float=True,
+        params=None,
+        parse_dates=None,
+        columns=None,
+        chunksize=None,
+        partition_column=None,
+        lower_bound=None,
+        upper_bound=None,
+        max_sessions=None,
+    ):
+        """
+        Read SQL query or database table into a DataFrame.
+
+        The function extended with `Spark-like parameters <https://spark.apache.org/docs/2.0.0/api/R/read.jdbc.html>`_
+        such as ``partition_column``, ``lower_bound`` and ``upper_bound``. With these
+        parameters, the user will be able to specify how to partition the imported data.
+
+        Parameters
+        ----------
+        sql : str or SQLAlchemy Selectable (select or text object)
+            SQL query to be executed or a table name.
+        con : SQLAlchemy connectable or str
+             Connection to database (sqlite3 connections are not supported).
+        index_col : str or list of str, optional
+            Column(s) to set as index(MultiIndex).
+        coerce_float : bool, default: True
+            Attempts to convert values of non-string, non-numeric objects
+            (like decimal.Decimal) to floating point, useful for SQL result sets.
+        params : list, tuple or dict, optional
+            List of parameters to pass to ``execute`` method. The syntax used
+            to pass parameters is database driver dependent. Check your
+            database driver documentation for which of the five syntax styles,
+            described in PEP 249's paramstyle, is supported.
+        parse_dates : list or dict, optional
+            The behavior is as follows:
+
+            - List of column names to parse as dates.
+            - Dict of `{column_name: format string}` where format string is
+              strftime compatible in case of parsing string times, or is one of
+              (D, s, ns, ms, us) in case of parsing integer timestamps.
+            - Dict of `{column_name: arg dict}`, where the arg dict corresponds
+              to the keyword arguments of ``pandas.to_datetime``.
+              Especially useful with databases without native Datetime support,
+              such as SQLite.
+        columns : list, optional
+            List of column names to select from SQL table (only used when reading a
+            table).
+        chunksize : int, optional
+            If specified, return an iterator where `chunksize` is the number of rows
+            to include in each chunk.
+        partition_column : str, optional
+            Column name used for data partitioning between the workers
+            (MUST be an INTEGER column).
+        lower_bound : int, optional
+            The minimum value to be requested from the `partition_column`.
+        upper_bound : int, optional
+            The maximum value to be requested from the `partition_column`.
+        max_sessions : int, optional
+            The maximum number of simultaneous connections allowed to use.
+
+        Returns
+        -------
+        BaseQueryCompiler
+            A new query compiler with imported data for further processing.
+        """
+        from .sql import is_distributed, get_query_info
+
+        if not is_distributed(partition_column, lower_bound, upper_bound):
+            warnings.warn("Defaulting to Modin core implementation")
+            return PandasOnUnidistIO.read_sql(
+                sql,
+                con,
+                index_col,
+                coerce_float=coerce_float,
+                params=params,
+                parse_dates=parse_dates,
+                columns=columns,
+                chunksize=chunksize,
+            )
+        #  starts the distributed alternative
+        cols_names, query = get_query_info(sql, con, partition_column)
+        num_parts = min(NPartitions.get(), max_sessions if max_sessions else 1)
+        num_splits = min(len(cols_names), num_parts)
+        diff = (upper_bound - lower_bound) + 1
+        min_size = diff // num_parts
+        rest = diff % num_parts
+        partition_ids = []
+        index_ids = []
+        end = lower_bound - 1
+        for part in range(num_parts):
+            if rest:
+                size = min_size + 1
+                rest -= 1
+            else:
+                size = min_size
+            start = end + 1
+            end = start + size - 1
+            partition_id = _read_sql_with_offset_pandas_on_unidist.options(
+                num_returns=num_splits + 1
+            ).remote(
+                partition_column,
+                start,
+                end,
+                num_splits,
+                query,
+                con,
+                index_col,
+                coerce_float,
+                params,
+                parse_dates,
+                columns,
+                chunksize,
+            )
+            partition_ids.append(
+                [PandasOnUnidistDataframePartition(obj) for obj in partition_id[:-1]]
+            )
+            index_ids.append(partition_id[-1])
+        new_index = pandas.RangeIndex(sum(UnidistWrapper.materialize(index_ids)))
+        new_query_compiler = cls.query_compiler_cls(
+            cls.frame_cls(np.array(partition_ids), new_index, cols_names)
+        )
+        new_query_compiler._modin_frame.synchronize_labels(axis=0)
+        return new_query_compiler
+
+    @classmethod
+    def to_pickle_distributed(cls, qc, **kwargs):
+        """
+        When `*` in the filename all partitions are written to their own separate file.
+
+        The filenames is determined as follows:
+        - if `*` in the filename then it will be replaced by the increasing sequence 0, 1, 2, …
+        - if `*` is not the filename, then will be used default implementation.
+
+        Examples #1: 4 partitions and input filename="partition*.pkl.gz", then filenames will be:
+        `partition0.pkl.gz`, `partition1.pkl.gz`, `partition2.pkl.gz`, `partition3.pkl.gz`.
+
+        Parameters
+        ----------
+        qc : BaseQueryCompiler
+            The query compiler of the Modin dataframe that we want
+            to run ``to_pickle_distributed`` on.
+        **kwargs : dict
+            Parameters for ``pandas.to_pickle(**kwargs)``.
+        """
+        if not (
+            isinstance(kwargs["filepath_or_buffer"], str)
+            and "*" in kwargs["filepath_or_buffer"]
+        ) or not isinstance(qc, PandasQueryCompiler):
+            warnings.warn("Defaulting to Modin core implementation")
+            return PandasOnUnidistIO.to_pickle(qc, **kwargs)
+
+        def func(df, **kw):
+            idx = str(kw["partition_idx"])
+            kwargs["path"] = kwargs.pop("filepath_or_buffer").replace("*", idx)
+            df.to_pickle(**kwargs)
+            return pandas.DataFrame()
+
+        result = qc._modin_frame.broadcast_apply_full_axis(
+            1, func, other=None, new_index=[], new_columns=[], enumerate_partitions=True
+        )
+        result.to_pandas()
+
+
+# unidist functions are not detected by codecov (thus pragma: no cover)
+@unidist.remote
+def _read_sql_with_offset_pandas_on_unidist(
+    partition_column,
+    start,
+    end,
+    num_splits,
+    sql,
+    con,
+    index_col=None,
+    coerce_float=True,
+    params=None,
+    parse_dates=None,
+    columns=None,
+    chunksize=None,
+):  # pragma: no cover
+    """
+    Read a chunk of SQL query or table into a pandas DataFrame using unidist task.
+
+    Parameters
+    ----------
+    partition_column : str
+        Column name used for data partitioning between the workers.
+    start : int
+        Lowest value to request from the `partition_column`.
+    end : int
+        Highest value to request from the `partition_column`.
+    num_splits : int
+        The number of partitions to split the column into.
+    sql : str or SQLAlchemy Selectable (select or text object)
+        SQL query to be executed or a table name.
+    con : SQLAlchemy connectable or str
+        Connection to database (sqlite3 connections are not supported).
+    index_col : str or list of str, optional
+        Column(s) to set as index(MultiIndex).
+    coerce_float : bool, default: True
+        Attempts to convert values of non-string, non-numeric objects
+        (like decimal.Decimal) to floating point, useful for SQL result sets.
+    params : list, tuple or dict, optional
+        List of parameters to pass to ``execute`` method. The syntax used
+        to pass parameters is database driver dependent. Check your
+        database driver documentation for which of the five syntax styles,
+        described in PEP 249's paramstyle, is supported.
+    parse_dates : list or dict, optional
+        The behavior is as follows:
+
+        - List of column names to parse as dates.
+        - Dict of `{column_name: format string}` where format string is
+          strftime compatible in case of parsing string times, or is one of
+          (D, s, ns, ms, us) in case of parsing integer timestamps.
+        - Dict of `{column_name: arg dict}`, where the arg dict corresponds
+          to the keyword arguments of ``pandas.to_datetime``
+          Especially useful with databases without native Datetime support,
+          such as SQLite.
+    columns : list, optional
+        List of column names to select from SQL table (only used when reading a
+        table).
+    chunksize : int, optional
+        If specified, return an iterator where `chunksize` is the number of rows
+        to include in each chunk.
+
+    Returns
+    -------
+    list
+        List with split read results and it's metadata (index, dtypes, etc.).
+    """
+    from .sql import query_put_bounders
+
+    query_with_bounders = query_put_bounders(sql, partition_column, start, end)
+    pandas_df = pandas.read_sql(
+        query_with_bounders,
+        con,
+        index_col=index_col,
+        coerce_float=coerce_float,
+        params=params,
+        parse_dates=parse_dates,
+        columns=columns,
+        chunksize=chunksize,
+    )
+    index = len(pandas_df)
+    return _split_result_for_readers(1, num_splits, pandas_df) + [index]

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -21,6 +21,7 @@ Query Compiler API, even if it is only extending the API.
 import numpy as np
 import pandas
 import warnings
+import unidist
 
 from modin.core.storage_formats.pandas.parsers import (
     _split_result_for_readers,
@@ -45,8 +46,6 @@ from modin.core.execution.unidist.implementations.pandas_on_unidist.partitioning
 )
 from modin.core.execution.unidist.common import UnidistWrapper
 from modin.config import NPartitions
-
-import unidist
 
 
 class ExperimentalPandasOnUnidistIO(PandasOnUnidistIO):

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/sql.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/sql.py
@@ -1,0 +1,275 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Module houses util functions for handling experimental SQL IO functions."""
+
+from collections import OrderedDict
+from sqlalchemy import MetaData, Table, create_engine, inspect
+
+
+def is_distributed(partition_column, lower_bound, upper_bound):
+    """
+    Check if is possible to distribute a query with the given args.
+
+    Parameters
+    ----------
+    partition_column : str
+        Column name used for data partitioning between the workers.
+    lower_bound : int
+        The minimum value to be requested from the `partition_column`.
+    upper_bound : int
+        The maximum value to be requested from the `partition_column`.
+
+    Returns
+    -------
+    bool
+        Whether the given query is distributable or not.
+    """
+    if (
+        (partition_column is not None)
+        and (lower_bound is not None)
+        and (upper_bound is not None)
+    ):
+        if upper_bound > lower_bound:
+            return True
+        else:
+            raise InvalidArguments("upper_bound must be greater than lower_bound.")
+    elif (partition_column is None) and (lower_bound is None) and (upper_bound is None):
+        return False
+    else:
+        raise InvalidArguments(
+            "Invalid combination of partition_column, lower_bound, upper_bound."
+            + "All these arguments should be passed (distributed) or none of them (standard pandas)."
+        )
+
+
+def is_table(engine, sql):
+    """
+    Check if given `sql` parameter is a table name.
+
+    Parameters
+    ----------
+    engine : sqlalchemy.engine.base.Engine
+        SQLAlchemy connection engine.
+    sql : str
+        SQL query to be executed or a table name.
+
+    Returns
+    -------
+    bool
+        Whether `sql` a table name or not.
+    """
+    if inspect(engine).has_table(sql):
+        return True
+    return False
+
+
+def get_table_metadata(engine, table):
+    """
+    Extract all useful data from the given table.
+
+    Parameters
+    ----------
+    engine : sqlalchemy.engine.base.Engine
+        SQLAlchemy connection engine.
+    table : str
+        Table name.
+
+    Returns
+    -------
+    sqlalchemy.sql.schema.Table
+        Extracted metadata.
+    """
+    metadata = MetaData()
+    metadata.reflect(bind=engine, only=[table])
+    table_metadata = Table(table, metadata, autoload=True)
+    return table_metadata
+
+
+def get_table_columns(metadata):
+    """
+    Extract columns names and python types from the `metadata`.
+
+    Parameters
+    ----------
+    metadata : sqlalchemy.sql.schema.Table
+        Table metadata.
+
+    Returns
+    -------
+    OrderedDict
+        Dictionary with columns names and python types.
+    """
+    cols = OrderedDict()
+    for col in metadata.c:
+        name = str(col).rpartition(".")[2]
+        cols[name] = col.type.python_type.__name__
+    return cols
+
+
+def build_query_from_table(name):
+    """
+    Create a query from the given table name.
+
+    Parameters
+    ----------
+    name : str
+        Table name.
+
+    Returns
+    -------
+    str
+        Query string.
+    """
+    return "SELECT * FROM {0}".format(name)
+
+
+def check_query(query):
+    """
+    Check query sanity.
+
+    Parameters
+    ----------
+    query : str
+        Query string.
+    """
+    q = query.lower()
+    if "select " not in q:
+        raise InvalidQuery("SELECT word not found in the query: {0}".format(query))
+    if " from " not in q:
+        raise InvalidQuery("FROM word not found in the query: {0}".format(query))
+
+
+def get_query_columns(engine, query):
+    """
+    Extract columns names and python types from the `query`.
+
+    Parameters
+    ----------
+    engine : sqlalchemy.engine.base.Engine
+        SQLAlchemy connection engine.
+    query : str
+        SQL query.
+
+    Returns
+    -------
+    OrderedDict
+        Dictionary with columns names and python types.
+    """
+    con = engine.connect()
+    result = con.execute(query).fetchone()
+    values = list(result)
+    cols_names = list(result.keys())
+    cols = OrderedDict()
+    for i in range(len(cols_names)):
+        cols[cols_names[i]] = type(values[i]).__name__
+    return cols
+
+
+def check_partition_column(partition_column, cols):
+    """
+    Check `partition_column` existence and it's type.
+
+    Parameters
+    ----------
+    partition_column : str
+        Column name used for data partitioning between the workers.
+    cols : OrderedDict/dict
+        Dictionary with columns names and python types.
+    """
+    for k, v in cols.items():
+        if k == partition_column:
+            if v == "int":
+                return
+            else:
+                raise InvalidPartitionColumn(
+                    "partition_column must be int, and not {0}".format(v)
+                )
+    raise InvalidPartitionColumn(
+        "partition_column {0} not found in the query".format(partition_column)
+    )
+
+
+def get_query_info(sql, con, partition_column):
+    """
+    Compute metadata needed for query distribution.
+
+    Parameters
+    ----------
+    sql : str
+        SQL query to be executed or a table name.
+    con : SQLAlchemy connectable or str
+        Database connection or url string.
+    partition_column : str
+        Column name used for data partitioning between the workers.
+
+    Returns
+    -------
+    list
+        Columns names list.
+    str
+        Query string.
+    """
+    engine = create_engine(con)
+    if is_table(engine, sql):
+        table_metadata = get_table_metadata(engine, sql)
+        query = build_query_from_table(sql)
+        cols = get_table_columns(table_metadata)
+    else:
+        check_query(sql)
+        query = sql.replace(";", "")
+        cols = get_query_columns(engine, query)
+    # TODO allow validation that takes into account edge cases of pandas e.g. "[index]"
+    # check_partition_column(partition_column, cols)
+    # TODO partition_column isn't used; we need to use it;
+    cols_names = list(cols.keys())
+    return cols_names, query
+
+
+def query_put_bounders(query, partition_column, start, end):
+    """
+    Put partition boundaries into the query.
+
+    Parameters
+    ----------
+    query : str
+        SQL query string.
+    partition_column : str
+        Column name used for data partitioning between the workers.
+    start : int
+        Lowest value to request from the `partition_column`.
+    end : int
+        Highest value to request from the `partition_column`.
+
+    Returns
+    -------
+    str
+        Query string with boundaries.
+    """
+    where = " WHERE TMP_TABLE.{0} >= {1} AND TMP_TABLE.{0} <= {2}".format(
+        partition_column, start, end
+    )
+    query_with_bounders = "SELECT * FROM ({0}) AS TMP_TABLE {1}".format(query, where)
+    return query_with_bounders
+
+
+class InvalidArguments(Exception):
+    """Exception that should be raised if invalid arguments combination was found."""
+
+
+class InvalidQuery(Exception):
+    """Exception that should be raised if invalid query statement was found."""
+
+
+class InvalidPartitionColumn(Exception):
+    """Exception that should be raised if `partition_column` doesn't satisfy predefined requirements."""

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -89,10 +89,6 @@ def test_from_sql_defaults(make_sql_connection):  # noqa: F811
 
 @pytest.mark.usefixtures("TestReadGlobCSVFixture")
 @pytest.mark.skipif(
-    condition=Engine.get() == "Unidist",
-    reason="Modin on unidist with MPI backend hangs.",
-)
-@pytest.mark.skipif(
     Engine.get() != "Ray", reason="Currently only support Ray engine for glob paths."
 )
 class TestCsvGlob:

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -37,7 +37,7 @@ from modin.pandas.test.utils import parse_dates_values_by_id, time_parsing_csv_p
     reason="Dask does not have experimental API",
 )
 def test_from_sql_distributed(make_sql_connection):  # noqa: F811
-    if Engine.get() == "Ray":
+    if Engine.get() in ("Ray", "Unidist"):
         with ensure_clean_dir() as dirname:
             filename = "test_from_sql_distributed.db"
             table = "test_from_sql_distributed"
@@ -88,6 +88,10 @@ def test_from_sql_defaults(make_sql_connection):  # noqa: F811
 
 
 @pytest.mark.usefixtures("TestReadGlobCSVFixture")
+@pytest.mark.skipif(
+    condition=Engine.get() == "Unidist",
+    reason="Modin on unidist with MPI backend hangs.",
+)
 @pytest.mark.skipif(
     Engine.get() != "Ray", reason="Currently only support Ray engine for glob paths."
 )
@@ -175,7 +179,8 @@ class TestCsvGlob:
     ],
 )
 @pytest.mark.skipif(
-    Engine.get() != "Ray", reason="Currently only support Ray engine for glob paths."
+    Engine.get() not in ("Ray", "Unidist"),
+    reason="Currently only support Ray and Unidist engines for glob paths.",
 )
 def test_read_multiple_csv_cloud_store(path):
     def _pandas_read_csv_glob(path, storage_options):
@@ -201,7 +206,8 @@ test_default_to_pickle_filename = "test_default_to_pickle.pkl"
 
 
 @pytest.mark.skipif(
-    get_current_execution() != "ExperimentalPandasOnRay",
+    get_current_execution()
+    not in ("ExperimentalPandasOnRay", "ExperimentalPandasOnUnidist"),
     reason=f"Execution {get_current_execution()} isn't supported.",
 )
 @pytest.mark.parametrize(
@@ -234,7 +240,7 @@ def test_read_multiple_csv_s3_storage_opts(storage_options):
 
 
 @pytest.mark.skipif(
-    not Engine.get() == "Ray",
+    Engine.get() not in ("Ray", "Unidist"),
     reason=f"{Engine.get()} does not have experimental API",
 )
 @pytest.mark.parametrize("compression", [None, "gzip"])
@@ -263,7 +269,7 @@ def test_distributed_pickling(filename, compression):
 
 
 @pytest.mark.skipif(
-    not Engine.get() == "Ray",
+    Engine.get() not in ("Ray", "Unidist"),
     reason=f"{Engine.get()} does not have experimental read_custom_text API",
 )
 def test_read_custom_json_text():
@@ -301,7 +307,7 @@ def test_read_custom_json_text():
 
 
 @pytest.mark.skipif(
-    not Engine.get() == "Ray",
+    Engine.get() not in ("Ray", "Unidist"),
     reason=f"{Engine.get()} does not have experimental API",
 )
 def test_read_evaluated_dict():

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -156,6 +156,11 @@ def _update_engine(publisher: Parameter):
             from modin.core.execution.dask.common import initialize_dask
 
             initialize_dask()
+    elif publisher.get() == "Unidist":
+        if _is_first_update.get("Unidist", True):
+            from modin.core.execution.unidist.common import initialize_unidist
+
+            initialize_unidist()
     elif publisher.get() == "Cloudray":
         from modin.experimental.cloud import get_connection
 

--- a/modin/pandas/test/internals/test_benchmark_mode.py
+++ b/modin/pandas/test/internals/test_benchmark_mode.py
@@ -33,6 +33,12 @@ elif engine == "Dask":
         + "pandas_on_dask.partitioning.partition_manager."
         + "PandasOnDaskDataframePartitionManager.wait_partitions"
     )
+elif engine == "Unidist":
+    wait_method = (
+        "modin.core.execution.unidist.implementations."
+        + "pandas_on_unidist.partitioning.partition_manager."
+        + "PandasOnUnidistDataframePartitionManager.wait_partitions"
+    )
 else:
     wait_method = (
         "modin.core.dataframe.pandas.partitioning."

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1070,10 +1070,6 @@ class TestCsv:
                 StringIO(open(pytest.csvs_names["test_read_csv_regular"], "r").read())
             )
 
-    @pytest.mark.skipif(
-        condition=Engine.get() == "Unidist",
-        reason="Modin on unidist with MPI backend hangs.",
-    )
     @pytest.mark.xfail(
         condition="config.getoption('--simulate-cloud').lower() != 'off'",
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #2340",
@@ -1101,10 +1097,6 @@ class TestCsv:
             cast_to_str=StorageFormat.get() != "Hdk",
         )
 
-    @pytest.mark.skipif(
-        condition=Engine.get() == "Unidist",
-        reason="Modin on unidist with MPI backend hangs",
-    )
     @pytest.mark.parametrize("skiprows", [None, 0, [], [1, 2], np.arange(0, 2)])
     def test_read_csv_skiprows_with_usecols(self, skiprows):
         usecols = {"float_data": "float64"}
@@ -1166,10 +1158,6 @@ class TestCsv:
         )
 
     @pytest.mark.skipif(
-        condition=Engine.get() == "Unidist",
-        reason="Modin on unidist with MPI backend hangs",
-    )
-    @pytest.mark.skipif(
         StorageFormat.get() == "Hdk",
         reason="to_csv is not implemented with HDK storage format yet - issue #3082",
     )
@@ -1196,10 +1184,6 @@ class TestCsv:
         )
 
     @pytest.mark.skipif(
-        condition=Engine.get() == "Unidist",
-        reason="Modin on unidist with MPI backend hangs",
-    )
-    @pytest.mark.skipif(
         StorageFormat.get() == "Hdk",
         reason="to_csv is not implemented with HDK storage format yet - issue #3082",
     )
@@ -1214,10 +1198,6 @@ class TestCsv:
             modin_obj=modin_df, pandas_obj=pandas_df, fn="to_csv", extension="csv"
         )
 
-    @pytest.mark.skipif(
-        condition=Engine.get() == "Unidist",
-        reason="Modin on unidist with MPI backend hangs",
-    )
     @pytest.mark.skipif(
         StorageFormat.get() == "Hdk",
         reason="to_csv is not implemented with HDK storage format yet - issue #3082",
@@ -1337,10 +1317,6 @@ class TestCsv:
             dtype="str",  # to avoid issues with heterogeneous data
         )
 
-    @pytest.mark.skipif(
-        condition=Engine.get() == "Unidist",
-        reason="Modin on unidist with MPI backend hangs.",
-    )
     def test_to_csv_with_index(self):
         cols = 100
         arows = 20000

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1070,6 +1070,10 @@ class TestCsv:
                 StringIO(open(pytest.csvs_names["test_read_csv_regular"], "r").read())
             )
 
+    @pytest.mark.skipif(
+        condition=Engine.get() == "Unidist",
+        reason="Modin on unidist with MPI backend hangs.",
+    )
     @pytest.mark.xfail(
         condition="config.getoption('--simulate-cloud').lower() != 'off'",
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #2340",
@@ -1097,6 +1101,10 @@ class TestCsv:
             cast_to_str=StorageFormat.get() != "Hdk",
         )
 
+    @pytest.mark.skipif(
+        condition=Engine.get() == "Unidist",
+        reason="Modin on unidist with MPI backend hangs",
+    )
     @pytest.mark.parametrize("skiprows", [None, 0, [], [1, 2], np.arange(0, 2)])
     def test_read_csv_skiprows_with_usecols(self, skiprows):
         usecols = {"float_data": "float64"}
@@ -1158,6 +1166,10 @@ class TestCsv:
         )
 
     @pytest.mark.skipif(
+        condition=Engine.get() == "Unidist",
+        reason="Modin on unidist with MPI backend hangs",
+    )
+    @pytest.mark.skipif(
         StorageFormat.get() == "Hdk",
         reason="to_csv is not implemented with HDK storage format yet - issue #3082",
     )
@@ -1184,6 +1196,10 @@ class TestCsv:
         )
 
     @pytest.mark.skipif(
+        condition=Engine.get() == "Unidist",
+        reason="Modin on unidist with MPI backend hangs",
+    )
+    @pytest.mark.skipif(
         StorageFormat.get() == "Hdk",
         reason="to_csv is not implemented with HDK storage format yet - issue #3082",
     )
@@ -1198,6 +1214,10 @@ class TestCsv:
             modin_obj=modin_df, pandas_obj=pandas_df, fn="to_csv", extension="csv"
         )
 
+    @pytest.mark.skipif(
+        condition=Engine.get() == "Unidist",
+        reason="Modin on unidist with MPI backend hangs",
+    )
     @pytest.mark.skipif(
         StorageFormat.get() == "Hdk",
         reason="to_csv is not implemented with HDK storage format yet - issue #3082",
@@ -1317,6 +1337,10 @@ class TestCsv:
             dtype="str",  # to avoid issues with heterogeneous data
         )
 
+    @pytest.mark.skipif(
+        condition=Engine.get() == "Unidist",
+        reason="Modin on unidist with MPI backend hangs.",
+    )
     def test_to_csv_with_index(self):
         cols = 100
         arows = 20000

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -73,6 +73,7 @@ class SupportsPublicToPandas(Protocol):  # noqa: PR01
 
 MIN_RAY_VERSION = version.parse("1.4.0")
 MIN_DASK_VERSION = version.parse("2.22.0")
+MIN_UNIDIST_VERSION = version.parse("0.2.0")
 
 PANDAS_API_URL_TEMPLATE = f"https://pandas.pydata.org/pandas-docs/version/{pandas.__version__}/reference/api/{{}}.html"
 

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -73,7 +73,7 @@ class SupportsPublicToPandas(Protocol):  # noqa: PR01
 
 MIN_RAY_VERSION = version.parse("1.4.0")
 MIN_DASK_VERSION = version.parse("2.22.0")
-MIN_UNIDIST_VERSION = version.parse("0.2.0")
+MIN_UNIDIST_VERSION = version.parse("0.2.1")
 
 PANDAS_API_URL_TEMPLATE = f"https://pandas.pydata.org/pandas-docs/version/{pandas.__version__}/reference/api/{{}}.html"
 

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -15,7 +15,7 @@ dependencies:
   - lxml
   - openpyxl
   - xlrd
-  - matplotlib<=3.2.2
+  - matplotlib
   - sqlalchemy>=1.4.0
   - pandas-gbq
   - pytables
@@ -26,7 +26,7 @@ dependencies:
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
   - packaging
-  - coverage<5.0
+  - coverage
   - pygithub==1.53
   - rpyc==4.1.5
   - cloudpickle

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -1,0 +1,52 @@
+name: modin_on_unidist
+channels:
+  - conda-forge
+dependencies:
+  - pandas==1.4.4
+  - numpy>=1.18.5
+  - pyarrow>=4.0.1
+  - fsspec
+  - xarray
+  - Jinja2
+  - scipy
+  - pip
+  - s3fs>=2021.8
+  - feather-format
+  - lxml
+  - openpyxl
+  - xlrd
+  - matplotlib<=3.2.2
+  - sqlalchemy>=1.4.0
+  - pandas-gbq
+  - pytables
+  - msgpack-python
+  - psutil
+  - pytest>=6.0.1
+  - pytest-benchmark
+  - pytest-cov>=2.10.1
+  - pytest-xdist>=2.1.0
+  - packaging
+  - coverage<5.0
+  - pygithub==1.53
+  - rpyc==4.1.5
+  - cloudpickle
+  - boto3
+  - scikit-learn
+  - pymssql
+  - psycopg2
+  - mypy
+  - pandas-stubs
+  - fastparquet
+  - pip:
+      # Fixes breaking ipywidgets changes, but didn't release yet.
+      - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
+      - tqdm
+      - connectorx>=0.2.6a4
+      - black
+      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
+      - flake8<5
+      - flake8-no-implicit-concat
+      - flake8-print
+      # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
+      - numpydoc==1.1.0
+      - git+https://github.com/modin-project/unidist#egg=unidist[mpi]

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -2,7 +2,8 @@ name: modin_on_unidist
 channels:
   - conda-forge
 dependencies:
-  - pandas==1.5.1
+  - unidist-mpi>=0.2.1
+  - pandas==1.5.2
   - numpy>=1.18.5
   - pyarrow>=4.0.1
   - fsspec
@@ -40,7 +41,6 @@ dependencies:
   # for release script
   - pygit2
   - pip:
-      - unidist[mpi]>=0.2.1
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - tqdm

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -2,7 +2,7 @@ name: modin_on_unidist
 channels:
   - conda-forge
 dependencies:
-  - pandas==1.4.4
+  - pandas==1.5.0
   - numpy>=1.18.5
   - pyarrow>=4.0.1
   - fsspec

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -2,7 +2,7 @@ name: modin_on_unidist
 channels:
   - conda-forge
 dependencies:
-  - pandas==1.5.0
+  - pandas==1.5.1
   - numpy>=1.18.5
   - pyarrow>=4.0.1
   - fsspec

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -5,6 +5,8 @@ dependencies:
   - pandas==1.5.1
   - numpy>=1.18.5
   - pyarrow>=4.0.1
+  # we install unidist-mpi as Modin only supports unidist on MPI backend for now
+  - unidist-mpi>=0.2.1
   - fsspec
   - xarray
   - Jinja2
@@ -49,4 +51,3 @@ dependencies:
       - flake8-print
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0
-      - git+https://github.com/modin-project/unidist#egg=unidist[mpi]

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -5,8 +5,6 @@ dependencies:
   - pandas==1.5.1
   - numpy>=1.18.5
   - pyarrow>=4.0.1
-  # we install unidist-mpi as Modin only supports unidist on MPI backend for now
-  - unidist-mpi>=0.2.1
   - fsspec
   - xarray
   - Jinja2
@@ -29,7 +27,7 @@ dependencies:
   - pytest-xdist>=2.1.0
   - packaging
   - coverage
-  - pygithub==1.53
+  - pygithub
   - rpyc==4.1.5
   - cloudpickle
   - boto3
@@ -39,7 +37,10 @@ dependencies:
   - mypy
   - pandas-stubs
   - fastparquet
+  # for release script
+  - pygit2
   - pip:
+      - unidist[mpi]>=0.2.1
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - tqdm

--- a/setup.py
+++ b/setup.py
@@ -16,10 +16,11 @@ ray_deps = [
     "pyarrow>=4.0.1",
     "redis>=3.5.0,<4.0.0",
 ]
+unidist_deps = ["unidist[mpi]>=0.2.1"]
 remote_deps = ["rpyc==4.1.5", "cloudpickle", "boto3"]
 spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]
 sql_deps = ["dfsql>=0.4.2", "pyparsing<=2.4.7"]
-all_deps = dask_deps + ray_deps + remote_deps + spreadsheet_deps
+all_deps = dask_deps + ray_deps + unidist_deps + remote_deps + spreadsheet_deps
 
 # Distribute 'modin-autoimport-pandas.pth' along with binary and source distributions.
 # This file provides the "import pandas before Ray init" feature if specific
@@ -60,6 +61,7 @@ setup(
         # can be installed by pip install modin[dask]
         "dask": dask_deps,
         "ray": ray_deps,
+        "unidist": unidist_deps,
         "remote": remote_deps,
         "spreadsheet": spreadsheet_deps,
         "sql": sql_deps,


### PR DESCRIPTION
Signed-off-by: Igoshev, Iaroslav <iaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR introduces `PandasOnUnidist` and `ExperimentalPandasOnUnidist` executions with MPI backend. The code is mostly just a copy of `PandasOnRay` and `ExperimentalPandasOnRay` executions. Unidist is supposed to work with every its execution backend using a generic code but for now we only use MPI backend as the initial step.

**Note that the changes in `ci.yml` should be migrated to `push-to-master.yml` before merging as we do not want to overload CI runs on pull request for now.**

**=== Performance ===**

**---taxi bench---**

**df.shape = (20000000, 51), num_cpus = n_parts = 90**
| engine | time, s |
| - | - |
| ray | 60.16 |
| mpich | 54.20 |
| intel mpi | 50.53 |

**---census bench---**

**df.shape = (21721922, 45), num_cpus = n_parts = 90**
| engine | time, s |
| - | - |
| ray | 51.02 |
| mpich | 69.98 |
| intel mpi | 67.83 |

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5053  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
