### PR TITLE
FIX-#5187: Fixed RecursionError in OmnisciLaunchParameters.get()

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -478,7 +478,7 @@ class PersistentPickle(EnvironmentVariable, type=bool):
 
 class HdkLaunchParameters(EnvironmentVariable, type=dict):
     """
-    Additional command line options for the OmniSci engine.
+    Additional command line options for the HDK engine.
 
     Please visit OmniSci documentation for the description of available parameters:
     https://docs.omnisci.com/installation-and-configuration/config-parameters#configuration-parameters-for-omniscidb
@@ -510,8 +510,20 @@ class HdkLaunchParameters(EnvironmentVariable, type=dict):
             OmnisciLaunchParameters.varname in os.environ
             and HdkLaunchParameters.varname not in os.environ
         ):
-            return OmnisciLaunchParameters.get()
+            return OmnisciLaunchParameters._get()
+        else:
+            return HdkLaunchParameters._get()
 
+    @classmethod
+    def _get(cls) -> dict:
+        """
+        Get the resulted command-line options.
+
+        Returns
+        -------
+        dict
+            Decoded and verified config value.
+        """
         custom_parameters = super().get()
         result = cls.default.copy()
         result.update(

--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -13,7 +13,7 @@
 
 import os
 import pytest
-
+import modin.config as cfg
 from modin.config.envvars import EnvironmentVariable, _check_vars, ExactStr
 
 
@@ -60,3 +60,32 @@ def test_custom_set(make_custom_envvar, set_custom_envvar):
 def test_custom_help(make_custom_envvar):
     assert "MODIN_CUSTOM" in make_custom_envvar.get_help()
     assert "custom var" in make_custom_envvar.get_help()
+
+
+def test_hdk_envvar():
+    os.environ[
+        cfg.OmnisciLaunchParameters.varname
+    ] = "enable_union=2,enable_thrift_logs=3"
+    params = cfg.OmnisciLaunchParameters.get()
+    assert params["enable_union"] == 2
+    assert params["enable_thrift_logs"] == 3
+
+    params = cfg.HdkLaunchParameters.get()
+    assert params["enable_union"] == 2
+    assert params["enable_thrift_logs"] == 3
+
+    os.environ[cfg.HdkLaunchParameters.varname] = "enable_union=4,enable_thrift_logs=5"
+    del cfg.HdkLaunchParameters._value
+    params = cfg.HdkLaunchParameters.get()
+    assert params["enable_union"] == 4
+    assert params["enable_thrift_logs"] == 5
+
+    params = cfg.OmnisciLaunchParameters.get()
+    assert params["enable_union"] == 2
+    assert params["enable_thrift_logs"] == 3
+
+    del os.environ[cfg.OmnisciLaunchParameters.varname]
+    del cfg.OmnisciLaunchParameters._value
+    params = cfg.OmnisciLaunchParameters.get()
+    assert params["enable_union"] == 4
+    assert params["enable_thrift_logs"] == 5


### PR DESCRIPTION
Signed-off-by: Andrey Pavlenko <andrey.a.pavlenko@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5187 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
