### PR TITLE
PERF-#5369: `GroupBy.skew` implementation via MapReduce pattern

### DIFF
--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -127,11 +127,10 @@ class GroupByReduce(TreeReduce):
         # present in the func-dict:
         apply_func = cls.try_filter_dict(map_func, df)
         if other is not None:
-            # Other is a broadcasted partition that represents 'by' columns
-            # Concatenate it with 'df' to group on its columns names
-            if not drop:
-                other = other.squeeze(axis=axis ^ 1)
-            if isinstance(other, pandas.DataFrame):
+            # Other is a broadcasted partition that represents 'by' data to group on.
+            # If 'drop' then the 'by' data came from the 'self' frame, thus
+            # inserting missed columns to the partition to group on them.
+            if drop or isinstance(other := other.squeeze(axis=1), pandas.DataFrame):
                 df = pandas.concat(
                     [df] + [other[[o for o in other if o not in df]]],
                     axis=1,

--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -130,7 +130,9 @@ class GroupByReduce(TreeReduce):
             # Other is a broadcasted partition that represents 'by' data to group on.
             # If 'drop' then the 'by' data came from the 'self' frame, thus
             # inserting missed columns to the partition to group on them.
-            if drop or isinstance(other := other.squeeze(axis=1), pandas.DataFrame):
+            if drop or isinstance(
+                other := other.squeeze(axis=axis ^ 1), pandas.DataFrame
+            ):
                 df = pandas.concat(
                     [df] + [other[[o for o in other if o not in df]]],
                     axis=1,

--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -80,6 +80,7 @@ class GroupByReduce(TreeReduce):
         agg_kwargs,
         other=None,
         by=None,
+        drop=False,
     ):
         """
         Execute Map phase of GroupByReduce.
@@ -108,6 +109,8 @@ class GroupByReduce(TreeReduce):
         by : level index name or list of such labels, optional
             Index levels, that is used to determine groups.
             If not specified, `other` parameter is used.
+        drop : bool, default: False
+            Indicates whether or not by-data came from the `self` frame.
 
         Returns
         -------
@@ -126,7 +129,8 @@ class GroupByReduce(TreeReduce):
         if other is not None:
             # Other is a broadcasted partition that represents 'by' columns
             # Concatenate it with 'df' to group on its columns names
-            other = other.squeeze(axis=axis ^ 1)
+            if not drop:
+                other = other.squeeze(axis=axis ^ 1)
             if isinstance(other, pandas.DataFrame):
                 df = pandas.concat(
                     [df] + [other[[o for o in other if o not in df]]],
@@ -439,6 +443,7 @@ class GroupByReduce(TreeReduce):
                     map_func=map_func,
                     agg_args=agg_args,
                     agg_kwargs=agg_kwargs,
+                    drop=drop,
                     **kwargs,
                 )
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2711,17 +2711,17 @@ class PandasQueryCompiler(BaseQueryCompiler):
         def map_skew(dfgb, *args, **kwargs):
             return pandas.concat(
                 [
-                    dfgb.count(),
-                    dfgb.sum(),
-                    dfgb.apply(lambda x: (x**2).sum()),
-                    dfgb.apply(lambda x: (x**3).sum()),
+                    dfgb.count(*args, **kwargs),
+                    dfgb.sum(*args, **kwargs),
+                    dfgb.apply(lambda x: (x**2).sum(*args, **kwargs)),
+                    dfgb.apply(lambda x: (x**3).sum(*args, **kwargs)),
                 ],
                 copy=False,
                 axis=1,
             )
 
         def reduce_skew(dfgb, *args, **kwargs):
-            df = dfgb.sum()
+            df = dfgb.sum(*args, **kwargs)
             chunk_size = df.shape[1] // 4
 
             count = df.iloc[:, :chunk_size]

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2721,8 +2721,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 [
                     dfgb.count(*args, **kwargs),
                     dfgb.sum(*args, **kwargs),
-                    df_pow2.groupby(dfgb.grouper).sum(*args, **kwargs),
-                    df_pow3.groupby(dfgb.grouper).sum(*args, **kwargs),
+                    df_pow2.groupby(dfgb.keys, **groupby_kwargs).sum(*args, **kwargs),
+                    df_pow3.groupby(dfgb.keys, **groupby_kwargs).sum(*args, **kwargs),
                 ],
                 copy=False,
                 axis=1,

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2710,9 +2710,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def groupby_skew(self, by, axis, groupby_kwargs, agg_args, agg_kwargs, drop=False):
         def map_skew(dfgb, *args, **kwargs):
             df = dfgb.obj
-            by_cols, cols_to_agg = dfgb.exclusions, df.columns.difference(
-                dfgb.exclusions
-            )
+            by_cols = dfgb.exclusions
+            cols_to_agg = df.columns.difference(by_cols)
 
             df_pow2 = pandas.concat([df[by_cols], df[cols_to_agg] ** 2], axis=1)
             df_pow3 = pandas.concat([df[by_cols], df[cols_to_agg] ** 3], axis=1)
@@ -2751,7 +2750,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
             # The equation for the 'skew' was taken directly from pandas:
             # https://github.com/pandas-dev/pandas/blob/8dab54d6573f7186ff0c3b6364d5e4dd635ff3e7/pandas/core/nanops.py#L1226
-            # skew = [ (count * sqrt(count - 1)) / (count - 2) ] * [ sum( (x - m)^3 ) / sum( (x - m)^2 ) ]
             skew_res = (count * (count - 1) ** 0.5 / (count - 2)) * (m3 / m2**1.5)
             return skew_res
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -1041,8 +1041,7 @@ class DataFrameGroupBy(ClassLogger):
         DataFrame or Series
             Returns the same type as `self._df`.
         """
-        if not isinstance(numeric_only, NumericOnly):
-            numeric_only = NumericOnly(numeric_only)
+        numeric_only = NumericOnly(numeric_only)
 
         agg_args = tuple() if agg_args is None else agg_args
         agg_kwargs = dict() if agg_kwargs is None else agg_kwargs

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -38,7 +38,7 @@ from modin.core.storage_formats.base.query_compiler import BaseQueryCompiler
 from modin.core.dataframe.algebra.default2pandas.groupby import GroupBy
 from modin.config import IsExperimental
 from .series import Series
-from .utils import is_label
+from .utils import is_label, NumericOnly
 
 
 @_inherit_docstrings(pandas.core.groupby.DataFrameGroupBy)
@@ -124,7 +124,7 @@ class DataFrameGroupBy(ClassLogger):
             type(self._query_compiler).groupby_skew,
             agg_args=args,
             agg_kwargs=kwargs,
-            numeric_only=True,
+            numeric_only=NumericOnly.TRUE_EXCL_NUMERIC_CATEGORIES,
         )
 
     def ffill(self, limit=None):
