### PR TITLE
FIX-#5380: Fix warning about setting _cache attribute.

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -56,6 +56,7 @@ from .utils import (
     from_pandas,
     from_non_pandas,
     broadcast_item,
+    SET_DATAFRAME_ATTRIBUTE_WARNING,
 )
 from . import _update_engine
 from .iterator import PartitionIterator
@@ -2674,8 +2675,7 @@ class DataFrame(BasePandasDataset):
             return
         elif is_list_like(value) and key not in ["index", "columns"]:
             warnings.warn(
-                "Modin doesn't allow columns to be created via a new attribute name - see "
-                + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
+                SET_DATAFRAME_ATTRIBUTE_WARNING,
                 UserWarning,
             )
         object.__setattr__(self, key, value)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2662,7 +2662,9 @@ class DataFrame(BasePandasDataset):
         # - `_query_compiler`, which Modin initializes before it appears in
         #   __dict__
         # - `_siblings`, which Modin initializes before it appears in __dict__
-        if key in ["_query_compiler", "_siblings"] or key in self.__dict__:
+        # - `_cache`, which pandas.cache_readonly uses to cache properties
+        #   before it appears in __dict__.
+        if key in ("_query_compiler", "_siblings", "_cache") or key in self.__dict__:
             pass
         elif key in self and key not in dir(self):
             self.__setitem__(key, value)

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -30,6 +30,7 @@ from modin.pandas.test.utils import (
     create_test_dfs,
     test_data,
 )
+from modin.pandas.utils import SET_DATAFRAME_ATTRIBUTE_WARNING
 from modin.config import NPartitions
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 
@@ -236,10 +237,7 @@ def test___repr__does_not_raise_attribute_column_warning():
     # See https://github.com/modin-project/modin/issues/5380
     df = pd.DataFrame([1])
     with warnings.catch_warnings():
-        warnings.filterwarnings(
-            action="error",
-            message="Modin doesn't allow columns to be created via a new attribute name",
-        )
+        warnings.filterwarnings(action="error", message=SET_DATAFRAME_ATTRIBUTE_WARNING)
         repr(df)
 
 
@@ -305,16 +303,14 @@ def test___setattr__mutating_column():
     # and adds the provided list as a new attribute and not a column.
     with pytest.warns(
         UserWarning,
-        match="Modin doesn't allow columns to be created via a new attribute name - see "
-        + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
+        match=SET_DATAFRAME_ATTRIBUTE_WARNING,
     ):
         modin_df.col1 = [4]
 
     with warnings.catch_warnings():
         warnings.filterwarnings(
             action="error",
-            message="Modin doesn't allow columns to be created via a new attribute name - see "
-            + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access",
+            message=SET_DATAFRAME_ATTRIBUTE_WARNING,
         )
         modin_df.col1 = [5]
         modin_df.new_attr = 6

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -232,6 +232,17 @@ def test___repr__():
     assert repr(pandas_df) == repr(modin_df)
 
 
+def test___repr__does_not_raise_attribute_column_warning():
+    # See https://github.com/modin-project/modin/issues/5380
+    df = pd.DataFrame([1])
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            action="error",
+            message="Modin doesn't allow columns to be created via a new attribute name",
+        )
+        repr(df)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_inplace_series_ops(data):
     pandas_df = pandas.DataFrame(data)

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -32,6 +32,11 @@ Returns
 {returns}
 """
 
+SET_DATAFRAME_ATTRIBUTE_WARNING = (
+    "Modin doesn't allow columns to be created via a new attribute name - see "
+    + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access"
+)
+
 
 def from_non_pandas(df, index, columns, dtype):
     """


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5380 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
