### PR TITLE
TEST-#5448: reduce Dataframe' shape for `time_merge_default` asv bench

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -173,6 +173,22 @@ class TimeJoinStringIndex:
         execute(self.df.join(self.df_key1, on="key1", sort=sort))
 
 
+class TimeMergeDefault:
+    param_names = ["shapes", "how", "sort"]
+    params = [
+        get_benchmark_shapes("TimeMergeDefault"),
+        ["left", "inner"],
+        [True, False],
+    ]
+
+    def setup(self, shapes, how, sort):
+        self.df1 = generate_dataframe("int", *shapes[0], RAND_LOW, RAND_HIGH)
+        self.df2 = generate_dataframe("int", *shapes[1], RAND_LOW, RAND_HIGH)
+
+    def time_merge(self, shapes, how, sort):
+        execute(IMPL.merge(self.df1, self.df2, how=how, sort=sort))
+
+
 class TimeMerge:
     param_names = ["shapes", "how", "sort"]
     params = [
@@ -192,9 +208,6 @@ class TimeMerge:
                 self.df2, left_index=True, right_index=True, how=how, sort=sort
             )
         )
-
-    def time_merge_default(self, shapes, how, sort):
-        execute(IMPL.merge(self.df1, self.df2, how=how, sort=sort))
 
     def time_merge_dataframe_empty_right(self, shapes, how, sort):
         # Getting an empty dataframe using `iloc` should be very fast,

--- a/asv_bench/benchmarks/utils/data_shapes.py
+++ b/asv_bench/benchmarks/utils/data_shapes.py
@@ -124,6 +124,7 @@ _DEFAULT_CONFIG_T = [
             # Pandas storage format benchmarks
             "TimeJoin",
             "TimeMerge",
+            "TimeMergeDefault",
             "TimeConcat",
             "TimeAppend",
             "TimeBinaryOp",
@@ -197,6 +198,13 @@ DEFAULT_CONFIG["TimeReplace"] = (
 for config in (_DEFAULT_CONFIG_T, _DEFAULT_HDK_CONFIG_T):
     for _shape, _names in config:
         DEFAULT_CONFIG.update({_name: _shape for _name in _names})
+
+# Correct forms in the case when the operation ended with a timeout error
+if ASV_DATASET_SIZE == "big":
+    DEFAULT_CONFIG["TimeMergeDefault"] = [
+        [[1000, 1000], [1000, 1000]],
+        [[500_000, 20], [1_000_000, 10]],
+    ]
 
 CONFIG_FROM_FILE = None
 


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5448 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
