### PR TITLE
FIX-#5184: Fix `get_dummies` to respect passed columns to be encoded

### DIFF
--- a/modin/pandas/test/test_reshape.py
+++ b/modin/pandas/test/test_reshape.py
@@ -65,6 +65,13 @@ def test_get_dummies():
     with warns_that_defaulting_to_pandas():
         pd.get_dummies(1)
 
+    # test from #5184
+    pandas_df = pandas.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6], "c": ["7", "8", "9"]})
+    modin_df = pd.DataFrame(pandas_df)
+    pandas_result = pandas.get_dummies(pandas_df, columns=["a", "b"])
+    modin_result = pd.get_dummies(modin_df, columns=["a", "b"])
+    df_equals(modin_result, pandas_result)
+
 
 def test_melt():
     data = test_data_values[0]


### PR DESCRIPTION
Signed-off-by: Igoshev, Iaroslav <iaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5184  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
