### PR TITLE
TEST-#5350: port DropDuplicates and LevelAlign benchmarks from pandas github 

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1043,10 +1043,10 @@ class TimeDropDuplicatesDataframe:
         execute(self.df)
 
     def time_drop_dups(self, shape):
-        execute(self.df.drop_duplicates(["key1", "key2"]))
+        execute(self.df.drop_duplicates(self.df.columns[:-1]))
 
     def time_drop_dups_inplace(self, shape):
-        self.df.drop_duplicates(["key1", "key2"], inplace=True)
+        self.df.drop_duplicates(self.df.columns[:-1], inplace=True)
         execute(self.df)
 
 

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1032,12 +1032,13 @@ class TimeDropDuplicatesDataframe:
     param_names = ["shape"]
 
     def setup(self, shape):
-        rows,cols = shape
+        rows, cols = shape
         N = rows // 10
         K = 10
         self.df = IMPL.DataFrame()
-        for col in range(cols-1): # dataframe would  have cols-1 keys(strings) and one value(int) column
-            self.df["key"+str(col+1)] = tm.makeStringIndex(N).values.repeat(K)
+        # dataframe would  have cols-1 keys(strings) and one value(int) column
+        for col in range(cols - 1):
+            self.df["key" + str(col + 1)] = tm.makeStringIndex(N).values.repeat(K)
         self.df["value"] = np.random.randn(N * K)
         execute(self.df)
 

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1032,19 +1032,14 @@ class TimeDropDuplicatesDataframe:
     param_names = ["shape"]
 
     def setup(self, shape):
-        N = shape[0]
-        K = shape[1]
+        N = shape[0] // 10
+        K = 10
         key1 = tm.makeStringIndex(N).values.repeat(K)
         key2 = tm.makeStringIndex(N).values.repeat(K)
         self.df = IMPL.DataFrame(
             {"key1": key1, "key2": key2, "value": np.random.randn(N * K)}
         )
-        self.df_nan = self.df.copy()
-        self.df_nan.iloc[:N, :] = np.nan
-        key1 = np.random.randint(0, K, size=N)
-        self.df_int = IMPL.DataFrame({"key1": key1})
-        execute(self.df), execute(self.df_nan)
-        execute(self.df_int)
+        execute(self.df)
 
     def time_drop_dups(self, shape):
         execute(self.df.drop_duplicates(["key1", "key2"]))
@@ -1053,20 +1048,6 @@ class TimeDropDuplicatesDataframe:
         self.df.drop_duplicates(["key1", "key2"], inplace=True)
         execute(self.df)
 
-    def time_drop_dups_na(self, shape):
-        execute(self.df_nan.drop_duplicates(["key1", "key2"]))
-
-    def time_drop_dups_na_inplace(self, shape):
-        self.df_nan.drop_duplicates(["key1", "key2"], inplace=True)
-        execute(self.df_nan)
-
-    def time_drop_dups_int(self, shape):
-        execute(self.df_int.drop_duplicates())
-
-    def time_drop_dups_int_inplace(self, shape):
-        self.df_int.drop_duplicates(inplace=True)
-        execute(self.df_int)
-
 
 class TimeDropDuplicatesSeries:
 
@@ -1074,17 +1055,9 @@ class TimeDropDuplicatesSeries:
     param_names = ["shape"]
 
     def setup(self, shape):
