### PR TITLE
PERF-#5162: precompute new row/column lengths in '._reorder_labels'

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1085,6 +1085,7 @@ class PandasDataframe(ClassLogger):
             A new PandasDataframe with reordered columns and/or rows.
         """
         new_lengths, new_widths = None, None
+        new_dtypes = self._dtypes
         if row_positions is not None:
             ordered_rows = self._partition_mgr_cls.map_axis_partitions(
                 0, self._partitions, lambda df: df.iloc[row_positions]
@@ -1113,6 +1114,8 @@ class PandasDataframe(ClassLogger):
                 1, ordered_rows, lambda df: df.iloc[:, col_positions]
             )
             col_idx = self.columns[col_positions]
+            if new_dtypes is not None:
+                new_dtypes = self._dtypes.iloc[col_positions]
 
             if self._partitions.shape[1] != ordered_cols.shape[1] or len(
                 col_idx
@@ -1132,7 +1135,7 @@ class PandasDataframe(ClassLogger):
             col_idx = self.columns
             new_widths = self._column_widths_cache
         return self.__constructor__(
-            ordered_cols, row_idx, col_idx, new_lengths, new_widths, self._dtypes
+            ordered_cols, row_idx, col_idx, new_lengths, new_widths, new_dtypes
         )
 
     @lazy_metadata_decorator(apply_axis=None)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -28,6 +28,7 @@ from pandas._libs.lib import no_default
 from typing import List, Hashable, Optional, Callable, Union, Dict, TYPE_CHECKING
 
 from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
+from modin.core.storage_formats.pandas.utils import get_length_list
 from modin.error_message import ErrorMessage
 from modin.core.storage_formats.pandas.parsers import (
     find_common_type_cat as find_common_type,
@@ -1083,23 +1084,43 @@ class PandasDataframe(ClassLogger):
         PandasDataframe
             A new PandasDataframe with reordered columns and/or rows.
         """
+        new_lengths, new_widths = None, None
         if row_positions is not None:
             ordered_rows = self._partition_mgr_cls.map_axis_partitions(
                 0, self._partitions, lambda df: df.iloc[row_positions]
             )
             row_idx = self.index[row_positions]
+
+            # The frame was re-partitioned along the 0 axis during reordering using
+            # the "standard" partitioning. Knowing the standard partitioning scheme
+            # we are able to compute new row lengths.
+            breakpoint()
+            new_lengths = get_length_list(
+                axis_len=len(row_idx), num_splits=ordered_rows.shape[0]
+            )
         else:
             ordered_rows = self._partitions
             row_idx = self.index
+            new_lengths = self._row_lengths_cache
         if col_positions is not None:
             ordered_cols = self._partition_mgr_cls.map_axis_partitions(
                 1, ordered_rows, lambda df: df.iloc[:, col_positions]
             )
             col_idx = self.columns[col_positions]
+
+            # The frame was re-partitioned along the 1 axis during reordering using
+            # the "standard" partitioning. Knowing the standard partitioning scheme
+            # we are able to compute new row lengths.
+            # new_widths = get_length_list(
+            #     axis_len=len(col_idx), num_splits=ordered_cols.shape[1]
+            # )
         else:
             ordered_cols = ordered_rows
             col_idx = self.columns
-        return self.__constructor__(ordered_cols, row_idx, col_idx)
+            new_widths = self._column_widths_cache
+        return self.__constructor__(
+            ordered_cols, row_idx, col_idx, new_lengths, new_widths, self._dtypes
+        )
 
     @lazy_metadata_decorator(apply_axis=None)
     def copy(self):

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1091,7 +1091,9 @@ class PandasDataframe(ClassLogger):
             )
             row_idx = self.index[row_positions]
 
-            if self._partitions.shape[0] != ordered_rows.shape[0]:
+            if self._partitions.shape[0] != ordered_rows.shape[0] or len(
+                row_idx
+            ) != len(self.index):
                 # The frame was re-partitioned along the 0 axis during reordering using
                 # the "standard" partitioning. Knowing the standard partitioning scheme
                 # we are able to compute new row lengths.
@@ -1112,7 +1114,9 @@ class PandasDataframe(ClassLogger):
             )
             col_idx = self.columns[col_positions]
 
-            if self._partitions.shape[1] != ordered_cols.shape[1]:
+            if self._partitions.shape[1] != ordered_cols.shape[1] or len(
+                col_idx
+            ) != len(self.columns):
                 # The frame was re-partitioned along the 1 axis during reordering using
                 # the "standard" partitioning. Knowing the standard partitioning scheme
                 # we are able to compute new column widths.

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1091,13 +1091,17 @@ class PandasDataframe(ClassLogger):
             )
             row_idx = self.index[row_positions]
 
