### PR TITLE
FIX-#1227: Avoid `RecursionError` for `__int__` and `__float__`

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -23,6 +23,7 @@ from pandas.core.dtypes.common import (
     is_dict_like,
     is_list_like,
 )
+from pandas.core.series import _coerce_method
 from pandas._libs.lib import no_default, NoDefault
 from pandas._typing import IndexKeyFunc, Axis
 from typing import Union, Optional, Hashable, TYPE_CHECKING, IO
@@ -271,16 +272,6 @@ class Series(BasePandasDataset):
     def __rdivmod__(self, left):
         return self.rdivmod(left)
 
-    def __float__(self):
-        """
-        Return float representation of Series.
-
-        Returns
-        -------
-        float
-        """
-        return float(self.squeeze())
-
     @_doc_binary_op(operation="integer division", bin_op="floordiv")
     def __floordiv__(self, right):
         return self.floordiv(right)
@@ -314,15 +305,8 @@ class Series(BasePandasDataset):
                 return self[key]
             raise err
 
-    def __int__(self):
-        """
-        Return integer representation of Series.
-
-        Returns
-        -------
-        int
-        """
-        return int(self.squeeze())
+    __float__ = _coerce_method(float)
+    __int__ = _coerce_method(int)
 
     def __iter__(self):
         """

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -399,16 +399,16 @@ def test___gt__(data):
 @pytest.mark.parametrize("count_elements", [0, 1, 10])
 def test___int__(count_elements):
     eval_general(
-        *create_test_series(test_data["float_nan_data"]),
-        lambda df: int(df[:count_elements]),
+        *create_test_series([1.5] * count_elements),
+        lambda df: int(df),
     )
 
 
 @pytest.mark.parametrize("count_elements", [0, 1, 10])
 def test___float__(count_elements):
     eval_general(
-        *create_test_series(test_data["int_data"]),
-        lambda df: float(df[:count_elements]),
+        *create_test_series([1] * count_elements),
+        lambda df: float(df),
     )
 
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -397,11 +397,18 @@ def test___gt__(data):
 
 
 @pytest.mark.parametrize("count_elements", [0, 1, 10])
-@pytest.mark.parametrize("converter", [int, float])
-def test___int__and__float__(converter, count_elements):
+def test___int__(count_elements):
+    eval_general(
+        *create_test_series(test_data["float_data"]),
+        lambda df: int(df[:count_elements]),
+    )
+
+
+@pytest.mark.parametrize("count_elements", [0, 1, 10])
+def test___float__(count_elements):
     eval_general(
         *create_test_series(test_data["int_data"]),
-        lambda df: converter(df[:count_elements]),
+        lambda df: float(df[:count_elements]),
     )
 
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -396,16 +396,13 @@ def test___gt__(data):
     inter_df_math_helper(modin_series, pandas_series, "__gt__")
 
 
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test___int__(data):
-    modin_series, pandas_series = create_test_series(data)
-    try:
-        pandas_result = int(pandas_series[0])
-    except Exception as err:
-        with pytest.raises(type(err)):
-            int(modin_series[0])
-    else:
-        assert int(modin_series[0]) == pandas_result
+@pytest.mark.parametrize("count_elements", [0, 1, 10])
+@pytest.mark.parametrize("converter", [int, float])
+def test___int__and__float__(converter, count_elements):
+    eval_general(
+        *create_test_series(test_data["int_data"]),
+        lambda df: converter(df[:count_elements]),
+    )
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -398,18 +398,12 @@ def test___gt__(data):
 
 @pytest.mark.parametrize("count_elements", [0, 1, 10])
 def test___int__(count_elements):
-    eval_general(
-        *create_test_series([1.5] * count_elements),
-        lambda df: int(df),
-    )
+    eval_general(*create_test_series([1.5] * count_elements), int)
 
 
 @pytest.mark.parametrize("count_elements", [0, 1, 10])
 def test___float__(count_elements):
-    eval_general(
-        *create_test_series([1] * count_elements),
-        lambda df: float(df),
-    )
+    eval_general(*create_test_series([1] * count_elements), float)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -399,7 +399,7 @@ def test___gt__(data):
 @pytest.mark.parametrize("count_elements", [0, 1, 10])
 def test___int__(count_elements):
     eval_general(
-        *create_test_series(test_data["float_data"]),
+        *create_test_series(test_data["float_nan_data"]),
         lambda df: int(df[:count_elements]),
     )
 


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1227 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
