### PR TITLE
REFACTOR-#5382: use `pandas.util.cache_readonly` for `__constructors__`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -176,7 +176,7 @@ class PandasDataframe(ClassLogger):
     _deferred_index = False
     _deferred_column = False
 
-    @property
+    @pandas.util.cache_readonly
     def __constructor__(self):
         """
         Create a new instance of this object.

--- a/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
@@ -18,6 +18,7 @@ import cudf
 import cupy
 import numpy as np
 import cupy as cp
+from pandas.util import cache_readonly
 
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from pandas.core.dtypes.common import is_list_like

--- a/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
@@ -18,7 +18,6 @@ import cudf
 import cupy
 import numpy as np
 import cupy as cp
-from pandas.util import cache_readonly
 
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from pandas.core.dtypes.common import is_list_like

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3225,7 +3225,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     # END Abstract methods for QueryCompiler
 
-    @property
+    @pandas.util.cache_readonly
     def __constructor__(self):
         """
         Get query compiler constructor.

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -70,7 +70,7 @@ sentinel = object()
 
 # Do not lookup certain attributes in columns or index, as they're used for some
 # special purposes, like serving remote context
-_ATTRS_NO_LOOKUP = {"____id_pack__", "__name__"}
+_ATTRS_NO_LOOKUP = {"____id_pack__", "__name__", "_cache"}
 
 _DEFAULT_BEHAVIOUR = {
     "__init__",
@@ -94,6 +94,7 @@ _DEFAULT_BEHAVIOUR = {
     "_reduce_dimension",
     "__repr__",
     "__len__",
+    "__constructor__",
     "_create_or_update_from_compiler",
     "_update_inplace",
     # for persistance support;

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -541,23 +541,17 @@ class BasePandasDataset(ClassLogger):
 
         return cls._pandas_class._get_axis_number(axis) if axis is not None else 0
 
-    def __constructor__(self, *args, **kwargs):
+    @pandas.util.cache_readonly
+    def __constructor__(self):
         """
         Construct DataFrame or Series object depending on self type.
-
-        Parameters
-        ----------
-        *args : list
-            Additional positional arguments to be passed to constructor.
-        **kwargs : dict
-            Additional keywords arguments to be passed to constructor.
 
         Returns
         -------
         modin.pandas.BasePandasDataset
             Constructed object.
         """
-        return type(self)(*args, **kwargs)
+        return type(self)
 
     def abs(self):  # noqa: RT01, D200
         """


### PR DESCRIPTION
Signed-off-by: Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5382 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
