### PR TITLE
REFACTOR-#5424: Replace dtypes="copy" with copy_dtypes flag

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -44,7 +44,13 @@ class Binary(Operator):
         """
 
         def caller(
-            query_compiler, other, broadcast=False, *args, dtypes=None, copy_dtypes=False, **kwargs
+            query_compiler,
+            other,
+            broadcast=False,
+            *args,
+            dtypes=None,
+            copy_dtypes=False,
+            **kwargs
         ):
             """
             Apply binary `func` to passed operands.

--- a/modin/core/dataframe/base/dataframe/dataframe.py
+++ b/modin/core/dataframe/base/dataframe/dataframe.py
@@ -19,6 +19,9 @@ ModinDataframe is a parent abstract class for any dataframe class.
 
 from abc import ABC, abstractmethod
 from typing import List, Hashable, Optional, Callable, Union, Dict
+
+import pandas
+
 from modin.core.dataframe.base.dataframe.utils import Axis, JoinType
 
 
@@ -92,7 +95,7 @@ class ModinDataframe(ABC):
         self,
         function: Callable,
         axis: Optional[Union[int, Axis]] = None,
-        dtypes: Optional = None,
+        dtypes: Optional[Union[pandas.Series, type]] = None,
         copy_dtypes: bool = False,
     ) -> "ModinDataframe":
         """
@@ -262,7 +265,7 @@ class ModinDataframe(ABC):
         self,
         axis: Union[int, Axis],
         function: Callable,
-        dtypes: Optional = None,
+        dtypes: Optional[pandas.Series] = None,
     ) -> "ModinDataframe":
         """
         Perform a user-defined aggregation on the specified axis, where the axis reduces down to a singleton.
@@ -295,7 +298,7 @@ class ModinDataframe(ABC):
         axis: Union[int, Axis],
         map_func: Callable,
         reduce_func: Optional[Callable] = None,
-        dtypes: Optional = None,
+        dtypes: Optional[pandas.Series] = None,
     ) -> "ModinDataframe":
         """
         Perform a user-defined aggregation on the specified axis, where the axis reduces down to a singleton using a tree-reduce computation pattern.

--- a/modin/core/dataframe/base/dataframe/dataframe.py
+++ b/modin/core/dataframe/base/dataframe/dataframe.py
@@ -92,7 +92,8 @@ class ModinDataframe(ABC):
         self,
         function: Callable,
         axis: Optional[Union[int, Axis]] = None,
-        dtypes: Optional[str] = None,
+        dtypes: Optional = None,
+        copy_dtypes: bool = False,
     ) -> "ModinDataframe":
         """
         Apply a user-defined function row-wise if `axis`=0, column-wise if `axis`=1, and cell-wise if `axis` is None.
@@ -103,10 +104,13 @@ class ModinDataframe(ABC):
             The function to map across the dataframe.
         axis : int or modin.core.dataframe.base.utils.Axis, optional
             The axis to map over.
-        dtypes : str, optional
+        dtypes : pandas.Series or scalar type, optional
             The data types for the result. This is an optimization
             because there are functions that always result in a particular data
             type, and this allows us to avoid (re)computing it.
+        copy_dtypes : bool, default: False
+            If True, the dtypes of the resulting dataframe are copied from the original,
+            and the ``dtypes`` argument is ignored.
 
         Returns
         -------
@@ -258,7 +262,7 @@ class ModinDataframe(ABC):
         self,
         axis: Union[int, Axis],
         function: Callable,
-        dtypes: Optional[str] = None,
+        dtypes: Optional = None,
     ) -> "ModinDataframe":
         """
         Perform a user-defined aggregation on the specified axis, where the axis reduces down to a singleton.
@@ -269,7 +273,7 @@ class ModinDataframe(ABC):
             The axis to perform the reduce over.
         function : callable(row|col) -> single value
             The reduce function to apply to each column.
-        dtypes : str, optional
+        dtypes : pandas.Series, optional
             The data types for the result. This is an optimization
             because there are functions that always result in a particular data
             type, and this allows us to avoid (re)computing it.
@@ -291,7 +295,7 @@ class ModinDataframe(ABC):
         axis: Union[int, Axis],
         map_func: Callable,
         reduce_func: Optional[Callable] = None,
-        dtypes: Optional[str] = None,
+        dtypes: Optional = None,
     ) -> "ModinDataframe":
         """
         Perform a user-defined aggregation on the specified axis, where the axis reduces down to a singleton using a tree-reduce computation pattern.
