### PR TITLE
TEST-#5064: Update `TimeConcat` benchmark with new parameter `ignore_index`

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -149,19 +149,24 @@ class TimeMerge:
 
 
 class TimeConcat:
-    param_names = ["shapes", "how", "axis"]
+    param_names = ["shapes", "how", "axis", "ignore_index"]
     params = [
         get_benchmark_shapes("TimeConcat"),
         ["inner"],
         [0, 1],
+        [True, False],
     ]
 
-    def setup(self, shapes, how, axis):
+    def setup(self, shapes, how, axis, ignore_index):
         self.df1 = generate_dataframe("int", *shapes[0], RAND_LOW, RAND_HIGH)
         self.df2 = generate_dataframe("int", *shapes[1], RAND_LOW, RAND_HIGH)
 
-    def time_concat(self, shapes, how, axis):
-        execute(IMPL.concat([self.df1, self.df2], axis=axis, join=how))
+    def time_concat(self, shapes, how, axis, ignore_index):
+        execute(
+            IMPL.concat(
+                [self.df1, self.df2], axis=axis, join=how, ignore_index=ignore_index
+            )
+        )
 
 
 class TimeAppend:

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -89,6 +89,7 @@ Key Features and Updates
 * Benchmarking enhancements
   * FEAT-#4706: Add Modin ClassLogger to PandasDataframePartitionManager (#4707)
   * TEST-#5014: Simplify adding new ASV benchmarks (#5015)
+  * TEST-#5064: Update `TimeConcat` benchmark with new parameter `ignore_index` (#5065)
   * PERF-#4944: Avoid default_to_pandas in ``Series.cat.codes``, ``Series.dt.tz``, and ``Series.dt.to_pytimedelta`` (#4833)
 * Refactor Codebase
   * REFACTOR-#4530: Standardize access to physical data in partitions (#4563)


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5064 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
