### PR TITLE
REFACTOR-#5303: Fix code scanning alert - Unused local variable

### DIFF
--- a/modin/experimental/batch/test/test_pipeline.py
+++ b/modin/experimental/batch/test/test_pipeline.py
@@ -409,7 +409,7 @@ class TestPipelineRayEngine:
             NotImplementedError,
             match="Dynamic repartitioning is currently only supported for DataFrames with 1 partition.",
         ):
-            _ = pipeline.compute_batch()
+            pipeline.compute_batch()
 
     def test_fan_out(self):
         """Check that the fan_out argument is appropriately handled."""

--- a/modin/experimental/batch/test/test_pipeline.py
+++ b/modin/experimental/batch/test/test_pipeline.py
@@ -409,7 +409,7 @@ class TestPipelineRayEngine:
             NotImplementedError,
             match="Dynamic repartitioning is currently only supported for DataFrames with 1 partition.",
         ):
-            new_dfs = pipeline.compute_batch()
+            _ = pipeline.compute_batch()
 
     def test_fan_out(self):
         """Check that the fan_out argument is appropriately handled."""
@@ -454,7 +454,7 @@ class TestPipelineRayEngine:
             NotImplementedError,
             match="Fan out is only supported with DataFrames with 1 partition.",
         ):
-            new_df = pipeline.compute_batch()[0]
+            _ = pipeline.compute_batch()[0]
 
     def test_pipeline_complex(self):
         """Create a complex pipeline with both `fan_out`, `repartition_after` and postprocessing and ensure that it runs end to end correctly."""

--- a/modin/experimental/batch/test/test_pipeline.py
+++ b/modin/experimental/batch/test/test_pipeline.py
@@ -454,7 +454,7 @@ class TestPipelineRayEngine:
             NotImplementedError,
             match="Fan out is only supported with DataFrames with 1 partition.",
         ):
-            _ = pipeline.compute_batch()[0]
+            pipeline.compute_batch()[0]
 
     def test_pipeline_complex(self):
         """Create a complex pipeline with both `fan_out`, `repartition_after` and postprocessing and ensure that it runs end to end correctly."""

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -192,7 +192,6 @@ def test_bfill(data):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_bool(data):
     modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)  # noqa F841
 
     with pytest.raises(ValueError):
         modin_df.bool()
@@ -211,7 +210,6 @@ def test_bool(data):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_boxplot(data):
     modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)  # noqa F841
 
     assert modin_df.boxplot() == to_pandas(modin_df).boxplot()
 
@@ -334,7 +332,7 @@ def test_matmul(data):
 
     # Test when input series index doesn't line up with columns
     with pytest.raises(ValueError):
-        modin_result = modin_df @ pd.Series(np.arange(col_len))
+        _ = modin_df @ pd.Series(np.arange(col_len))
 
 
 def test_first():

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -332,7 +332,7 @@ def test_matmul(data):
 
     # Test when input series index doesn't line up with columns
     with pytest.raises(ValueError):
-        _ = modin_df @ pd.Series(np.arange(col_len))
+        modin_df @ pd.Series(np.arange(col_len))
 
 
 def test_first():

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -198,7 +198,6 @@ def test_head(data, n):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_iat(data):
     modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)  # noqa F841
 
     with pytest.raises(NotImplementedError):
         modin_df.iat()
@@ -1829,7 +1828,6 @@ def test_getitem_same_name():
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test___getattr__(request, data):
     modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)  # noqa F841
 
     if "empty_data" not in request.node.name:
         key = modin_df.columns[0]

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -284,7 +284,6 @@ def test_axes(data):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_copy(data):
     modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)  # noqa F841
 
     # pandas_df is unused but there so there won't be confusing list comprehension
     # stuff in the pytest.mark.parametrize
@@ -1433,7 +1432,6 @@ def test___delitem__(request, data):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test___nonzero__(data):
     modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)  # noqa F841
 
     with pytest.raises(ValueError):
         # Always raises ValueError

--- a/modin/pandas/test/dataframe/test_window.py
+++ b/modin/pandas/test/dataframe/test_window.py
@@ -410,7 +410,6 @@ def test_fillna_columns(data):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_fillna_invalid_method(data):
     modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)  # noqa F841
 
     with pytest.raises(ValueError):
         modin_df.fillna(method="ffil")

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -308,7 +308,7 @@ def test_merge_asof_suffixes():
             suffixes=(False, False),
         )
     with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
