### PR TITLE
FIX-#5204: fix binary operations with a dictionary

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -102,7 +102,9 @@ class Binary(Operator):
                         )
                     )
             else:
-                if isinstance(other, (list, np.ndarray, pandas.Series)):
+                # TODO: it's possible to chunk the `other` and broadcast them to partitions
+                # accordingly, in that way we will be able to use more efficient `._modin_frame.map()`
+                if isinstance(other, (dict, list, np.ndarray, pandas.Series)):
                     new_modin_frame = query_compiler._modin_frame.apply_full_axis(
                         axis,
                         lambda df: func(df, other, *args, **kwargs),

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -268,7 +268,13 @@ class BasePandasDataset(BasePandasDatasetCompat):
             if hasattr(other, "dtype"):
                 other_dtypes = [other.dtype] * len(other)
             elif is_dict_like(other):
-                other_dtypes = [type(x) for x in other.values()]
+                other_dtypes = [
+                    type(other[label])
+                    for label in self._query_compiler.get_axis(axis)
+                    # The binary operation is applied for intersection of axis labels
+                    # and dictionary keys. So filtering out extra keys.
+                    if label in other
+                ]
             else:
                 other_dtypes = [type(x) for x in other]
         else:
@@ -285,6 +291,19 @@ class BasePandasDataset(BasePandasDatasetCompat):
                 raise TypeError("Cannot perform operation with non-equal index")
         # Do dtype checking.
         if dtype_check:
+            self_dtypes = self._get_dtypes()
+            if is_dict_like(other):
+                # The binary operation is applied for the intersection of axis labels
+                # and dictionary keys. So filtering `self_dtypes` to match the `other`
+                # dictionary.
+                self_dtypes = [
+                    dtype
+                    for label, dtype in zip(
+                        self._query_compiler.get_axis(axis), self._get_dtypes()
+                    )
+                    if label in other
+                ]
+
             if not all(
                 (is_numeric_dtype(self_dtype) and is_numeric_dtype(other_dtype))
                 or (is_object_dtype(self_dtype) and is_object_dtype(other_dtype))
@@ -293,7 +312,7 @@ class BasePandasDataset(BasePandasDatasetCompat):
                     and is_datetime_or_timedelta_dtype(other_dtype)
                 )
                 or is_dtype_equal(self_dtype, other_dtype)
-                for self_dtype, other_dtype in zip(self._get_dtypes(), other_dtypes)
+                for self_dtype, other_dtype in zip(self_dtypes, other_dtypes)
             ):
                 raise TypeError("Cannot do operation with improper dtypes")
         return result

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -267,6 +267,8 @@ class BasePandasDataset(BasePandasDatasetCompat):
                     )
             if hasattr(other, "dtype"):
                 other_dtypes = [other.dtype] * len(other)
+            elif is_dict_like(other):
+                other_dtypes = [type(x) for x in other.values()]
             else:
                 other_dtypes = [type(x) for x in other]
         else:

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -47,8 +47,12 @@ pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
     [
         lambda df: 4,
         lambda df, axis: df.iloc[0] if axis == "columns" else list(df[df.columns[0]]),
+        lambda df, axis: {
+            label: idx + 1
+            for idx, label in enumerate(df.axes[0 if axis == "rows" else 1])
+        },
     ],
-    ids=["scalar", "series_or_list"],
+    ids=["scalar", "series_or_list", "dictionary"],
 )
 @pytest.mark.parametrize("axis", ["rows", "columns"])
 @pytest.mark.parametrize(

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -51,8 +51,17 @@ pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
             label: idx + 1
             for idx, label in enumerate(df.axes[0 if axis == "rows" else 1])
         },
+        lambda df, axis: {
+            label if idx % 2 else f"random_key{idx}": idx + 1
+            for idx, label in enumerate(df.axes[0 if axis == "rows" else 1][::-1])
+        },
     ],
-    ids=["scalar", "series_or_list", "dictionary"],
+    ids=[
+        "scalar",
+        "series_or_list",
+        "dictionary_keys_equal_columns",
+        "dictionary_keys_unequal_columns",
+    ],
 )
 @pytest.mark.parametrize("axis", ["rows", "columns"])
 @pytest.mark.parametrize(


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The PR fixes the [` ._validate other()`](https://github.com/modin-project/modin/blob/c30ab4c132295b1e168fbb06a050c76554759e11/modin/pandas/base.py#L212) behavior when the `other` is a dictionary. The function iterates through the `other` container in order to extract the inner types:
```python
other_dtypes = [type(x) for x in other]
```
It appeared that this doesn't work for dictionaries as the `dict.__iter__()` iterates on the keys but not on the values. So, the PR introduces a special case for dictionaries in the [`._validate_other()`](https://github.com/modin-project/modin/blob/c30ab4c132295b1e168fbb06a050c76554759e11/modin/pandas/base.py#L212).

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5204 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
