### PR TITLE
PERF-#5551: Preserve index and columns on `_repartition`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2697,19 +2697,30 @@ class PandasDataframe(ClassLogger):
 
         if not keep_partitioning:
             if kw["row_lengths"] is None:
-                if new_index is not None and axis == 0:
-                    kw["row_lengths"] = get_length_list(
-                        axis_len=len(new_index), num_splits=new_partitions.shape[0]
-                    )
-                elif axis == 1:
-                    kw["row_lengths"] = self._row_lengths_cache
+                if new_index is not None:
+                    if axis == 0:
+                        kw["row_lengths"] = get_length_list(
+                            axis_len=len(new_index), num_splits=new_partitions.shape[0]
+                        )
+                    elif (
+                        axis == 1
+                        and self._row_lengths_cache is not None
+                        and len(new_index) == sum(self._row_lengths_cache)
+                    ):
+                        kw["row_lengths"] = self._row_lengths_cache
             if kw["column_widths"] is None:
-                if new_columns is not None and axis == 1:
-                    kw["column_widths"] = get_length_list(
-                        axis_len=len(new_columns), num_splits=new_partitions.shape[1]
-                    )
-                elif axis == 0:
-                    kw["column_widths"] = self._column_widths_cache
+                if new_columns is not None:
+                    if axis == 1:
+                        kw["column_widths"] = get_length_list(
+                            axis_len=len(new_columns),
+                            num_splits=new_partitions.shape[1],
+                        )
+                    elif (
+                        axis == 0
+                        and self._column_widths_cache is not None
+                        and len(new_columns) == sum(self._column_widths_cache)
+                    ):
+                        kw["column_widths"] = self._column_widths_cache
         result = self.__constructor__(new_partitions, **kw)
         if synchronize and new_index is not None:
             result.synchronize_labels(axis=0)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2694,6 +2694,22 @@ class PandasDataframe(ClassLogger):
             kw["dtypes"] = pandas.Series(
                 [np.dtype(dtypes)] * len(kw["columns"]), index=kw["columns"]
             )
+
+        if not keep_partitioning:
+            if kw["row_lengths"] is None:
+                if new_index is not None and axis == 0:
+                    kw["row_lengths"] = get_length_list(
+                        axis_len=len(new_index), num_splits=new_partitions.shape[0]
+                    )
+                elif axis == 1:
+                    kw["row_lengths"] = self._row_lengths_cache
+            if kw["column_widths"] is None:
+                if new_columns is not None and axis == 1:
+                    kw["column_widths"] = get_length_list(
+                        axis_len=len(new_columns), num_splits=new_partitions.shape[1]
+                    )
+                elif axis == 0:
+                    kw["column_widths"] = self._column_widths_cache
         result = self.__constructor__(new_partitions, **kw)
         if synchronize and new_index is not None:
             result.synchronize_labels(axis=0)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2656,6 +2656,8 @@ class PandasDataframe(ClassLogger):
             Setting it to True disables shuffling data from one partition to another.
         synchronize : boolean, default: True
             Synchronize external indexes (`new_index`, `new_columns`) with internal indexes.
+            This could be used when you're certain that the indices in partitions are equal to
+            the provided hints in order to save time on syncing them.
 
         Returns
         -------

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2187,6 +2187,7 @@ class PandasDataframe(ClassLogger):
         new_columns=None,
         dtypes=None,
         keep_partitioning=True,
+        synchronize=True,
     ):
         """
         Perform a function across an entire axis.
@@ -2210,6 +2211,8 @@ class PandasDataframe(ClassLogger):
         keep_partitioning : boolean, default: True
             The flag to keep partition boundaries for Modin Frame.
             Setting it to True disables shuffling data from one partition to another.
+        synchronize : boolean, default: True
+            Synchronize external indexes (`new_index`, `new_columns`) with internal indexes.
 
         Returns
         -------
@@ -2228,6 +2231,7 @@ class PandasDataframe(ClassLogger):
             dtypes=dtypes,
             other=None,
             keep_partitioning=keep_partitioning,
+            synchronize=synchronize,
         )
 
     @lazy_metadata_decorator(apply_axis="both")
@@ -2619,6 +2623,7 @@ class PandasDataframe(ClassLogger):
         enumerate_partitions=False,
         dtypes=None,
         keep_partitioning=True,
+        synchronize=True,
     ):
         """
         Broadcast partitions of `other` Modin DataFrame and apply a function along full axis.
@@ -2649,6 +2654,8 @@ class PandasDataframe(ClassLogger):
         keep_partitioning : boolean, default: True
             The flag to keep partition boundaries for Modin Frame.
             Setting it to True disables shuffling data from one partition to another.
+        synchronize : boolean, default: True
+            Synchronize external indexes (`new_index`, `new_columns`) with internal indexes.
 
         Returns
         -------
@@ -2684,9 +2691,9 @@ class PandasDataframe(ClassLogger):
                 [np.dtype(dtypes)] * len(kw["columns"]), index=kw["columns"]
             )
         result = self.__constructor__(new_partitions, **kw)
-        if new_index is not None:
+        if synchronize and new_index is not None:
             result.synchronize_labels(axis=0)
