### PR TITLE
FEAT-#4747: Implement release notes generation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ wheels/
 .installed.cfg
 *.egg
 MANIFEST
+scripts/gh-users-cache.json
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/docs/release-procedure.md
+++ b/docs/release-procedure.md
@@ -71,18 +71,15 @@ or the `release-X.Y.Z` branch (in `upstream`) for a patch release.
 
         git tag -as X.Y.Z
 
-  * Look for [other releases](https://github.com/modin-project/modin/releases) on examples of how to compose the release documentation
-    * Start with a `Modin X.Y.Z` line followed by an empty line
-    * Always try to make a one-line summary
-    * The annotation should contain features and changes compared to previous release
-    * You can link to merge commits, but try to "explain" what a PR does instead of blindly copying its title
-    * Gather and mention the list of all participants in the release, including those mentioned in "Co-Authored-By" part of PRs
+  * Use `scripts/release.py` to draft the release notes (might be as simple as `python scripts/release.py notes > draft.txt`)
+    * If you're experiencing [rate limiting by GitHub](https://docs.github.com/en/rest/overview/resources-in-the-rest-api#rate-limiting) during username resolving, pass a token via `--token` option to the script
+    * Fill in the placeholder for summary of the release
+    * Please look into PR sections and split them if necessary into smaller but better fitting ones, as the script only categorizes by prefix (`FIX-`, `TEST-`, etc.)
+    * Make sure to correctly resolve contributors whom script failed to transform to GitHub usernames if there are any!
   * Include release documentation in the annotation and make sure it is signed.
   * Push the tag to `master` or `release-X.Y.Z` branch: `git push upstream X.Y.Z`
     * If you're re-pushing a tag (beware! you shouldn't be doing that, no, _really_!), you can remove remote tag and push a local one by `git push upstream :refs/tags/X.Y.Z`
 
