### PR TITLE
TEST-#5280: Test pandas objects for non-commutative multiply.

### DIFF
--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -360,7 +360,7 @@ def test_non_commutative_multiply_pandas():
     # The non commutative integer class implementation is tricky. Check that
     # multiplying such an integer with a pandas dataframe is really not
     # commutative.
-    pandas_df = pd.DataFrame([[1]], dtype=int)
+    pandas_df = pandas.DataFrame([[1]], dtype=int)
     integer = NonCommutativeMultiplyInteger(2)
     assert not (integer * pandas_df).equals(pandas_df * integer)
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4282,7 +4282,7 @@ def test_non_commutative_multiply_pandas():
     # The non commutative integer class implementation is tricky. Check that
     # multiplying such an integer with a pandas series is really not
     # commutative.
-    pandas_series = pd.DataFrame([[1]], dtype=int)
+    pandas_series = pandas.Series(1, dtype=int)
     integer = NonCommutativeMultiplyInteger(2)
     assert not (integer * pandas_series).equals(pandas_series * integer)
 


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5280 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