-        modin_merged = pd.merge_asof(
+        _ = pd.merge_asof(
             modin_left,
             modin_right,
             left_index=True,

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -308,7 +308,7 @@ def test_merge_asof_suffixes():
             suffixes=(False, False),
         )
     with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
-        _ = pd.merge_asof(
+        pd.merge_asof(
             modin_left,
             modin_right,
             left_index=True,

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1968,7 +1968,6 @@ class TestHdf:
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
     )
     def test_HDFStore(self):
-        hdf_file = None
         with ensure_clean_dir() as dirname:
             unique_filename_modin = get_unique_filename(
                 extension="hdf", data_dir=dirname

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1084,7 +1084,7 @@ def test_astype(data):
     "data", [["A", "A", "B", "B", "A"], [1, 1, 2, 1, 2, 2, 3, 1, 2, 1, 2]]
 )
 def test_astype_categorical(data):
-    modin_df, pandas_df = pd.Series(data), pandas.Series(data)
+    modin_df, pandas_df = create_test_series(data)
 
     modin_result = modin_df.astype("category")
     pandas_result = pandas_df.astype("category")

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1080,17 +1080,14 @@ def test_astype(data):
     # dict to astype() for a series with no name.
 
 
-def test_astype_categorical():
-    modin_df = pd.Series(["A", "A", "B", "B", "A"])
-    pandas_df = pandas.Series(["A", "A", "B", "B", "A"])
+@pytest.mark.parametrize(
+    "data", [["A", "A", "B", "B", "A"], [1, 1, 2, 1, 2, 2, 3, 1, 2, 1, 2]]
+)
+def test_astype_categorical(data):
+    modin_df, pandas_df = pd.Series(data), pandas.Series(data)
 
     modin_result = modin_df.astype("category")
     pandas_result = pandas_df.astype("category")
-    df_equals(modin_result, pandas_result)
-    assert modin_result.dtype == pandas_result.dtype
-
-    modin_df = pd.Series([1, 1, 2, 1, 2, 2, 3, 1, 2, 1, 2])
-    pandas_df = pandas.Series([1, 1, 2, 1, 2, 2, 3, 1, 2, 1, 2])
     df_equals(modin_result, pandas_result)
     assert modin_result.dtype == pandas_result.dtype
 
@@ -1580,7 +1577,7 @@ def test_matmul(data):
 
     # Test when input series index doesn't line up with columns
     with pytest.raises(ValueError):
-        modin_result = modin_series @ pd.Series(
+        _ = modin_series @ pd.Series(
             np.arange(ind_len), index=["a" for _ in range(len(modin_series.index))]
         )
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1577,7 +1577,7 @@ def test_matmul(data):
 
     # Test when input series index doesn't line up with columns
     with pytest.raises(ValueError):
-        _ = modin_series @ pd.Series(
+        modin_series @ pd.Series(
             np.arange(ind_len), index=["a" for _ in range(len(modin_series.index))]
         )
 

--- a/modin/test/interchange/dataframe_protocol/hdk/test_protocol.py
+++ b/modin/test/interchange/dataframe_protocol/hdk/test_protocol.py
@@ -239,7 +239,7 @@ def test_zero_copy_export_for_primitives(data_has_nulls):
     protocol_df = md_df.__dataframe__(allow_copy=False)
 
     for i, col in enumerate(protocol_df.get_columns()):
-        col_arr, memory_owner = primitive_column_to_ndarray(col)
+        col_arr, _ = primitive_column_to_ndarray(col)
 
         exported_ptr = col_arr.__array_interface__["data"][0]
         producer_ptr = at.column(i).chunks[0].buffers()[-1].address
@@ -251,7 +251,7 @@ def test_zero_copy_export_for_primitives(data_has_nulls):
     non_zero_copy_protocol_df = md_df.__dataframe__(allow_copy=False)
 
     with pytest.raises(RuntimeError):
-        col_arr, memory_owner = primitive_column_to_ndarray(
+        _, _ = primitive_column_to_ndarray(
             non_zero_copy_protocol_df.get_column_by_name("float32")
         )
 

--- a/modin/test/interchange/dataframe_protocol/hdk/test_protocol.py
+++ b/modin/test/interchange/dataframe_protocol/hdk/test_protocol.py
@@ -251,7 +251,7 @@ def test_zero_copy_export_for_primitives(data_has_nulls):
     non_zero_copy_protocol_df = md_df.__dataframe__(allow_copy=False)
 
     with pytest.raises(RuntimeError):
-        _, _ = primitive_column_to_ndarray(
+        primitive_column_to_ndarray(
             non_zero_copy_protocol_df.get_column_by_name("float32")
         )
 


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5303  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
