### PR TITLE
PERF-#5182: pre compute dtypes in query compiler for binary operations

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -99,6 +99,7 @@ class Binary(Operator):
                             lambda x, y: func(x, y, *args, **kwargs),
                             [other._modin_frame],
                             join_type=join_type,
+                            dtypes=dtypes,
                         )
                     )
             else:

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2810,7 +2810,12 @@ class PandasDataframe(ClassLogger):
 
     @lazy_metadata_decorator(apply_axis="both")
     def n_ary_op(
-        self, op, right_frames: list, join_type="outer", copartition_along_columns=True
+        self,
+        op,
+        right_frames: list,
+        join_type="outer",
+        copartition_along_columns=True,
+        dtypes=None,
     ):
         """
         Perform an n-opary operation by joining with other Modin DataFrame(s).
@@ -2826,6 +2831,9 @@ class PandasDataframe(ClassLogger):
         copartition_along_columns : bool, default: True
             Whether to perform copartitioning along columns or not.
             For some ops this isn't needed (e.g., `fillna`).
+        dtypes : series, default: None
+            Dtypes of the resultant dataframe, this argument will be
+            received if the resultant dtypes of n-opary operation is precomputed.
 
         Returns
         -------
@@ -2880,6 +2888,7 @@ class PandasDataframe(ClassLogger):
             joined_columns,
             row_lengths,
             column_widths,
+            dtypes,
         )
 
     @lazy_metadata_decorator(apply_axis="both")

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -473,7 +473,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         dtypes = self._precompute_dtypes_common_cast(other, broadcast)
         return Binary.register(
             pandas.DataFrame.add,
-        )(self, other, dtypes=dtypes, *args, **kwargs)
+        )(self, other, dtypes=dtypes, broadcast=broadcast, *args, **kwargs)
 
     def eq(self, other, broadcast=False, *args, **kwargs):
         dtypes = self._precompute_dtypes_boolean(other, broadcast)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -390,6 +390,21 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # To precompute datatypes for binary operations which follow pandas find_common_type
     def _precompute_dtypes_common_cast(self, other, broadcast):
+        """
+        Precompute data types for those binary operations by finding common type between operands.
+
+        Parameters
+        ----------
+        other : PandasQueryCompiler
+            Operand dataframe for which the binary operation would be performed later.
+        broadcast : boolean
+            Whether the subsequent binary operation involves broadcasting operands.
+
+        Returns
+        -------
+        dtypes
+            The pandas series with precomputed dtypes.
+        """
         dtypes = None
         if isinstance(other, type(self)) and not broadcast:
             if other.dtypes is not None and self.dtypes is not None:
@@ -424,6 +439,21 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # To precompute datatypes for binary boolean operations across dataframes
     def _precompute_dtypes_boolean(self, other, broadcast):
+        """
+        Precompute datatype series for boolean operations.
+
+        Parameters
+        ----------
+        other : PandasQueryCompiler
+            Operand dataframe for which the binary operation would be performed later.
+        broadcast : boolean
+            Whether the subsequent binary operation involves broadcasting operands.
+
+        Returns
+        -------
+        dtypes
+            The pandas series with precomputed dtypes.
+        """
         dtypes = None
         if isinstance(other, type(self)) and not broadcast:
             if other.dtypes is not None and self.dtypes is not None:

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -389,7 +389,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # END To NumPy
 
     # To precompute datatypes for binary operations which follow pandas find_common_type
-    def precompute_dtypes_common_cast(self, other, broadcast):
+    def _precompute_dtypes_common_cast(self, other, broadcast):
         dtypes = None
         if isinstance(other, type(self)) and not broadcast:
             if other.dtypes is not None and self.dtypes is not None:
@@ -423,7 +423,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         return dtypes
 
     # To precompute datatypes for binary boolean operations across dataframes
-    def precompute_dtypes_boolean(self, other, broadcast):
+    def _precompute_dtypes_boolean(self, other, broadcast):
         dtypes = None
         if isinstance(other, type(self)) and not broadcast:
             if other.dtypes is not None and self.dtypes is not None:
@@ -437,13 +437,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # result in NaN values.
 
     def add(self, other, broadcast=False, *args, **kwargs):
-        dtypes = self.precompute_dtypes_common_cast(other, broadcast)
+        dtypes = self._precompute_dtypes_common_cast(other, broadcast)
         return Binary.register(
             pandas.DataFrame.add,
         )(self, other, dtypes=dtypes, *args, **kwargs)
 
     def eq(self, other, broadcast=False, *args, **kwargs):
-        dtypes = self.precompute_dtypes_boolean(other, broadcast)
+        dtypes = self._precompute_dtypes_boolean(other, broadcast)
         return Binary.register(
             pandas.DataFrame.eq,
         )(self, other, dtypes=dtypes, *args, **kwargs)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -388,16 +388,73 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # END To NumPy
 
+    # To precompute datatypes for binary operations which follow pandas find_common_type
+    def precompute_dtypes_common_cast(self, other, broadcast):
+        dtypes = None
+        if isinstance(other, type(self)) and not broadcast:
+            if other.dtypes is not None and self.dtypes is not None:
+                dtypes_self = dict(zip(self.columns, self.dtypes))
+                dtypes_other = dict(zip(other.columns, other.dtypes))
+                columns_self = set(self.columns)
+                columns_other = set(other.columns)
+                # If one columns dont match the result of the non matching column would be nan.
+                nan_dtype = np.dtype(type(np.nan))
+                dtypes = pandas.Series(
+                    [
+                        pandas.core.dtypes.cast.find_common_type(
+                            [
+                                dtypes_self.get(x, nan_dtype),
+                                dtypes_other[x],
+                            ]
+                        )
+                        for x in columns_self
+                    ],
+                    index=columns_self,
+                )
+                dtypes = pandas.concat(
+                    [
+                        dtypes,
+                        pandas.Series(
+                            [nan_dtype] * (len(columns_other - columns_self)),
+                            index=columns_other - columns_self,
+                        ),
+                    ]
+                )
+        return dtypes
+
+    # To precompute datatypes for binary boolean operations across dataframes
+    def precompute_dtypes_boolean(self, other, broadcast):
+        dtypes = None
+        if isinstance(other, type(self)) and not broadcast:
+            if other.dtypes is not None and self.dtypes is not None:
+                dtypes = pandas.Series([bool] * len(other.dtypes))
+        return dtypes
+
     # Binary operations (e.g. add, sub)
     # These operations require two DataFrames and will change the shape of the
     # data if the index objects don't match. An outer join + op is performed,
     # such that columns/rows that don't have an index on the other DataFrame
     # result in NaN values.
 
-    add = Binary.register(pandas.DataFrame.add)
+    def add(self, other, broadcast=False, *args, **kwargs):
+        dtypes = self.precompute_dtypes_common_cast(other, broadcast)
+        return Binary.register(
+            pandas.DataFrame.add,
+        )(self, other, dtypes=dtypes, *args, **kwargs)
+
+    def eq(self, other, broadcast=False, *args, **kwargs):
+        dtypes = self.precompute_dtypes_boolean(other, broadcast)
+        return Binary.register(
+            pandas.DataFrame.eq,
+        )(self, other, dtypes=dtypes, *args, **kwargs)
+
+    # Binary operations (e.g. add, sub)
+    # These operations require two DataFrames and will change the shape of the
+    # data if the index objects don't match. An outer join + op is performed,
+    # such that columns/rows that don't have an index on the other DataFrame
+    # result in NaN values.
     combine = Binary.register(pandas.DataFrame.combine)
     combine_first = Binary.register(pandas.DataFrame.combine_first)
-    eq = Binary.register(pandas.DataFrame.eq)
     floordiv = Binary.register(pandas.DataFrame.floordiv)
     ge = Binary.register(pandas.DataFrame.ge)
     gt = Binary.register(pandas.DataFrame.gt)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -476,10 +476,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
         )(self, other, dtypes=dtypes, broadcast=broadcast, *args, **kwargs)
 
     def eq(self, other, broadcast=False, *args, **kwargs):
-        dtypes = self._precompute_dtypes_boolean(other, broadcast)
+        if "dtypes" not in kwargs:
+            kwargs["dtypes"] = self._precompute_dtypes_boolean(other, broadcast)
         return Binary.register(
             pandas.DataFrame.eq,
-        )(self, other, dtypes=dtypes, *args, **kwargs)
+        )(self, other, broadcast=broadcast, *args, **kwargs)
 
     # Binary operations (e.g. add, sub)
     # These operations require two DataFrames and will change the shape of the


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Similar to #5494 with the logic for pre computing dtypes moved to the query compiler.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