@@ -308,7 +312,7 @@ class ModinDataframe(ABC):
             The map function to apply to each column.
         reduce_func : callable(row|col) -> single value, optional
             The reduce function to apply to the results of the map function.
-        dtypes : str, optional
+        dtypes : pandas.Series, optional
             The data types for the result. This is an optimization
             because there are functions that always result in a particular data
             type, and this allows us to avoid (re)computing it.

--- a/modin/core/dataframe/base/dataframe/dataframe.py
+++ b/modin/core/dataframe/base/dataframe/dataframe.py
@@ -111,6 +111,7 @@ class ModinDataframe(ABC):
             The data types for the result. This is an optimization
             because there are functions that always result in a particular data
             type, and this allows us to avoid (re)computing it.
+            If the argument is a scalar type, then that type is assigned to each result column.
         copy_dtypes : bool, default: False
             If True, the dtypes of the resulting dataframe are copied from the original,
             and the ``dtypes`` argument is ignored.

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1728,6 +1728,7 @@ class PandasDataframe(ClassLogger):
             The data types for the result. This is an optimization
             because there are functions that always result in a particular data
             type, and this allows us to avoid (re)computing it.
+            If the argument is a scalar type, then that type is assigned to each result column.
         copy_dtypes : bool, default: False
             If True, the dtypes of the resulting dataframe are copied from the original,
             and the ``dtypes`` argument is ignored.
@@ -2210,7 +2211,7 @@ class PandasDataframe(ClassLogger):
         new_columns : list-like, optional
             The columns of the result. We may know this in
             advance, and if not provided it must be computed.
-        dtypes : list-like, optional
+        dtypes : pandas.Series, optional
             The data types of the result. This is an optimization
             because there are functions that always result in a particular data
             type, and allows us to avoid (re)computing it.
@@ -2437,7 +2438,7 @@ class PandasDataframe(ClassLogger):
         labels : {"keep", "replace", "drop"}, default: "keep"
             Whether keep labels from `self` Modin DataFrame, replace them with labels
             from joined DataFrame or drop altogether to make them be computed lazily later.
-        dtypes : list-like, optional
+        dtypes : pandas.Series, optional
             The data types of the result. This is an optimization
             because there are functions that always result in a particular data
             type, and allows us to avoid (re)computing it.
@@ -2664,7 +2665,7 @@ class PandasDataframe(ClassLogger):
         enumerate_partitions : bool, default: False
             Whether pass partition index into applied `func` or not.
             Note that `func` must be able to obtain `partition_idx` kwarg.
-        dtypes : list-like, optional
+        dtypes : pandas.Series, optional
             Data types of the result. This is an optimization
             because there are functions that always result in a particular data
             type, and allows us to avoid (re)computing it.

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1714,7 +1714,9 @@ class PandasDataframe(ClassLogger):
         return self._compute_tree_reduce_metadata(axis.value, reduce_parts, dtypes)
 
     @lazy_metadata_decorator(apply_axis=None)
-    def map(self, func: Callable, dtypes: Optional = None, copy_dtypes: bool = False) -> "PandasDataframe":
+    def map(
+        self, func: Callable, dtypes: Optional = None, copy_dtypes: bool = False
+    ) -> "PandasDataframe":
         """
         Perform a function that maps across the entire dataset.
 
@@ -2410,7 +2412,14 @@ class PandasDataframe(ClassLogger):
 
     @lazy_metadata_decorator(apply_axis="both")
     def broadcast_apply(
-        self, axis, func, other, join_type="left", labels="keep", dtypes=None, copy_dtypes=False,
+        self,
+        axis,
+        func,
+        other,
+        join_type="left",
+        labels="keep",
+        dtypes=None,
+        copy_dtypes=False,
     ):
         """
         Broadcast axis partitions of `other` to partitions of `self` and apply a function.

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1339,7 +1339,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # Map partitions operations
     # These operations are operations that apply a function to every partition.
