### PR TITLE
FIX-#2320: Raise exceptions in read_csv in some cases with `skipfooter!=0`

### DIFF
--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -663,7 +663,7 @@ class TextFileDispatcher(FileDispatcher):
 
         if read_kwargs.get("skipfooter"):
             if read_kwargs.get("nrows") or read_kwargs.get("engine") == "c":
-                return (False, "raise exception by pandas itself")
+                return (False, "Exception is raised by pandas itself")
 
         skiprows_supported = True
         if is_list_like(skiprows_md) and skiprows_md[0] < header_size:

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -661,6 +661,10 @@ class TextFileDispatcher(FileDispatcher):
         if read_kwargs["lineterminator"] is not None:
             return (False, "`lineterminator` parameter is not supported")
 
+        if read_kwargs.get("skipfooter"):
+            if read_kwargs.get("nrows") or read_kwargs.get("engine") == "c":
+                return (False, "raise exception by pandas itself")
+
         skiprows_supported = True
         if is_list_like(skiprows_md) and skiprows_md[0] < header_size:
             skiprows_supported = False

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -454,6 +454,9 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
                     f"Invalid file path or buffer object type: {type(filepath_or_buffer)}"
                 )
 
+        if read_csv_kwargs.get("skipfooter") and read_csv_kwargs.get("nrows"):
+            return (False, "raise exception by pandas itself")
+
         for arg, def_value in cls.read_csv_unsup_defaults.items():
             if read_csv_kwargs[arg] != def_value:
                 return (

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -455,7 +455,7 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
                 )
 
         if read_csv_kwargs.get("skipfooter") and read_csv_kwargs.get("nrows"):
-            return (False, "raise exception by pandas itself")
+            return (False, "Exception is raised by pandas itself")
 
         for arg, def_value in cls.read_csv_unsup_defaults.items():
             if read_csv_kwargs[arg] != def_value:

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -335,7 +335,6 @@ class TestCsv:
 
         eval_io(
             fn_name="read_csv",
-            check_exception_type=None,  # issue #2320
             raising_exceptions=None,
             check_kwargs_callable=not callable(converters),
             # read_csv kwargs
@@ -421,7 +420,6 @@ class TestCsv:
                     )
             eval_io(
                 fn_name="read_csv",
-                check_exception_type=None,  # issue #2320
                 raising_exceptions=None,
                 check_kwargs_callable=not callable(skiprows),
                 # read_csv kwargs
@@ -449,7 +447,6 @@ class TestCsv:
 
         eval_io(
             fn_name="read_csv",
-            check_exception_type=None,  # issue #2320
             raising_exceptions=None,
             # read_csv kwargs
             filepath_or_buffer=pytest.csvs_names["test_read_csv_yes_no"],
@@ -744,7 +741,6 @@ class TestCsv:
                 )
 
             eval_io(
-                check_exception_type=None,  # issue #2320
                 raising_exceptions=None,
                 fn_name="read_csv",
                 # read_csv kwargs


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2320 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
