### PR TITLE
FIX-#3080: Fix case when there is duplicated columns for read_csv on hdk

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -299,6 +299,9 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
                 parse_options=po,
                 convert_options=co,
             )
+            if len(set(at.schema.names)) < len(at.schema.names):
+                ErrorMessage.default_to_pandas("`read_csv`")
+                return super().read_csv(**mykwargs)
 
             return cls.from_arrow(at)
         except (

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -378,17 +378,6 @@ class TestCsv:
         names,
         encoding,
     ):
-        xfail_case = (
-            StorageFormat.get() == "Hdk"
-            and header is not None
-            and isinstance(skiprows, int)
-            and names is None
-            and nrows is None
-        )
-        if xfail_case:
-            pytest.xfail(
-                "read_csv fails because of duplicated columns names - issue #3080"
-            )
         if request.config.getoption(
             "--simulate-cloud"
         ).lower() != "off" and is_list_like(skiprows):
@@ -495,10 +484,6 @@ class TestCsv:
             )
 
     def test_read_csv_mangle_dupe_cols(self):
-        if StorageFormat.get() == "Hdk":
-            pytest.xfail(
-                "processing of duplicated columns in HDK storage format is not supported yet - issue #3080"
-            )
         with ensure_clean() as unique_filename, pytest.warns(
             FutureWarning, match="'mangle_dupe_cols' keyword is deprecated"
         ):
@@ -1001,13 +986,6 @@ class TestCsv:
     @pytest.mark.parametrize("names", [list("XYZ"), None])
     @pytest.mark.parametrize("skiprows", [1, 2, 3, 4, None])
     def test_read_csv_skiprows_names(self, names, skiprows):
-        if StorageFormat.get() == "Hdk" and names is None and skiprows in [1, None]:
-            # If these conditions are satisfied, columns names will be inferred
-            # from the first row, that will contain duplicated values, that is
-            # not supported by  `HDK` storage format yet.
-            pytest.xfail(
-                "processing of duplicated columns in HDK storage format is not supported yet - issue #3080"
-            )
         eval_io(
             fn_name="read_csv",
             # read_csv kwargs


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3080 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