-        if new_columns is not None:
+        if synchronize and new_columns is not None:
             result.synchronize_labels(axis=1)
         return result
 

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2213,6 +2213,8 @@ class PandasDataframe(ClassLogger):
             Setting it to True disables shuffling data from one partition to another.
         synchronize : boolean, default: True
             Synchronize external indexes (`new_index`, `new_columns`) with internal indexes.
+            This could be used when you're certain that the indices in partitions are equal to
+            the provided hints in order to save time on syncing them.
 
         Returns
         -------

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
@@ -143,7 +143,7 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
         PandasOnPythonDataframePartition
             New ``PandasOnPythonDataframePartition`` object.
         """
-        return cls(obj.copy())
+        return cls(obj.copy(), len(obj.index), len(obj.columns))
 
     @classmethod
     def preprocess_func(cls, func):

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -5095,7 +5095,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
                     new_index=self._modin_frame._index_cache,
                     new_columns=self._modin_frame._columns_cache,
                     keep_partitioning=False,
-                    synchronize=False,
+                    sync_labels=False,
                 )
             )
         return new_query_compiler

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -5090,7 +5090,12 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         for _ax in axes:
             new_query_compiler = new_query_compiler.__constructor__(
                 new_query_compiler._modin_frame.apply_full_axis(
-                    _ax, lambda df: df, keep_partitioning=False
+                    _ax,
+                    lambda df: df,
+                    new_index=self._modin_frame._index_cache,
+                    new_columns=self._modin_frame._columns_cache,
+                    keep_partitioning=False,
+                    synchronize=False,
                 )
             )
         return new_query_compiler

--- a/modin/pandas/test/internals/test_repartition.py
+++ b/modin/pandas/test/internals/test_repartition.py
@@ -12,6 +12,7 @@
 # governing permissions and limitations under the License.
 
 import pytest
+import numpy as np
 
 import modin.pandas as pd
 from modin.config import NPartitions
@@ -46,15 +47,22 @@ def test_repartition(axis, dtype):
 
     if dtype == "DataFrame":
         results = {
-            None: (1, 1),
-            0: (1, 2),
-            1: (2, 1),
+            None: ([4, 0, 0, 0], [3, 0, 0, 0]),
+            0: ([4, 0, 0, 0], [2, 1]),
+            1: ([2, 2], [3, 0, 0, 0]),
         }
     else:
         results = {
-            None: (1, 1),
-            0: (1, 1),
-            1: (2, 1),
+            None: ([4, 0, 0, 0], [1]),
+            0: ([4, 0, 0, 0], [1]),
+            1: ([2, 2], [1]),
         }
-
-    assert obj._query_compiler._modin_frame._partitions.shape == results[axis]
+    # in some cases empty partitions aren't filtered so it's better to use
+    # `row_lengths` and `column_widths` to check the result of repartitioning
+    # than `._partitions.shape`.
+    assert np.array_equal(
+        obj._query_compiler._modin_frame.row_lengths, results[axis][0]
+    )
+    assert np.array_equal(
+        obj._query_compiler._modin_frame.column_widths, results[axis][1]
+    )

--- a/modin/pandas/test/internals/test_repartition.py
+++ b/modin/pandas/test/internals/test_repartition.py
@@ -47,14 +47,14 @@ def test_repartition(axis, dtype):
 
     if dtype == "DataFrame":
         results = {
-            None: ([4, 0, 0, 0], [3, 0, 0, 0]),
-            0: ([4, 0, 0, 0], [2, 1]),
-            1: ([2, 2], [3, 0, 0, 0]),
+            None: ([4], [3]),
+            0: ([4], [2, 1]),
+            1: ([2, 2], [3]),
         }
     else:
         results = {
-            None: ([4, 0, 0, 0], [1]),
-            0: ([4, 0, 0, 0], [1]),
+            None: ([4], [1]),
+            0: ([4], [1]),
             1: ([2, 2], [1]),
         }
     # in some cases empty partitions aren't filtered so it's better to use

--- a/modin/pandas/test/internals/test_repartition.py
+++ b/modin/pandas/test/internals/test_repartition.py
@@ -12,7 +12,6 @@
 # governing permissions and limitations under the License.
 
 import pytest
-import numpy as np
 
 import modin.pandas as pd
 from modin.config import NPartitions
@@ -47,22 +46,15 @@ def test_repartition(axis, dtype):
 
     if dtype == "DataFrame":
         results = {
-            None: ([4], [3]),
-            0: ([4], [2, 1]),
-            1: ([2, 2], [3]),
+            None: (1, 1),
+            0: (1, 2),
+            1: (2, 1),
         }
     else:
         results = {
-            None: ([4], [1]),
-            0: ([4], [1]),
-            1: ([2, 2], [1]),
+            None: (1, 1),
+            0: (1, 1),
+            1: (2, 1),
         }
-    # in some cases empty partitions aren't filtered so it's better to use
-    # `row_lengths` and `column_widths` to check the result of repartitioning
-    # than `._partitions.shape`.
-    assert np.array_equal(
-        obj._query_compiler._modin_frame.row_lengths, results[axis][0]
-    )
-    assert np.array_equal(
-        obj._query_compiler._modin_frame.column_widths, results[axis][1]
-    )
+
+    assert obj._query_compiler._modin_frame._partitions.shape == results[axis]


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5551 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
