### PR TITLE
REFACTOR-#5334: make `_validate` as classmethod

### DIFF
--- a/modin/pandas/accessor.py
+++ b/modin/pandas/accessor.py
@@ -46,7 +46,8 @@ class BaseSparseAccessor(ClassLogger):
         self._parent = data
         self._validate(data)
 
-    def _validate(self, data):
+    @classmethod
+    def _validate(cls, data):
         """
         Verify that `data` dtypes are compatible with `pandas.core.arrays.sparse.dtype.SparseDtype`.
 
@@ -87,7 +88,8 @@ class BaseSparseAccessor(ClassLogger):
 
 @_inherit_docstrings(pandas.core.arrays.sparse.accessor.SparseFrameAccessor)
 class SparseFrameAccessor(BaseSparseAccessor):
-    def _validate(self, data):
+    @classmethod
+    def _validate(cls, data):
         """
         Verify that `data` dtypes are compatible with `pandas.core.arrays.sparse.dtype.SparseDtype`.
 
@@ -103,7 +105,7 @@ class SparseFrameAccessor(BaseSparseAccessor):
         """
         dtypes = data.dtypes
         if not all(isinstance(t, SparseDtype) for t in dtypes):
-            raise AttributeError(self._validation_msg)
+            raise AttributeError(cls._validation_msg)
 
     @property
     def density(self):
@@ -125,7 +127,8 @@ class SparseFrameAccessor(BaseSparseAccessor):
 
 @_inherit_docstrings(pandas.core.arrays.sparse.accessor.SparseAccessor)
 class SparseAccessor(BaseSparseAccessor):
-    def _validate(self, data):
+    @classmethod
+    def _validate(cls, data):
         """
         Verify that `data` dtype is compatible with `pandas.core.arrays.sparse.dtype.SparseDtype`.
 
@@ -140,7 +143,7 @@ class SparseAccessor(BaseSparseAccessor):
             If check fails.
         """
         if not isinstance(data.dtype, SparseDtype):
-            raise AttributeError(self._validation_msg)
+            raise AttributeError(cls._validation_msg)
 
     @property
     def density(self):


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5334 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
