### PR TITLE
FEAT-#5230: Support external query compiler and IO

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -140,11 +140,10 @@ class Engine(EnvironmentVariable, type=str):
         )
 
     @classmethod
-    def add_option(cls, choice: Any) -> None:
-        if isinstance(choice, str):
-            choice = choice.title()
-        super().add_option(choice)
+    def add_option(cls, choice: Any) -> Any:
+        choice = super().add_option(choice)
         cls.NOINIT_ENGINES.add(choice)
+        return choice
 
 
 class StorageFormat(EnvironmentVariable, type=str):
@@ -153,12 +152,6 @@ class StorageFormat(EnvironmentVariable, type=str):
     varname = "MODIN_STORAGE_FORMAT"
     default = "Pandas"
     choices = ("Pandas", "Hdk", "Pyarrow", "Cudf")
-
-    @classmethod
-    def add_option(cls, choice: Any) -> None:
-        if isinstance(choice, str):
-            choice = choice.title()
-        super().add_option(choice)
 
 
 class IsExperimental(EnvironmentVariable, type=bool):

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -20,7 +20,7 @@ import warnings
 from packaging import version
 import secrets
 
-from pandas.util._decorators import doc
+from pandas.util._decorators import doc  # type: ignore[attr-defined]
 
 from .pubsub import Parameter, _TYPE_PARAMS, ExactStr, ValueSource
 from typing import Any, Optional

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -20,6 +20,8 @@ import warnings
 from packaging import version
 import secrets
 
+from pandas.util._decorators import doc
+
 from .pubsub import Parameter, _TYPE_PARAMS, ExactStr, ValueSource
 from typing import Any, Optional
 
@@ -140,6 +142,7 @@ class Engine(EnvironmentVariable, type=str):
         )
 
     @classmethod
+    @doc(Parameter.add_option.__doc__)
     def add_option(cls, choice: Any) -> Any:
         choice = super().add_option(choice)
         cls.NOINIT_ENGINES.add(choice)

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -21,7 +21,7 @@ from packaging import version
 import secrets
 
 from .pubsub import Parameter, _TYPE_PARAMS, ExactStr, ValueSource
-from typing import Optional
+from typing import Any, Optional
 
 
 class EnvironmentVariable(Parameter, type=str, abstract=True):
@@ -76,6 +76,10 @@ class Engine(EnvironmentVariable, type=str):
 
     varname = "MODIN_ENGINE"
     choices = ("Ray", "Dask", "Python", "Native")
+
+    NOINIT_ENGINES = {
+        "Python",
+    }  # engines that don't require initialization, useful for unit tests
 
     @classmethod
     def _get_default(cls) -> str:
@@ -135,6 +139,13 @@ class Engine(EnvironmentVariable, type=str):
             "Please refer to installation documentation page to install an engine"
         )
 
+    @classmethod
+    def add_option(cls, choice: Any) -> None:
+        if isinstance(choice, str):
+            choice = choice.title()
+        super().add_option(choice)
+        cls.NOINIT_ENGINES.add(choice)
+
 
 class StorageFormat(EnvironmentVariable, type=str):
     """Engine to run on a single node of distribution."""
@@ -142,6 +153,12 @@ class StorageFormat(EnvironmentVariable, type=str):
     varname = "MODIN_STORAGE_FORMAT"
     default = "Pandas"
     choices = ("Pandas", "Hdk", "Pyarrow", "Cudf")
+
+    @classmethod
+    def add_option(cls, choice: Any) -> None:
+        if isinstance(choice, str):
+            choice = choice.title()
+        super().add_option(choice)
 
 
 class IsExperimental(EnvironmentVariable, type=bool):

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -345,7 +345,15 @@ class Parameter(object):
         """
         Add a new choice for the parameter.
 
+        Parameters
+        ----------
+        choice : Any
+            New choice to add to the available choices.
 
+        Returns
+        -------
+        Any
+            Added choice normalized according to the parameter type.
         """
         if cls.choices is not None:
             if not _TYPE_PARAMS[cls.type].verify(choice):

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -15,7 +15,7 @@
 
 from collections import defaultdict
 from enum import IntEnum
