### PR TITLE
REFACTOR-#5459: Install code linters through conda and unpin flake8

### DIFF
--- a/.github/workflows/ci-notebooks.yml
+++ b/.github/workflows/ci-notebooks.yml
@@ -70,8 +70,7 @@ jobs:
       # install test dependencies
       # NOTE: If you are changing the set of packages installed here, make sure that
       # the dev requirements match them.
-      # TODO: remove pin when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
-      - run: pip install pytest pytest-cov black "flake8<5" flake8-print flake8-no-implicit-concat
+      - run: pip install pytest pytest-cov black flake8 flake8-print flake8-no-implicit-concat
         if: matrix.execution != 'hdk_on_native'
       - run: pip install flake8-print jupyter nbformat nbconvert
         if: matrix.execution == 'hdk_on_native'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,7 @@ jobs:
           architecture: "x64"
       # NOTE: If you are changing the set of packages installed here, make sure that
       # the dev requirements match them.
-      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
-      - run: pip install "flake8<5" flake8-print flake8-no-implicit-concat
+      - run: pip install flake8 flake8-print flake8-no-implicit-concat
       # NOTE: keep the flake8 command here in sync with the pre-commit hook in
       # /contributing/pre-commit
       - run: flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -50,17 +50,17 @@ dependencies:
   # when we use collective instead of rabit.
   - xgboost>=1.7.1,<2.0.0
   - tqdm
+  # code linters
+  - black
+  - flake8
+  - flake8-no-implicit-concat
+  - flake8-print
   - pip:
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
       # no conda package for windows so we install it with pip
       - connectorx>=0.2.6a4
-      - black
-      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
-      - flake8<5
-      - flake8-no-implicit-concat
-      - flake8-print
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0
       # experimental version of fuzzydata requires at least 0.0.6 to successfully resolve all dependencies

--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -86,7 +86,9 @@ class Binary(Operator):
                     return query_compiler.__constructor__(
                         query_compiler._modin_frame.broadcast_apply(
                             axis,
-                            lambda l, r: func(l, r.squeeze(), *args, **kwargs),
+                            lambda left, right: func(
+                                left, right.squeeze(), *args, **kwargs
+                            ),
                             other._modin_frame,
                             join_type=join_type,
                             labels=labels,

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -332,7 +332,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
     @classmethod
     @wait_computations_if_benchmark_mode
-    def broadcast_apply(cls, axis, apply_func, left, right, other_name="r"):
+    def broadcast_apply(cls, axis, apply_func, left, right, other_name="right"):
         """
         Broadcast the `right` partitions to `left` and apply `apply_func` function.
 
@@ -346,7 +346,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             NumPy array of left partitions.
         right : np.ndarray
             NumPy array of right partitions.
-        other_name : str, default: "r"
+        other_name : str, default: "right"
             Name of key-value argument for `apply_func` that
             is used to pass `right` to `apply_func`.
 

--- a/modin/core/execution/dask/common/engine_wrapper.py
+++ b/modin/core/execution/dask/common/engine_wrapper.py
@@ -55,7 +55,7 @@ class DaskWrapper:
         remote_task_future = client.submit(func, *args, pure=pure, **kwargs)
         if num_returns != 1:
             return [
-                client.submit(lambda l, i: l[i], remote_task_future, i)
+                client.submit(lambda tup, i: tup[i], remote_task_future, i)
                 for i in range(num_returns)
             ]
         return remote_task_future

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1945,8 +1945,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
                 else:
                     # Value is a DataFrame type object
-                    def fillna_builder(df, r):
-                        return df.fillna(value=r, **kwargs)
+                    def fillna_builder(df, right):
+                        return df.fillna(value=right, **kwargs)
 
                     new_modin_frame = self._modin_frame.broadcast_apply(
                         0, fillna_builder, value._modin_frame

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3397,7 +3397,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
         return self.__constructor__(
             self._modin_frame.broadcast_apply_full_axis(
                 0,
-                lambda l, r: pandas.DataFrame.compare(l, other=r, **kwargs),
+                lambda left, right: pandas.DataFrame.compare(
+                    left, other=right, **kwargs
+                ),
                 other._modin_frame,
             )
         )

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2277,7 +2277,8 @@ def test_map(data, na_values):
 
     # Index into list objects
     df_equals(
-        modin_series_lists.map(lambda l: l[0]), pandas_series_lists.map(lambda l: l[0])
+        modin_series_lists.map(lambda list: list[0]),
+        pandas_series_lists.map(lambda list: list[0]),
     )
 
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2277,8 +2277,8 @@ def test_map(data, na_values):
 
     # Index into list objects
     df_equals(
-        modin_series_lists.map(lambda list: list[0]),
-        pandas_series_lists.map(lambda list: list[0]),
+        modin_series_lists.map(lambda lst: lst[0]),
+        pandas_series_lists.map(lambda lst: lst[0]),
     )
 
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -38,8 +38,7 @@ pymssql
 psycopg2
 connectorx>=0.2.6a4
 black
-# TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
-flake8<5
+flake8
 flake8-no-implicit-concat
 flake8-print
 # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -21,11 +21,11 @@ dependencies:
   - scipy
   - xgboost>=1.7.1,<2.0.0
   - scikit-learn-intelex
+  # code linters
+  - black
+  - flake8
+  - flake8-no-implicit-concat
+  - flake8-print
   - pip:
-      - black
-      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
-      - flake8<5
-      - flake8-no-implicit-concat
-      - flake8-print
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -38,17 +38,17 @@ dependencies:
   - mypy
   - pandas-stubs
   - fastparquet
+  - tqdm
   # for release script
   - pygit2
+  # code linters
+  - black
+  - flake8
+  - flake8-no-implicit-concat
+  - flake8-print
   - pip:
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
-      - tqdm
       - connectorx>=0.2.6a4
-      - black
-      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
-      - flake8<5
-      - flake8-no-implicit-concat
-      - flake8-print
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -33,16 +33,16 @@ dependencies:
   # when we use collective instead of rabit.
   - xgboost>=1.7.1,<2.0.0
   - tqdm
+  # code linters
+  - black
+  - flake8
+  - flake8-no-implicit-concat
+  - flake8-print
   - pip:
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - git+https://github.com/airspeed-velocity/asv.git@ef016e233cb9a0b19d517135104f49e0a3c380e9
       # no conda package for windows
       - connectorx>=0.2.6a4
-      - black
-      # TODO: remove when flake8 5.x stabilizes and appears in both pip and conda-forge; see GH-#4745
-      - flake8<5
-      - flake8-no-implicit-concat
-      - flake8-print
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5459 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
