### PR TITLE
FIX-#4023: Fall back to pandas in case of MultiIndex columns

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -2385,6 +2385,14 @@ class HdkOnNativeDataframe(PandasDataframe):
         """
         new_index = df.index
         new_columns = df.columns
+
+        if isinstance(new_columns, MultiIndex):
+            # MultiIndex columns are not supported by the HDK backend.
+            # We just print this warning here and fall back to pandas.
+            index_cols = None
+            ErrorMessage.single_warning(
+                "MultiIndex columns are not currently supported by the HDK backend."
+            )
         # If there is non-trivial index, we put it into columns.
         # If the index is trivial, but there are no columns, we put
         # it into columns either because, otherwise, we don't know
@@ -2392,7 +2400,7 @@ class HdkOnNativeDataframe(PandasDataframe):
         # That's what we usually have for arrow tables and execution
         # result. Unnamed index is renamed to __index__. Also all
         # columns get 'F_' prefix to handle names unsupported in HDK.
-        if len(new_index) == 0 or (
+        elif len(new_index) == 0 or (
             len(new_columns) != 0 and cls._is_trivial_index(new_index)
         ):
             index_cols = None

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -163,6 +163,8 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
 
             if obj.empty:
                 unsupported_cols = []
+            elif isinstance(obj.columns, pandas.MultiIndex):
+                unsupported_cols = [str(c) for c in obj.columns]
             else:
                 cols = [name for name, col in obj.dtypes.items() if col == "object"]
                 type_samples = obj.iloc[0][cols]

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -447,10 +447,7 @@ class TestMultiIndex:
         eval_general(pd, pandas, applier)
 
     @pytest.mark.parametrize("is_multiindex", [True, False])
-    @pytest.mark.parametrize(
-        "column_names", [None, ["level1", None], ["level1", "level2"]]
-    )
-    def test_reset_index_multicolumns(self, is_multiindex, column_names):
+    def test_reset_index_multicolumns(self, is_multiindex):
         index = (
             pandas.MultiIndex.from_tuples(
                 [(i, j, k) for i in range(2) for j in range(3) for k in range(4)],
@@ -458,9 +455,6 @@ class TestMultiIndex:
             )
             if is_multiindex
             else pandas.Index(np.arange(1, len(self.data["a"]) + 1), name="index")
-        )
-        columns = pandas.MultiIndex.from_tuples(
-            [("a", "b"), ("b", "c")], names=column_names
         )
         data = np.array(list(self.data.values())).T
 
@@ -471,7 +465,7 @@ class TestMultiIndex:
         run_and_compare(
             fn=applier,
             data=data,
-            constructor_kwargs={"index": index, "columns": columns},
+            constructor_kwargs={"index": index},
         )
 
     def test_set_index_name(self):
@@ -497,6 +491,27 @@ class TestMultiIndex:
         )
 
         df_equals(pandas_df, modin_df)
+
+    def test_rename(self):
+        index = pandas.MultiIndex.from_tuples(
+            [("foo1", "bar1"), ("foo2", "bar2")], names=["foo", "bar"]
+        )
+        columns = pandas.MultiIndex.from_tuples(
+            [("fizz1", "buzz1"), ("fizz2", "buzz2")], names=["fizz", "buzz"]
+        )
+
+        def rename(df, **kwargs):
+            return df.rename(
+                index={"foo1": "foo3", "bar2": "bar3"},
+                columns={"fizz1": "fizz3", "buzz2": "buzz3"},
+            )
+
+        run_and_compare(
+            fn=rename,
+            data=[(0, 0), (1, 1)],
+            constructor_kwargs={"index": index, "columns": columns},
+            force_lazy=False,
+        )
 
 
 class TestFillna:


### PR DESCRIPTION
MultiIndex columns are not currently supported by HDK.

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4023? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
