### PR TITLE
FIX-#5188: Fix `getitem_bool` when the key is Series with empty partition

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -21,6 +21,7 @@ queries for the ``PandasDataframe``.
 import numpy as np
 import pandas
 import functools
+from pandas.api.types import is_scalar
 from pandas.core.common import is_bool_indexer
 from pandas.core.indexing import check_bool_indexer
 from pandas.core.indexes.api import ensure_index_from_sequences
@@ -2181,10 +2182,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # __getitem__ methods
     __getitem_bool = Binary.register(
-        # r is usually a list, but when r.size == 1, the array is squeezed to a scalar
-        lambda df, r: df[r]
-        if r.size > 1 or isinstance(r, (pandas.Series, pandas.DataFrame)) and r.empty
-        else df[[r]],
+        lambda df, r: df[[r]] if is_scalar(r) else df[r],
         join_type="left",
         labels="drop",
     )

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2182,7 +2182,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # __getitem__ methods
     __getitem_bool = Binary.register(
         # r is usually a list, but when r.size == 1, the array is squeezed to a scalar
-        lambda df, r: df[r] if r.size > 1 else df[[r]],
+        lambda df, r: df[r]
+        if r.size > 1 or isinstance(r, (pandas.Series, pandas.DataFrame)) and r.empty
+        else df[[r]],
         join_type="left",
         labels="drop",
     )


### PR DESCRIPTION
Signed-off-by: Igoshev, Iaroslav <iaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5188  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
