### PR TITLE
TEST-#5124: Disable codecov comments.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,1 @@
+comment: false

--- a/modin/pandas/test/internals/test_benchmark_mode.py
+++ b/modin/pandas/test/internals/test_benchmark_mode.py
@@ -50,7 +50,6 @@ def test_from_environment_variable():
 
 def test_turn_off():
     df = pd.DataFrame([0])
-    pass
     BenchmarkMode.put(False)
     with mock.patch(wait_method) as wait:
         df.dropna()

--- a/modin/pandas/test/internals/test_benchmark_mode.py
+++ b/modin/pandas/test/internals/test_benchmark_mode.py
@@ -50,6 +50,7 @@ def test_from_environment_variable():
 
 def test_turn_off():
     df = pd.DataFrame([0])
+    pass
     BenchmarkMode.put(False)
     with mock.patch(wait_method) as wait:
         df.dropna()


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

I confirmed that I no longer get the comment on this PR even when I make a test run for this PR by editing a test file.

For rationale see #5122.

- [x] commit message follows format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5125
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