-        N = shape[0]
-        self.s = IMPL.Series(np.random.randint(0, N // 10, size=N))
-        self.s_str = IMPL.Series(np.tile(tm.makeStringIndex(N // 10).values, 10))
-        execute(self.s), execute(self.s_str)
-
-    def time_drop_dups_int(self, shape):
-        execute(self.s.drop_duplicates())
-
-    def time_drop_dups_int_inplace(self, shape):
-        self.s.drop_duplicates(inplace=True)
-        execute(self.s)
+        rows = shape[0]
+        self.s_str = IMPL.Series(np.tile(tm.makeStringIndex(rows // 10).values, 10))
+        execute(self.s_str)
 
     def time_drop_dups_string(self, shape):
         execute(self.s_str.drop_duplicates())

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -998,24 +998,23 @@ class TimeLevelAlign:
     param_names = ["shapes"]
 
     def setup(self, shapes):
-        row1, col1 = shapes[0]
-        row2, col2 = shapes[1]
-        Nroot = round(math.sqrt(row1))
-        N = Nroot * Nroot
+        rows, cols = shapes[0]
+        rows_sqrt = round(math.sqrt(rows))
+        # the new number of rows may differ from the requested (slightly, so ok)
+        rows = rows_sqrt * rows_sqrt
         self.index = IMPL.MultiIndex(
-            levels=[np.arange(10), np.arange(Nroot), np.arange(Nroot)],
+            levels=[np.arange(10), np.arange(rows_sqrt), np.arange(rows_sqrt)],
             codes=[
-                np.arange(10).repeat(N),
-                np.tile(np.arange(Nroot).repeat(Nroot), 10),
-                np.tile(np.tile(np.arange(Nroot), Nroot), 10),
+                np.arange(10).repeat(rows),
+                np.tile(np.arange(rows_sqrt).repeat(rows_sqrt), 10),
+                np.tile(np.tile(np.arange(rows_sqrt), rows_sqrt), 10),
             ],
         )
         self.df1 = IMPL.DataFrame(
-            np.random.randn(len(self.index), col1), index=self.index
+            np.random.randn(len(self.index), cols), index=self.index
         )
-        self.df2 = IMPL.DataFrame(np.random.randn(row2, col2))
-        execute(self.df1)
-        execute(self.df2)
+        self.df2 = IMPL.DataFrame(np.random.randn(*shapes[1]))
+        execute(self.df1), execute(self.df2)
 
     def time_align_level(self, shapes):
         left, right = self.df1.align(self.df2, level=1, copy=False)

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1032,13 +1032,13 @@ class TimeDropDuplicatesDataframe:
     param_names = ["shape"]
 
     def setup(self, shape):
-        N = shape[0] // 10
+        rows,cols = shape
+        N = rows // 10
         K = 10
-        key1 = tm.makeStringIndex(N).values.repeat(K)
-        key2 = tm.makeStringIndex(N).values.repeat(K)
-        self.df = IMPL.DataFrame(
-            {"key1": key1, "key2": key2, "value": np.random.randn(N * K)}
-        )
+        self.df = IMPL.DataFrame()
+        for col in range(cols-1): # dataframe would  have cols-1 keys(strings) and one value(int) column
+            self.df["key"+str(col+1)] = tm.makeStringIndex(N).values.repeat(K)
+        self.df["value"] = np.random.randn(N * K)
         execute(self.df)
 
     def time_drop_dups(self, shape):

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1018,8 +1018,7 @@ class TimeLevelAlign:
 
     def time_align_level(self, shapes):
         left, right = self.df1.align(self.df2, level=1, copy=False)
-        execute(left)
-        execute(right)
+        execute(left), execute(right)
 
     # reindex returns  the same result as align. Approximately the same performance is expected.
     def time_reindex_level(self, shapes):

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1047,24 +1047,24 @@ class TimeDropDuplicatesDataframe:
         execute(self.df), execute(self.df_nan)
         execute(self.df_int)
 
-    def time_frame_drop_dups(self, shape):
+    def time_drop_dups(self, shape):
         execute(self.df.drop_duplicates(["key1", "key2"]))
 
-    def time_frame_drop_dups_inplace(self, shape):
+    def time_drop_dups_inplace(self, shape):
         self.df.drop_duplicates(["key1", "key2"], inplace=True)
         execute(self.df)
 
-    def time_frame_drop_dups_na(self, shape):
+    def time_drop_dups_na(self, shape):
         execute(self.df_nan.drop_duplicates(["key1", "key2"]))
 
-    def time_frame_drop_dups_na_inplace(self, shape):
+    def time_drop_dups_na_inplace(self, shape):
         self.df_nan.drop_duplicates(["key1", "key2"], inplace=True)
         execute(self.df_nan)
 
-    def time_frame_drop_dups_int(self, shape):
+    def time_drop_dups_int(self, shape):
         execute(self.df_int.drop_duplicates())
 
-    def time_frame_drop_dups_int_inplace(self, shape):
+    def time_drop_dups_int_inplace(self, shape):
         self.df_int.drop_duplicates(inplace=True)
         execute(self.df_int)
 
@@ -1080,17 +1080,17 @@ class TimeDropDuplicatesSeries:
         self.s_str = IMPL.Series(np.tile(tm.makeStringIndex(N // 10).values, 10))
         execute(self.s), execute(self.s_str)
 
-    def time_series_drop_dups_int(self, shape):
+    def time_drop_dups_int(self, shape):
         execute(self.s.drop_duplicates())
 
-    def time_series_drop_dups_int_inplace(self, shape):
+    def time_drop_dups_int_inplace(self, shape):
         self.s.drop_duplicates(inplace=True)
         execute(self.s)
 
-    def time_series_drop_dups_string(self, shape):
+    def time_drop_dups_string(self, shape):
         execute(self.s_str.drop_duplicates())
 
-    def time_series_drop_dups_string_inplace(self, shape):
+    def time_drop_dups_string_inplace(self, shape):
         self.s_str.drop_duplicates(inplace=True)
         execute(self.s_str)
 

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1020,8 +1020,9 @@ class TimeLevelAlign:
         left, right = self.df1.align(self.df2, level=1, copy=False)
         execute(left), execute(right)
 
-    # reindex returns  the same result as align. Approximately the same performance is expected.
     def time_reindex_level(self, shapes):
+        # `reindex` returns the same result here as `align`.
+        # Approximately the same performance is expected.
         execute(self.df2.reindex(self.index, level=1))
 
 

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1056,15 +1056,15 @@ class TimeDropDuplicatesSeries:
 
     def setup(self, shape):
         rows = shape[0]
-        self.s_str = IMPL.Series(np.tile(tm.makeStringIndex(rows // 10).values, 10))
-        execute(self.s_str)
+        self.series = IMPL.Series(np.tile(tm.makeStringIndex(rows // 10).values, 10))
+        execute(self.series)
+
+    def time_drop_dups(self, shape):
+        execute(self.series.drop_duplicates())
 
     def time_drop_dups_string(self, shape):
-        execute(self.s_str.drop_duplicates())
-
-    def time_drop_dups_string_inplace(self, shape):
-        self.s_str.drop_duplicates(inplace=True)
-        execute(self.s_str)
+        self.series.drop_duplicates(inplace=True)
+        execute(self.series)
 
 
 from .utils import setup  # noqa: E402, F401

--- a/asv_bench/benchmarks/utils/data_shapes.py
+++ b/asv_bench/benchmarks/utils/data_shapes.py
@@ -100,6 +100,7 @@ _DEFAULT_CONFIG_T = [
             "TimeReindex",
             "TimeReindexMethod",
             "TimeFillnaMethodDataframe",
+            "TimeDropDuplicates",
             # IO benchmarks
             "TimeReadCsvSkiprows",
             "TimeReadCsvTrueFalseValues",
@@ -119,6 +120,7 @@ _DEFAULT_CONFIG_T = [
             "TimeConcat",
             "TimeAppend",
             "TimeBinaryOp",
+            "TimeLevelAlign",
         ],
     ),
     (

--- a/asv_bench/benchmarks/utils/data_shapes.py
+++ b/asv_bench/benchmarks/utils/data_shapes.py
@@ -100,7 +100,7 @@ _DEFAULT_CONFIG_T = [
             "TimeReindex",
             "TimeReindexMethod",
             "TimeFillnaMethodDataframe",
-            "TimeDropDuplicates",
+            "TimeDropDuplicatesDataframe",
             # IO benchmarks
             "TimeReadCsvSkiprows",
             "TimeReadCsvTrueFalseValues",
@@ -130,6 +130,7 @@ _DEFAULT_CONFIG_T = [
             "TimeFillnaSeries",
             "TimeIndexingNumericSeries",
             "TimeFillnaMethodSeries",
+            "TimeDropDuplicatesSeries",
         ],
     ),
     (


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Adding 2 benchmark classes from pandas benchmark
Source PR https://github.com/modin-project/modin/pull/5047

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5350 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
