### PR TITLE
REFACTOR-#5092: Fix future warning for `set_axis` function

### DIFF
--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -127,7 +127,6 @@ Key Features and Updates
   * REFACTOR-#5009: Use `RayWrapper.materialize` instead of `ray.get` (#5010)
   * REFACTOR-#4755: Rewrite Pandas version mismatch warning (#4965)
   * REFACTOR-#5012: Add mypy checks for singleton files in base modin directory (#5013)
-  * REFACTOR-#5092: Fix future warning for `set_axis` function (#5093)
   * REFACTOR-#5038: Remove unnecessary _method argument from resamplers (#5039)
   * REFACTOR-#5081: Remove `c323f7fe385011ed849300155de07645.db` file (#5082)
 * Pandas API implementations and improvements

--- a/docs/release_notes/release_notes-0.16.0.rst
+++ b/docs/release_notes/release_notes-0.16.0.rst
@@ -127,6 +127,7 @@ Key Features and Updates
   * REFACTOR-#5009: Use `RayWrapper.materialize` instead of `ray.get` (#5010)
   * REFACTOR-#4755: Rewrite Pandas version mismatch warning (#4965)
   * REFACTOR-#5012: Add mypy checks for singleton files in base modin directory (#5013)
+  * REFACTOR-#5092: Fix future warning for `set_axis` function (#5093)
   * REFACTOR-#5038: Remove unnecessary _method argument from resamplers (#5039)
   * REFACTOR-#5081: Remove `c323f7fe385011ed849300155de07645.db` file (#5082)
 * Pandas API implementations and improvements

--- a/modin/_compat/pandas_api/latest/base.py
+++ b/modin/_compat/pandas_api/latest/base.py
@@ -331,6 +331,8 @@ class LatestCompatibleBasePandasDataset(BaseCompatibleBasePandasDataset):
         )
 
     def set_axis(self, labels, axis=0, inplace=no_default, *, copy=no_default):
