### PR TITLE
REFACTOR-#5299: `Variable defined multiple times` error found by CodeQL

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1095,7 +1095,6 @@ class PandasDataframe(ClassLogger):
         PandasDataframe
             A new PandasDataframe with reordered columns and/or rows.
         """
-        new_lengths, new_widths = None, None
         new_dtypes = self._dtypes
         if row_positions is not None:
             ordered_rows = self._partition_mgr_cls.map_axis_partitions(

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1480,7 +1480,6 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                     for obj in partitions[stop]:
                         obj._length_cache = new_last_partition_size
 
-                    partition_size = ideal_partition_size
                 # The new virtual partitions are not `full_axis`, even if they
                 # happen to span all rows in the dataframe, because they are
                 # meant to be the final partitions of the dataframe. They've

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -271,7 +271,7 @@ def test_dot(data):
 
     # Test bad dimensions
     with pytest.raises(ValueError):
-        modin_result = modin_df.dot(np.arange(col_len + 10))
+        _ = modin_df.dot(np.arange(col_len + 10))
 
     # Test series input
     modin_series = pd.Series(np.arange(col_len), index=modin_df.columns)
@@ -287,7 +287,7 @@ def test_dot(data):
 
     # Test when input series index doesn't line up with columns
     with pytest.raises(ValueError):
-        modin_result = modin_df.dot(pd.Series(np.arange(col_len)))
+        _ = modin_df.dot(pd.Series(np.arange(col_len)))
 
     # Test case when left dataframe has size (n x 1)
     # and right dataframe has size (1 x n)
@@ -318,7 +318,7 @@ def test_matmul(data):
 
     # Test bad dimensions
     with pytest.raises(ValueError):
-        modin_result = modin_df @ np.arange(col_len + 10)
+        _ = modin_df @ np.arange(col_len + 10)
 
     # Test series input
     modin_series = pd.Series(np.arange(col_len), index=modin_df.columns)

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -271,7 +271,7 @@ def test_dot(data):
 
     # Test bad dimensions
     with pytest.raises(ValueError):
-        _ = modin_df.dot(np.arange(col_len + 10))
+        modin_df.dot(np.arange(col_len + 10))
 
     # Test series input
     modin_series = pd.Series(np.arange(col_len), index=modin_df.columns)
@@ -287,7 +287,7 @@ def test_dot(data):
 
     # Test when input series index doesn't line up with columns
     with pytest.raises(ValueError):
-        _ = modin_df.dot(pd.Series(np.arange(col_len)))
+        modin_df.dot(pd.Series(np.arange(col_len)))
 
     # Test case when left dataframe has size (n x 1)
     # and right dataframe has size (1 x n)
@@ -318,7 +318,7 @@ def test_matmul(data):
 
     # Test bad dimensions
     with pytest.raises(ValueError):
-        _ = modin_df @ np.arange(col_len + 10)
+        modin_df @ np.arange(col_len + 10)
 
     # Test series input
     modin_series = pd.Series(np.arange(col_len), index=modin_df.columns)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -970,7 +970,7 @@ def test_rename_sanity():
         modin_df.rename()
 
     # partial columns
-    _ = source_df.rename(columns={"col3": "foo", "col4": "bar"})
+    source_df.rename(columns={"col3": "foo", "col4": "bar"})
     modin_df = pd.DataFrame(source_df)
     assert_index_equal(
         modin_df.rename(columns={"col3": "foo", "col4": "bar"}).index,
@@ -978,7 +978,7 @@ def test_rename_sanity():
     )
 
     # other axis
-    _ = source_df.T.rename(index={"col3": "foo", "col4": "bar"})
+    source_df.T.rename(index={"col3": "foo", "col4": "bar"})
     assert_index_equal(
         source_df.T.rename(index={"col3": "foo", "col4": "bar"}).index,
         modin_df.T.rename(index={"col3": "foo", "col4": "bar"}).index,
@@ -1833,7 +1833,7 @@ def test___getattr__(request, data):
 
     if "empty_data" not in request.node.name:
         key = modin_df.columns[0]
-        _ = modin_df.__getattr__(key)
+        modin_df.__getattr__(key)
 
         col = modin_df.__getattr__("col1")
         assert isinstance(col, pd.Series)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -970,7 +970,7 @@ def test_rename_sanity():
         modin_df.rename()
 
     # partial columns
-    renamed = source_df.rename(columns={"col3": "foo", "col4": "bar"})
+    _ = source_df.rename(columns={"col3": "foo", "col4": "bar"})
     modin_df = pd.DataFrame(source_df)
     assert_index_equal(
         modin_df.rename(columns={"col3": "foo", "col4": "bar"}).index,
@@ -978,7 +978,7 @@ def test_rename_sanity():
     )
 
     # other axis
-    renamed = source_df.T.rename(index={"col3": "foo", "col4": "bar"})
+    _ = source_df.T.rename(index={"col3": "foo", "col4": "bar"})
     assert_index_equal(
         source_df.T.rename(index={"col3": "foo", "col4": "bar"}).index,
         modin_df.T.rename(index={"col3": "foo", "col4": "bar"}).index,
@@ -1833,7 +1833,7 @@ def test___getattr__(request, data):
 
     if "empty_data" not in request.node.name:
         key = modin_df.columns[0]
-        col = modin_df.__getattr__(key)
+        _ = modin_df.__getattr__(key)
 
         col = modin_df.__getattr__("col1")
         assert isinstance(col, pd.Series)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1512,7 +1512,7 @@ def test_dot(data):
 
     # Test bad dimensions
     with pytest.raises(ValueError):
-        _ = modin_series.dot(np.arange(ind_len + 10))
+        modin_series.dot(np.arange(ind_len + 10))
 
     # Test dataframe input
     modin_df = pd.DataFrame(data)
@@ -1530,7 +1530,7 @@ def test_dot(data):
 
     # Test when input series index doesn't line up with columns
     with pytest.raises(ValueError):
-        _ = modin_series.dot(
+        modin_series.dot(
             pd.Series(
                 np.arange(ind_len), index=["a" for _ in range(len(modin_series.index))]
             )
@@ -1562,7 +1562,7 @@ def test_matmul(data):
 
     # Test bad dimensions
     with pytest.raises(ValueError):
-        _ = modin_series @ np.arange(ind_len + 10)
+        modin_series @ np.arange(ind_len + 10)
 
     # Test dataframe input
     modin_df = pd.DataFrame(data)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1512,7 +1512,7 @@ def test_dot(data):
 
     # Test bad dimensions
     with pytest.raises(ValueError):
-        modin_result = modin_series.dot(np.arange(ind_len + 10))
+        _ = modin_series.dot(np.arange(ind_len + 10))
 
     # Test dataframe input
     modin_df = pd.DataFrame(data)
@@ -1530,7 +1530,7 @@ def test_dot(data):
 
     # Test when input series index doesn't line up with columns
     with pytest.raises(ValueError):
-        modin_result = modin_series.dot(
+        _ = modin_series.dot(
             pd.Series(
                 np.arange(ind_len), index=["a" for _ in range(len(modin_series.index))]
             )
@@ -1562,7 +1562,7 @@ def test_matmul(data):
 
     # Test bad dimensions
     with pytest.raises(ValueError):
-        modin_result = modin_series @ np.arange(ind_len + 10)
+        _ = modin_series @ np.arange(ind_len + 10)
 
     # Test dataframe input
     modin_df = pd.DataFrame(data)
@@ -1849,7 +1849,6 @@ def test_fillna(data, reindex, limit):
     if reindex is not None:
         if reindex > 0:
             pandas_series = pandas_series[:reindex].reindex(index)
-            modin_series = pd.Series(pandas_series)
         else:
             pandas_series = pandas_series[reindex:].reindex(index)
         # Because of bug #3178 modin Series has to be created from pandas

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -1108,7 +1108,6 @@ def insert_lines_to_csv(
     encoding: str
         Encoding type that should be used during file reading and writing.
     """
-    cols_number = len(pandas.read_csv(csv_name, nrows=1).columns)
     if lines_type == "blank":
         lines_data = []
     elif lines_type == "bad":
@@ -1119,7 +1118,6 @@ def insert_lines_to_csv(
             f"acceptable values for  parameter are ['blank', 'bad'], actually passed {lines_type}"
         )
     lines = []
-    dialect = "excel"
     with open(csv_name, "r", encoding=encoding, newline="") as read_file:
         try:
             dialect = csv.Sniffer().sniff(read_file.read())


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5299  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
