### PR TITLE
FIX-#5238: Make rmul really rmul instead of mul.

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -529,6 +529,14 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     def mul(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.mul)(self, other=other, **kwargs)
 
+    @doc_utils.doc_binary_method(
+        operation="multiplication", sign="*", self_on_right=True
+    )
+    def rmul(self, other, **kwargs):  # noqa: PR02
+        return BinaryDefault.register(pandas.DataFrame.rmul)(
+            self, other=other, **kwargs
+        )
+
     @doc_utils.add_refer_to("DataFrame.corr")
     def corr(self, **kwargs):  # noqa: PR02
         """

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -404,6 +404,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     lt = Binary.register(pandas.DataFrame.lt)
     mod = Binary.register(pandas.DataFrame.mod)
     mul = Binary.register(pandas.DataFrame.mul)
+    rmul = Binary.register(pandas.DataFrame.rmul)
     ne = Binary.register(pandas.DataFrame.ne)
     pow = Binary.register(pandas.DataFrame.pow)
     radd = Binary.register(pandas.DataFrame.radd)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2322,7 +2322,15 @@ class BasePandasDataset(BasePandasDatasetCompat):
             "rmod", other, axis=axis, level=level, fill_value=fill_value
         )
 
-    rmul = mul
+    def rmul(
+        self, other, axis="columns", level=None, fill_value=None
+    ):  # noqa: PR01, RT01, D200
+        """
+        Get Multiplication of dataframe and other, element-wise (binary operator `rmul`).
+        """
+        return self._binary_op(
+            "rmul", other, axis=axis, level=level, fill_value=fill_value
+        )
 
     def _rolling(
         self, window, min_periods, center, win_type, *args, **kwargs

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1525,7 +1525,22 @@ class DataFrame(DataFrameCompat, BasePandasDataset):
             broadcast=isinstance(other, Series),
         )
 
-    rmul = multiply = mul
+    multiply = mul
+
+    def rmul(
+        self, other, axis="columns", level=None, fill_value=None
+    ):  # noqa: PR01, RT01, D200
+        """
+        Get multiplication of ``DataFrame`` and `other`, element-wise (binary operator `mul`).
+        """
+        return self._binary_op(
+            "rmul",
+            other,
+            axis=axis,
+            level=level,
+            fill_value=fill_value,
+            broadcast=isinstance(other, Series),
+        )
 
     def ne(self, other, axis="columns", level=None):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1301,7 +1301,18 @@ class Series(SeriesCompat, BasePandasDataset):
             new_other, level=level, fill_value=None, axis=axis
         )
 
-    multiply = rmul = mul
+    multiply = mul
+
+    def rmul(
+        self, other, level=None, fill_value=None, axis=0
+    ):  # noqa: PR01, RT01, D200
+        """
+        Return multiplication of series and `other`, element-wise (binary operator `mul`).
+        """
+        new_self, new_other = self._prepare_inter_op(other)
+        return super(Series, new_self).rmul(
+            new_other, level=level, fill_value=None, axis=axis
+        )
 
     def ne(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -29,10 +29,7 @@ from modin.pandas.test.utils import (
     create_test_dfs,
     default_to_pandas_ignore_string,
     CustomIntegerForAddition,
-<<<<<<< HEAD
-=======
     NonCommutativeMultiplyInteger,
->>>>>>> 513be39b (FIX-#5238: Make rmul really rmul instead of mul.)
 )
 from modin.config import Engine, NPartitions
 from modin.test.test_utils import warns_that_defaulting_to_pandas

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -356,15 +356,20 @@ def test_add_custom_class():
     )
 
 
+def test_non_commutative_multiply_pandas():
+    # The non commutative integer class implementation is tricky. Check that
+    # multiplying such an integer with a pandas dataframe is really not
+    # commutative.
+    pandas_df = pd.DataFrame([[1]], dtype=int)
+    integer = NonCommutativeMultiplyInteger(2)
+    assert not (integer * pandas_df).equals(pandas_df * integer)
+
+
 def test_non_commutative_multiply():
     # This test checks that mul and rmul do different things when
     # multiplication is not commutative, e.g. for adding a string to a string.
     # For context see https://github.com/modin-project/modin/issues/5238
     modin_df, pandas_df = create_test_dfs([1], dtype=int)
     integer = NonCommutativeMultiplyInteger(2)
-    # It's tricky to get the non commutative integer class implementation
-    # right, so before we do the actual test, check that the operation
-    # we care about is really not commmutative in pandas.
-    assert not (integer * pandas_df).equals(pandas_df * integer)
     eval_general(modin_df, pandas_df, lambda s: integer * s)
     eval_general(modin_df, pandas_df, lambda s: s * integer)

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -29,6 +29,10 @@ from modin.pandas.test.utils import (
     create_test_dfs,
     default_to_pandas_ignore_string,
     CustomIntegerForAddition,
+<<<<<<< HEAD
+=======
+    NonCommutativeMultiplyInteger,
+>>>>>>> 513be39b (FIX-#5238: Make rmul really rmul instead of mul.)
 )
 from modin.config import Engine, NPartitions
 from modin.test.test_utils import warns_that_defaulting_to_pandas
@@ -353,3 +357,17 @@ def test_add_custom_class():
         *create_test_dfs(test_data["int_data"]),
         lambda df: df + CustomIntegerForAddition(4),
     )
+
+
+def test_non_commutative_multiply():
+    # This test checks that mul and rmul do different things when
+    # multiplication is not commutative, e.g. for adding a string to a string.
+    # For context see https://github.com/modin-project/modin/issues/5238
+    modin_df, pandas_df = create_test_dfs([1], dtype=int)
+    integer = NonCommutativeMultiplyInteger(2)
+    # It's tricky to get the non commutative integer class implementation
+    # right, so before we do the actual test, check that the operation
+    # we care about is really not commmutative in pandas.
+    assert not (integer * pandas_df).equals(pandas_df * integer)
+    eval_general(modin_df, pandas_df, lambda s: integer * s)
+    eval_general(modin_df, pandas_df, lambda s: s * integer)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4267,16 +4267,21 @@ def test_non_commutative_add_string_to_series(data):
     eval_general(*create_test_series(data), lambda s: s + "string")
 
 
+def test_non_commutative_multiply_pandas():
+    # The non commutative integer class implementation is tricky. Check that
+    # multiplying such an integer with a pandas series is really not
+    # commutative.
+    pandas_series = pd.DataFrame([[1]], dtype=int)
+    integer = NonCommutativeMultiplyInteger(2)
+    assert not (integer * pandas_series).equals(pandas_series * integer)
+
+
 def test_non_commutative_multiply():
     # This test checks that mul and rmul do different things when
     # multiplication is not commutative, e.g. for adding a string to a string.
     # For context see https://github.com/modin-project/modin/issues/5238
     modin_series, pandas_series = create_test_series(1, dtype=int)
     integer = NonCommutativeMultiplyInteger(2)
-    # It's tricky to get the non commutative integer class implementation
-    # right, so before we do the actual test, check that the operation
-    # we care about is really not commmutative in pandas.
-    assert not (integer * pandas_series).equals(pandas_series * integer)
     eval_general(modin_series, pandas_series, lambda s: integer * s)
     eval_general(modin_series, pandas_series, lambda s: s * integer)
 


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5238 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
