### PR TITLE
FIX-#5128: Fix reading parquet directory from s3.

### DIFF
--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -223,7 +223,9 @@ class PyArrowDataset(ColumnStoreDataset):
     ):
         from pyarrow.parquet import read_table
 
-        return read_table(self.path, columns=columns, filesystem=self.fs).to_pandas()
+        return read_table(
+            self._fs_path, columns=columns, filesystem=self.fs
+        ).to_pandas()
 
 
 @_inherit_docstrings(ColumnStoreDataset)

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1579,7 +1579,7 @@ class TestParquet:
             engine=engine,
         )
 
-    @pytest.mark.parametrize("path_type", ["url", "object"])
+    @pytest.mark.parametrize("path_type", ["url", "object", "directory"])
     @pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
     @pytest.mark.xfail(
         condition="config.getoption('--simulate-cloud').lower() != 'off'",
@@ -1593,6 +1593,15 @@ class TestParquet:
             fs = s3fs.S3FileSystem(anon=True)
             with fs.open(dataset_url, "rb") as file_obj:
                 eval_io("read_parquet", path=file_obj, engine=engine)
+        elif path_type == "directory":
+            # TODO(mvashishtha): DO NOT MERGE until we make
+            # s3://modin-datasets/testing publicly accessible and test reading
+            # that directory instead.
+            eval_io(
+                "read_parquet",
+                path="s3://mahesh-vashishtha/part",
+                engine=engine,
+            )
         else:
             if PandasCompatVersion.CURRENT == PandasCompatVersion.PY36:
                 pytest.xfail(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1619,12 +1619,9 @@ class TestParquet:
                     # n.b. conda doesn't seem to have pytest>6.2.5 for python
                     # 3.6, and pytest 6.2.5 doesn't accept "skip" parameter.
                     pytest.skip()
-            # TODO(mvashishtha): DO NOT MERGE until we make
-            # s3://modin-datasets/testing publicly accessible and test reading
-            # that directory instead.
             eval_io(
                 "read_parquet",
-                path="s3://mahesh-vashishtha/part",
+                path="s3://modin-datasets/test_data_dir.parquet",
                 storage_options={"anon": True},
                 engine=engine,
             )

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1613,15 +1613,12 @@ class TestParquet:
                         reason="older pandas.read_parquet does not support storage_options"
                     )
                 else:
-                    pytest.skip(
-                        reason=(
-                            "older pandas.read_parquet does not "
-                            + "support storage_options, but modin "
-                            + "and pandas both happen to give "
-                            + "different ValueErrors, so we cannot "
-                            + "xfail"
-                        )
-                    )
+                    # older pandas.read_parquet does not support
+                    # storage_options, but modin and pandas both happen to
+                    # give different ValueErrors, so we cannot xfail.
+                    # n.b. conda doesn't seem to have pytest>6.2.5 for python
+                    # 3.6, and pytest 6.2.5 doesn't accept "skip" parameter.
+                    pytest.skip()
             # TODO(mvashishtha): DO NOT MERGE until we make
             # s3://modin-datasets/testing publicly accessible and test reading
             # that directory instead.


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5128
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
