### PR TITLE
FIX-#5488: Remove usage of deprecated numpy types

### DIFF
--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1666,7 +1666,7 @@ def test_select_dtypes():
     df = pandas.DataFrame(frame_data)
     rd = pd.DataFrame(frame_data)
 
-    include = np.float, "integer"
+    include = np.float64, "integer"
     exclude = (np.bool_,)
     r = rd.select_dtypes(include=include, exclude=exclude)
 

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -196,7 +196,7 @@ def test_describe_column_partition_has_different_index():
     [
         ([np.float64], None),
         (np.float64, None),
-        (None, [np.timedelta64, np.datetime64, np.object, np.bool_]),
+        (None, [np.timedelta64, np.datetime64, np.object_, np.bool_]),
         (None, "all"),
         (None, np.number),
     ],

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -522,7 +522,7 @@ def test___repr__(name, dt_index, data):
 
     if get_current_execution() == "BaseOnPython" and data == "empty":
         # TODO: Remove this when default `dtype` of empty Series will be `object` in pandas (see #3142).
-        assert modin_series.dtype == np.object
+        assert modin_series.dtype == np.object_
         assert pandas_series.dtype == np.float64
         df_equals(modin_series.index, pandas_series.index)
     else:
@@ -1426,16 +1426,16 @@ def test_describe(data):
 
     try:
         pandas_result = pandas_series.describe(
-            include=[np.timedelta64, np.datetime64, np.object, np.bool_]
+            include=[np.timedelta64, np.datetime64, np.object_, np.bool_]
         )
     except Exception as err:
         with pytest.raises(type(err)):
             modin_series.describe(
-                include=[np.timedelta64, np.datetime64, np.object, np.bool_]
+                include=[np.timedelta64, np.datetime64, np.object_, np.bool_]
             )
     else:
         modin_result = modin_series.describe(
-            include=[np.timedelta64, np.datetime64, np.object, np.bool_]
+            include=[np.timedelta64, np.datetime64, np.object_, np.bool_]
         )
         df_equals(modin_result, pandas_result)
 
@@ -1632,7 +1632,7 @@ def test_dtype_empty():
     modin_series, pandas_series = pd.Series(), pandas.Series()
     if get_current_execution() == "BaseOnPython":
         # TODO: Remove this when default `dtype` of empty Series will be `object` in pandas (see #3142).
-        assert modin_series.dtype == np.object
+        assert modin_series.dtype == np.object_
         assert pandas_series.dtype == np.float64
     else:
         assert modin_series.dtype == pandas_series.dtype


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5488 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
