### PR TITLE
TEST-#4562: In windows CI, try to start ray a few times

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -836,13 +836,16 @@ jobs:
           conda info
           conda list
       - name: Start local ray cluster
-        run: |
-          ray start --head --port=6379 --object-store-memory=1000000000
-          while [ $? -ne 0 ]; do
-            echo "Failed to start ray cluster. retrying..."
+        # Try a few times to start ray to work around
+        # https://github.com/modin-project/modin/issues/4562
+        uses: nick-fields/retry@v2
+        with:
+          shell: bash
+          timeout_minutes: 5
+          max_attempts: 5
+          command: |
             ray start --head --port=6379 --object-store-memory=1000000000
-          done
-          echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
+            echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
         if: matrix.engine == 'ray'
       - run: python -m pytest ${{matrix.test-task}}
         if: matrix.test-task != 'modin/pandas/test/test_io.py'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -808,9 +808,6 @@ jobs:
       MODIN_ENGINE: ${{matrix.engine}}
     name: test-windows
     steps:
-      - name: Limit ray memory
-        run: echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
-        if: matrix.engine == 'ray'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -838,6 +835,15 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Start local ray cluster
+        run: |
+          ray start --head --port=6379 --object-store-memory=1000000000
+          while [ $? -ne 0 ]; do
+            echo "Failed to start ray cluster. retrying..."
+            ray start --head --port=6379 --object-store-memory=1000000000
+          done
+          echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
+        if: matrix.engine == 'ray'
       - run: python -m pytest ${{matrix.test-task}}
         if: matrix.test-task != 'modin/pandas/test/test_io.py'
       - timeout-minutes: 30

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,9 +844,9 @@ jobs:
           max_attempts: 5
           command: |
             ray start --head --port=6379 --object-store-memory=1000000000
-            echo "going to set MODIN_RAY_CLUSTER=True..."
-            echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
-            echo "set MODIN_RAY_CLUSTER=TRUE"
+        if: matrix.engine == 'ray'
+      - name: Tell Modin to use existing ray cluster
+        run: echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
         if: matrix.engine == 'ray'
       - run: python -m pytest ${{matrix.test-task}}
         if: matrix.test-task != 'modin/pandas/test/test_io.py'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -844,7 +844,9 @@ jobs:
           max_attempts: 5
           command: |
             ray start --head --port=6379 --object-store-memory=1000000000
+            echo "going to set MODIN_RAY_CLUSTER=True..."
             echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
+            echo "set MODIN_RAY_CLUSTER=TRUE"
         if: matrix.engine == 'ray'
       - run: python -m pytest ${{matrix.test-task}}
         if: matrix.test-task != 'modin/pandas/test/test_io.py'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -840,7 +840,6 @@ jobs:
         # https://github.com/modin-project/modin/issues/4562
         uses: nick-fields/retry@v2
         with:
-          shell: bash
           timeout_minutes: 5
           max_attempts: 5
           command: |

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -379,6 +379,9 @@ jobs:
             ray start --head --port=6379 --object-store-memory=1000000000
             echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
         if: matrix.engine == 'ray'
+      - name: Tell Modin to use existing ray cluster
+        run: echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
+        if: matrix.engine == 'ray'
       - run: python -m pytest ${{matrix.test-task}}
         if: matrix.test-task != 'modin/pandas/test/test_io.py'
       - timeout-minutes: 30

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -377,7 +377,6 @@ jobs:
           max_attempts: 5
           command: |
             ray start --head --port=6379 --object-store-memory=1000000000
-            echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
         if: matrix.engine == 'ray'
       - name: Tell Modin to use existing ray cluster
         run: echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -369,13 +369,16 @@ jobs:
           conda info
           conda list
       - name: Start local ray cluster
-        run: |
-          ray start --head --port=6379 --object-store-memory=1000000000
-          while [ $? -ne 0 ]; do
-            echo "Failed to start ray cluster. retrying..."
+        # Try a few times to start ray to work around
+        # https://github.com/modin-project/modin/issues/4562
+        uses: nick-fields/retry@v2
+        with:
+          shell: bash
+          timeout_minutes: 5
+          max_attempts: 5
+          command: |
             ray start --head --port=6379 --object-store-memory=1000000000
