### PR TITLE
TEST-#5074: Fix --extra-test-parameters for pytest --collect-only.

### DIFF
--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -83,6 +83,7 @@ def pytest_addoption(parser):
         "--extra-test-parameters",
         action="store_true",
         help="activate extra test parameter combinations",
+        default=False,
     )
 
 
@@ -309,10 +310,9 @@ def get_unique_base_execution():
 
 
 def pytest_configure(config):
-    if config.option.extra_test_parameters is not None:
-        import modin.pandas.test.utils as utils
+    import modin.pandas.test.utils as utils
 
-        utils.extra_test_parameters = config.option.extra_test_parameters
+    utils.extra_test_parameters = config.getoption("--extra-test-parameters")
 
     execution = config.option.execution
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

TEST-#5074: Fix --extra-test-parameters for pytest --discover-only. 

Both before and after this commit, `--extra-test-parameters` sets `extra_test_parameters` in a testing util file to False. The result is that `--extra-test-parameters` enables tests like this:

```shell
python -m pytest --extra-test-parameters    modin/pandas/test/dataframe/test_join_sort.py::test_sort_values[rotate_decimal_digits_or_symbols-ignore_index_None-last-heapsort-inplace_None-ascending_list_first_False-over_columns_str-first,last,middle-float_nan_data] -rP  --execution=BaseOnPython
```

Both before and after this test, tests like the one above are skipped without `--extra-test-parameters`:

```shell
python -m pytest modin/pandas/test/dataframe/test_join_sort.py::test_sort_values[rotate_decimal_digits_or_symbols-ignore_index_None-last-heapsort-inplace_None-ascending_list_first_False-over_columns_str-first,last,middle-float_nan_data] -rP  --execution=BaseOnPython
```

Before this commit, `pytest --collect-only` run at modin root fails with:

<details>

<summary>Error</summary>

```python-traceback
_______________________________________________ ERROR collecting test session ________________________________________________
../../opt/anaconda3/envs/modin-dev/lib/python3.10/site-packages/pluggy/_manager.py:115: in register
    hook._maybe_apply_history(hookimpl)
../../opt/anaconda3/envs/modin-dev/lib/python3.10/site-packages/pluggy/_hooks.py:300: in _maybe_apply_history
    res = self._hookexec(self.name, [method], kwargs, False)
../../opt/anaconda3/envs/modin-dev/lib/python3.10/site-packages/pluggy/_manager.py:80: in _hookexec
    return self._inner_hookexec(hook_name, methods, kwargs, firstresult)
modin/conftest.py:312: in pytest_configure
    if config.option.extra_test_parameters is not None:
E   AttributeError: 'Namespace' object has no attribute 'extra_test_parameters'
```
</details>

After this commit, I stop getting that failure.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5074 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
- [x] added (Issue Number: PR title (PR Number)) and github username to release notes for next major release <!-- e.g. DOCS-#4077: Add release notes template to docs folder (#4078) -->