-            # The frame was re-partitioned along the 0 axis during reordering using
-            # the "standard" partitioning. Knowing the standard partitioning scheme
-            # we are able to compute new row lengths.
-            breakpoint()
-            new_lengths = get_length_list(
-                axis_len=len(row_idx), num_splits=ordered_rows.shape[0]
-            )
+            if self._partitions.shape[0] != ordered_rows.shape[0]:
+                # The frame was re-partitioned along the 0 axis during reordering using
+                # the "standard" partitioning. Knowing the standard partitioning scheme
+                # we are able to compute new row lengths.
+                new_lengths = get_length_list(
+                    axis_len=len(row_idx), num_splits=ordered_rows.shape[0]
+                )
+            else:
+                # If the frame's partitioning was preserved then
+                # we can use previous row lengths cache
+                new_lengths = self._row_lengths_cache
         else:
             ordered_rows = self._partitions
             row_idx = self.index
@@ -1108,12 +1112,17 @@ class PandasDataframe(ClassLogger):
             )
             col_idx = self.columns[col_positions]
 
-            # The frame was re-partitioned along the 1 axis during reordering using
-            # the "standard" partitioning. Knowing the standard partitioning scheme
-            # we are able to compute new row lengths.
-            # new_widths = get_length_list(
-            #     axis_len=len(col_idx), num_splits=ordered_cols.shape[1]
-            # )
+            if self._partitions.shape[1] != ordered_cols.shape[1]:
+                # The frame was re-partitioned along the 1 axis during reordering using
+                # the "standard" partitioning. Knowing the standard partitioning scheme
+                # we are able to compute new column widths.
+                new_widths = get_length_list(
+                    axis_len=len(col_idx), num_splits=ordered_cols.shape[1]
+                )
+            else:
+                # If the frame's partitioning was preserved then
+                # we can use previous column widths cache
+                new_widths = self._column_widths_cache
         else:
             ordered_cols = ordered_rows
             col_idx = self.columns

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -179,7 +179,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         """
         dataframe = pandas.concat(list(partitions), axis=axis, copy=False)
         result = func(dataframe, *f_args, **f_kwargs)
-
+        # breakpoint()
         if num_splits == 1:
             # If we're not going to split the result, we don't need to specify
             # split lengths.

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -179,7 +179,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         """
         dataframe = pandas.concat(list(partitions), axis=axis, copy=False)
         result = func(dataframe, *f_args, **f_kwargs)
-        # breakpoint()
+
         if num_splits == 1:
             # If we're not going to split the result, we don't need to specify
             # split lengths.

--- a/modin/core/storage_formats/pandas/utils.py
+++ b/modin/core/storage_formats/pandas/utils.py
@@ -93,7 +93,7 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
     if length_list is None:
         length_list = get_length_list(result.shape[axis], num_splits)
     # Inserting the first "zero" to properly compute cumsum indexing slices
-    length_list.insert(0, 0)
+    length_list = np.insert(length_list, obj=0, values=[0])
 
     sums = np.cumsum(length_list)
     # We do this to restore block partitioning

--- a/modin/core/storage_formats/pandas/utils.py
+++ b/modin/core/storage_formats/pandas/utils.py
@@ -103,7 +103,7 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
         return [result.iloc[:, sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
 
 
-def get_length_list(axis_len, num_splits):
+def get_length_list(axis_len: int, num_splits: int) -> list:
     """
     Compute partitions lengths along the axis with the specified number of splits.
 

--- a/modin/core/storage_formats/pandas/utils.py
+++ b/modin/core/storage_formats/pandas/utils.py
@@ -90,18 +90,42 @@ def split_result_of_axis_func_pandas(axis, num_splits, result, length_list=None)
     if num_splits == 1:
         return [result]
 
-    if length_list is not None:
-        length_list.insert(0, 0)
-    else:
-        chunksize = compute_chunksize(result.shape[axis], num_splits)
-        length_list = np.full(num_splits + 1, chunksize)
-        length_list[0] = 0
+    if length_list is None:
+        length_list = get_length_list(result.shape[axis], num_splits)
+    # Inserting the first "zero" to properly compute cumsum indexing slices
+    length_list.insert(0, 0)
+
     sums = np.cumsum(length_list)
     # We do this to restore block partitioning
     if axis == 0 or isinstance(result, pandas.Series):
         return [result.iloc[sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
     else:
         return [result.iloc[:, sums[i] : sums[i + 1]] for i in range(len(sums) - 1)]
+
+
+def get_length_list(axis_len, num_splits):
+    """
+    Compute partitions lengths along the axis with the specified number of splits.
+
+    Parameters
+    ----------
+    axis_len : int
+        Element count in an axis.
+    num_splits : int
+        Number of splits along the axis.
+
+    Returns
+    -------
+    list of ints
+        List of integer lengths of partitions.
+    """
+    chunksize = compute_chunksize(axis_len, num_splits)
+    return [
+        chunksize
+        if (i + 1) * chunksize <= axis_len
+        else max(0, axis_len - i * chunksize)
+        for i in range(num_splits)
+    ]
 
 
 def length_fn_pandas(df):


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The PR adds precomputation of row/column lengths cache for the `._reorder_labels` result based on the source frame. You can find more info on why we can do it in such a way in source issue #5162.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5162 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
