### PR TITLE
FIX-#5285: Check for both pyarrow and fastparquet when read parquet format

### DIFF
--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -27,7 +27,7 @@ from modin.config import NPartitions
 
 
 from modin.core.io.column_stores.column_store_dispatcher import ColumnStoreDispatcher
-from modin.utils import import_optional_dependency, _inherit_docstrings
+from modin.utils import _inherit_docstrings
 
 
 class ColumnStoreDataset:
@@ -603,16 +603,6 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         ParquetFile API is used. Please refer to the documentation here
         https://arrow.apache.org/docs/python/parquet.html
         """
-        try:
-            import_optional_dependency(
-                "pyarrow",
-                "pyarrow or fastparquet is required to read parquet files.",
-            )
-        except ImportError:
-            import_optional_dependency(
-                "fastparquet",
-                "pyarrow or fastparquet is required to read parquet files.",
-            )
         from modin.pandas.io import PQ_INDEX_REGEX
 
         if isinstance(path, str):

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -603,10 +603,16 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         ParquetFile API is used. Please refer to the documentation here
         https://arrow.apache.org/docs/python/parquet.html
         """
-        import_optional_dependency(
-            "pyarrow",
-            "pyarrow is required to read parquet files.",
-        )
+        try:
+            import_optional_dependency(
+                "pyarrow",
+                "pyarrow or fastparquet is required to read parquet files.",
+            )
+        except ImportError:
+            import_optional_dependency(
+                "fastparquet",
+                "pyarrow or fastparquet is required to read parquet files.",
+            )
         from modin.pandas.io import PQ_INDEX_REGEX
 
         if isinstance(path, str):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

As explain in https://github.com/modin-project/modin/issues/5285, [Line 606-609 from parquet_dispatcher.py](https://github.com/modin-project/modin/blob/master/modin/core/io/column_stores/parquet_dispatcher.py#L606-L609) only check for `pyarrow` while modin support both `pyarrow` and `fastparquet`.

With this fix, one should be able to read Parquet format with `fastparquet` without the need for installing `pyarrow`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5285 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
