### PR TITLE
REFACTOR-#5312: Let lazy query compilers check for astype and drop errors.

### DIFF
--- a/modin/core/io/file_dispatcher.py
+++ b/modin/core/io/file_dispatcher.py
@@ -170,7 +170,8 @@ class FileDispatcher(ClassLogger):
                     t: dtypes[t]
                     for t in dtypes.index
                     if isinstance(dtypes[t], kernel_lib.CategoricalDtype)
-                }
+                },
+                kwargs.get("errors", "raise"),
             )
         return query_compiler
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1415,7 +1415,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     # Abstract map partitions across select indices
-    def astype(self, col_dtypes, **kwargs):  # noqa: PR02
+    def astype(self, col_dtypes, errors: str = "raise"):  # noqa: PR02
         """
         Convert columns dtypes to given dtypes.
 
@@ -1423,8 +1423,10 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         ----------
         col_dtypes : dict
             Map for column names and new dtypes.
-        **kwargs : dict
-            Serves the compatibility purpose. Does not affect the result.
+        errors : {'raise', 'ignore'}, default 'raise'
+            Control raising of exceptions on invalid data for provided dtype.
+            - raise : allow exceptions to be raised
+            - ignore : suppress exceptions. On error return original object.
 
         Returns
         -------
@@ -1432,7 +1434,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             New QueryCompiler with updated dtypes.
         """
         return DataFrameDefault.register(pandas.DataFrame.astype)(
-            self, dtype=col_dtypes, **kwargs
+            self, dtype=col_dtypes, errors=errors
         )
 
     def infer_objects(self):
@@ -2209,7 +2211,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     # END Abstract insert
 
     # Abstract drop
