### PR TITLE
TEST-#5154: add `py` to requirements to fix CI failures

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,6 +27,7 @@ dependencies:
   - pytest-benchmark
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
+  - py # See: https://github.com/ionelmc/pytest-benchmark/issues/226
   - packaging
   - coverage<5.0
   - pygithub==1.53

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -27,6 +27,7 @@ dependencies:
   - pytest-benchmark
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
+  # TODO: remove py from dependencies after pytest-benchmark makes a new release
   - py # See: https://github.com/ionelmc/pytest-benchmark/issues/226
   - packaging
   - coverage<5.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -48,3 +48,5 @@ fuzzydata>=0.0.6
 mypy
 pandas-stubs
 fastparquet
+# See: https://github.com/ionelmc/pytest-benchmark/issues/226
+py

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -10,6 +10,7 @@ dependencies:
   - pytest>=6.0.1
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
+  # TODO: remove py from dependencies after pytest-benchmark makes a new release
   - py # See: https://github.com/ionelmc/pytest-benchmark/issues/226
   - coverage<5.0
   - pygithub==1.53

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -10,6 +10,7 @@ dependencies:
   - pytest>=6.0.1
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
+  - py # See: https://github.com/ionelmc/pytest-benchmark/issues/226
   - coverage<5.0
   - pygithub==1.53
   - pyhdk==0.2

--- a/requirements/environment-py36.yml
+++ b/requirements/environment-py36.yml
@@ -28,6 +28,7 @@ dependencies:
   - pytest-benchmark
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
+  - py # See: https://github.com/ionelmc/pytest-benchmark/issues/226
   - packaging
   - coverage<5.0
   - pygithub==1.53

--- a/requirements/environment-py36.yml
+++ b/requirements/environment-py36.yml
@@ -28,6 +28,7 @@ dependencies:
   - pytest-benchmark
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
+  # TODO: remove py from dependencies after pytest-benchmark makes a new release
   - py # See: https://github.com/ionelmc/pytest-benchmark/issues/226
   - packaging
   - coverage<5.0

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -24,6 +24,7 @@ dependencies:
   - pytest-benchmark
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
+  # TODO: remove py from dependencies after pytest-benchmark makes a new release
   - py # See: https://github.com/ionelmc/pytest-benchmark/issues/226
   - coverage<5.0
   - pygithub==1.53

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -24,6 +24,7 @@ dependencies:
   - pytest-benchmark
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
+  - py # See: https://github.com/ionelmc/pytest-benchmark/issues/226
   - coverage<5.0
   - pygithub==1.53
   - rpyc==4.1.5


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5154 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
