### PR TITLE
FIX-#3925: Fixed AssertionError on columns and index drop

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -2513,6 +2513,7 @@ class HdkOnNativeDataframe(PandasDataframe):
             else:
                 df.set_index(idx_col_names, inplace=True)
                 df.index.rename(self._index_names(self._index_cols), inplace=True)
+            assert len(df.columns) == len(self.columns)
         else:
             assert self._index_cols is None
             assert df.index.name is None, f"index name '{df.index.name}' is not None"

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -2506,15 +2506,21 @@ class HdkOnNativeDataframe(PandasDataframe):
         # index columns.
         if len(df.columns) != len(self.columns):
             assert self._index_cols
-            df.set_index([f"F_{col}" for col in self._index_cols], inplace=True)
-            df.index.rename(self._index_names(self._index_cols), inplace=True)
-            assert len(df.columns) == len(self.columns)
+            idx_col_names = [f"F_{col}" for col in self._index_cols]
+            if self._index_cache is not None:
+                df.drop(columns=idx_col_names, inplace=True)
+                df.index = self._index_cache.copy()
+            else:
+                df.set_index(idx_col_names, inplace=True)
+                df.index.rename(self._index_names(self._index_cols), inplace=True)
         else:
             assert self._index_cols is None
             assert df.index.name is None, f"index name '{df.index.name}' is not None"
+            if self._index_cache is not None:
+                df.index = self._index_cache.copy()
 
         # Restore original column labels encoded in HDK to meet its
-        # restirctions on column names.
+        # restrictions on column names.
         df.columns = self.columns
 
         return df

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -391,10 +391,20 @@ class TestMasks:
         run_and_compare(projection, data=self.data, cols=cols)
 
     def test_drop(self):
-        def drop(df, **kwargs):
-            return df.drop(columns="a")
+        def drop(df, column_names, **kwargs):
+            return df.drop(columns=column_names)
 
-        run_and_compare(drop, data=self.data)
+        run_and_compare(drop, data=self.data, column_names="a")
+        run_and_compare(drop, data=self.data, column_names=self.data.keys())
+
+    def test_drop_index(self):
+        def drop(df, **kwargs):
+            return df.drop(df.index[0])
+
+        idx = list(map(str, self.data["a"]))
+        run_and_compare(
+            drop, data=self.data, constructor_kwargs={"index": idx}, force_lazy=False
+        )
 
     def test_iloc(self):
         def mask(df, **kwargs):

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -557,17 +557,26 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
     def drop(self, index=None, columns=None, errors: str = "raise"):
         if index is not None:
+            # Only column drop is supported by the HDK engine
             raise NotImplementedError("Row drop")
         if errors != "raise":
             raise NotImplementedError(
                 "This lazy query compiler will always "
                 + "raise an error on invalid columns."
             )
-        return self.__constructor__(
-            self._modin_frame.take_2d_labels_or_positional(
-                row_labels=index, col_labels=self.columns.drop(columns)
-            )
+
+        columns = self.columns.drop(columns)
+        new_frame = self._modin_frame.take_2d_labels_or_positional(
+            row_labels=index, col_labels=columns
         )
+
+        # If all columns are dropped and the index is trivial, we are
+        # not able to restore it, since we don't know the number of rows.
+        # In this case, we copy the index from the current frame.
+        if len(columns) == 0 and new_frame._index_cols is None:
+            new_frame._index_cache = self._modin_frame.index.copy()
+
+        return self.__constructor__(new_frame)
 
     def dropna(self, axis=0, how=no_default, thresh=no_default, subset=None):
         if thresh is not no_default or axis != 0:

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -574,6 +574,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         # not able to restore it, since we don't know the number of rows.
         # In this case, we copy the index from the current frame.
         if len(columns) == 0 and new_frame._index_cols is None:
+            assert index is None, "Can't copy old indexes as there was a row drop"
             new_frame._index_cache = self._modin_frame.index.copy()
 
         return self.__constructor__(new_frame)


### PR DESCRIPTION
## What do these changes do?

1. Index drop is not supported by the HDK engine. In this case - fall back to pandas.
2. If all columns are dropped and the index is trivial, we are not able to restore it, since we don't know the number of rows. In this case, we calculate the index from the current frame.

**Fixes #3916**

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3925? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
