### PR TITLE
FIX-#5398: Resolve length 1 nonNA partition issue, and off by one error in sort

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2040,7 +2040,7 @@ class PandasDataframe(ClassLogger):
         index = -1
         for i, length in enumerate(self.column_widths):
             cols_seen += length
-            if major_col_partition_index <= cols_seen:
+            if major_col_partition_index < cols_seen:
                 index = i
                 break
         new_partitions = self._partition_mgr_cls.shuffle_partitions(

--- a/modin/core/dataframe/pandas/dataframe/utils.py
+++ b/modin/core/dataframe/pandas/dataframe/utils.py
@@ -261,13 +261,21 @@ def split_partitions_using_pivots_for_sort(
         # in descending order, we need to swap the new indices.
         if not ascending:
             groupby_col = len(pivots) - groupby_col
-    grouped = non_na_rows.groupby(groupby_col)
-    groups = [
-        grouped.get_group(i)
-        if i in grouped.keys
-        else pandas.DataFrame(columns=df.columns).astype(df.dtypes)
-        for i in range(len(pivots) + 1)
-    ]
+    if len(non_na_rows) == 1:
+        groups = [
+            pandas.DataFrame(columns=df.columns).astype(df.dtypes)
+            if i != groupby_col
+            else non_na_rows
+            for i in range(len(pivots) + 1)
+        ]
+    else:
+        grouped = non_na_rows.groupby(groupby_col)
+        groups = [
+            grouped.get_group(i)
+            if i in grouped.keys
+            else pandas.DataFrame(columns=df.columns).astype(df.dtypes)
+            for i in range(len(pivots) + 1)
+        ]
     index_to_insert_na_vals = -1 if kwargs.get("na_position", "last") == "last" else 0
     groups[index_to_insert_na_vals] = pandas.concat(
         [groups[index_to_insert_na_vals], na_rows]


### PR DESCRIPTION


Signed-off-by: Rehan Durrani <rehan@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #5398 ? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
