### PR TITLE
FIX-#5276: make `InterceptedNumpy` objects are picklable by `cloudpickle`

### DIFF
--- a/modin/experimental/cloud/test/test_cloud.py
+++ b/modin/experimental/cloud/test/test_cloud.py
@@ -15,6 +15,9 @@ import unittest.mock as mock
 import pytest
 from collections import namedtuple
 from inspect import signature
+
+import pandas
+
 from modin.experimental.cloud.rayscale import (
     RayCluster,
     create_or_update_cluster,
@@ -23,6 +26,7 @@ from modin.experimental.cloud.rayscale import (
     bootstrap_config,
 )
 from modin.experimental.cloud.cluster import Provider
+from modin.pandas.test.utils import df_equals
 
 
 @pytest.fixture
@@ -137,3 +141,15 @@ def test_update_conda_requirements(
             assert package in setup_commands_result
     else:
         assert "modin=" in setup_commands_result
+
+
+def test_pickling_proxy_class_for_numpy():
+    import modin.experimental.pandas as pd
+    import numpy as np
+
+    md_s = pd.Series([1, 2, 0, 3, 0])
+    md_s = md_s.apply(lambda x: x if x else np.nan)
+
+    pd_s = pandas.Series([1, 2, 0, 3, 0])
+    pd_s = pd_s.apply(lambda x: x if x else np.nan)
+    df_equals(md_s, pd_s)

--- a/modin/experimental/pandas/numpy_wrap.py
+++ b/modin/experimental/pandas/numpy_wrap.py
@@ -140,6 +140,30 @@ else:
                 self.__reducers[name] = reducer
             return reducer
 
+        """
+        def __getstate__(self):
+            #res = {key: getattr(self, key) for key in self.__own_attrs__}
+            res = {}
+            res["__own_attrs__"] = self.__own_attrs__
+            for key in ["__current_numpy", "__prev_numpy", "__has_to_warn"]:
+                full_key = f"_InterceptedNumpy{key}"
+                res[full_key] = getattr(self, full_key)
+            return res
+
+        def __setstate__(self, state):
+            # self.__dict__ is readonly
+            for key in state:
+                setattr(self, key, state[key])
+        """
+
+        def __getstate__(self):
+            return real_numpy
+
+        def __setstate__(self, state):
+            # The state is not saved, but allows us to use this class in lambdas
+            #
+            pass
+
         def __get_numpy(self):
             frame = sys._getframe()
             try:


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5276 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