+        if inplace is True and copy is True:
+            raise ValueError("Cannot specify both inplace=True and copy=True")
         return self._set_axis(
             labels=labels,
             axis=axis,

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -548,9 +548,7 @@ class PandasDataframe(ClassLogger):
         if axis is None:
 
             def apply_idx_objs(df, idx, cols):
-                return df.set_axis(idx, axis="index", inplace=False).set_axis(
-                    cols, axis="columns", inplace=False
-                )
+                return df.set_axis(idx, axis="index").set_axis(cols, axis="columns")
 
             self._partitions = np.array(
                 [
@@ -576,7 +574,7 @@ class PandasDataframe(ClassLogger):
         elif axis == 0:
 
             def apply_idx_objs(df, idx):
-                return df.set_axis(idx, axis="index", inplace=False)
+                return df.set_axis(idx, axis="index")
 
             self._partitions = np.array(
                 [
@@ -598,7 +596,7 @@ class PandasDataframe(ClassLogger):
         elif axis == 1:
 
             def apply_idx_objs(df, cols):
-                return df.set_axis(cols, axis="columns", inplace=False)
+                return df.set_axis(cols, axis="columns")
 
             self._partitions = np.array(
                 [

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1544,9 +1544,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def first_valid_index(self):
         def first_valid_index_builder(df):
             """Get the position of the first valid index in a single partition."""
-            return df.set_axis(
-                pandas.RangeIndex(len(df.index)), axis="index", inplace=False
-            ).apply(lambda df: df.first_valid_index())
+            return df.set_axis(pandas.RangeIndex(len(df.index)), axis="index").apply(
+                lambda df: df.first_valid_index()
+            )
 
         # We get the minimum from each column, then take the min of that to get
         # first_valid_index. The `to_pandas()` here is just for a single value and
@@ -1562,9 +1562,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def last_valid_index(self):
         def last_valid_index_builder(df):
             """Get the position of the last valid index in a single partition."""
-            return df.set_axis(
-                pandas.RangeIndex(len(df.index)), axis="index", inplace=False
-            ).apply(lambda df: df.last_valid_index())
+            return df.set_axis(pandas.RangeIndex(len(df.index)), axis="index").apply(
+                lambda df: df.last_valid_index()
+            )
 
         # We get the maximum from each column, then take the max of that to get
         # last_valid_index. The `to_pandas()` here is just for a single value and

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2532,13 +2532,9 @@ class BasePandasDataset(BasePandasDatasetCompat):
                 stacklevel=2,
             )
             labels, axis = axis, labels
-        if inplace:
-            setattr(self, pandas.DataFrame()._get_axis_name(axis), labels)
-        else:
-            obj = self.copy() if copy else self
-            # only `inplace=True` is allowed here to avoid `RecursionError`
-            obj.set_axis(labels, axis=axis, inplace=True)
-            return obj
+        obj = self.copy() if copy and inplace == False else self
+        setattr(obj, pandas.DataFrame._get_axis_name(axis), labels)
+        return None if inplace else obj
 
     def _shift(self, periods, freq, axis, fill_value):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2988,7 +2988,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
             )
             .index
         )
-        return self.set_axis(labels=new_labels, axis=axis, copy=copy)
+        return self._set_axis(new_labels, axis, inplace=False, copy=copy)
 
     # TODO: uncomment the following lines when #3331 issue will be closed
     # @prepend_to_notes(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2537,7 +2537,8 @@ class BasePandasDataset(BasePandasDatasetCompat):
         else:
             if copy:
                 obj = self.copy()
-            obj = obj.set_axis(labels, axis=axis, copy=False)
+            # only `inplace=True` is allowed here to avoid `RecursionError`
+            obj.set_axis(labels, axis=axis, inplace=True)
             return obj
 
     def _shift(self, periods, freq, axis, fill_value):  # noqa: PR01, RT01, D200

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2532,7 +2532,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
                 stacklevel=2,
             )
             labels, axis = axis, labels
-        obj = self.copy() if copy and not inplace else self
+        obj = self.copy() if copy else self
         setattr(obj, pandas.DataFrame._get_axis_name(axis), labels)
         return None if inplace else obj
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2971,7 +2971,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         else:
             new_labels = self.axes[axis].tz_convert(tz)
         obj = self.copy() if copy else self
-        return obj.set_axis(new_labels, axis, copy=copy)
+        return obj._set_axis(new_labels, axis, inplace=False, copy=copy)
 
     def tz_localize(
         self, tz, axis=0, level=None, copy=True, ambiguous="raise", nonexistent="raise"

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2532,7 +2532,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
                 stacklevel=2,
             )
             labels, axis = axis, labels
-        obj = self.copy() if copy and inplace == False else self
+        obj = self.copy() if copy and not inplace else self
         setattr(obj, pandas.DataFrame._get_axis_name(axis), labels)
         return None if inplace else obj
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2205,7 +2205,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         axis = self._get_axis_number(axis)
         new_labels = self.axes[axis].reorder_levels(order)
-        return self.set_axis(new_labels, axis=axis, inplace=False)
+        return self.set_axis(new_labels, axis=axis)
 
     def _resample(
         self,
@@ -2537,7 +2537,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         else:
             if copy:
                 obj = self.copy()
-            obj.set_axis(labels, axis=axis, inplace=True)
+            obj = obj.set_axis(labels, axis=axis, copy=False)
             return obj
 
     def _shift(self, periods, freq, axis, fill_value):  # noqa: PR01, RT01, D200
@@ -2744,7 +2744,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         axis = self._get_axis_number(axis)
         idx = self.index if axis == 0 else self.columns
-        return self.set_axis(idx.swaplevel(i, j), axis=axis, inplace=False)
+        return self.set_axis(idx.swaplevel(i, j), axis=axis)
 
     def tail(self, n=5):  # noqa: PR01, RT01, D200
         """
@@ -2939,7 +2939,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         """
         axis = self._get_axis_number(axis)
         new_labels = self.axes[axis].shift(periods, freq=freq)
-        return self.set_axis(new_labels, axis=axis, inplace=False)
+        return self.set_axis(new_labels, axis=axis)
 
     def transform(self, func, axis=0, *args, **kwargs):  # noqa: PR01, RT01, D200
         """
@@ -2971,7 +2971,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         else:
             new_labels = self.axes[axis].tz_convert(tz)
         obj = self.copy() if copy else self
-        return obj.set_axis(new_labels, axis, inplace=not copy)
+        return obj.set_axis(new_labels, axis, copy=copy)
 
     def tz_localize(
         self, tz, axis=0, level=None, copy=True, ambiguous="raise", nonexistent="raise"
@@ -2992,7 +2992,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
             )
             .index
         )
-        return self.set_axis(labels=new_labels, axis=axis, inplace=not copy)
+        return self.set_axis(labels=new_labels, axis=axis, copy=copy)
 
     # TODO: uncomment the following lines when #3331 issue will be closed
     # @prepend_to_notes(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2535,8 +2535,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
         if inplace:
             setattr(self, pandas.DataFrame()._get_axis_name(axis), labels)
         else:
-            if copy:
-                obj = self.copy()
+            obj = self.copy() if copy else self
             # only `inplace=True` is allowed here to avoid `RecursionError`
             obj.set_axis(labels, axis=axis, inplace=True)
             return obj

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -348,18 +348,18 @@ def test_sort_index(axis, ascending, na_position):
         for df in [modin_df, pandas_df]:
             df.index = [(i - length / 2) % length for i in range(length)]
 
+    dfs = [modin_df, pandas_df]
     # Add NaNs to sorted index
-    for df in [modin_df, pandas_df]:
-        sort_index = df.axes[axis]
-        df = df.set_axis(
+    for idx in range(len(dfs)):
+        sort_index = dfs[idx].axes[axis]
+        dfs[idx] = dfs[idx].set_axis(
             [np.nan if i % 2 == 0 else sort_index[i] for i in range(len(sort_index))],
             axis=axis,
             copy=False,
         )
 
     eval_general(
-        modin_df,
-        pandas_df,
+        *dfs,
         lambda df: df.sort_index(
             axis=axis, ascending=ascending, na_position=na_position
         ),

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -349,13 +349,16 @@ def test_sort_index(axis, ascending, na_position):
             df.index = [(i - length / 2) % length for i in range(length)]
 
     dfs = [modin_df, pandas_df]
+    kw = {"copy": False}
+    if PandasCompatVersion.CURRENT == PandasCompatVersion.PY36:
+        kw = {"inplace": False}
     # Add NaNs to sorted index
     for idx in range(len(dfs)):
         sort_index = dfs[idx].axes[axis]
         dfs[idx] = dfs[idx].set_axis(
             [np.nan if i % 2 == 0 else sort_index[i] for i in range(len(sort_index))],
             axis=axis,
-            copy=False,
+            **kw,
         )
     modin_df, pandas_df = dfs
 

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -357,10 +357,11 @@ def test_sort_index(axis, ascending, na_position):
             axis=axis,
             copy=False,
         )
+    modin_df, pandas_df = dfs
 
     eval_general(
-        dfs[0],
-        dfs[1],
+        modin_df,
+        pandas_df,
         lambda df: df.sort_index(
             axis=axis, ascending=ascending, na_position=na_position
         ),

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -351,10 +351,10 @@ def test_sort_index(axis, ascending, na_position):
     # Add NaNs to sorted index
     for df in [modin_df, pandas_df]:
         sort_index = df.axes[axis]
-        df.set_axis(
+        df = df.set_axis(
             [np.nan if i % 2 == 0 else sort_index[i] for i in range(len(sort_index))],
             axis=axis,
-            inplace=True,
+            copy=False,
         )
 
     eval_general(

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -359,7 +359,8 @@ def test_sort_index(axis, ascending, na_position):
         )
 
     eval_general(
-        *dfs,
+        dfs[0],
+        dfs[1],
         lambda df: df.sort_index(
             axis=axis, ascending=ascending, na_position=na_position
         ),

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -1217,12 +1217,12 @@ def test_set_axis(data, axis):
     index = modin_df.columns if x else modin_df.index
     labels = ["{0}_{1}".format(index[i], i) for i in range(modin_df.shape[x])]
 
-    modin_result = modin_df.set_axis(labels, axis=axis, inplace=False)
-    pandas_result = pandas_df.set_axis(labels, axis=axis, inplace=False)
+    modin_result = modin_df.set_axis(labels, axis=axis)
+    pandas_result = pandas_df.set_axis(labels, axis=axis)
     df_equals(modin_result, pandas_result)
 
     modin_df_copy = modin_df.copy()
-    modin_df.set_axis(labels, axis=axis, inplace=True)
+    modin_df = modin_df.set_axis(labels, axis=axis, copy=False)
 
     # Check that the copy and original are different
     try:
@@ -1232,7 +1232,7 @@ def test_set_axis(data, axis):
     else:
         assert False
 
-    pandas_df.set_axis(labels, axis=axis, inplace=True)
+    pandas_df = pandas_df.set_axis(labels, axis=axis, copy=False)
     df_equals(modin_df, pandas_df)
 
 

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -1217,12 +1217,17 @@ def test_set_axis(data, axis):
     index = modin_df.columns if x else modin_df.index
     labels = ["{0}_{1}".format(index[i], i) for i in range(modin_df.shape[x])]
 
-    modin_result = modin_df.set_axis(labels, axis=axis)
-    pandas_result = pandas_df.set_axis(labels, axis=axis)
+    kw = {"copy": True}
+    if PandasCompatVersion.CURRENT == PandasCompatVersion.PY36:
+        kw = {"inplace": False}
+    modin_result = modin_df.set_axis(labels, axis=axis, **kw)
+    pandas_result = pandas_df.set_axis(labels, axis=axis, **kw)
     df_equals(modin_result, pandas_result)
 
     modin_df_copy = modin_df.copy()
-    modin_df = modin_df.set_axis(labels, axis=axis, copy=False)
+    if "copy" in kw:
+        kw["copy"] = False
+    modin_df = modin_df.set_axis(labels, axis=axis, **kw)
 
     # Check that the copy and original are different
     try:
@@ -1232,7 +1237,7 @@ def test_set_axis(data, axis):
     else:
         assert False
 
-    pandas_df = pandas_df.set_axis(labels, axis=axis, copy=False)
+    pandas_df = pandas_df.set_axis(labels, axis=axis, **kw)
     df_equals(modin_df, pandas_df)
 
 

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -1220,9 +1220,7 @@ def test_set_axis(data, axis):
     kw = {"copy": True}
     if PandasCompatVersion.CURRENT == PandasCompatVersion.PY36:
         kw = {"inplace": False}
-    modin_result = modin_df.set_axis(labels, axis=axis, **kw)
-    pandas_result = pandas_df.set_axis(labels, axis=axis, **kw)
-    df_equals(modin_result, pandas_result)
+    eval_general(modin_df, pandas_df, lambda df: df.set_axis(labels, axis=axis, **kw))
 
     modin_df_copy = modin_df.copy()
     if "copy" in kw:


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5092 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
