### PR TITLE
REFACTOR-#5386: move `partition.split` implementation in base class

### DIFF
--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -22,6 +22,7 @@ from pandas.util import cache_readonly
 
 from modin.pandas.indexing import compute_sliced_len
 from modin.core.storage_formats.pandas.utils import length_fn_pandas, width_fn_pandas
+from modin.logging import get_logger
 
 
 class PandasDataframePartition(ABC):  # pragma: no cover
@@ -351,7 +352,15 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         list
             A list of partitions.
         """
-        pass
+        logger = get_logger()
+        logger.debug(f"ENTER::Partition.split::{self._identity}")
+
+        logger.debug(f"SUBMIT::_split_df::{self._identity}")
+        outputs = self.execution_wrapper.deploy(
+            split_func, [self._data] + list(args), num_returns=num_splits
+        )
+        logger.debug(f"EXIT::Partition.split::{self._identity}")
+        return [self.__constructor__(output) for output in outputs]
 
     @classmethod
     def empty(cls):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -44,6 +44,8 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         Call queue that needs to be executed on wrapped ``pandas.DataFrame``.
     """
 
+    execution_wrapper = RayWrapper
+
     def __init__(self, data, length=None, width=None, ip=None, call_queue=None):
         assert isinstance(data, ObjectIDType)
         self._data = data
@@ -317,37 +319,6 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         if isinstance(self._ip_cache, ObjectIDType):
             self._ip_cache = RayWrapper.materialize(self._ip_cache)
         return self._ip_cache
-
-    def split(self, split_func, num_splits, *args):
-        """
-        Split the object wrapped by the partition into multiple partitions.
-
-        Parameters
-        ----------
-        split_func : Callable[pandas.DataFrame, List[Any]] -> List[pandas.DataFrame]
-            The function that will split this partition into multiple partitions. The list contains
-            pivots to split by, and will have the same dtype as the major column we are shuffling on.
-        num_splits : int
-            The number of resulting partitions, which may be empty.
-        *args : List[Any]
-            Arguments to pass to ``split_func``.
-
-        Returns
-        -------
-        list
-            A list of partitions.
-        """
-        logger = get_logger()
-        logger.debug(f"ENTER::Partition.split::{self._identity}")
-
-        @ray.remote(num_returns=num_splits)
-        def _split_df(df, split_func, *args):  # pragma: no cover
-            return split_func(df, *args)
-
-        logger.debug(f"SUBMIT::_split_df::{self._identity}")
-        outputs = _split_df.remote(self._data, split_func, *args)
-        logger.debug(f"EXIT::Partition.split::{self._identity}")
-        return [PandasOnRayDataframePartition(output) for output in outputs]
 
 
 @ray.remote(num_returns=2)


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5386 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
