### PR TITLE
FIX-#5319: Do not use deprecated '.iteritems()'

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2891,7 +2891,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 external_by_df = by[external_by].squeeze(axis=1)
 
                 if isinstance(external_by_df, pandas.DataFrame):
-                    external_by_cols = [o for _, o in external_by_df.iteritems()]
+                    external_by_cols = [o for _, o in external_by_df.items()]
                 else:
                     external_by_cols = [external_by_df]
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2043,7 +2043,7 @@ class DataFrame(BasePandasDataset):
             return column, functools.partial(issubclass, dtype.type)
 
         for column, f in itertools.starmap(
-            is_dtype_instance_mapper, self.dtypes.iteritems()
+            is_dtype_instance_mapper, self.dtypes.items()
         ):
             if include:  # checks for the case of empty include or exclude
                 include_these[column] = any(map(f, include))


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Gets rid of FutureWarnings raised by `.iteritems()` usage.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5319
- [x] tests <s>added and</s> passing;
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
