### PR TITLE
REFACTOR-#0000: make deploy functions in `virtual_partition.py` files private

### DIFF
--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -190,7 +190,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         """
         result_num_splits = len(lengths) if lengths else num_splits
         return DaskWrapper.deploy(
-            func=deploy_dask_func,
+            func=_deploy_dask_func,
             f_args=(
                 PandasDataframeAxisPartition.deploy_axis_func,
                 axis,
@@ -250,7 +250,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
             A list of distributed.Future.
         """
         return DaskWrapper.deploy(
-            func=deploy_dask_func,
+            func=_deploy_dask_func,
             f_args=(
                 PandasDataframeAxisPartition.deploy_func_between_two_axis_partitions,
                 axis,
@@ -505,7 +505,7 @@ class PandasOnDaskDataframeRowPartition(PandasOnDaskDataframeVirtualPartition):
     axis = 1
 
 
-def deploy_dask_func(deployer, axis, f_to_deploy, f_args, f_kwargs, *args, **kwargs):
+def _deploy_dask_func(deployer, axis, f_to_deploy, f_args, f_kwargs, *args, **kwargs):
     """
     Execute a function on an axis partition in a worker process.
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -193,7 +193,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         list
             A list of ``ray.ObjectRef``-s.
         """
-        return deploy_ray_func.options(
+        return _deploy_ray_func.options(
             num_returns=(num_splits if lengths is None else len(lengths)) * 4,
             **({"max_retries": max_retries} if max_retries is not None else {}),
         ).remote(
@@ -249,7 +249,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         list
             A list of ``ray.ObjectRef``-s.
         """
-        return deploy_ray_func.options(num_returns=num_splits * 4).remote(
+        return _deploy_ray_func.options(num_returns=num_splits * 4).remote(
             PandasDataframeAxisPartition.deploy_func_between_two_axis_partitions,
             axis,
             func,
@@ -327,8 +327,8 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         Notes
         -----
         In older versions of Modin, ``args`` was passed internally as ``kwargs["args"]``, and
-        deserialization was handled in a special case in ``deploy_ray_func``, making control flow
-        difficult to follow. All deserialization is still handled in ``deploy_ray_func``, but
+        deserialization was handled in a special case in ``_deploy_ray_func``, making control flow
+        difficult to follow. All deserialization is still handled in ``_deploy_ray_func``, but
         in a more direct fashion.
         """
         if not self.full_axis:
@@ -518,7 +518,7 @@ class PandasOnRayDataframeRowPartition(PandasOnRayDataframeVirtualPartition):
 
 
 @ray.remote
-def deploy_ray_func(
+def _deploy_ray_func(
     deployer, axis, f_to_deploy, f_args, f_kwargs, *args, **kwargs
 ):  # pragma: no cover
     """

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -193,7 +193,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         list
             A list of ``unidist.ObjectRef``-s.
         """
-        return deploy_unidist_func.options(
+        return _deploy_unidist_func.options(
             num_returns=(num_splits if lengths is None else len(lengths)) * 4,
             **({"max_retries": max_retries} if max_retries is not None else {}),
         ).remote(
@@ -249,7 +249,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         list
             A list of ``unidist.ObjectRef``-s.
         """
-        return deploy_unidist_func.options(num_returns=num_splits * 4).remote(
+        return _deploy_unidist_func.options(num_returns=num_splits * 4).remote(
             PandasDataframeAxisPartition.deploy_func_between_two_axis_partitions,
             axis,
             func,
@@ -507,7 +507,7 @@ class PandasOnUnidistDataframeRowPartition(PandasOnUnidistDataframeVirtualPartit
 
 
 @unidist.remote
-def deploy_unidist_func(
+def _deploy_unidist_func(
     deployer, axis, f_to_deploy, f_args, f_kwargs, *args, **kwargs
 ):  # pragma: no cover
     """


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
