### PR TITLE
FIX-#4186: Fix `__repr__` of Modin categorical Series

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -420,7 +420,10 @@ class Series(BasePandasDataset):
         )
         if len(self) == 0:
             return "Series([], {}{}{}".format(freq_str, name_str, dtype_str)
-        return temp_str.rsplit("\n", 1)[0] + "\n{}{}{}{}".format(
+        maxsplit = 1
+        if "Name:" in temp_str:
+            maxsplit = 2
+        return temp_str.rsplit("\n", maxsplit)[0] + "\n{}{}{}{}".format(
             freq_str, name_str, len_str, dtype_str
         )
 

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -421,7 +421,11 @@ class Series(BasePandasDataset):
         if len(self) == 0:
             return "Series([], {}{}{}".format(freq_str, name_str, dtype_str)
         maxsplit = 1
-        if "Name:" in temp_str:
+        if (
+            isinstance(temp_df, pandas.Series)
+            and temp_df.name is not None
+            and temp_df.dtype == "category"
+        ):
             maxsplit = 2
         return temp_str.rsplit("\n", maxsplit)[0] + "\n{}{}{}{}".format(
             freq_str, name_str, len_str, dtype_str

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -529,6 +529,13 @@ def test___repr__(name, dt_index, data):
         assert repr(modin_series) == repr(pandas_series)
 
 
+def test___repr__4186():
+    modin_series, pandas_series = create_test_series(
+        ["a", "b", "c", "a"], dtype="category"
+    )
+    assert repr(modin_series) == repr(pandas_series)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test___round__(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4186 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