-    abs = Map.register(pandas.DataFrame.abs, dtypes="copy")
+    abs = Map.register(pandas.DataFrame.abs, copy_dtypes=True)
     applymap = Map.register(pandas.DataFrame.applymap)
     conj = Map.register(lambda df, *args, **kwargs: pandas.DataFrame(np.conj(df)))
     convert_dtypes = Map.register(pandas.DataFrame.convert_dtypes)
@@ -1374,15 +1374,15 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # String map partitions operations
 
-    str_capitalize = Map.register(_str_map("capitalize"), dtypes="copy")
-    str_center = Map.register(_str_map("center"), dtypes="copy")
+    str_capitalize = Map.register(_str_map("capitalize"), copy_dtypes=True)
+    str_center = Map.register(_str_map("center"), copy_dtypes=True)
     str_contains = Map.register(_str_map("contains"), dtypes=np.bool_)
     str_count = Map.register(_str_map("count"), dtypes=int)
     str_endswith = Map.register(_str_map("endswith"), dtypes=np.bool_)
-    str_find = Map.register(_str_map("find"), dtypes="copy")
-    str_findall = Map.register(_str_map("findall"), dtypes="copy")
-    str_get = Map.register(_str_map("get"), dtypes="copy")
-    str_index = Map.register(_str_map("index"), dtypes="copy")
+    str_find = Map.register(_str_map("find"), copy_dtypes=True)
+    str_findall = Map.register(_str_map("findall"), copy_dtypes=True)
+    str_get = Map.register(_str_map("get"), copy_dtypes=True)
+    str_index = Map.register(_str_map("index"), copy_dtypes=True)
     str_isalnum = Map.register(_str_map("isalnum"), dtypes=np.bool_)
     str_isalpha = Map.register(_str_map("isalpha"), dtypes=np.bool_)
     str_isdecimal = Map.register(_str_map("isdecimal"), dtypes=np.bool_)
@@ -1392,17 +1392,17 @@ class PandasQueryCompiler(BaseQueryCompiler):
     str_isspace = Map.register(_str_map("isspace"), dtypes=np.bool_)
     str_istitle = Map.register(_str_map("istitle"), dtypes=np.bool_)
     str_isupper = Map.register(_str_map("isupper"), dtypes=np.bool_)
-    str_join = Map.register(_str_map("join"), dtypes="copy")
+    str_join = Map.register(_str_map("join"), copy_dtypes=True)
     str_len = Map.register(_str_map("len"), dtypes=int)
-    str_ljust = Map.register(_str_map("ljust"), dtypes="copy")
-    str_lower = Map.register(_str_map("lower"), dtypes="copy")
-    str_lstrip = Map.register(_str_map("lstrip"), dtypes="copy")
-    str_match = Map.register(_str_map("match"), dtypes="copy")
-    str_normalize = Map.register(_str_map("normalize"), dtypes="copy")
-    str_pad = Map.register(_str_map("pad"), dtypes="copy")
-    str_partition = Map.register(_str_map("partition"), dtypes="copy")
-    str_repeat = Map.register(_str_map("repeat"), dtypes="copy")
-    _str_extract = Map.register(_str_map("extract"), dtypes="copy")
+    str_ljust = Map.register(_str_map("ljust"), copy_dtypes=True)
+    str_lower = Map.register(_str_map("lower"), copy_dtypes=True)
+    str_lstrip = Map.register(_str_map("lstrip"), copy_dtypes=True)
+    str_match = Map.register(_str_map("match"), copy_dtypes=True)
+    str_normalize = Map.register(_str_map("normalize"), copy_dtypes=True)
+    str_pad = Map.register(_str_map("pad"), copy_dtypes=True)
+    str_partition = Map.register(_str_map("partition"), copy_dtypes=True)
+    str_repeat = Map.register(_str_map("repeat"), copy_dtypes=True)
+    _str_extract = Map.register(_str_map("extract"), copy_dtypes=True)
 
     def str_extract(self, pat, flags, expand):
         regex = re.compile(pat, flags=flags)
