### PR TITLE
FIX-#5252: Disable notebook tests until access control issues are resolved for `modin-test` bucket

### DIFF
--- a/examples/tutorial/jupyter/execution/hdk_on_native/test/test_notebooks.py
+++ b/examples/tutorial/jupyter/execution/hdk_on_native/test/test_notebooks.py
@@ -13,6 +13,7 @@
 
 import os
 import sys
+import pytest
 
 import nbformat
 
@@ -44,6 +45,9 @@ def test_exercise_1():
 
 
 # this notebook works "as is"
+# GH #5252: Access to the modin-test bucket has changed, so we cannot currently run this test.
+# We will need to come back and unskip this test once the access control issue is resolved.
+@pytest.mark.skip(reason="Bucket cannot currently be accessed.")
 def test_exercise_2():
     modified_notebook_path = os.path.join(local_notebooks_dir, "exercise_2_test.ipynb")
     nb = nbformat.read(

--- a/examples/tutorial/jupyter/execution/pandas_on_dask/test/test_notebooks.py
+++ b/examples/tutorial/jupyter/execution/pandas_on_dask/test/test_notebooks.py
@@ -13,6 +13,7 @@
 
 import os
 import sys
+import pytest
 
 import nbformat
 
@@ -46,6 +47,9 @@ def test_exercise_1():
 
 
 # this notebook works "as is" but for testing purposes we can use smaller dataset
+# GH #5252: Access to the modin-test bucket has changed, so we cannot currently run this test.
+# We will need to come back and unskip this test once the access control issue is resolved.
+@pytest.mark.skip(reason="Bucket cannot currently be accessed.")
 def test_exercise_2():
     modified_notebook_path = os.path.join(local_notebooks_dir, "exercise_2_test.ipynb")
     nb = nbformat.read(
@@ -99,6 +103,9 @@ modin_mad_custom = df.sq_mad_custom()
 
 
 # this notebook works "as is" but for testing purposes we can use smaller dataset
+# GH #5252: Access to the modin-test bucket has changed, so we cannot currently run this test.
+# We will need to come back and unskip this test once the access control issue is resolved.
+@pytest.mark.skip(reason="Bucket cannot currently be accessed.")
 def test_exercise_4():
     modified_notebook_path = os.path.join(local_notebooks_dir, "exercise_4_test.ipynb")
     nb = nbformat.read(

--- a/examples/tutorial/jupyter/execution/pandas_on_ray/test/test_notebooks.py
+++ b/examples/tutorial/jupyter/execution/pandas_on_ray/test/test_notebooks.py
@@ -13,6 +13,7 @@
 
 import os
 import sys
+import pytest
 
 import nbformat
 
@@ -47,6 +48,9 @@ def test_exercise_1():
 
 
 # this notebook works "as is" but for testing purposes we can use smaller dataset
+# GH #5252: Access to the modin-test bucket has changed, so we cannot currently run this test.
+# We will need to come back and unskip this test once the access control issue is resolved.
+@pytest.mark.skip(reason="Bucket cannot currently be accessed.")
 def test_exercise_2():
     modified_notebook_path = os.path.join(local_notebooks_dir, "exercise_2_test.ipynb")
     nb = nbformat.read(
@@ -103,6 +107,9 @@ modin_mad_custom = df.sq_mad_custom()
 
 
 # this notebook works "as is" but for testing purposes we can use smaller dataset
+# GH #5252: Access to the modin-test bucket has changed, so we cannot currently run this test.
+# We will need to come back and unskip this test once the access control issue is resolved.
+@pytest.mark.skip(reason="Bucket cannot currently be accessed.")
 def test_exercise_4():
     modified_notebook_path = os.path.join(local_notebooks_dir, "exercise_4_test.ipynb")
     nb = nbformat.read(


### PR DESCRIPTION


Signed-off-by: Rehan Durrani <rehan@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
