### PR TITLE
REFACTOR-#5413: check `Index.dtype` instead of `isinstance(obj, Int64Index)`

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -2558,7 +2558,7 @@ class HdkOnNativeDataframe(PandasDataframe):
             return True
         if isinstance(index, pd.RangeIndex):
             return index.start == 0 and index.step == 1
-        if not isinstance(index, pd.Int64Index):
+        if not (isinstance(index, pd.Index) and index.dtype == np.int64):
             return False
         return (
             index.is_monotonic_increasing

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -1217,8 +1217,8 @@ class TestAgg:
                 with pytest.warns(UserWarning) as warns:
                     res = getattr(df, method)()
                 assert (
-                    len(warns) == 2
-                ), f"More than two warnings were arisen: len(warns) != 2 ({len(warns)} != 2)"
+                    len(warns) == 1
+                ), f"More than one warning was arisen: len(warns) != 1 ({len(warns)} != 1)"
                 message = warns[0].message.args[0]
                 assert (
                     re.match(r".*transpose.*defaulting to pandas", message) is not None

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -1214,7 +1214,6 @@ class TestAgg:
                 # At the end of reduce function it does inevitable `transpose`, which
                 # is defaulting to pandas. The following logic check that `transpose` is the only
                 # function that falling back to pandas in the reduce operation flow.
-                # Another warning comes from deprecated pandas.Int64Index usage.
                 with pytest.warns(UserWarning) as warns:
                     res = getattr(df, method)()
                 assert (


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5413 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
