### PR TITLE
FEAT-#5255: Add a timestamp to the folder names generated by the logger

### DIFF
--- a/modin/logging/config.py
+++ b/modin/logging/config.py
@@ -141,7 +141,8 @@ def _create_logger(
 def configure_logging() -> None:
     """Configure Modin logging by setting up directory structure and formatting."""
     global __LOGGER_CONFIGURED__
-    job_id = uuid.uuid4().hex
+    current_timestamp = dt.datetime.now().strftime("%Y.%m.%d_%H-%M-%S")
+    job_id = f"{current_timestamp}_{uuid.uuid4().hex}"
 
     logger = _create_logger(
         "modin.logger.default",


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Adds a timestamp to the folder name pattern that the logger stores its logs so one could easily identify the required logs.

How the logs used to look like:
```
└─.modin
  ├─── job_a7fc1cf78051447a88bb65734b577285
  │    ├─── error.log
  │    ├─── memory.log
  │    └─── trace.log
  ├─── job_c819f2f7c0514693bf72cdc75b06ce15
  └─── job_3045a14facbd4c9a9e655e193ebceed0
```

How they now look like:
```
└─.modin
  ├─── job_2022.12.02_20-49-00_a7fc1cf78051447a88bb65734b577285
  │    ├─── error.log
  │    ├─── memory.log
  │    └─── trace.log
  ├─── job_2022.12.02_20-54-01_c819f2f7c0514693bf72cdc75b06ce15
  └─── job_2022.11.26_02-11-45_3045a14facbd4c9a9e655e193ebceed0
```

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5255 <!-- issue must be created for each patch -->
- [x] <s>tests added and passing</s> do we run any tests for the logger?
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
