### PR TITLE
FEAT-#3044: add support for `api.extensions.register_*` functions

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -11,8 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-import pandas
+import os
 import warnings
+
+import pandas
 
 __pandas_version__ = "1.5.2"
 
@@ -79,14 +81,12 @@ with warnings.catch_warnings():
         datetime,
         NamedAgg,
         NA,
-        api,
         ArrowDtype,
         Flags,
         Float32Dtype,
         Float64Dtype,
         from_dummies,
     )
-import os
 
 from modin.config import Parameter
 
@@ -246,6 +246,7 @@ from .general import (
 )
 
 from .plotting import Plotting as plotting
+import modin.pandas.api
 from modin.utils import show_versions
 
 __all__ = [  # noqa: F405

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -246,7 +246,7 @@ from .general import (
 )
 
 from .plotting import Plotting as plotting
-import modin.pandas.api
+from modin.pandas import api
 from modin.utils import show_versions
 
 __all__ = [  # noqa: F405

--- a/modin/pandas/api/__init__.py
+++ b/modin/pandas/api/__init__.py
@@ -1,3 +1,16 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 """ public toolkit API """
 
 

--- a/modin/pandas/api/__init__.py
+++ b/modin/pandas/api/__init__.py
@@ -1,0 +1,16 @@
+""" public toolkit API """
+
+
+from modin.pandas.api import (
+    extensions,
+    indexers,
+    interchange,
+    types,
+)
+
+__all__ = [
+    "interchange",
+    "extensions",
+    "indexers",
+    "types",
+]

--- a/modin/pandas/api/extensions/__init__.py
+++ b/modin/pandas/api/extensions/__init__.py
@@ -1,3 +1,16 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 """
 Public API for extending modin objects.
 """

--- a/modin/pandas/api/extensions/__init__.py
+++ b/modin/pandas/api/extensions/__init__.py
@@ -1,0 +1,24 @@
+"""
+Public API for extending modin objects.
+"""
+
+from pandas.core.accessor import _register_accessor
+from pandas.api.extensions import *  # noqa: F401, F403
+
+
+def register_dataframe_accessor(name):
+    from modin.pandas import DataFrame
+
+    return _register_accessor(name, DataFrame)
+
+
+def register_series_accessor(name):
+    from modin.pandas import Series
+
+    return _register_accessor(name, Series)
+
+
+def register_index_accessor(name):
+    from modin.pandas import Index
+
+    return _register_accessor(name, Index)

--- a/modin/pandas/api/indexers/__init__.py
+++ b/modin/pandas/api/indexers/__init__.py
@@ -1,0 +1,5 @@
+"""
+Public API for Rolling Window Indexers.
+"""
+
+from pandas.api.indexers import *  # noqa: F401, F403

--- a/modin/pandas/api/indexers/__init__.py
+++ b/modin/pandas/api/indexers/__init__.py
@@ -1,3 +1,16 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 """
 Public API for Rolling Window Indexers.
 """

--- a/modin/pandas/api/interchange/__init__.py
+++ b/modin/pandas/api/interchange/__init__.py
@@ -1,0 +1,5 @@
+"""
+Public API for DataFrame interchange protocol.
+"""
+
+from pandas.api.interchange import *  # noqa: F401, F403

--- a/modin/pandas/api/interchange/__init__.py
+++ b/modin/pandas/api/interchange/__init__.py
@@ -1,3 +1,16 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 """
 Public API for DataFrame interchange protocol.
 """

--- a/modin/pandas/api/types/__init__.py
+++ b/modin/pandas/api/types/__init__.py
@@ -1,3 +1,16 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 """
 Public toolkit API.
 """

--- a/modin/pandas/api/types/__init__.py
+++ b/modin/pandas/api/types/__init__.py
@@ -1,0 +1,5 @@
+"""
+Public toolkit API.
+"""
+
+from pandas.api.types import *  # noqa: F401, F403

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -113,6 +113,7 @@ class DataFrame(BasePandasDataset):
     """
 
     _pandas_class = pandas.DataFrame
+    _accessors: set[str] = {"sparse"}
 
     def __init__(
         self,

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -81,6 +81,7 @@ class Series(BasePandasDataset):
 
     _pandas_class = pandas.Series
     __array_priority__ = pandas.Series.__array_priority__
+    _accessors = {"dt", "cat", "str", "sparse"}
 
     def __init__(
         self,

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -35,7 +35,6 @@ def test_top_level_api_equality():
         "offsets",
         "datetime",
         "arrays",
-        "api",
         "tseries",
         "errors",
         "to_msgpack",  # This one is experimental, and doesn't look finished


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3044 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
