### PR TITLE
REFACTOR-#5404: fix returning tuples with varying lengths

### DIFF
--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -718,8 +718,9 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
         Returns
         -------
-        np.ndarray or (np.ndarray, row_lengths, col_widths)
-            A NumPy array with partitions (with dimensions or not).
+        (partitions, row_lengths, col_widths)
+            A NumPy array with partitions and dimensions.
+            The dimensions will be None if `return_dims==False`.
         """
 
         def update_bar(pbar, f):

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -768,7 +768,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         if ProgressBar.get():
             pbar.close()
         if not return_dims:
-            return np.array(parts)
+            return np.array(parts), None, None
         else:
             row_lengths = [
                 row_chunksize

--- a/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition_manager.py
@@ -134,7 +134,7 @@ class cuDFOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
             (num_splits, 1)
         )
         if not return_dims:
-            return parts
+            return parts, None, None
         else:
             row_lengths = [len(df.index) for df in pandas_dfs]
             col_widths = [

--- a/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition_manager.py
@@ -117,9 +117,9 @@ class cuDFOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
 
         Returns
         -------
-        list or tuple
-            List of partitions in case `return_dims` == False,
-            tuple (partitions, row lengths, col widths) in other case.
+        (partitions, row_lengths, col_widths).
+            A NumPy array with partitions and dimensions.
+            The dimensions will be None if `return_dims==False`.
         """
         num_splits = GpuCount.get()
         put_func = cls._partition_class.put

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -125,9 +125,9 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
 
         Returns
         -------
-        tuple
-            Tuple holding array of partitions, list of columns with unsupported
-            data and optionally partitions' dimensions.
+        (partitions, row_lengths, col_widths)
+            A NumPy array with partitions and dimensions.
+            The dimensions will be None if `return_dims==False`.
         """
         put_func = cls._partition_class.put_arrow
 

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -136,7 +136,7 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
             _, unsupported_cols = cls._get_unsupported_cols(at)
 
         if not return_dims:
-            return np.array(parts), unsupported_cols
+            return np.array(parts), None, None, unsupported_cols
         else:
             row_lengths = [at.num_rows]
             col_widths = [at.num_columns]


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5404 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
