### PR TITLE
FIX-#2508: Defaults to pandas for read_csv if `dialect!=None`

### DIFF
--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -655,6 +655,9 @@ class TextFileDispatcher(FileDispatcher):
         if read_kwargs["chunksize"] is not None:
             return (False, "`chunksize` parameter is not supported")
 
+        if read_kwargs["dialect"] is not None:
+            return (False, "`dialect` parameter is not supported")
+
         skiprows_supported = True
         if is_list_like(skiprows_md) and skiprows_md[0] < header_size:
             skiprows_supported = False

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -655,7 +655,7 @@ class TextFileDispatcher(FileDispatcher):
         if read_kwargs["chunksize"] is not None:
             return (False, "`chunksize` parameter is not supported")
 
-        if read_kwargs["dialect"] is not None:
+        if read_kwargs.get("dialect") is not None:
             return (False, "`dialect` parameter is not supported")
 
         skiprows_supported = True

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -705,7 +705,7 @@ class TestCsv:
     @pytest.mark.parametrize("decimal", [".", "_"])
     @pytest.mark.parametrize("lineterminator", [None, "x", "\n"])
     @pytest.mark.parametrize("escapechar", [None, "d", "x"])
-    @pytest.mark.parametrize("dialect", ["test_csv_dialect", None])
+    @pytest.mark.parametrize("dialect", ["test_csv_dialect", "use_dialect_name", None])
     def test_read_csv_file_format(
         self,
         make_csv_file,
@@ -721,10 +721,6 @@ class TestCsv:
             pytest.xfail(
                 "read_csv with Ray engine fails with some 'escapechar' parameters - issue #2494"
             )
-        elif Engine.get() != "Python" and dialect:
-            pytest.xfail(
-                "read_csv with Ray engine fails with `dialect` parameter - issue #2508"
-            )
 
         with ensure_clean(".csv") as unique_filename:
             if dialect:
@@ -736,7 +732,9 @@ class TestCsv:
                     "quoting": csv.QUOTE_ALL,
                 }
                 csv.register_dialect(dialect, **test_csv_dialect_params)
-                dialect = csv.get_dialect(dialect)
+                if dialect != "use_dialect_name":
+                    # otherwise try with dialect name instead of `_csv.Dialect` object
+                    dialect = csv.get_dialect(dialect)
                 make_csv_file(filename=unique_filename, **test_csv_dialect_params)
             else:
                 make_csv_file(


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

If a csv' object is passed as a dialect, then Modin does not work, since this object is not serializable. If its name is passed as a dialect, then this dialect will not be found on the workers, since it is registered only in the main process.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2508 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
