### PR TITLE
REFACTOR-#5363: introduce partition constructor; move `add_to_apply_calls` impl in base class

### DIFF
--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -34,6 +34,18 @@ class PandasDataframePartition(ABC):  # pragma: no cover
     _width_cache = None
     _data = None
 
+    @property
+    def __constructor__(self):
+        """
+        Create a new instance of this object.
+
+        Returns
+        -------
+        PandasDataframePartition
+            New instance of pandas partition.
+        """
+        return type(self)
+
     def get(self):
         """
         Get the object wrapped by this partition.
@@ -119,7 +131,12 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         This function will be executed when `apply` is called. It will be executed
         in the order inserted; apply's func operates the last and return.
         """
-        pass
+        return self.__constructor__(
+            self._data,
+            call_queue=self.call_queue + [[func, args, kwargs]],
+            length=length,
+            width=width,
+        )
 
     def drain_call_queue(self):
         """Execute all operations stored in the call queue on the object wrapped by this partition."""

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -18,6 +18,7 @@ from copy import copy
 
 import pandas
 from pandas.api.types import is_scalar
+from pandas.util import cache_readonly
 
 from modin.pandas.indexing import compute_sliced_len
 from modin.core.storage_formats.pandas.utils import length_fn_pandas, width_fn_pandas
@@ -34,7 +35,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
     _width_cache = None
     _data = None
 
-    @property
+    @cache_readonly
     def __constructor__(self):
         """
         Create a new instance of this object.

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
@@ -103,40 +103,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
                 num_returns=2,
                 pure=False,
             )
-        return PandasOnDaskDataframePartition(futures[0], ip=futures[1])
-
-    def add_to_apply_calls(self, func, *args, length=None, width=None, **kwargs):
-        """
-        Add a function to the call queue.
-
-        Parameters
-        ----------
-        func : callable
-            Function to be added to the call queue.
-        *args : iterable
-            Additional positional arguments to be passed in `func`.
-        length : distributed.Future or int, optional
-            Length, or reference to length, of wrapped ``pandas.DataFrame``.
-        width : distributed.Future or int, optional
-            Width, or reference to width, of wrapped ``pandas.DataFrame``.
-        **kwargs : dict
-            Additional keyword arguments to be passed in `func`.
-
-        Returns
-        -------
-        PandasOnDaskDataframePartition
-            A new ``PandasOnDaskDataframePartition`` object.
-
-        Notes
-        -----
-        The keyword arguments are sent as a dictionary.
-        """
-        return PandasOnDaskDataframePartition(
-            self._data,
-            call_queue=self.call_queue + [[func, args, kwargs]],
-            length=length,
-            width=width,
-        )
+        return self.__constructor__(futures[0], ip=futures[1])
 
     def drain_call_queue(self):
         """Execute all operations stored in the call queue on the object wrapped by this partition."""
@@ -214,7 +181,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         PandasOnDaskDataframePartition
             A copy of this partition.
         """
