### PR TITLE
FIX-#5436: Fix '.index' extraction for an empty frame 

### DIFF
--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -2265,6 +2265,14 @@ def test_lazy_eval_index():
 
 
 def test_index_of_empty_frame():
+    # Test on an empty frame created by user
+    md_df, pd_df = create_test_dfs(
+        {}, index=pandas.Index([], name="index name"), columns=["a", "b"]
+    )
+    assert md_df.empty and md_df.empty
+    df_equals(md_df.index, md_df.index)
+
+    # Test on an empty frame produced by Modin's logic
     data = test_data_values[0]
     md_df, pd_df = create_test_dfs(
         data, index=pandas.RangeIndex(len(next(iter(data.values()))), name="index name")

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -2269,8 +2269,8 @@ def test_index_of_empty_frame():
     md_df, pd_df = create_test_dfs(
         {}, index=pandas.Index([], name="index name"), columns=["a", "b"]
     )
-    assert md_df.empty and md_df.empty
-    df_equals(md_df.index, md_df.index)
+    assert md_df.empty and pd_df.empty
+    df_equals(md_df.index, pd_df.index)
 
     # Test on an empty frame produced by Modin's logic
     data = test_data_values[0]

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -2262,3 +2262,16 @@ def test_lazy_eval_index():
         return df_copy
 
     eval_general(modin_df, pandas_df, func)
+
+
+def test_index_of_empty_frame():
+    data = test_data_values[0]
+    md_df, pd_df = create_test_dfs(
+        data, index=pandas.RangeIndex(len(next(iter(data.values()))), name="index name")
+    )
+
+    md_res = md_df.query(f"{md_df.columns[0]} > {RAND_HIGH}")
+    pd_res = pd_df.query(f"{pd_df.columns[0]} > {RAND_HIGH}")
+
+    assert md_res.empty and pd_res.empty
+    df_equals(md_res.index, pd_res.index)


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Fixes a bug when a list was assigned to the `.index` attribute of an empty frame.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] resolves #5436
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
