### PR TITLE
REFACTOR-#5330: remove `BaseIO._read`

### DIFF
--- a/modin/core/io/io.py
+++ b/modin/core/io/io.py
@@ -143,33 +143,14 @@ class BaseIO:
         **kwargs,
     ):  # noqa: PR01
         ErrorMessage.default_to_pandas("`read_csv`")
-        return cls._read(filepath_or_buffer=filepath_or_buffer, **kwargs)
-
-    @classmethod
-    def _read(cls, **kwargs):
-        """
-        Read csv file into query compiler.
-
-        Parameters
-        ----------
-        **kwargs : dict
-            `read_csv` function kwargs including `filepath_or_buffer` parameter.
-
-        Returns
-        -------
-        BaseQueryCompiler
-            QueryCompiler with read data.
-        """
-        pd_obj = pandas.read_csv(**kwargs)
+        pd_obj = pandas.read_csv(filepath_or_buffer, **kwargs)
         if isinstance(pd_obj, pandas.DataFrame):
             return cls.from_pandas(pd_obj)
         if isinstance(pd_obj, pandas.io.parsers.TextFileReader):
             # Overwriting the read method should return a Modin DataFrame for calls
             # to __next__ and get_chunk
             pd_read = pd_obj.read
-            pd_obj.read = lambda *args, **kwargs: cls.from_pandas(
-                pd_read(*args, **kwargs)
-            )
+            pd_obj.read = lambda *args, **kw: cls.from_pandas(pd_read(*args, **kw))
         return pd_obj
 
     @classmethod

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -232,7 +232,7 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
         eng = str(engine).lower().strip()
         try:
             if eng in ["pandas", "c"]:
-                return cls._read(**mykwargs)
+                return cls.read_csv(**mykwargs)
 
             cls._validate_read_csv_kwargs(mykwargs)
             use_modin_impl, error_message = cls._read_csv_check_support(
@@ -311,7 +311,7 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
                 raise
 
             ErrorMessage.default_to_pandas("`read_csv`")
-            return cls._read(**mykwargs)
+            return cls.read_csv(**mykwargs)
 
     @classmethod
     def _dtype_to_arrow(cls, dtype):

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -232,7 +232,7 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
         eng = str(engine).lower().strip()
         try:
             if eng in ["pandas", "c"]:
-                return cls.read_csv(**mykwargs)
+                return super().read_csv(**mykwargs)
 
             cls._validate_read_csv_kwargs(mykwargs)
             use_modin_impl, error_message = cls._read_csv_check_support(
@@ -311,7 +311,7 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
                 raise
 
             ErrorMessage.default_to_pandas("`read_csv`")
-            return cls.read_csv(**mykwargs)
+            return super().read_csv(**mykwargs)
 
     @classmethod
     def _dtype_to_arrow(cls, dtype):


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

We already have `_read` methods in the dispatcher hierarchy. Since there is no need to make such a method also in the IO hierarchy, we can remove it and this will help us stop figuring out which method from the hierarchy was called.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5330 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