-        return PandasOnDaskDataframePartition(
+        return self.__constructor__(
             self._data,
             length=self._length_cache,
             width=self._width_cache,

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
@@ -42,7 +42,7 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
     """
 
     def __init__(self, data, length=None, width=None, call_queue=None):
-        self._data = data
+        self._data = data.copy()
         if call_queue is None:
             call_queue = []
         self.call_queue = call_queue
@@ -110,38 +110,7 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
 
         self._data = call_queue_closure(self._data, self.call_queue)
         self.call_queue = []
-        return PandasOnPythonDataframePartition(
-            func(self._data.copy(), *args, **kwargs)
-        )
-
-    def add_to_apply_calls(self, func, *args, length=None, width=None, **kwargs):
-        """
-        Add a function to the call queue.
-
-        Parameters
-        ----------
-        func : callable
-            Function to be added to the call queue.
-        *args : iterable
-            Additional positional arguments to be passed in `func`.
-        length : int, optional
-            Length of wrapped ``pandas.DataFrame``.
-        width : int, optional
-            Width of wrapped ``pandas.DataFrame``.
-        **kwargs : dict
-            Additional keyword arguments to be passed in `func`.
-
-        Returns
-        -------
-        PandasOnPythonDataframePartition
-            New ``PandasOnPythonDataframePartition`` object with extended call queue.
-        """
-        return PandasOnPythonDataframePartition(
-            self._data.copy(),
-            call_queue=self.call_queue + [[func, args, kwargs]],
-            length=length,
-            width=width,
-        )
+        return self.__constructor__(func(self._data.copy(), *args, **kwargs))
 
     def drain_call_queue(self):
         """Execute all operations stored in the call queue on the object wrapped by this partition."""

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
@@ -42,7 +42,9 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
     """
 
     def __init__(self, data, length=None, width=None, call_queue=None):
-        self._data = data.copy()
+        if hasattr(data, "copy"):
+            data = data.copy()
+        self._data = data
         if call_queue is None:
             call_queue = []
         self.call_queue = call_queue

--- a/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
@@ -41,18 +41,6 @@ class cuDFOnRayDataframePartition(PandasDataframePartition):
         Width or reference to it of wrapped ``pandas.DataFrame``.
     """
 
-    @property
-    def __constructor__(self):
-        """
-        Create a new instance of this object.
-
-        Returns
-        -------
-        cuDFOnRayDataframePartition
-            New instance of cuDF partition.
-        """
-        return type(self)
-
     def __init__(self, gpu_manager, key, length=None, width=None):
         self.gpu_manager = gpu_manager
         self.key = key
@@ -69,7 +57,7 @@ class cuDFOnRayDataframePartition(PandasDataframePartition):
             A copy of this object.
         """
         # Shallow copy.
-        return cuDFOnRayDataframePartition(
+        return self.__constructor__(
             self.gpu_manager, self.key, self._length_cache, self._width_cache
         )
 
@@ -165,7 +153,7 @@ class cuDFOnRayDataframePartition(PandasDataframePartition):
         -----
         We eagerly schedule the apply `func` and produce a new ``cuDFOnRayDataframePartition``.
         """
-        return cuDFOnRayDataframePartition(
+        return self.__constructor__(
             self.gpu_manager,
             self.apply(func, *args, **kwargs),
             length=length,

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -121,41 +121,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             )
             logger.debug(f"SUBMIT::_apply_func::{self._identity}")
         logger.debug(f"EXIT::Partition.apply::{self._identity}")
-        return PandasOnRayDataframePartition(result, length, width, ip)
-
-    def add_to_apply_calls(self, func, *args, length=None, width=None, **kwargs):
-        """
-        Add a function to the call queue.
-
-        Parameters
-        ----------
-        func : callable or ray.ObjectRef
-            Function to be added to the call queue.
-        *args : iterable
-            Additional positional arguments to be passed in `func`.
-        length : ray.ObjectRef or int, optional
-            Length, or reference to length, of wrapped ``pandas.DataFrame``.
-        width : ray.ObjectRef or int, optional
-            Width, or reference to width, of wrapped ``pandas.DataFrame``.
-        **kwargs : dict
-            Additional keyword arguments to be passed in `func`.
-
-        Returns
-        -------
-        PandasOnRayDataframePartition
-            A new ``PandasOnRayDataframePartition`` object.
-
-        Notes
-        -----
-        It does not matter if `func` is callable or an ``ray.ObjectRef``. Ray will
-        handle it correctly either way. The keyword arguments are sent as a dictionary.
-        """
-        return PandasOnRayDataframePartition(
-            self._data,
-            call_queue=self.call_queue + [[func, args, kwargs]],
-            length=length,
-            width=width,
-        )
+        return self.__constructor__(result, length, width, ip)
 
     def drain_call_queue(self):
         """Execute all operations stored in the call queue on the object wrapped by this partition."""
@@ -208,7 +174,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         PandasOnRayDataframePartition
             A copy of this partition.
         """
-        return PandasOnRayDataframePartition(
+        return self.__constructor__(
             self._data,
             length=self._length_cache,
             width=self._width_cache,
@@ -275,9 +241,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         PandasOnRayDataframePartition
             A new ``PandasOnRayDataframePartition`` object.
         """
-        return PandasOnRayDataframePartition(
-            ray.put(obj), len(obj.index), len(obj.columns)
-        )
+        return cls(ray.put(obj), len(obj.index), len(obj.columns))
 
     @classmethod
     def preprocess_func(cls, func):

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -115,41 +115,7 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
             result, length, width, ip = _apply_func.remote(data, func, *args, **kwargs)
             logger.debug(f"SUBMIT::_apply_func::{self._identity}")
         logger.debug(f"EXIT::Partition.apply::{self._identity}")
-        return PandasOnUnidistDataframePartition(result, length, width, ip)
-
-    def add_to_apply_calls(self, func, *args, length=None, width=None, **kwargs):
-        """
-        Add a function to the call queue.
-
-        Parameters
-        ----------
-        func : callable or unidist.ObjectRef
-            Function to be added to the call queue.
-        *args : iterable
-            Additional positional arguments to be passed in `func`.
-        length : unidist.ObjectRef or int, optional
-            Length, or reference to length, of wrapped ``pandas.DataFrame``.
-        width : unidist.ObjectRef or int, optional
-            Width, or reference to width, of wrapped ``pandas.DataFrame``.
-        **kwargs : dict
-            Additional keyword arguments to be passed in `func`.
-
-        Returns
-        -------
-        PandasOnUnidistDataframePartition
-            A new ``PandasOnUnidistDataframePartition`` object.
-
-        Notes
-        -----
-        It does not matter if `func` is callable or an ``unidist.ObjectRef``. Unidist will
-        handle it correctly either way. The keyword arguments are sent as a dictionary.
-        """
-        return PandasOnUnidistDataframePartition(
-            self._data,
-            call_queue=self.call_queue + [[func, args, kwargs]],
-            length=length,
-            width=width,
-        )
+        return self.__constructor__(result, length, width, ip)
 
     def drain_call_queue(self):
         """Execute all operations stored in the call queue on the object wrapped by this partition."""
@@ -250,9 +216,7 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
         PandasOnUnidistDataframePartition
             A new ``PandasOnUnidistDataframePartition`` object.
         """
-        return PandasOnUnidistDataframePartition(
-            unidist.put(obj), len(obj.index), len(obj.columns)
-        )
+        return cls(unidist.put(obj), len(obj.index), len(obj.columns))
 
     @classmethod
     def preprocess_func(cls, func):

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition.py
@@ -111,9 +111,7 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
         HdkOnNativeDataframePartition
             The new partition.
         """
-        return HdkOnNativeDataframePartition(
-            pandas_df=obj.copy(), length=len(obj.index), width=len(obj.columns)
-        )
+        return cls(pandas_df=obj.copy(), length=len(obj.index), width=len(obj.columns))
 
     def wait(self):
         """
@@ -143,7 +141,7 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
         HdkOnNativeDataframePartition
             The new partition.
         """
-        return HdkOnNativeDataframePartition(
+        return cls(
             arrow_table=obj,
             length=len(obj),
             width=len(obj.columns),


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5363 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
