### PR TITLE
TEST-#5444: reduce Series' shape for `TimeReindex` asv bench

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -901,14 +901,14 @@ class TimeReindex:
         self.df2 = IMPL.DataFrame(
             index=range(rows), data=np.random.rand(rows, cols), columns=range(cols)
         )
-        level1 = tm.makeStringIndex(rows).values.repeat(cols)
-        level2 = np.tile(tm.makeStringIndex(cols).values, rows)
+        level1 = tm.makeStringIndex(rows // 10).values.repeat(10)
+        level2 = np.tile(tm.makeStringIndex(10).values, rows // 10)
         index = IMPL.MultiIndex.from_arrays([level1, level2])
-        self.s = IMPL.Series(np.random.randn(rows * cols), index=index)
+        self.s = IMPL.Series(np.random.randn(rows), index=index)
         self.s_subset = self.s[::2]
         self.s_subset_no_cache = self.s[::2].copy()
 
-        mi = IMPL.MultiIndex.from_product([rng, range(100)])
+        mi = IMPL.MultiIndex.from_product([rng[: len(rng) // 10], range(10)])
         self.s2 = IMPL.Series(np.random.randn(len(mi)), index=mi)
         self.s2_subset = self.s2[::2].copy()
         execute(self.df), execute(self.df2)


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5444 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
