### PR TITLE
FIX-#5492: Fix `Series.values` when `Series.dtype==ExtensionDtype`

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -476,7 +476,11 @@ class BasePandasDataset(ClassLogger):
             # it is a DataFrame, Series, etc.) as a pandas object. The outer `getattr`
             # will get the operation (`op`) from the pandas version of the class and run
             # it on the object after we have converted it to pandas.
-            result = getattr(self._pandas_class, op)(pandas_obj, *args, **kwargs)
+            attr = getattr(self._pandas_class, op)
+            if isinstance(attr, property):
+                result = getattr(pandas_obj, op)
+            else:
+                result = attr(pandas_obj, *args, **kwargs)
         else:
             ErrorMessage.catch_bugs_and_request_email(
                 failure_condition=True,

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -486,7 +486,9 @@ class Series(BasePandasDataset):
         """
         import modin.pandas as pd
 
-        if isinstance(self.dtype, pandas.core.dtypes.dtypes.ExtensionDtype):
+        if isinstance(
+            self.dtype, pandas.core.dtypes.dtypes.ExtensionDtype
+        ) and not isinstance(self.dtype, pd.CategoricalDtype):
             return self._default_to_pandas("values")
 
         data = self.to_numpy()

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -486,6 +486,9 @@ class Series(BasePandasDataset):
         """
         import modin.pandas as pd
 
+        if isinstance(self.dtype, pandas.core.dtypes.dtypes.ExtensionDtype):
+            return self._default_to_pandas("values")
+
         data = self.to_numpy()
         if isinstance(self.dtype, pd.CategoricalDtype):
             data = pd.Categorical(data, dtype=self.dtype)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3624,6 +3624,16 @@ def test_values_non_numeric():
     df_equals(modin_series.values, pandas_series.values)
 
 
+def test_values_ea():
+    data = pandas.arrays.SparseArray(np.arange(10, dtype="int64"))
+    modin_series, pandas_series = create_test_series(data)
+    modin_values = modin_series.values
+    pandas_values = pandas_series.values
+
+    assert modin_values.dtype == pandas_values.dtype
+    df_equals(modin_values, pandas_values)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize(
     "skipna", bool_arg_values, ids=arg_keys("skipna", bool_arg_keys)

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -640,7 +640,12 @@ def df_equals(df1, df2):
         assert_index_equal(df1, df2)
     elif isinstance(df1, pandas.Series) and isinstance(df2, pandas.Series):
         assert_series_equal(df1, df2, check_dtype=False, check_series_type=False)
-    elif isinstance(df1, pandas.Categorical) and isinstance(df2, pandas.Categorical):
+    elif (
+        hasattr(df1, "dtype")
+        and hasattr(df2, "dtype")
+        and isinstance(df1.dtype, pandas.core.dtypes.dtypes.ExtensionDtype)
+        and isinstance(df2.dtype, pandas.core.dtypes.dtypes.ExtensionDtype)
+    ):
         assert_extension_array_equal(df1, df2)
     elif isinstance(df1, groupby_types) and isinstance(df2, groupby_types):
         for g1, g2 in zip(df1, df2):


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5492 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