@@ -1414,25 +1414,25 @@ class PandasQueryCompiler(BaseQueryCompiler):
         qc.columns = get_group_names(regex)
         return qc
 
-    str_replace = Map.register(_str_map("replace"), dtypes="copy")
-    str_rfind = Map.register(_str_map("rfind"), dtypes="copy")
-    str_rindex = Map.register(_str_map("rindex"), dtypes="copy")
-    str_rjust = Map.register(_str_map("rjust"), dtypes="copy")
-    str_rpartition = Map.register(_str_map("rpartition"), dtypes="copy")
-    str_rsplit = Map.register(_str_map("rsplit"), dtypes="copy")
-    str_rstrip = Map.register(_str_map("rstrip"), dtypes="copy")
-    str_slice = Map.register(_str_map("slice"), dtypes="copy")
-    str_slice_replace = Map.register(_str_map("slice_replace"), dtypes="copy")
-    str_split = Map.register(_str_map("split"), dtypes="copy")
+    str_replace = Map.register(_str_map("replace"), copy_dtypes=True)
+    str_rfind = Map.register(_str_map("rfind"), copy_dtypes=True)
+    str_rindex = Map.register(_str_map("rindex"), copy_dtypes=True)
+    str_rjust = Map.register(_str_map("rjust"), copy_dtypes=True)
+    str_rpartition = Map.register(_str_map("rpartition"), copy_dtypes=True)
+    str_rsplit = Map.register(_str_map("rsplit"), copy_dtypes=True)
+    str_rstrip = Map.register(_str_map("rstrip"), copy_dtypes=True)
+    str_slice = Map.register(_str_map("slice"), copy_dtypes=True)
+    str_slice_replace = Map.register(_str_map("slice_replace"), copy_dtypes=True)
+    str_split = Map.register(_str_map("split"), copy_dtypes=True)
     str_startswith = Map.register(_str_map("startswith"), dtypes=np.bool_)
-    str_strip = Map.register(_str_map("strip"), dtypes="copy")
-    str_swapcase = Map.register(_str_map("swapcase"), dtypes="copy")
-    str_title = Map.register(_str_map("title"), dtypes="copy")
-    str_translate = Map.register(_str_map("translate"), dtypes="copy")
-    str_upper = Map.register(_str_map("upper"), dtypes="copy")
-    str_wrap = Map.register(_str_map("wrap"), dtypes="copy")
-    str_zfill = Map.register(_str_map("zfill"), dtypes="copy")
-    str___getitem__ = Map.register(_str_map("__getitem__"), dtypes="copy")
+    str_strip = Map.register(_str_map("strip"), copy_dtypes=True)
+    str_swapcase = Map.register(_str_map("swapcase"), copy_dtypes=True)
+    str_title = Map.register(_str_map("title"), copy_dtypes=True)
+    str_translate = Map.register(_str_map("translate"), copy_dtypes=True)
+    str_upper = Map.register(_str_map("upper"), copy_dtypes=True)
+    str_wrap = Map.register(_str_map("wrap"), copy_dtypes=True)
+    str_zfill = Map.register(_str_map("zfill"), copy_dtypes=True)
+    str___getitem__ = Map.register(_str_map("__getitem__"), copy_dtypes=True)
 
     # END String map partitions operations
 
@@ -2063,7 +2063,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             ),
             new_index,
             new_columns,
-            dtypes="copy" if axis == 0 else None,
+            copy_dtypes=True if axis == 0 else None,
         )
         return self.__constructor__(new_modin_frame)
 
@@ -2195,7 +2195,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             # ones are just of bool dtype
             if len(key.dtypes) == 1 and is_bool_dtype(key.dtypes[0]):
                 self.__validate_bool_indexer(key.index)
-                return self.__getitem_bool(key, broadcast=True, dtypes="copy")
+                return self.__getitem_bool(key, broadcast=True, copy_dtypes=True)
 
             key = key.to_pandas().squeeze(axis=1)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
This replaces the `dtypes="copy"` argument (used in some operators and internal dataframe apply/broadcast methods) with a boolean flag `copy_dtypes`.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5424
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
