### PR TITLE
FIX-#5277: fix internal `execute` function

### DIFF
--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -497,7 +497,7 @@ def execute(
             return
         partitions = df._query_compiler._modin_frame._partitions.flatten()
         if len(partitions) > 0 and hasattr(partitions[0], "wait"):
-            all(map(lambda partition: partition.wait(), partitions))
+            all(map(lambda partition: partition.wait() or True, partitions))
             return
 
         # compatibility with old Modin versions

--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -497,7 +497,9 @@ def execute(
             return
         partitions = df._query_compiler._modin_frame._partitions.flatten()
         if len(partitions) > 0 and hasattr(partitions[0], "wait"):
-            df._query_compiler._modin_frame._partition_mgr_cls.wait_partitions(partitions)
+            df._query_compiler._modin_frame._partition_mgr_cls.wait_partitions(
+                partitions
+            )
             return
 
         # compatibility with old Modin versions

--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -496,10 +496,9 @@ def execute(
             df._query_compiler._modin_frame._execute()
             return
         partitions = df._query_compiler._modin_frame._partitions.flatten()
-        if len(partitions) > 0 and hasattr(partitions[0], "wait"):
-            df._query_compiler._modin_frame._partition_mgr_cls.wait_partitions(
-                partitions
-            )
+        mgr_cls = df._query_compiler._modin_frame._partition_mgr_cls
+        if len(partitions) and hasattr(mgr_cls, "wait_partitions"):
+            mgr_cls.wait_partitions(partitions)
             return
 
         # compatibility with old Modin versions

--- a/asv_bench/benchmarks/utils/common.py
+++ b/asv_bench/benchmarks/utils/common.py
@@ -497,7 +497,7 @@ def execute(
             return
         partitions = df._query_compiler._modin_frame._partitions.flatten()
         if len(partitions) > 0 and hasattr(partitions[0], "wait"):
-            all(map(lambda partition: partition.wait() or True, partitions))
+            df._query_compiler._modin_frame._partition_mgr_cls.wait_partitions(partitions)
             return
 
         # compatibility with old Modin versions


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5277 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
