### PR TITLE
REFACTOR-#5425: Unify internal usage of axis parameter and named kwargs

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -85,11 +85,11 @@ class Binary(Operator):
                         other = other.transpose()
                     return query_compiler.__constructor__(
                         query_compiler._modin_frame.broadcast_apply(
-                            axis,
                             lambda left, right: func(
                                 left, right.squeeze(), *args, **kwargs
                             ),
-                            other._modin_frame,
+                            axis=axis,
+                            other=other._modin_frame,
                             join_type=join_type,
                             labels=labels,
                             dtypes=dtypes,
@@ -108,8 +108,8 @@ class Binary(Operator):
                 # accordingly, in that way we will be able to use more efficient `._modin_frame.map()`
                 if isinstance(other, (dict, list, np.ndarray, pandas.Series)):
                     new_modin_frame = query_compiler._modin_frame.apply_full_axis(
-                        axis,
                         lambda df: func(df, other, *args, **kwargs),
+                        axis=axis,
                         new_index=query_compiler.index,
                         new_columns=query_compiler.columns,
                         dtypes=dtypes,

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1127,7 +1127,9 @@ class PandasDataframe(ClassLogger):
             new_lengths = self._row_lengths_cache
         if col_positions is not None:
             ordered_cols = self._partition_mgr_cls.map_axis_partitions(
-                1, ordered_rows, lambda df: df.iloc[:, col_positions]
+                ordered_rows,
+                lambda df: df.iloc[:, col_positions],
+                axis=1,
             )
             col_idx = self.columns[col_positions]
             if new_dtypes is not None:

--- a/modin/core/dataframe/pandas/interchange/dataframe_protocol/column.py
+++ b/modin/core/dataframe/pandas/interchange/dataframe_protocol/column.py
@@ -293,9 +293,9 @@ class PandasProtocolColumn(ProtocolColumn):
         new_lengths[-1] = n_rows % n_chunks + new_lengths[-1]
 
         new_partitions = self._col._partition_mgr_cls.map_axis_partitions(
-            0,
             self._col._partitions,
             lambda df: df,
+            axis=0,
             keep_partitioning=False,
             lengths=new_lengths,
         )

--- a/modin/core/dataframe/pandas/interchange/dataframe_protocol/dataframe.py
+++ b/modin/core/dataframe/pandas/interchange/dataframe_protocol/dataframe.py
@@ -177,9 +177,9 @@ class PandasProtocolDataframe(ProtocolDataframe):
         new_lengths[-1] = n_rows % n_chunks + new_lengths[-1]
 
         new_partitions = self._df._partition_mgr_cls.map_axis_partitions(
-            0,
             self._df._partitions,
             lambda df: df,
+            axis=0,
             keep_partitioning=False,
             lengths=new_lengths,
         )

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -242,20 +242,21 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
         if by is not None:
             mapped_partitions = cls.broadcast_apply(
-                axis, map_func, left=partitions, right=by, other_name="other"
+                map_func, axis=axis, left=partitions, right=by, other_name="other"
             )
         else:
             mapped_partitions = cls.map_partitions(partitions, map_func)
         return cls.map_axis_partitions(
-            axis, mapped_partitions, reduce_func, enumerate_partitions=True
+            mapped_partitions, reduce_func, axis=axis, enumerate_partitions=True
         )
 
     @classmethod
     @wait_computations_if_benchmark_mode
     def broadcast_apply_select_indices(
         cls,
-        axis,
         apply_func,
+        *,
+        axis,
         left,
         right,
         left_indices,
@@ -267,10 +268,10 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
         Parameters
         ----------
-        axis : {0, 1}
-            Axis to apply and broadcast over.
         apply_func : callable
             Function to apply.
+        axis : {0, 1}
+            Axis to apply and broadcast over.
         left : NumPy 2D array
             Left partitions.
         right : NumPy 2D array
@@ -332,16 +333,16 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
     @classmethod
     @wait_computations_if_benchmark_mode
-    def broadcast_apply(cls, axis, apply_func, left, right, other_name="right"):
+    def broadcast_apply(cls, apply_func, *, axis, left, right, other_name="right"):
         """
         Broadcast the `right` partitions to `left` and apply `apply_func` function.
 
         Parameters
         ----------
-        axis : {0, 1}
-            Axis to apply and broadcast over.
         apply_func : callable
             Function to apply.
+        axis : {0, 1}
+            Axis to apply and broadcast over.
         left : np.ndarray
             NumPy array of left partitions.
         right : np.ndarray
@@ -390,8 +391,9 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
     @wait_computations_if_benchmark_mode
     def broadcast_axis_partitions(
         cls,
-        axis,
         apply_func,
+        *,
+        axis,
         left,
         right,
         keep_partitioning=False,
@@ -405,10 +407,10 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
         Parameters
         ----------
-        axis : {0, 1}
-            Axis to apply and broadcast over.
         apply_func : callable
             Function to apply.
+        axis : {0, 1}
+            Axis to apply and broadcast over.
         left : NumPy 2D array
             Left partitions.
         right : NumPy 2D array
@@ -529,9 +531,10 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
     @classmethod
     def map_axis_partitions(
         cls,
-        axis,
         partitions,
         map_func,
+        *,
+        axis,
         keep_partitioning=False,
         lengths=None,
         enumerate_partitions=False,
@@ -542,12 +545,12 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
         Parameters
         ----------
-        axis : {0, 1}
-            Axis to perform the map across (0 - index, 1 - columns).
         partitions : NumPy 2D array
             Partitions of Modin Frame.
         map_func : callable
             Function to apply.
+        axis : {0, 1}
+            Axis to perform the map across (0 - index, 1 - columns).
         keep_partitioning : bool, default: False
             Whether to keep partitioning for Modin Frame.
             Setting it to True stops data shuffling between partitions.
@@ -963,19 +966,19 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
     @classmethod
     @wait_computations_if_benchmark_mode
     def apply_func_to_select_indices(
-        cls, axis, partitions, func, indices, keep_remaining=False
+        cls, partitions, func, *, axis, indices, keep_remaining=False
     ):
         """
         Apply a function to select indices.
 
         Parameters
         ----------
-        axis : {0, 1}
-            Axis to apply the `func` over.
         partitions : np.ndarray
             The partitions to which the `func` will apply.
         func : callable
             The function to apply to these indices of partitions.
+        axis : {0, 1}
+            Axis to apply the `func` over.
         indices : dict
             The indices to apply the function to.
         keep_remaining : bool, default: False
@@ -1077,19 +1080,19 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
     @classmethod
     @wait_computations_if_benchmark_mode
     def apply_func_to_select_indices_along_full_axis(
-        cls, axis, partitions, func, indices, keep_remaining=False
+        cls, partitions, func, *, axis, indices, keep_remaining=False
     ):
         """
         Apply a function to a select subset of full columns/rows.
 
         Parameters
         ----------
-        axis : {0, 1}
-            The axis to apply the function over.
         partitions : np.ndarray
             The partitions to which the `func` will apply.
         func : callable
             The function to apply.
+        axis : {0, 1}
+            The axis to apply the function over.
         indices : list-like
             The global indices to apply the func to.
         keep_remaining : bool, default: False
@@ -1195,6 +1198,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         cls,
         partitions,
         func,
+        *,
         row_partitions_list,
         col_partitions_list,
         item_to_distribute=no_default,

--- a/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -111,7 +111,9 @@ class PandasOnRayIO(RayIO):
 
         # Ensure that the metadata is syncrhonized
         qc._modin_frame._propagate_index_objs(axis=None)
-        result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
+        result = qc._modin_frame.apply_full_axis(
+            func, axis=1, new_index=[], new_columns=[]
+        )
         # FIXME: we should be waiting for completion less expensievely, maybe use _modin_frame.materialize()?
         result.to_pandas()  # blocking operation
 

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -116,7 +116,9 @@ class PandasOnUnidistIO(UnidistIO):
 
         # Ensure that the metadata is syncrhonized
         qc._modin_frame._propagate_index_objs(axis=None)
-        result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
+        result = qc._modin_frame.apply_full_axis(
+            func, axis=1, new_index=[], new_columns=[]
+        )
         # FIXME: we should be waiting for completion less expensievely, maybe use _modin_frame.materialize()?
         result.to_pandas()  # blocking operation
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -5090,7 +5090,9 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         for _ax in axes:
             new_query_compiler = new_query_compiler.__constructor__(
                 new_query_compiler._modin_frame.apply_full_axis(
-                    lambda df: df, keep_partitioning=False, axis=_ax,
+                    lambda df: df,
+                    keep_partitioning=False,
+                    axis=_ax,
                 )
             )
         return new_query_compiler

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -5090,7 +5090,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         for _ax in axes:
             new_query_compiler = new_query_compiler.__constructor__(
                 new_query_compiler._modin_frame.apply_full_axis(
-                    _ax, lambda df: df, keep_partitioning=False
+                    lambda df: df, keep_partitioning=False, axis=_ax,
                 )
             )
         return new_query_compiler

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2433,7 +2433,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         # map.
         return self.__constructor__(
             self._modin_frame.apply_full_axis(
-                lambda df: df.squeeze(axis=1).apply(func, *args, **kwargs, axis=1)
+                lambda df: df.squeeze(axis=1).apply(func, *args, **kwargs),
+                axis=1,
             )
         )
 

--- a/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -239,7 +239,7 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
             return pandas.DataFrame()
 
         result = qc._modin_frame.broadcast_apply_full_axis(
-            1, func, other=None, new_index=[], new_columns=[], enumerate_partitions=True
+            func, axis=1, other=None, new_index=[], new_columns=[], enumerate_partitions=True
         )
         result.to_pandas()
 

--- a/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -239,7 +239,12 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
             return pandas.DataFrame()
 
         result = qc._modin_frame.broadcast_apply_full_axis(
-            func, axis=1, other=None, new_index=[], new_columns=[], enumerate_partitions=True
+            func,
+            axis=1,
+            other=None,
+            new_index=[],
+            new_columns=[],
+            enumerate_partitions=True,
         )
         result.to_pandas()
 

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -244,7 +244,7 @@ class ExperimentalPandasOnUnidistIO(PandasOnUnidistIO):
             return pandas.DataFrame()
 
         result = qc._modin_frame.broadcast_apply_full_axis(
-            1, func, other=None, new_index=[], new_columns=[], enumerate_partitions=True
+            func, axis=1, other=None, new_index=[], new_columns=[], enumerate_partitions=True
         )
         result.to_pandas()
 

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -244,7 +244,12 @@ class ExperimentalPandasOnUnidistIO(PandasOnUnidistIO):
             return pandas.DataFrame()
 
         result = qc._modin_frame.broadcast_apply_full_axis(
-            func, axis=1, other=None, new_index=[], new_columns=[], enumerate_partitions=True
+            func,
+            axis=1,
+            other=None,
+            new_index=[],
+            new_columns=[],
+            enumerate_partitions=True,
         )
         result.to_pandas()
 


### PR DESCRIPTION
Signed-off-by: Jonathan Shi <jhshi@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
This makes the internal usage of the "axis" keyword argument more consistent, and forces callers of most dataframe/partition manager apply and broadcast methods to name keyword arguments in most situation, to avoid possible confusion and subtle bugs from when argument orders are mistakenly swapped.

The new orders are as follows:

**Dataframe:** `apply_*(func, axis, ... [other kwargs])`
**Partition manager:** `apply_*(partitions, func, axis, ... [other kwargs])` 

The rationale for placing func in front of axis is to more closely align with the way non-axis apply methods (like [`modin_dataframe.map`](https://github.com/modin-project/modin/blob/ba7ab8eb80dd6412f275ffff806db37ff7ebdb01/modin/core/dataframe/pandas/dataframe/dataframe.py#L1711) are called.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5425
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