-***Note***: We are currently working on automating the release notes procedure - check 
-[#4747](https://github.com/modin-project/modin/issues/4747) for updates!
 
 ### Build wheel:
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -29,7 +29,7 @@ dependencies:
   - pytest-xdist>=2.1.0
   - packaging
   - coverage
-  - pygithub==1.53
+  - pygithub
   - rpyc==4.1.5
   - cloudpickle
   - boto3
@@ -40,7 +40,6 @@ dependencies:
   - pandas-stubs
   - fastparquet
   # for release script
-  - pygithub
   - pygit2
   - pip:
       # TODO(https://github.com/modin-project/modin/issues/5194): Uncap xgboost

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -39,6 +39,9 @@ dependencies:
   - mypy<0.990
   - pandas-stubs
   - fastparquet
+  # for release script
+  - pygithub
+  - pygit2
   - pip:
       # TODO(https://github.com/modin-project/modin/issues/5194): Uncap xgboost
       # when we use collective instead of rabit.

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -50,3 +50,6 @@ fuzzydata>=0.0.6
 mypy<0.990
 pandas-stubs
 fastparquet
+# for release script
+PyGithub
+pygit2

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -11,7 +11,7 @@ dependencies:
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
   - coverage
-  - pygithub==1.53
+  - pygithub
   - pyhdk==0.2
   - s3fs>=2021.8
   - psutil

--- a/requirements/environment-py36.yml
+++ b/requirements/environment-py36.yml
@@ -30,7 +30,7 @@ dependencies:
   - pytest-xdist>=2.1.0
   - packaging
   - coverage
-  - pygithub==1.53
+  - pygithub
   - rpyc==4.1.5
   - cloudpickle
   - boto3

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -25,7 +25,7 @@ dependencies:
   - pytest-cov>=2.10.1
   - pytest-xdist>=2.1.0
   - coverage
-  - pygithub==1.53
+  - pygithub
   - rpyc==4.1.5
   - cloudpickle
   - boto3

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -1,0 +1,276 @@
+import re
+import json
+import atexit
+import collections
+import argparse
+from pathlib import Path
+import sys
+from packaging import version
+
+import pygit2
+import github
+
+
+class GithubUserResolver:
+    def __init__(self, email2commit, token):
+        self.__cache_file = Path(__file__).parent / "gh-users-cache.json"
+        self.__cache = (
+            json.loads(self.__cache_file.read_text())
+            if self.__cache_file.exists()
+            else {}
+        )
+        # filter unknown users hoping we'd be able to find them this time
+        self.__cache = {key: value for key, value in self.__cache.items() if value}
+        # using anonymous access if token not specified
+        self.__github = github.Github(token or None)
+        self.__modin_repo = self.__github.get_repo("modin-project/modin")
+        self.__email2commit = email2commit
+        atexit.register(self.__save)
+
+    def __search_commits(self, term):
+        if commit := self.__email2commit.get(term):
+            gh_commit = self.__modin_repo.get_commit(str(commit))
+            return gh_commit.author.login
+        return None
+
+    @staticmethod
+    def __is_email(term):
+        return re.match(r".*@.*\..*", term)
+
+    def __search_github(self, term):
+        search = f"in:email {term}" if self.__is_email(term) else f"fullname:{term}"
+        match = [user.login for user in self.__github.search_users(search)]
+        return match[0] if len(match) == 1 else None
+
+    def __try_user(self, term):
+        if self.__is_email(term):
+            return None
+        try:
+            return self.__github.get_user(term).login
+        except github.GithubException as ex:
+            if ex.status != 404:
+                raise
+            return None
+
+    def __resolve_single(self, term):
+        return (
+            self.__search_commits(term)
+            or self.__search_github(term)
+            or self.__try_user(term)
+        )
+
+    def __resolve_cache(self, name, email):
+        return self.__cache.get(f"{name} <{email}>", None)
+
+    def __register(self, name, email, match):
+        self.__cache[f"{name} <{email}>"] = match
+
+    def resolve(self, people):
+        logins, unknowns = set(), set()
+
+        for name, email in people:
+            if match := self.__resolve_cache(name, email):
+                logins.add(match)
+            elif match := self.__resolve_single(email):
+                self.__register(name, email, match)
+                logins.add(match)
+            else:
+                if match := self.__resolve_single(name):
+                    logins.add(match)
+                else:
+                    unknowns.add((name, email))
+                self.__register(name, email, match)
+
+        return logins, unknowns
+
+    def resolve_by_reviews(self, unknowns, email2pr):
+        logins, new_unknowns = set(), set()
+        for name, email in unknowns:
+            commit = self.__modin_repo.get_commit(str(email2pr[email]))
+            found = set()
+            for pull in commit.get_pulls():
+                for review in pull.get_reviews():
+                    user = review.user
+                    if user.name == name and (not user.email or user.email == email):
+                        found.add(user.login)
+
+            if len(found) == 1:
+                self.__register(name, email, list(found)[0])
+                logins |= found
+            else:
+                new_unknowns.add((name, email))
+
+        return logins, new_unknowns
+
+    def __save(self):
+        self.__cache_file.write_text(json.dumps(self.__cache, indent=4, sort_keys=True))
+
+
+class GitWrapper:
+    def __init__(self):
+        self.repo = pygit2.Repository(Path(__file__).parent)
+
+    def is_on_master(self):
+        return self.repo.references["refs/heads/master"] == self.repo.head
+
+    def get_previous_release(self, rel_type):
+        tags = [
+            (entry, version.parse(entry.lstrip("refs/tags/")))
+            for entry in self.repo.references
+            if entry.startswith("refs/tags/")
+        ]
+        # filter away legacy versions (which aren't following the proper naming schema)
+        tags = [(entry, ver) for entry, ver in tags if isinstance(ver, version.Version)]
+        if rel_type == "minor":
+            # leave only minor releases
+            tags = [(entry, ver) for entry, ver in tags if ver.micro == 0]
+        else:
+            assert rel_type == "patch"
+        prev_ref, prev_ver = max(tags, key=lambda pair: pair[1])
+        return prev_ref, self.repo.references[prev_ref].peel(), prev_ver
+
+    def get_commits_upto(self, stop_commit):
+        history = []
+        for obj in self.repo.walk(self.repo.head.target):
+            if obj.id == stop_commit.id:
+                break
+            history.append(obj)
+        else:
+            raise ValueError("Current HEAD is not derived from previous release")
+        return history
+
+    def ensure_title_link(self, obj: pygit2.Commit):
+        title = obj.message.splitlines()[0]
+        if not re.match(r".*\(#(\d+)\)$", title):
+            title += f" ({obj.short_id})"
+        return title
+
+
+def make_notes(args):
+    wrapper = GitWrapper()
+    release_type = "minor" if wrapper.is_on_master() else "patch"
+    sys.stderr.write(f"Detected release type: {release_type}\n")
+
+    pref_ref, prev_commit, prev_ver = wrapper.get_previous_release(release_type)
+    sys.stderr.write(f"Previous {release_type} release: {pref_ref}\n")
+
+    next_major, next_minor, next_patch = prev_ver.release
+    if release_type == "minor":
+        next_minor += 1
+    elif release_type == "patch":
+        next_patch += 1
+    else:
+        raise ValueError(f"Unexpected release type: {release_type}")
+    next_ver = version.Version(f"{next_major}.{next_minor}.{next_patch}")
+
+    sys.stderr.write(f"Computing release notes for {prev_ver} -> {next_ver}...\n")
+    try:
+        history = wrapper.get_commits_upto(prev_commit)
+    except ValueError as ex:
+        sys.stderr.write(
+            f"{ex}: did you forget to checkout correct branch or pull tags?"
+        )
+        return 1
+    if not history:
+        sys.stderr.write(f"No commits since {prev_ver} found, nothing to generate!\n")
+        return 1
+
+    titles = collections.defaultdict(list)
+    people = set()
+    email2commit, email2pr = {}, {}
+    for obj in history:
+        title = obj.message.splitlines()[0]
+        titles[title.split("-")[0]].append(obj)
+        new_people = set(
+            re.findall(
+                r"(?:(?:Signed-off-by|Co-authored-by):\s*)([\w\s,]+?)\s*<([^>]+)>",
+                obj.message,
+            )
+        )
+        for _, email in new_people:
+            email2pr[email] = obj.id
+        people |= new_people
+        email2commit[obj.author.email] = obj.id
+    sys.stderr.write(f"Found {len(history)} commit(s) since {pref_ref}\n")
+
+    sys.stderr.write("Resolving contributors...\n")
+    user_resolver = GithubUserResolver(email2commit, args.token)
+    logins, unknowns = user_resolver.resolve(people)
+    new_logins, unknowns = user_resolver.resolve_by_reviews(unknowns, email2pr)
+    logins |= new_logins
+    sys.stderr.write(f"Found {len(logins)} GitHub usernames.\n")
+    if unknowns:
+        sys.stderr.write(
+            f"Warning! Failed to resolve {len(unknowns)} usernames, please resolve them manually!\n"
+        )
+
+    sections = [
+        ("Stability and Bugfixes", "FIX"),
+        ("Performance enhancements", "PERF"),
+        ("Refactor Codebase", "REFACTOR"),
+        ("Update testing suite", "TEST"),
+        ("Documentation improvements", "DOCS"),
+        ("New Features", "FEAT"),
+    ]
+
+    notes = rf"""Modin {next_ver}
+
+<Please fill in short release summary>
+
+Key Features and Updates Since {prev_ver}
+-------------------------------{'-' * len(str(prev_ver))}
+"""
+
+    def _add_section(section, prs):
+        nonlocal notes
+        if prs:
+            notes += f"* {section}\n"
+            notes += "\n".join(
+                [
+                    f"  * {wrapper.ensure_title_link(obj)}"
+                    for obj in sorted(prs, key=lambda obj: obj.message)
+                ]
+            )
+            notes += "\n"
+
+    for section, key in sections:
+        _add_section(section, titles.pop(key, None))
+
+    uncategorized = sum(titles.values(), [])
+    _add_section("Uncategorized improvements", uncategorized)
+
+    notes += r"""
+Contributors
+------------
+"""
+    notes += "\n".join(f"@{login}" for login in sorted(logins)) + "\n"
+    notes += (
+        "\n".join(
+            f"<unknown-login> {name} <{email}>" for name, email in sorted(unknowns)
+        )
+        + "\n"
+    )
+
+    sys.stdout.write(notes)
+
+
+def main():
+    parse = argparse.ArgumentParser()
+    parse.add_argument(
+        "--token",
+        type=str,
+        default="",
+        help="GitHub token for queries (optional, bumps up rate limit)",
+    )
+    parse.set_defaults(func=lambda _: parse.print_usage())
+    subparsers = parse.add_subparsers()
+
+    notes = subparsers.add_parser("notes", help="Generate release notes")
+    notes.set_defaults(func=make_notes)
+
+    args = parse.parse_args()
+    sys.exit(args.func(args))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -151,8 +151,8 @@ def make_notes(args):
     release_type = "minor" if wrapper.is_on_master() else "patch"
     sys.stderr.write(f"Detected release type: {release_type}\n")
 
-    pref_ref, prev_commit, prev_ver = wrapper.get_previous_release(release_type)
-    sys.stderr.write(f"Previous {release_type} release: {pref_ref}\n")
+    prev_ref, prev_commit, prev_ver = wrapper.get_previous_release(release_type)
+    sys.stderr.write(f"Previous {release_type} release: {prev_ref}\n")
 
     next_major, next_minor, next_patch = prev_ver.release
     if release_type == "minor":
@@ -191,7 +191,7 @@ def make_notes(args):
             email2pr[email] = obj.id
         people |= new_people
         email2commit[obj.author.email] = obj.id
-    sys.stderr.write(f"Found {len(history)} commit(s) since {pref_ref}\n")
+    sys.stderr.write(f"Found {len(history)} commit(s) since {prev_ref}\n")
 
     sys.stderr.write("Resolving contributors...\n")
     user_resolver = GithubUserResolver(email2commit, args.token)


### PR DESCRIPTION
Signed-off-by: Vasily Litvinov <fam1ly.n4me@yandex.ru>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This implements a release notes generator. The CLI is designed to (eventually) hold the whole release procedure with subcommands, but for now only `notes` (which drafts the notes) is implemented.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4747
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
