### PR TITLE
FEAT-#5317: introduce `order_broken` parameter for `partition.mask`

### DIFF
--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -171,9 +171,12 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         """Perform `iloc` on dataframes wrapped in partitions (helper function)."""
         return df.iloc[row_labels, col_labels]
 
-    def mask(self, row_labels, col_labels):
+    def mask(self, row_labels, col_labels, order_broken=False):
         """
         Lazily create a mask that extracts the indices provided.
+
+        By default, assumes that the order of the requested roes/cols is
+        the same as the order in which they are stored.
 
         Parameters
         ----------
@@ -181,6 +184,8 @@ class PandasDataframePartition(ABC):  # pragma: no cover
             The row labels for the rows to extract.
         col_labels : list-like, slice or label
             The column labels for the columns to extract.
+        order_broken : bool, default: False
+            If the value is True, then some optimizations are not applicable.
 
         Returns
         -------
@@ -204,8 +209,10 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         row_labels = [row_labels] if is_scalar(row_labels) else row_labels
         col_labels = [col_labels] if is_scalar(col_labels) else col_labels
 
-        if is_full_axis_mask(row_labels, self._length_cache) and is_full_axis_mask(
-            col_labels, self._width_cache
+        if (
+            not order_broken
+            and is_full_axis_mask(row_labels, self._length_cache)
+            and is_full_axis_mask(col_labels, self._width_cache)
         ):
             return copy(self)
 

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
@@ -170,7 +170,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         self.drain_call_queue()
         wait(self._data)
 
-    def mask(self, row_labels, col_labels):
+    def mask(self, row_labels, col_labels, order_broken=False):
         """
         Lazily create a mask that extracts the indices provided.
 
@@ -180,13 +180,15 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
             The row labels for the rows to extract.
         col_labels : list-like, slice or label
             The column labels for the columns to extract.
+        order_broken : bool, default: False
+            If the value is True, then some optimizations are not applicable.
 
         Returns
         -------
         PandasOnDaskDataframePartition
             A new ``PandasOnDaskDataframePartition`` object.
         """
-        new_obj = super().mask(row_labels, col_labels)
+        new_obj = super().mask(row_labels, col_labels, order_broken)
         if isinstance(row_labels, slice) and isinstance(self._length_cache, Future):
             if row_labels == slice(None):
                 # fast path - full axis take

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -363,7 +363,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = materialized.list_of_block_partitions
         return materialized
 
-    def mask(self, row_indices, col_indices):
+    def mask(self, row_indices, col_indices, order_broken=False):
         """
         Create (synchronously) a mask that extracts the indices provided.
 
@@ -373,6 +373,8 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
             The row labels for the rows to extract.
         col_indices : list-like, slice or label
             The column labels for the columns to extract.
+        order_broken : bool, default: False
+            If the value is True, then some optimizations are not applicable.
 
         Returns
         -------
@@ -383,7 +385,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         return (
             self.force_materialization()
             .list_of_block_partitions[0]
-            .mask(row_indices, col_indices)
+            .mask(row_indices, col_indices, order_broken)
         )
 
     def to_pandas(self):

--- a/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
@@ -215,7 +215,7 @@ class cuDFOnRayDataframePartition(PandasDataframePartition):
             return self._width_cache
         return self.gpu_manager.width.remote(self.get_key())
 
-    def mask(self, row_labels, col_labels):
+    def mask(self, row_labels, col_labels, order_broken=False):
         """
         Select columns or rows from given indices.
 
@@ -225,6 +225,8 @@ class cuDFOnRayDataframePartition(PandasDataframePartition):
             The row labels to extract.
         col_labels : list of hashable
             The column labels to extract.
+        order_broken : bool, default: False
+            If the value is True, then some optimizations are not applicable.
 
         Returns
         -------

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -218,7 +218,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
 
     _iloc = ray.put(PandasDataframePartition._iloc)
 
-    def mask(self, row_labels, col_labels):
+    def mask(self, row_labels, col_labels, order_broken=False):
         """
         Lazily create a mask that extracts the indices provided.
 
@@ -228,6 +228,8 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             The row labels for the rows to extract.
         col_labels : list-like, slice or label
             The column labels for the columns to extract.
+        order_broken : bool, default: False
+            If the value is True, then some optimizations are not applicable.
 
         Returns
         -------
@@ -236,7 +238,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         """
         logger = get_logger()
         logger.debug(f"ENTER::Partition.mask::{self._identity}")
-        new_obj = super().mask(row_labels, col_labels)
+        new_obj = super().mask(row_labels, col_labels, order_broken)
         if isinstance(row_labels, slice) and isinstance(
             self._length_cache, ObjectIDType
         ):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -373,7 +373,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = materialized.list_of_block_partitions
         return materialized
 
-    def mask(self, row_indices, col_indices):
+    def mask(self, row_indices, col_indices, order_broken=False):
         """
         Create (synchronously) a mask that extracts the indices provided.
 
@@ -383,6 +383,8 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             The row labels for the rows to extract.
         col_indices : list-like, slice or label
             The column labels for the columns to extract.
+        order_broken : bool, default: False
+            If the value is True, then some optimizations are not applicable.
 
         Returns
         -------
@@ -393,7 +395,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         return (
             self.force_materialization()
             .list_of_block_partitions[0]
-            .mask(row_indices, col_indices)
+            .mask(row_indices, col_indices, order_broken)
         )
 
     def to_pandas(self):

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -197,7 +197,7 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
     # unidist itself handles initialization when calling `unidist.put`.
     _iloc = unidist.put(PandasDataframePartition._iloc)
 
-    def mask(self, row_labels, col_labels):
+    def mask(self, row_labels, col_labels, order_broken=False):
         """
         Lazily create a mask that extracts the indices provided.
 
@@ -207,6 +207,8 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
             The row labels for the rows to extract.
         col_labels : list-like, slice or label
             The column labels for the columns to extract.
+        order_broken : bool, default: False
+            If the value is True, then some optimizations are not applicable.
 
         Returns
         -------
@@ -215,7 +217,7 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
         """
         logger = get_logger()
         logger.debug(f"ENTER::Partition.mask::{self._identity}")
-        new_obj = super().mask(row_labels, col_labels)
+        new_obj = super().mask(row_labels, col_labels, order_broken)
         if isinstance(row_labels, slice) and unidist.is_object_ref(self._length_cache):
             if row_labels == slice(None):
                 # fast path - full axis take

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -366,7 +366,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         self._list_of_block_partitions = materialized.list_of_block_partitions
         return materialized
 
-    def mask(self, row_indices, col_indices):
+    def mask(self, row_indices, col_indices, order_broken=False):
         """
         Create (synchronously) a mask that extracts the indices provided.
 
@@ -376,6 +376,8 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
             The row labels for the rows to extract.
         col_indices : list-like, slice or label
             The column labels for the columns to extract.
+        order_broken : bool, default: False
+            If the value is True, then some optimizations are not applicable.
 
         Returns
         -------
@@ -386,7 +388,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         return (
             self.force_materialization()
             .list_of_block_partitions[0]
-            .mask(row_indices, col_indices)
+            .mask(row_indices, col_indices, order_broken)
         )
 
     def to_pandas(self):


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

In the future, we will have the opportunity to take all the rows or all the columns in an arbitrary order via `mask`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5317 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