-    def drop(self, index=None, columns=None):
+    def drop(self, index=None, columns=None, errors: str = "raise"):
         """
         Drop specified rows or columns.
 
@@ -2219,6 +2221,8 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             Labels of rows to drop.
         columns : list of labels, optional
             Labels of columns to drop.
+        errors : str, default: "raise"
+            If 'ignore', suppress error and only existing labels are dropped.
 
         Returns
         -------
@@ -2229,7 +2233,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             return self
         else:
             return DataFrameDefault.register(pandas.DataFrame.drop)(
-                self, index=index, columns=columns
+                self, index=index, columns=columns, errors=errors
             )
 
     # END drop

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1423,7 +1423,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         ----------
         col_dtypes : dict
             Map for column names and new dtypes.
-        errors : {'raise', 'ignore'}, default 'raise'
+        errors : {'raise', 'ignore'}, default: 'raise'
             Control raising of exceptions on invalid data for provided dtype.
             - raise : allow exceptions to be raised
             - ignore : suppress exceptions. On error return original object.

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1522,7 +1522,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # END Dt map partitions operations
 
-    def astype(self, col_dtypes, **kwargs):
+    def astype(self, col_dtypes, errors: str = "raise"):
+        # `errors` parameter needs to be part of the function signature because
+        # other query compilers may not take care of error handling at the API
+        # layer. This query compiler assumes there won't be any errors due to
+        # invalid type keys.
         return self.__constructor__(self._modin_frame.astype(col_dtypes))
 
     def infer_objects(self):
@@ -2334,7 +2338,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
             )
         )
 
-    def drop(self, index=None, columns=None):
+    def drop(self, index=None, columns=None, errors: str = "raise"):
+        # `errors` parameter needs to be part of the function signature because
+        # other query compilers may not take care of error handling at the API
+        # layer. This query compiler assumes there won't be any errors due to
+        # invalid keys.
         if index is not None:
             index = np.sort(self.index.get_indexer_for(self.index.difference(index)))
         if columns is not None:

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -556,6 +556,10 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         return self.__constructor__(new_modin_frame)
 
     def drop(self, index=None, columns=None):
+        # `errors` parameter needs to be part of the function signature because
+        # other query compilers may not take care of error handling at the API
+        # layer. This query compiler assumes there won't be any errors due to
+        # invalid keys.
         if index is not None:
             raise NotImplementedError("Row drop")
         return self.__constructor__(
@@ -688,9 +692,14 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             self._modin_frame.reset_index(drop), shape_hint=shape_hint
         )
 
-    def astype(self, col_dtypes, **kwargs):
+    def astype(self, col_dtypes, errors: str = "raise"):
+        # `errors` parameter needs to be part of the function signature because
+        # other query compilers may not take care of error handling at the API
+        # layer. This query compiler assumes there won't be any errors due to
+        # invalid type keys.
         return self.__constructor__(
-            self._modin_frame.astype(col_dtypes), self._shape_hint
+            self._modin_frame.astype(col_dtypes),
+            self._shape_hint,
         )
 
     def setitem(self, axis, key, value):

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -555,13 +555,14 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         )
         return self.__constructor__(new_modin_frame)
 
-    def drop(self, index=None, columns=None):
-        # `errors` parameter needs to be part of the function signature because
-        # other query compilers may not take care of error handling at the API
-        # layer. This query compiler assumes there won't be any errors due to
-        # invalid keys.
+    def drop(self, index=None, columns=None, errors: str = "raise"):
         if index is not None:
             raise NotImplementedError("Row drop")
+        if errors != "raise":
+            raise NotImplementedError(
+                "This lazy query compiler will always "
+                + "raise an error on invalid columns."
+            )
         return self.__constructor__(
             self._modin_frame.take_2d_labels_or_positional(
                 row_labels=index, col_labels=self.columns.drop(columns)
@@ -693,10 +694,11 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         )
 
     def astype(self, col_dtypes, errors: str = "raise"):
-        # `errors` parameter needs to be part of the function signature because
-        # other query compilers may not take care of error handling at the API
-        # layer. This query compiler assumes there won't be any errors due to
-        # invalid type keys.
+        if errors != "raise":
+            raise NotImplementedError(
+                "This lazy query compiler will always "
+                + "raise an error on invalid type keys."
+            )
         return self.__constructor__(
             self._modin_frame.astype(col_dtypes),
             self._shape_hint,

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -950,8 +950,12 @@ class BasePandasDataset(ClassLogger):
         # If we got a series or dict originally, dtype is a dict now. Its keys
         # must be column names.
         if isinstance(dtype, dict):
+            # avoid materializing columns in lazy mode. the query compiler
+            # will handle errors where dtype dict includes keys that are not
+            # in columns.
             if (
-                not set(dtype.keys()).issubset(set(self._query_compiler.columns))
+                not self._query_compiler.lazy_execution
+                and not set(dtype.keys()).issubset(set(self._query_compiler.columns))
                 and errors == "raise"
             ):
                 raise KeyError(
@@ -963,7 +967,7 @@ class BasePandasDataset(ClassLogger):
             # Assume that the dtype is a scalar.
             col_dtypes = {column: dtype for column in self._query_compiler.columns}
 
-        new_query_compiler = self._query_compiler.astype(col_dtypes)
+        new_query_compiler = self._query_compiler.astype(col_dtypes, errors=errors)
         return self._create_or_update_from_compiler(new_query_compiler, not copy)
 
     @property
@@ -1285,6 +1289,10 @@ class BasePandasDataset(ClassLogger):
             elif axes[axis] is not None:
                 if not is_list_like(axes[axis]):
                     axes[axis] = [axes[axis]]
+                # In case of lazy execution we should bypass these error checking components
+                # because they can force the materialization of the row or column labels.
+                if self._query_compiler.lazy_execution:
+                    continue
                 if errors == "raise":
                     non_existent = pandas.Index(axes[axis]).difference(
                         getattr(self, axis)
@@ -1300,7 +1308,7 @@ class BasePandasDataset(ClassLogger):
                         axes[axis] = None
 
         new_query_compiler = self._query_compiler.drop(
-            index=axes["index"], columns=axes["columns"]
+            index=axes["index"], columns=axes["columns"], errors=errors
         )
         return self._create_or_update_from_compiler(new_query_compiler, inplace)
 


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5312
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
