### PR TITLE
FIX-#5150: Sync row labels after read_csv when index_col is False

### DIFF
--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -939,7 +939,7 @@ class TextFileDispatcher(FileDispatcher):
                 new_query_compiler = new_query_compiler.take_2d(
                     pandas.RangeIndex(len(new_query_compiler.index))[:nrows]
                 )
-        if index_col is None:
+        if index_col is None or index_col is False:
             new_query_compiler._modin_frame.synchronize_labels(axis=0)
 
         return new_query_compiler

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1335,11 +1335,14 @@ class TestCsv:
         eval_to_file(modin_df, pandas_df, "to_csv", "csv")
 
     def test_read_csv_issue_5150(self):
-        pandas_df = pandas.DataFrame(np.random.randint(0, 100, size=(2**6, 2**6)))
-        pandas_df.to_csv("issue5150.csv", index=False)
-        expected_pandas_df = pandas.read_csv("issue5150.csv", index_col=False)
-        modin_df = pd.read_csv("issue5150.csv", index_col=False)
-        actual_pandas_df = modin_df._to_pandas()
+        with ensure_clean(".csv") as unique_filename:
+            pandas_df = pandas.DataFrame(
+                np.random.randint(0, 100, size=(2**6, 2**6))
+            )
+            pandas_df.to_csv(unique_filename, index=False)
+            expected_pandas_df = pandas.read_csv(unique_filename, index_col=False)
+            modin_df = pd.read_csv(unique_filename, index_col=False)
+            actual_pandas_df = modin_df._to_pandas()
         df_equals(expected_pandas_df, actual_pandas_df)
 
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1334,6 +1334,14 @@ class TestCsv:
         ).set_index("key")
         eval_to_file(modin_df, pandas_df, "to_csv", "csv")
 
+    def test_read_csv_issue_5150(self):
+        pandas_df = pandas.DataFrame(np.random.randint(0, 100, size=(2**6, 2**6)))
+        pandas_df.to_csv("issue5150.csv", index=False)
+        expected_pandas_df = pandas.read_csv("issue5150.csv", index_col=False)
+        modin_df = pd.read_csv("issue5150.csv", index_col=False)
+        actual_pandas_df = modin_df._to_pandas()
+        df_equals(expected_pandas_df, actual_pandas_df)
+
 
 class TestTable:
     def test_read_table(self, make_csv_file):


### PR DESCRIPTION
Signed-off-by: Igoshev, Iaroslav <iaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5150  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
