### PR TITLE
REFACTOR-#5287: remove code to test getting TypeError for Series.dropna

### DIFF
--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1628,10 +1628,6 @@ def test_drop_duplicates(data, keep, inplace):
 @pytest.mark.parametrize("how", ["any", "all"], ids=["any", "all"])
 def test_dropna(data, how):
     modin_series, pandas_series = create_test_series(data)
-
-    with pytest.raises(TypeError):
-        modin_series.dropna(how=None, thresh=None)
-
     modin_result = modin_series.dropna(how=how)
     pandas_result = pandas_series.dropna(how=how)
     df_equals(modin_result, pandas_result)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1641,10 +1641,6 @@ def test_dropna_inplace(data):
     df_equals(modin_series, pandas_result)
 
     modin_series, pandas_series = create_test_series(data)
-    with pytest.raises(TypeError):
-        modin_series.dropna(thresh=2, inplace=True)
-
-    modin_series, pandas_series = create_test_series(data)
     pandas_series.dropna(how="any", inplace=True)
     modin_series.dropna(how="any", inplace=True)
     df_equals(modin_series, pandas_series)


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

`CodeQL` defines this place as problematic, I see no reason not to delete it.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5287 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
