### PR TITLE
REFACTOR-#5322: remove python3.7 related code from read_csv_glob

### DIFF
--- a/modin/core/io/text/csv_glob_dispatcher.py
+++ b/modin/core/io/text/csv_glob_dispatcher.py
@@ -17,7 +17,6 @@ from contextlib import ExitStack
 import csv
 import glob
 import os
-import sys
 from typing import List, Tuple
 import warnings
 import fsspec
@@ -85,29 +84,6 @@ class CSVGlobDispatcher(CSVDispatcher):
         compression_type = cls.infer_compression(
             filepath_or_buffer, kwargs.get("compression")
         )
-        if compression_type is not None:
-            # need python3.7 to .seek and .tell ZipExtFile
-            supports_zip = sys.version_info[0] == 3 and sys.version_info[1] >= 7
-            if (
-                compression_type == "gzip"
-                or compression_type == "bz2"
-                or compression_type == "xz"
-            ):
-                kwargs["compression"] = compression_type
-            elif compression_type == "zip" and supports_zip:
-                kwargs["compression"] = compression_type
-            else:
-                supported_types = ["gzip", "bz2", "xz"]
-                if supports_zip:
-                    supported_types.append("zip")
-                supported_str = ", ".join(f"'{s}'" for s in supported_types)
-                if compression_type == "zip" and not supports_zip:
-                    reason_str = "zip compression requires python version >=3.7"
-                else:
-                    reason_str = f"Unsupported compression type '{compression_type}' (supported types are {supported_str})"
-                return cls.single_worker_read(
-                    filepath_or_buffer, reason=reason_str, **kwargs
-                )
 
         chunksize = kwargs.get("chunksize")
         if chunksize is not None:


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5322 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
