### PR TITLE
TEST-#5345: Stop running CI for some worfklow changes.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on:
       # NOTE: keep these paths in sync with the paths that trigger the
       # fuzzydata Github Actions in .github/workflows/fuzzydata-test.yml
       - .github/workflows/**
+      - '!.github/workflows/push-to-master.yml'
+      - '!.github/workflows/push.yml'
       - asv_bench/**
       - modin/**
       - requirements/**

--- a/.github/workflows/fuzzydata-test.yml
+++ b/.github/workflows/fuzzydata-test.yml
@@ -5,6 +5,8 @@ on:
       # NOTE: keep these paths in sync with the paths that trigger the CI Github
       # Actions in .github/workflows/ci.yml
       - .github/workflows/**
+      - '!.github/workflows/push-to-master.yml'
+      - '!.github/workflows/push.yml'
       - asv_bench/**
       - modin/**
       - requirements/**


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Using the syntax shown [here](https://github.com/mvashishtha/modin/pull/new/5345-skip-ci-for-workflow-changes), skip PR CI for changes to workflows that only run on push to master.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5345 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