@@ -1015,7 +1015,7 @@ class DataFrameGroupBy(ClassLogger):
     def _wrap_aggregation(
         self,
         qc_method,
-        numeric_only=None,
+        numeric_only=NumericOnly.AUTO,
         agg_args=None,
         agg_kwargs=None,
         **kwargs,
@@ -1027,12 +1027,8 @@ class DataFrameGroupBy(ClassLogger):
         ----------
         qc_method : callable
             The query compiler method to call.
-        numeric_only : {None, True, False}, default: None
-            Specifies whether to aggregate non numeric columns:
-                - True: include only numeric columns (including categories that holds a numeric dtype)
-                - False: include all columns
-                - None: infer the parameter, ``False`` if there are no numeric types in the frame,
-                  ``True`` otherwise.
+        numeric_only : NumericOnly or its values, default: NumericOnly.AUTO
+            Specifies whether to aggregate non numeric columns.
         agg_args : list-like, optional
             Positional arguments to pass to the aggregation function.
         agg_kwargs : dict-like, optional
@@ -1045,18 +1041,21 @@ class DataFrameGroupBy(ClassLogger):
         DataFrame or Series
             Returns the same type as `self._df`.
         """
+        if not isinstance(numeric_only, NumericOnly):
+            numeric_only = NumericOnly(numeric_only)
+
         agg_args = tuple() if agg_args is None else agg_args
         agg_kwargs = dict() if agg_kwargs is None else agg_kwargs
 
-        if numeric_only is None:
+        if numeric_only is NumericOnly.AUTO:
             # pandas behavior: if `numeric_only` wasn't explicitly specified then
             # the parameter is considered to be `False` if there are no numeric types
             # in the frame and `True` otherwise.
-            numeric_only = any(
-                is_numeric_dtype(dtype) for dtype in self._query_compiler.dtypes
+            numeric_only = NumericOnly(
+                any(is_numeric_dtype(dtype) for dtype in self._query_compiler.dtypes)
             )
 
-        if numeric_only and self.ndim == 2:
+        if numeric_only > NumericOnly.FALSE and self.ndim == 2:
             by_cols = self._internal_by
             mask_cols = [
                 col
@@ -1064,7 +1063,8 @@ class DataFrameGroupBy(ClassLogger):
                 if (
                     is_numeric_dtype(dtype)
                     or (
-                        isinstance(dtype, pandas.CategoricalDtype)
+                        numeric_only != NumericOnly.TRUE_EXCL_NUMERIC_CATEGORIES
+                        and isinstance(dtype, pandas.CategoricalDtype)
                         and is_numeric_dtype(dtype.categories.dtype)
                     )
                     or col in by_cols

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -14,7 +14,7 @@
 """Implement utils for pandas component."""
 
 from pandas.util._decorators import doc
-from enum import IntEnum
+from enum import IntFlag
 import pandas
 import numpy as np
 
@@ -381,9 +381,9 @@ def _doc_binary_op(operation, bin_op, left="Series", right="right", returns="Ser
     return doc_op
 
 
-class NumericOnly(IntEnum):  # noqa: PR01
+class NumericOnly(IntFlag):  # noqa: PR01
     """
-    An enum that represents the `numeric_only` argument provided to some aggregation function.
+    An integer flag that represents the `numeric_only` argument provided to some aggregation function.
 
     Attributes
     ----------

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -14,7 +14,6 @@
 """Implement utils for pandas component."""
 
 from pandas.util._decorators import doc
-from enum import IntFlag
 import pandas
 import numpy as np
 
@@ -379,49 +378,6 @@ def _doc_binary_op(operation, bin_op, left="Series", right="right", returns="Ser
     )
 
     return doc_op
-
-
-class NumericOnly(IntFlag):  # noqa: PR01
-    """
-    An integer flag that represents the `numeric_only` argument provided to some aggregation function.
-
-    Attributes
-    ----------
-    AUTO : -1
-        Infer the parameter, ``False`` if there are no numeric types in the frame,
-        ``True`` otherwise.
-    FALSE : 0
-        Use every column in aggregation and raise an error if it fails.
-    TRUE : 1
-        Apply an aggregation only to numeric columns (int, float, bool) including categorical
-        that holds a numeric data type.
-    TRUE_EXCL_NUMERIC_CATEGORIES : 2
-        Apply an aggregation only to numeric columns (int, float, bool).
-    """
-
-    AUTO = -1
-    FALSE = 0
-    TRUE = 1
-    TRUE_EXCL_NUMERIC_CATEGORIES = 2
-
-    @classmethod
-    def _missing_(cls, name):
-        """
-        Get corresponding ``NumericOnly`` from a native value.
-
-        Parameters
-        ----------
-        name : object
-            Native value for ``numeric_only`` parameter.
-
-        Returns
-        -------
-        NumericOnly
-        """
-        value = {None: cls.AUTO, False: cls.FALSE, True: cls.TRUE}.get(name)
-        if value is None:
-            return super()._missing_(name)
-        return value
 
 
 _original_pandas_MultiIndex_from_frame = pandas.MultiIndex.from_frame

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -381,7 +381,7 @@ def _doc_binary_op(operation, bin_op, left="Series", right="right", returns="Ser
     return doc_op
 
 
-class NumericOnly(IntEnum):
+class NumericOnly(IntEnum):  # noqa: PR01
     """
     An enum that represents the `numeric_only` argument provided to some aggregation function.
 
@@ -406,6 +406,18 @@ class NumericOnly(IntEnum):
 
     @classmethod
     def _missing_(cls, name):
+        """
+        Get corresponding ``NumericOnly`` from a native value.
+
+        Parameters
+        ----------
+        name : object
+            Native value for ``numeric_only`` parameter.
+
+        Returns
+        -------
+        NumericOnly
+        """
         value = {None: cls.AUTO, False: cls.FALSE, True: cls.TRUE}.get(name)
         if value is None:
             return super()._missing_(name)

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -14,6 +14,7 @@
 """Implement utils for pandas component."""
 
 from pandas.util._decorators import doc
+from enum import IntEnum
 import pandas
 import numpy as np
 
@@ -378,6 +379,37 @@ def _doc_binary_op(operation, bin_op, left="Series", right="right", returns="Ser
     )
 
     return doc_op
+
+
+class NumericOnly(IntEnum):
+    """
+    An enum that represents the `numeric_only` argument provided to some aggregation function.
+
+    Attributes
+    ----------
+    AUTO : -1
+        Infer the parameter, ``False`` if there are no numeric types in the frame,
+        ``True`` otherwise.
+    FALSE : 0
+        Use every column in aggregation and raise an error if it fails.
+    TRUE : 1
+        Apply an aggregation only to numeric columns (int, float, bool) including categorical
+        that holds a numeric data type.
+    TRUE_EXCL_NUMERIC_CATEGORIES : 2
+        Apply an aggregation only to numeric columns (int, float, bool).
+    """
+
+    AUTO = -1
+    FALSE = 0
+    TRUE = 1
+    TRUE_EXCL_NUMERIC_CATEGORIES = 2
+
+    @classmethod
+    def _missing_(cls, name):
+        value = {None: cls.AUTO, False: cls.FALSE, True: cls.TRUE}.get(name)
+        if value is None:
+            return super()._missing_(name)
+        return value
 
 
 _original_pandas_MultiIndex_from_frame = pandas.MultiIndex.from_frame


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Here are some performance comparisons of `.groupby().skew()` between the current master and MapReduce implementation. The comparison was run via ASV with our existing groupby scenarios. CPU: 2x 28 Cores (56 threads) Xeon Platinum-8276L @ 2.20

<details><summary>NCPUS=112</summary>

```
       before           after         ratio
     [a77a6464]       [05027610]
     <master>         <skew_impl>
+      1.46±0.04s        7.03±0.3s     4.83  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([5000, 5000], ngroups=100)
+      1.85±0.06s       7.59±0.03s     4.09  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([5000, 5000], ngroups=100, by_ncols=6)
+       3.53±0.1s        7.11±0.1s     2.02  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([5000, 5000], 'huge_amount_groups')
+      4.18±0.05s        8.30±0.4s     1.98  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([5000, 5000], 'huge_amount_groups', by_ncols=6)
-       4.38±0.1s       3.04±0.07s     0.69  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1_000_000, 256], 'huge_amount_groups', by_ncols=6)
-       3.86±0.2s       2.60±0.02s     0.67  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1_000_000, 256], 'huge_amount_groups')
-      1.91±0.01s       1.24±0.04s     0.65  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1_000_000, 256], ngroups=100, by_ncols=6)
-       1.66±0.1s       1.04±0.02s     0.63  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1_000_000, 256], 100)
-      3.33±0.07s       1.20±0.03s     0.36  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1_000_000, 32], 'huge_amount_groups', by_ncols=6)
-      1.10±0.03s          388±7ms     0.35  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1_000_000, 32], ngroups=100, by_ncols=6)
-        939±20ms         308±10ms     0.33  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1_000_000, 32], ngroups=100)
-      3.06±0.05s         982±70ms     0.32  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1_000_000, 32], 'huge_amount_groups')
-       10.0±0.2s       1.93±0.07s     0.19  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([10_000_000, 32], 'huge_amount_groups')
-       12.2±0.3s        2.02±0.1s     0.17  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([10_000_000, 32], 'huge_amount_groups', by_ncols=6)
-       12.7±0.2s       1.14±0.06s     0.09  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([10_000_000, 32], ngroups=100, by_ncols=6)
-       12.0±0.8s       1.07±0.04s     0.09  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([10_000_000, 32], ngroups=100)
```

</details>

<details><summary>NCPUS=16</summary>

```
       before           after         ratio
     [a77a6464]       [bb932f4d]
       <master>       <skew_impl>
+        202±20ms         504±20ms     2.49  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([5000, 5000], ngroups=100, by_ncols=6)
+        217±20ms         424±20ms     1.95  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([5000, 5000], ngroups=100)
        1.61±0.1s       1.48±0.01s     0.92  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1_000_000, 256], ngroups=100, by_ncols=6)
-      1.42±0.04s       1.28±0.01s     0.91  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1_000_000, 256], ngroups=100)
-      1.66±0.04s         906±50ms     0.55  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([5000, 5000], 'huge_amount_groups', by_ncols=6)
-      1.67±0.03s         832±30ms     0.50  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([5000, 5000], 'huge_amount_groups')
-      3.47±0.06s       1.68±0.04s     0.48  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1_000_000, 256], 'huge_amount_groups')
-       3.93±0.1s       1.79±0.01s     0.46  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1_000_000, 256], 'huge_amount_groups', by_ncols=6)
-        782±10ms         219±30ms     0.28  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1_000_000, 32], ngroups=100)
-        888±40ms         226±20ms     0.26  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1_000_000, 32], ngroups=100, by_ncols=6)
-       9.56±0.3s        1.76±0.1s     0.18  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([10_000_000, 32], 'huge_amount_groups')
-       10.5±0.3s        1.79±0.2s     0.17  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([10_000_000, 32], ngroups=100, 6)
-       11.1±0.1s       1.86±0.07s     0.17  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([10_000_000, 32], 'huge_amount_groups', by_ncols=6)
-       11.8±0.2s        1.68±0.1s     0.14  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([10_000_000, 32], ngroups=100)
-      2.60±0.08s         345±20ms     0.13  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1_000_000, 32], 'huge_amount_groups')
-      2.91±0.06s         361±10ms     0.12  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1_000_000, 32], 'huge_amount_groups', by_ncols=6)
```

</details>

<details><summary>How to run this?</summary>
1. Add an ASV benchmark for a skew function by applying the following patch:

```diff
From bb932f4d3eb58f2c83155aaddcd1d538a5eb879e Mon Sep 17 00:00:00 2001
From: Dmitry Chigarev <dmitry.chigarev@intel.com>
Date: Tue, 6 Dec 2022 15:23:17 -0600
Subject: [PATCH] Skew benchmarks

Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>
---
 asv_bench/benchmarks/benchmarks.py | 8 ++++++++
 1 file changed, 8 insertions(+)

diff --git a/asv_bench/benchmarks/benchmarks.py b/asv_bench/benchmarks/benchmarks.py
index 3ec5d197..ff8b11d8 100644
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -54,6 +54,7 @@ class BaseTimeGroupBy:
 
 
 class TimeGroupByMultiColumn(BaseTimeGroupBy):
+    timeout = 720
     param_names = ["shape", "ngroups", "groupby_ncols"]
     params = [
         get_benchmark_shapes("TimeGroupByMultiColumn"),
@@ -66,9 +67,13 @@ class TimeGroupByMultiColumn(BaseTimeGroupBy):
 
     def time_groupby_agg_mean(self, *args, **kwargs):
         execute(self.df.groupby(by=self.groupby_columns).apply(lambda df: df.mean()))
+    
+    def time_groupby_agg_skew(self, *args, **kwargs):
+        execute(self.df.groupby(by=self.groupby_columns).skew())
 
 
 class TimeGroupByDefaultAggregations(BaseTimeGroupBy):
+    timeout = 720
     param_names = ["shape", "ngroups"]
     params = [
         get_benchmark_shapes("TimeGroupByDefaultAggregations"),
@@ -86,6 +91,9 @@ class TimeGroupByDefaultAggregations(BaseTimeGroupBy):
 
     def time_groupby_mean(self, *args, **kwargs):
         execute(self.df.groupby(by=self.groupby_columns).mean())
+    
+    def time_groupby_skew(self, *args, **kwargs):
+        execute(self.df.groupby(by=self.groupby_columns).skew())
 
 
 class TimeGroupByDictionaryAggregation(BaseTimeGroupBy):
-- 
2.25.1

```

2. Specify custom data shapes for groupby benchmarks by creating the following json file:
```json
{
    "TimeGroupByDefaultAggregations": [[1000000, 32], [10000000, 32], [5000, 5000], [1000000, 256]],
    "TimeGroupByMultiColumn": [[1000000, 32], [10000000, 32], [5000, 5000], [1000000, 256]]
}
```

3. Run ASV with the following command substituting the `$ASV_CONFIG_PATH` with the path to the JSON file created in the previous step:
```
MODIN_TEST_DATASET_SIZE="Big" MODIN_ASV_DATASIZE_CONFIG=$ASV_CONFIG_PATH asv continuous origin/master skew_impl --launch-method=spawn -b TimeGroupByDefaultAggregations.time_groupby_skew -b TimeGroupByMultiColumn.time_groupby_agg_skew --no-only-changed -a repeat=5
```

</details>

Square-like frames are some kind of anti-pattern for Map and MapReduce implementation in Modin ([see optimization notes](https://modin.readthedocs.io/en/stable/usage_guide/optimization_notes/index.html#how-to-tune-partitioning)) so the new implementation is slower than the previous one on these cases. Filled an issue to resolve this problem generally (#5394).


- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5369 <!-- issue must be created for each patch -->
- [x] <s>test added</s> existing tests for `.skew()` are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
