### PR TITLE
FIX-#5208: pin ray version under 2.1.0

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -12,7 +12,7 @@ pyyaml
 recommonmark
 sphinx
 sphinx-click
-ray[default]>=1.4.0
+ray[default]>=1.4.0,<2.1.0
 # Override to latest version of modin-spreadsheet
 git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
 sphinxcontrib_plantuml

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -47,7 +47,7 @@ dependencies:
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - tqdm
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
-      - ray[default]>=1.4.0
+      - ray[default]>=1.4.0,<2.1.0
       - connectorx>=0.2.6a4
       # TODO: remove when resolving GH#4398
       - redis>=3.5.0,<4.0.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,7 +3,7 @@ numpy>=1.18.5
 pyarrow>=4.0.1
 dask[complete]>=2.22.0
 distributed>=2.22.0
-ray[default]>=1.4.0
+ray[default]>=1.4.0,<2.1.0
 redis>=3.5.0,<4.0.0
 psutil
 fsspec

--- a/requirements/environment-py36.yml
+++ b/requirements/environment-py36.yml
@@ -43,7 +43,7 @@ dependencies:
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - tqdm
-      - ray[default]>=1.4.0
+      - ray[default]>=1.4.0,<2.1.0
       # TODO: remove when resolving GH#4398
       - redis>=3.5.0,<4.0.0
       - black

--- a/requirements/requirements-py36.txt
+++ b/requirements/requirements-py36.txt
@@ -3,7 +3,7 @@ numpy>=1.18.5
 pyarrow>=4.0.1
 dask[complete]>=2.22.0
 distributed>=2.22.0
-ray[default]>=1.4.0
+ray[default]>=1.4.0,<2.1.0
 redis>=3.5.0,<4.0.0
 psutil
 fsspec

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ if sys.version_info < (3, 8):
     dask_deps.append("pickle5")
 
 ray_deps = [
-    "ray[default]>=1.4.0",
+    "ray[default]>=1.4.0,<2.1.0",
     "pyarrow>=4.0.1",
     "redis>=3.5.0,<4.0.0",
 ]


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The PR limits Ray version under 2.1.0 until we figure out the root cause of the #5208

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
