### PR TITLE
FIX-#5364: fix `get_indices` internal function

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2058,18 +2058,7 @@ class PandasDataframe(ClassLogger):
                 new_axes[axis.value],
                 new_lengths[axis.value],
             ) = self._compute_axis_labels_and_lengths(axis.value, new_partitions)
-        # If we have a MultiIndex, but the first partition is empty, which may happen when
-        # the dataframe is small, `_compute_axis_labels_and_lengths` will return us a flattened
-        # MultiIndex - i.e. an Index consisting of tuples. This is because the MultiIndex from
-        # the remaining partitions is appended to an empty flat Index, which results in a
-        # flattened index. To work around this, we need to convert this flattened Index back
-        # into a MultiIndex.
-        if isinstance(self.axes[axis.value], pandas.MultiIndex) and isinstance(
-            new_axes[axis.value][0], tuple
-        ):
-            new_axes[axis.value] = pandas.MultiIndex.from_tuples(
-                new_axes[axis.value].values
-            )
+
         new_axes[axis.value] = new_axes[axis.value].set_names(
             self.axes[axis.value].names
         )

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -881,9 +881,10 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         new_idx = [idx.apply(func) for idx in target[0]] if len(target) else []
         new_idx = cls.get_objects_from_partitions(new_idx)
         # filter empty indexes
-        new_idx = list(filter(lambda idx: len(idx), new_idx))
-        # TODO FIX INFORMATION LEAK!!!!1!!1!!
-        total_idx = new_idx[0].append(new_idx[1:]) if new_idx else new_idx
+        total_idx = list(filter(len, new_idx))
+        if len(total_idx) > 0:
+            # TODO FIX INFORMATION LEAK!!!!1!!1!!
+            total_idx = total_idx[0].append(total_idx[1:])
         return total_idx, new_idx
 
     @classmethod

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -880,6 +880,8 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         target = partitions.T if axis == 0 else partitions
         new_idx = [idx.apply(func) for idx in target[0]] if len(target) else []
         new_idx = cls.get_objects_from_partitions(new_idx)
+        # filter empty indexes
+        new_idx = list(filter(lambda idx: len(idx), new_idx))
         # TODO FIX INFORMATION LEAK!!!!1!!1!!
         total_idx = new_idx[0].append(new_idx[1:]) if new_idx else new_idx
         return total_idx, new_idx


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5364 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
