### PR TITLE
FIX-#2494: Defaults to pandas for read_csv if `escapechar!=None`

### DIFF
--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -661,6 +661,9 @@ class TextFileDispatcher(FileDispatcher):
         if read_kwargs["lineterminator"] is not None:
             return (False, "`lineterminator` parameter is not supported")
 
+        if read_kwargs["escapechar"] is not None:
+            return (False, "`escapechar` parameter is not supported")
+
         skiprows_supported = True
         if is_list_like(skiprows_md) and skiprows_md[0] < header_size:
             skiprows_supported = False

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -715,11 +715,6 @@ class TestCsv:
         escapechar,
         dialect,
     ):
-        if Engine.get() != "Python" and escapechar:
-            pytest.xfail(
-                "read_csv with Ray engine fails with some 'escapechar' parameters - issue #2494"
-            )
-
         with ensure_clean(".csv") as unique_filename:
             if dialect:
                 test_csv_dialect_params = {


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2494 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