-          done
-          echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
+            echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
         if: matrix.engine == 'ray'
       - run: python -m pytest ${{matrix.test-task}}
         if: matrix.test-task != 'modin/pandas/test/test_io.py'

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -341,9 +341,6 @@ jobs:
       MODIN_ENGINE: ${{matrix.engine}}
     name: test-windows
     steps:
-      - name: Limit ray memory
-        run: echo "MODIN_MEMORY=1000000000" >> $GITHUB_ENV
-        if: matrix.engine == 'ray'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 2
@@ -371,6 +368,15 @@ jobs:
         run: |
           conda info
           conda list
+      - name: Start local ray cluster
+        run: |
+          ray start --head --port=6379 --object-store-memory=1000000000
+          while [ $? -ne 0 ]; do
+            echo "Failed to start ray cluster. retrying..."
+            ray start --head --port=6379 --object-store-memory=1000000000
+          done
+          echo "MODIN_RAY_CLUSTER=True" >> $GITHUB_ENV
+        if: matrix.engine == 'ray'
       - run: python -m pytest ${{matrix.test-task}}
         if: matrix.test-task != 'modin/pandas/test/test_io.py'
       - timeout-minutes: 30

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -373,7 +373,6 @@ jobs:
         # https://github.com/modin-project/modin/issues/4562
         uses: nick-fields/retry@v2
         with:
-          shell: bash
           timeout_minutes: 5
           max_attempts: 5
           command: |


### PR DESCRIPTION
Results from comparing infinite tries on baseline on  [this branch](https://github.com/mvashishtha/modin/tree/4562-windows-matrix-ray-startup-playground) versus  [base](https://github.com/mvashishtha/modin/tree/4562-windows-matrix-ray-startup-playground-base):

- base: 2/38 runs had the time out error. First round was 1/8 (it was [this one](https://github.com/mvashishtha/modin/actions/runs/3190138370/jobs/5204845152) out of all the commits between [Test only test-windows[ray] in push.yml.](https://github.com/mvashishtha/modin/commit/c5a7d6be82273df72861cd833dd07131d3de5abc) and [Empty commit 7 to trigger CI.](https://github.com/mvashishtha/modin/commit/9bfd7a5fd0bd1658ff32f0d929fb0e84679d633a)). Later i ran another series of 30 tests from [this one](https://github.com/mvashishtha/modin/commit/b7ee3fdb7788c0265576978f853ca91f8139f839) through [this one](https://github.com/mvashishtha/modin/commit/6aa96e81f1f56a3ec3e232ad6c6d73c24c4897c9) and just [this commit](https://github.com/mvashishtha/modin/commit/e82b737056f64d342432b20723852d5f39e1f255) had this error. 
- with infinite retries: 0/50 runs had this error. used [this branch](https://github.com/mvashishtha/modin/tree/4562-windows-matrix-ray-startup-playground). Ran 50 times between [this commit](https://github.com/mvashishtha/modin/commit/bb884f5c229d16b264bb45eba0e4852f80c7ec19) and [this one](https://github.com/mvashishtha/modin/commit/9ab47f095ba12c985758f964d9c10aafed217162). 0/50 tests had this failure.

striked off because i ran more times and gave updated numbers above: ~~I tried this change with several test-windows runs on [this branch](https://github.com/mvashishtha/modin/tree/4562-windows-matrix-ray-startup-playground). Before the change to push.yml, 1/8 runs had the time out error (it was [this one](https://github.com/mvashishtha/modin/actions/runs/3190138370/jobs/5204845152) out of all the commits between [Test only test-windows[ray] in push.yml.](https://github.com/mvashishtha/modin/commit/c5a7d6be82273df72861cd833dd07131d3de5abc) and [Empty commit 7 to trigger CI.](https://github.com/mvashishtha/modin/commit/9bfd7a5fd0bd1658ff32f0d929fb0e84679d633a)). (one out of 8 failed due to unrelated error #4905.) After this change, 0/20 runs had the time out error ([1/20](https://github.com/mvashishtha/modin/commit/bb884f5c229d16b264bb45eba0e4852f80c7ec19) had a mysterious other failure).~~

Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4562 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
