### PR TITLE
REFACTOR-#5332: define `PQ_INDEX_REGEX` as class variable

### DIFF
--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -44,7 +44,6 @@ from pandas._typing import (
 )
 import pathlib
 import pickle
-import re
 from typing import (
     Union,
     IO,
@@ -68,8 +67,6 @@ from .dataframe import DataFrame
 from .series import Series
 from modin.utils import _inherit_docstrings, Engine
 from . import _update_engine
-
-PQ_INDEX_REGEX = re.compile(r"__index_level_\d+__")
 
 
 def _read(**kwargs):


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5332 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
