### PR TITLE
PERF-#5225: do not convert 'value' to a list at '.insert()'

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2374,9 +2374,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
             value.columns = [column]
             return self.insert_item(axis=1, loc=loc, value=value, how=None)
 
-        if is_list_like(value):
-            value = list(value)
-        else:
+        if is_list_like(value) and not isinstance(value, np.ndarray):
+            value = np.array(value)
+        elif is_scalar(value):
             value = [value] * len(self.index)
 
         def insert(df, internal_indices=[]):


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The PR gets rid of conversion to a python list of any list-like `value` passed to `PandasQueryCompiler.insert`. This allows us not to meet with a bad side of Ray serializer that is painfully slow when it deals with pure python lists.

This change allowed to significantly improve the time of `.insert()` operation:

| |Master branch | This PR |
|-|-|-|
|Inserting a numpy array | 33.3s | 0.02s |
|Inserting a list | 53.97s | 1.78s |

<details><summary>Code to measure</summary>

```python
import modin.pandas as pd
import numpy as np
from timeit import default_timer as timer

df = pd.DataFrame({"a": np.arange(10_000_000)})

numpy_array = np.arange(10_000_000)
python_list = list(numpy_array)

t1 = timer()
df["new_col_numpy"] = numpy_array
print(f"Inserting a numpy array: {timer() - t1}")

t1 = timer()
df["new_col_list"] = python_list
print(f"Inserting a python list: {timer() - t1}")
```

</details>

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5225 <!-- issue must be created for each patch -->
- [x] tests <s>added</s> and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
