### PR TITLE
FEAT-#4263: Efficiently construct dataframes from a dict of modin Series

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -179,6 +179,13 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
             elif is_dict_like(data) and not isinstance(
                 data, (pandas.Series, Series, pandas.DataFrame, DataFrame)
             ):
+                if all(isinstance(v, Series) for v in data.values()):
+                    from .general import concat
+
+                    self._query_compiler = concat(
+                        data.values(), axis=1, keys=data.keys()
+                    )._query_compiler
+                    return
                 data = {
                     k: v._to_pandas() if isinstance(v, Series) else v
                     for k, v in data.items()

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -179,7 +179,7 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
             elif is_dict_like(data) and not isinstance(
                 data, (pandas.Series, Series, pandas.DataFrame, DataFrame)
             ):
-                if all(isinstance(v, Series) for v in data.values()):
+                if len(data) and all(isinstance(v, Series) for v in data.values()):
                     from .general import concat
 
                     self._query_compiler = concat(

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -1478,3 +1478,31 @@ def test___round__():
     data = test_data_values[0]
     with warns_that_defaulting_to_pandas():
         pd.DataFrame(data).__round__()
+
+
+def test_constructor_from_modin_series():
+    modin_df, pandas_df = create_test_dfs(test_data_values[0])
+
+    # Construct from Modin series only
+    new_modin = pd.DataFrame(
+        {f"new_col{i}": modin_df.iloc[:, i] for i in range(modin_df.shape[1])}
+    )
+    pandas_df.columns = [f"new_col{i}" for i in range(pandas_df.shape[1])]
+    df_equals(new_modin, pandas_df)
+
+    # Construct from mixed data
+    new_modin = pd.DataFrame(
+        {
+            "new_col1": modin_df.iloc[:, 0],
+            "new_col2": np.arange(len(modin_df)),
+            "new_col3": modin_df.iloc[:, 1],
+        }
+    )
+    new_pandas = pandas.DataFrame(
+        {
+            "new_col1": pandas_df.iloc[:, 0],
+            "new_col2": np.arange(len(pandas_df)),
+            "new_col3": pandas_df.iloc[:, 1],
+        }
+    )
+    df_equals(new_modin, new_pandas)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The PR introduces a way of constructing a new modin DataFrame from multiple modin Series' passed as a dict without converting them to pandas. The logic in the constructor now just concatenates the Series' using `modin.pandas.concat` which is literally concatenating partitions without any materialization and thus is very fast.

Here are the performance measurements of constructing frames on master and on this PR, the table shows an average of 20 runs in seconds. The test cases are the following:
1. Construction: `pd.DataFrame(data_dict)`
2. Construction + custom columns, thus reindexing is required: `pd.DataFrame(data_dict, columns=custom_columns)`
3. Construction + custom columns and custom dtype, thus reindexing and type casting is required: `pd.DataFrame(data_dict, columns=custom_columns, dtype="str")`

| Data shape| Construction | | Construction + reindex | | Construction + reindex + astype | |
|-|-|-|-|-|-|-|
| | **This PR** | **Master** | **This PR** | **Master** | **This PR** | **Master** |
|100x6| 0.00s | 0.03s. | 0.03s. | 0.01s.| 0.03s.| 0.01s.|
|100_000x6| 0.01s | 0.33s. | 0.38s. | 0.28s.| 0.40s.| 0.50s. |
|1_000_000x6| 0.01s | 0.42s. | 0.36s.| 0.55s.| 0.42s.| 2.90s. |

<details><summary>timeit script</summary>

```python
import timeit
import numpy as np
import modin.pandas as pd

import ray
ray.init()

NROWS = [100, 100_000, 1_000_000]
NCOLS = 6
NRUNS = 20

for nrows in NROWS:
    data = {f"col{i}": pd.Series(np.arange(nrows)) for i in range(NCOLS)}

    def time_construction():
        return pd.DataFrame(data)

    def time_construction_and_reindex():
        return pd.DataFrame(data, columns=list(data.keys())[::-1])

    def time_construction_and_reindex_and_cast():
        return pd.DataFrame(data, columns=list(data.keys())[::-1], dtype="str")

    res1 = timeit.timeit(time_construction, number=NRUNS)
    res2 = timeit.timeit(time_construction_and_reindex, number=NRUNS)
    res3 = timeit.timeit(time_construction_and_reindex_and_cast, number=NRUNS)

    print(f"=== shape ({nrows}, {NCOLS}) ===")
    print(f"time_construction: {res1:.2f}s. | {res1 / NRUNS:.2f}s. per run")
    print(f"time_construction_and_reindex: {res2:.2f}s. | {res2 / NRUNS:.2f}s. per run")
    print(f"time_construction_and_reindex_and_cast: {res3:.2f}s. | {res3 / NRUNS:.2f}s. per run")

```

</details>

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #4263. Only partially though. The PR brings support for dictionaries that consist of Series objects only, so any mixed data goes through the old path.
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date 
