### PR TITLE
TEST-#5378: port stack, unstack, replace and groups benchmarks from pandas

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1138,6 +1138,7 @@ class TimeStack(BaseReshape):
     def time_stack(self, shape):
         execute(self.udf.stack())
 
+
 class TimeUnstack(BaseReshape):
     params = [get_benchmark_shapes("TimeUnstack")]
     param_names = ["shape"]
@@ -1154,9 +1155,7 @@ class TimeReplace:
     def setup(self, shape):
         rows, cols = shape
         self.to_replace = {i: getattr(IMPL, "Timestamp")(i) for i in range(rows)}
-        self.df = IMPL.DataFrame()
-        for col in range(cols):
-            self.df["col" + str(col + 1)] = np.random.randint(rows, size=rows)
+        self.df = IMPL.DataFrame(np.random.randint(rows, size=(rows, cols)))
         execute(self.df)
 
     def time_replace(self, shape):

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1170,4 +1170,6 @@ class TimeGroups:
     # returns a  dict thus not calling execute
     def time_series_indices(self, shape):
         self.series.groupby(self.series).indices
+
+
 from .utils import setup  # noqa: E402, F401

--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -1113,11 +1113,7 @@ class TimeRemoveCategories(BaseCategories):
         execute(self.ts.cat.remove_categories(self.ts.cat.categories[::2]))
 
 
-class TimeSimpleReshape:
-
-    params = [get_benchmark_shapes("TimeSimpleReshape")]
-    param_names = ["shape"]
-
+class BaseReshape:
     def setup(self, shape):
         rows, cols = shape
         k = 10
@@ -1127,11 +1123,24 @@ class TimeSimpleReshape:
         ]
         index = IMPL.MultiIndex.from_arrays(arrays)
         self.df = IMPL.DataFrame(np.random.randn(rows, cols), index=index)
+        execute(self.df)
+
+
+class TimeStack(BaseReshape):
+    params = [get_benchmark_shapes("TimeStack")]
+    param_names = ["shape"]
+
+    def setup(self, shape):
+        super().setup(shape)
         self.udf = self.df.unstack(1)
-        execute(self.df), execute(self.udf)
+        execute(self.udf)
 
     def time_stack(self, shape):
         execute(self.udf.stack())
+
+class TimeUnstack(BaseReshape):
+    params = [get_benchmark_shapes("TimeUnstack")]
+    param_names = ["shape"]
 
     def time_unstack(self, shape):
         execute(self.df.unstack(1))
@@ -1167,7 +1176,7 @@ class TimeGroups:
     def time_series_groups(self, shape):
         self.series.groupby(self.series).groups
 
-    # returns a  dict thus not calling execute
+    # returns a dict thus not calling execute
     def time_series_indices(self, shape):
         self.series.groupby(self.series).indices
 

--- a/asv_bench/benchmarks/utils/data_shapes.py
+++ b/asv_bench/benchmarks/utils/data_shapes.py
@@ -103,7 +103,6 @@ _DEFAULT_CONFIG_T = [
             "TimeDropDuplicatesDataframe",
             "TimeStack",
             "TimeUnstack",
-            "TimeReplace",
             # IO benchmarks
             "TimeReadCsvSkiprows",
             "TimeReadCsvTrueFalseValues",
@@ -186,6 +185,9 @@ DEFAULT_CONFIG["MergeCategoricals"] = (
 )
 DEFAULT_CONFIG["TimeJoinStringIndex"] = (
     [[100_000, 64]] if ASV_DATASET_SIZE == "big" else [[1_000, 4]]
+)
+DEFAULT_CONFIG["TimeReplace"] = (
+    [[10_000, 2]] if ASV_DATASET_SIZE == "big" else [[1_000, 2]]
 )
 for config in (_DEFAULT_CONFIG_T, _DEFAULT_HDK_CONFIG_T):
     for _shape, _names in config:

--- a/asv_bench/benchmarks/utils/data_shapes.py
+++ b/asv_bench/benchmarks/utils/data_shapes.py
@@ -101,7 +101,8 @@ _DEFAULT_CONFIG_T = [
             "TimeReindexMethod",
             "TimeFillnaMethodDataframe",
             "TimeDropDuplicatesDataframe",
-            "TimeSimpleReshape",
+            "TimeStack",
+            "TimeUnstack",
             "TimeReplace",
             # IO benchmarks
             "TimeReadCsvSkiprows",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Adding 3 benchmark classes from pandas benchmark TimeSimpleReshape , TimeReplace and TimeGroups.

Source PRs #5055 , #5056 , #5057 

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5378 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
