### PR TITLE
PERF-#5550: Don't trigger axes computation in `to_pandas` function

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3230,16 +3230,15 @@ class PandasDataframe(ClassLogger):
         if df.empty:
             df = pandas.DataFrame(columns=self.columns, index=self.index)
         else:
-            if self._index_cache is not None and self._columns_cache is not None:
+            for axis, public_index in enumerate([self._index_cache, self._columns_cache]):
                 # no need to check external and internal axes since in that case
                 # external axes will be computed from internal partitions
-                for axis in [0, 1]:
+                if public_index is not None:
                     ErrorMessage.catch_bugs_and_request_email(
-                        not df.axes[axis].equals(self.axes[axis]),
+                        not df.axes[axis].equals(public_index),
                         f"Internal and external indices on axis {axis} do not match.",
                     )
-                df.index = self.index
-                df.columns = self.columns
+                    df.set_axis(axis=axis, labels=public_index, inplace=True, copy=False)
 
         return df
 

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3230,7 +3230,9 @@ class PandasDataframe(ClassLogger):
         if df.empty:
             df = pandas.DataFrame(columns=self.columns, index=self.index)
         else:
-            for axis, public_index in enumerate([self._index_cache, self._columns_cache]):
+            for axis, public_index in enumerate(
+                [self._index_cache, self._columns_cache]
+            ):
                 # no need to check external and internal axes since in that case
                 # external axes will be computed from internal partitions
                 if public_index is not None:
@@ -3238,7 +3240,9 @@ class PandasDataframe(ClassLogger):
                         not df.axes[axis].equals(public_index),
                         f"Internal and external indices on axis {axis} do not match.",
                     )
-                    df.set_axis(axis=axis, labels=public_index, inplace=True, copy=False)
+                    df.set_axis(
+                        axis=axis, labels=public_index, inplace=True, copy=False
+                    )
 
         return df
 

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3240,6 +3240,9 @@ class PandasDataframe(ClassLogger):
                         not df.axes[axis].equals(external_index),
                         f"Internal and external indices on axis {axis} do not match.",
                     )
+                    # have to do this in order to assign some potentially missing metadata,
+                    # the ones that were set to the external index but were never propagated
+                    # into the internal ones
                     df.set_axis(
                         axis=axis, labels=external_index, inplace=True, copy=False
                     )

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3230,18 +3230,18 @@ class PandasDataframe(ClassLogger):
         if df.empty:
             df = pandas.DataFrame(columns=self.columns, index=self.index)
         else:
-            for axis, public_index in enumerate(
+            for axis, external_index in enumerate(
                 [self._index_cache, self._columns_cache]
             ):
                 # no need to check external and internal axes since in that case
                 # external axes will be computed from internal partitions
-                if public_index is not None:
+                if external_index is not None:
                     ErrorMessage.catch_bugs_and_request_email(
-                        not df.axes[axis].equals(public_index),
+                        not df.axes[axis].equals(external_index),
                         f"Internal and external indices on axis {axis} do not match.",
                     )
                     df.set_axis(
-                        axis=axis, labels=public_index, inplace=True, copy=False
+                        axis=axis, labels=external_index, inplace=True, copy=False
                     )
 
         return df

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3230,13 +3230,16 @@ class PandasDataframe(ClassLogger):
         if df.empty:
             df = pandas.DataFrame(columns=self.columns, index=self.index)
         else:
-            for axis in [0, 1]:
-                ErrorMessage.catch_bugs_and_request_email(
-                    not df.axes[axis].equals(self.axes[axis]),
-                    f"Internal and external indices on axis {axis} do not match.",
-                )
-            df.index = self.index
-            df.columns = self.columns
+            if self._index_cache is not None and self._columns_cache is not None:
+                # no need to check external and internal axes since in that case
+                # external axes will be computed from internal partitions
+                for axis in [0, 1]:
+                    ErrorMessage.catch_bugs_and_request_email(
+                        not df.axes[axis].equals(self.axes[axis]),
+                        f"Internal and external indices on axis {axis} do not match.",
+                    )
+                df.index = self.index
+                df.columns = self.columns
 
         return df
 


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5550 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
