### PR TITLE
TEST-#5348: Instead of capping mypy, exclude 0.990.

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -41,7 +41,8 @@ dependencies:
   - scikit-learn
   - pymssql
   - psycopg2
-  - mypy<=0.991
+  # Mypy 0.990 doesn't work: https://github.com/modin-project/modin/issues/5206  
+  - mypy!=0.990
   - pandas-stubs
   - fastparquet
   # for release script

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -47,7 +47,8 @@ flake8-print
 numpydoc==1.1.0
 # experimental version of fuzzydata requires at least 0.0.6 to successfully resolve all dependencies
 fuzzydata>=0.0.6
-mypy<=0.991
+# Mypy 0.990 doesn't work: https://github.com/modin-project/modin/issues/5206
+mypy!=0.990
 pandas-stubs
 fastparquet
 # for release script


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5348 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