-from typing import Any, Callable, DefaultDict, NamedTuple, Optional, Sequence
+from typing import Any, Callable, DefaultDict, NamedTuple, Optional, Tuple
 
 
 class TypeDescriptor(NamedTuple):
@@ -136,7 +136,7 @@ class Parameter(object):
         ``ValueSource``.
     """
 
-    choices: Optional[Sequence[str]] = None
+    choices: Optional[Tuple[str, ...]] = None
     type = str
     default: Optional[Any] = None
     is_abstract = True
@@ -360,7 +360,7 @@ class Parameter(object):
                 raise ValueError(f"Unsupported choice value: {choice}")
             choice = _TYPE_PARAMS[cls.type].normalize(choice)
             if choice not in cls.choices:
-                cls.choices += type(cls.choices)([choice])
+                cls.choices += (choice,)
             return choice
         raise TypeError("Cannot add a choice to a parameter where choices is None")
 

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -340,5 +340,19 @@ class Parameter(object):
         for callback in cls._once.pop(cls.get(), ()):
             callback(cls)
 
+    @classmethod
+    def add_option(cls, choice: Any) -> None:
+        """
+        Add a new choice for the parameter.
+
+
+        """
+        if cls.choices is not None:
+            if isinstance(cls.choices, tuple) and choice not in cls.choices:
+                if isinstance(choice, str):
+                    cls.choices += (choice,)
+            return
+        raise TypeError("Cannot add a choice to a parameter where choices is None")
+
 
 __all__ = ["Parameter"]

--- a/modin/config/pubsub.py
+++ b/modin/config/pubsub.py
@@ -341,17 +341,19 @@ class Parameter(object):
             callback(cls)
 
     @classmethod
-    def add_option(cls, choice: Any) -> None:
+    def add_option(cls, choice: Any) -> Any:
         """
         Add a new choice for the parameter.
 
 
         """
         if cls.choices is not None:
-            if isinstance(cls.choices, tuple) and choice not in cls.choices:
-                if isinstance(choice, str):
-                    cls.choices += (choice,)
-            return
+            if not _TYPE_PARAMS[cls.type].verify(choice):
+                raise ValueError(f"Unsupported choice value: {choice}")
+            choice = _TYPE_PARAMS[cls.type].normalize(choice)
+            if choice not in cls.choices:
+                cls.choices += type(cls.choices)([choice])
+            return choice
         raise TypeError("Cannot add a choice to a parameter where choices is None")
 
 

--- a/modin/core/execution/dispatching/factories/dispatcher.py
+++ b/modin/core/execution/dispatching/factories/dispatcher.py
@@ -138,8 +138,8 @@ class FactoryDispatcher(object):
                 # allow missing factories in experimenal mode only
                 if hasattr(factories, "Experimental" + factory_name):
                     msg = (
-                        "{0} on {1} is only accessible through the experimental API.\nRun "
-                        + "`import modin.experimental.pandas as pd` to use {0} on {1}."
+                        "{0} is only accessible through the experimental API.\nRun "
+                        + "`import modin.experimental.pandas as pd` to use {0}."
                     )
                 else:
                     msg = (

--- a/modin/core/execution/dispatching/factories/dispatcher.py
+++ b/modin/core/execution/dispatching/factories/dispatcher.py
@@ -143,13 +143,11 @@ class FactoryDispatcher(object):
                     )
                 else:
                     msg = (
-                        "Cannot find a factory for partition '{}' and execution engine '{}'. "
+                        "Cannot find factory {}. "
                         + "Potential reason might be incorrect environment variable value for "
                         + f"{StorageFormat.varname} or {Engine.varname}"
                     )
-                raise FactoryNotFoundError(
-                    msg.format(StorageFormat.get(), Engine.get())
-                )
+                raise FactoryNotFoundError(msg.format(factory_name))
             cls.__factory = StubFactory.set_failing_name(factory_name)
         else:
             cls.__factory.prepare()

--- a/modin/core/execution/dispatching/factories/factories.py
+++ b/modin/core/execution/dispatching/factories/factories.py
@@ -126,7 +126,7 @@ class NotRealFactory(Exception):
 
 @doc(_doc_abstract_factory_class, role="")
 class BaseFactory(object):
-    io_cls: BaseIO = None  # The module where the I/O functionality exists.
+    io_cls: typing.Type[BaseIO] = None  # The module where the I/O functionality exists.
 
     @classmethod
     def get_info(cls) -> FactoryInfo:

--- a/modin/core/execution/dispatching/factories/test/test_dispatcher.py
+++ b/modin/core/execution/dispatching/factories/test/test_dispatcher.py
@@ -31,12 +31,12 @@ import modin.pandas as pd
 
 
 @contextmanager
-def _switch_execution(engine: str, execution: str):
-    old_engine, old_execution = set_execution(engine, execution)
+def _switch_execution(engine: str, storage_format: str):
+    old_engine, old_storage = set_execution(engine, storage_format)
     try:
         yield
     finally:
-        set_execution(old_engine, old_execution)
+        set_execution(old_engine, old_storage)
 
 
 @contextmanager
@@ -102,13 +102,14 @@ def test_default_factory():
 
 
 def test_factory_switch():
-    with _switch_value(Engine, "Test"):
-        assert FactoryDispatcher.get_factory() == PandasOnTestFactory
-        assert FactoryDispatcher.get_factory().io_cls == "Foo"
+    with _switch_execution("Python", "Pandas"):
+        with _switch_value(Engine, "Test"):
+            assert FactoryDispatcher.get_factory() == PandasOnTestFactory
+            assert FactoryDispatcher.get_factory().io_cls == "Foo"
 
-    with _switch_value(StorageFormat, "Test"):
-        assert FactoryDispatcher.get_factory() == TestOnPythonFactory
-        assert FactoryDispatcher.get_factory().io_cls == "Bar"
+        with _switch_value(StorageFormat, "Test"):
+            assert FactoryDispatcher.get_factory() == TestOnPythonFactory
+            assert FactoryDispatcher.get_factory().io_cls == "Bar"
 
 
 def test_engine_wrong_factory():

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -99,16 +99,13 @@ with warnings.catch_warnings():
     )
 import os
 
-from modin.config import Engine, Parameter
+from modin.config import Parameter
 
 _is_first_update = {}
-_NOINIT_ENGINES = {
-    "Python",
-}  # engines that don't require initialization, useful for unit tests
 
 
 def _update_engine(publisher: Parameter):
-    from modin.config import StorageFormat, CpuCount
+    from modin.config import Engine, StorageFormat, CpuCount
     from modin.config.envvars import IsExperimental
     from modin.config.pubsub import ValueSource
 
@@ -196,7 +193,7 @@ def _update_engine(publisher: Parameter):
         ), f"Storage format should be 'Hdk' with 'Cloudnative' engine, but provided {sfmt}."
         get_connection().modules["modin"].set_execution("Native", "Hdk")
 
-    elif publisher.get() not in _NOINIT_ENGINES:
+    elif publisher.get() not in Engine.NOINIT_ENGINES:
         raise ImportError("Unrecognized execution engine: {}.".format(publisher.get()))
 
     _is_first_update[publisher.get()] = False
@@ -381,4 +378,4 @@ if PandasCompatVersion.CURRENT != PandasCompatVersion.PY36:
     )
 del PandasCompatVersion
 
-del pandas, Engine, Parameter
+del pandas, Parameter


### PR DESCRIPTION
Resolves #5230

Signed-off-by: Devin Petersohn <devin.petersohn@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
