### PR TITLE
PERF-#5557: Don't trigger axes computation in `pivot_table`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2678,9 +2678,11 @@ class PandasDataframe(ClassLogger):
         kw = {}
         if dtypes == "copy":
             kw["dtypes"] = self._dtypes
-        elif dtypes is not None:
+        elif dtypes is not None and new_columns is not None:
+            # Replacement is not one to one, need to figure out how to save
+            # this information when the columns are not known
             kw["dtypes"] = pandas.Series(
-                [np.dtype(dtypes)] * len(kw["columns"]), index=kw["columns"]
+                [np.dtype(dtypes)] * new_columns, index=new_columns
             )
         result = self.__constructor__(
             new_partitions, index=new_index, columns=new_columns, **kw

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2679,9 +2679,13 @@ class PandasDataframe(ClassLogger):
         if dtypes == "copy":
             kw["dtypes"] = self._dtypes
         elif dtypes is not None:
-            columns = new_columns if new_columns is not None else self.columns
+            if new_columns is None:
+                (
+                    new_columns,
+                    kw["column_widths"],
+                ) = self._compute_axis_labels_and_lengths(1, new_partitions)
             kw["dtypes"] = pandas.Series(
-                [np.dtype(dtypes)] * len(columns), index=columns
+                [np.dtype(dtypes)] * len(new_columns), index=new_columns
             )
         result = self.__constructor__(
             new_partitions, index=new_index, columns=new_columns, **kw

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2686,7 +2686,7 @@ class PandasDataframe(ClassLogger):
             enumerate_partitions=enumerate_partitions,
             keep_partitioning=keep_partitioning,
         )
-        kw = {}
+        kw = {"row_lengths": None, "column_widths": None}
         if dtypes == "copy":
             kw["dtypes"] = self._dtypes
         elif dtypes is not None:

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2678,7 +2678,7 @@ class PandasDataframe(ClassLogger):
         kw = {}
         if dtypes == "copy":
             kw["dtypes"] = self._dtypes
-        elif dtypes is not None and new_columns is not None:
+        elif dtypes is not None:
             columns = new_columns if new_columns is not None else self.columns
             kw["dtypes"] = pandas.Series(
                 [np.dtype(dtypes)] * len(columns), index=columns

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2682,7 +2682,7 @@ class PandasDataframe(ClassLogger):
             # Replacement is not one to one, need to figure out how to save
             # this information when the columns are not known
             kw["dtypes"] = pandas.Series(
-                [np.dtype(dtypes)] * new_columns, index=new_columns
+                [np.dtype(dtypes)] * len(new_columns), index=new_columns
             )
         result = self.__constructor__(
             new_partitions, index=new_index, columns=new_columns, **kw

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2675,15 +2675,16 @@ class PandasDataframe(ClassLogger):
             enumerate_partitions=enumerate_partitions,
             keep_partitioning=keep_partitioning,
         )
-        # Index objects for new object creation. This is shorter than if..else
-        kw = self.__make_init_labels_args(new_partitions, new_index, new_columns)
+        kw = {}
         if dtypes == "copy":
             kw["dtypes"] = self._dtypes
         elif dtypes is not None:
             kw["dtypes"] = pandas.Series(
                 [np.dtype(dtypes)] * len(kw["columns"]), index=kw["columns"]
             )
-        result = self.__constructor__(new_partitions, **kw)
+        result = self.__constructor__(
+            new_partitions, index=new_index, columns=new_columns, **kw
+        )
         if new_index is not None:
             result.synchronize_labels(axis=0)
         if new_columns is not None:

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2679,10 +2679,9 @@ class PandasDataframe(ClassLogger):
         if dtypes == "copy":
             kw["dtypes"] = self._dtypes
         elif dtypes is not None and new_columns is not None:
-            # Replacement is not one to one, need to figure out how to save
-            # this information when the columns are not known
+            columns = new_columns if new_columns is not None else self.columns
             kw["dtypes"] = pandas.Series(
-                [np.dtype(dtypes)] * len(new_columns), index=new_columns
+                [np.dtype(dtypes)] * len(columns), index=columns
             )
         result = self.__constructor__(
             new_partitions, index=new_index, columns=new_columns, **kw

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3155,6 +3155,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
             to_group = self.drop(columns=unique_keys)
 
         keys_columns = self.getitem_column_array(unique_keys)
+        len_values = len(values)
+        if len_values == 0:
+            len_values = len(self.columns.drop(unique_keys))
 
         def applyier(df, other):
             """
@@ -3188,13 +3191,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 sort=sort,
             )
 
-            new_values = values
-            if len(values) == 0:
-                new_values = df.columns.drop(unique_keys)
-
             # if only one value is specified, removing level that maps
             # columns from `values` to the actual values
-            if len(index) > 0 and len(new_values) == 1 and result.columns.nlevels > 1:
+            if len(index) > 0 and len_values == 1 and result.columns.nlevels > 1:
                 result.columns = result.columns.droplevel(int(margins))
 
             # in that case Pandas transposes the result of `pivot_table`,

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3188,12 +3188,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 sort=sort,
             )
 
+            new_values = values
             if len(values) == 0:
-                values = df.columns.drop(unique_keys)
+                new_values = df.columns.drop(unique_keys)
 
             # if only one value is specified, removing level that maps
             # columns from `values` to the actual values
-            if len(index) > 0 and len(values) == 1 and result.columns.nlevels > 1:
+            if len(index) > 0 and len(new_values) == 1 and result.columns.nlevels > 1:
                 result.columns = result.columns.droplevel(int(margins))
 
             # in that case Pandas transposes the result of `pivot_table`,

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3188,6 +3188,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 sort=sort,
             )
 
+            if len(values) == 0:
+                values = df.columns.drop(unique_keys)
+
+            # if only one value is specified, removing level that maps
+            # columns from `values` to the actual values
+            if len(index) > 0 and len(values) == 1 and result.columns.nlevels > 1:
+                result.columns = result.columns.droplevel(int(margins))
+
             # in that case Pandas transposes the result of `pivot_table`,
             # transposing it back to be consistent with column axis values along
             # different partitions
@@ -3205,14 +3213,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
         # transposing the result again, to be consistent with Pandas result
         if len(index) == 0 and len(columns) > 0:
             result = result.transpose()
-
-        if len(values) == 0:
-            values = self.columns.drop(unique_keys)
-
-        # if only one value is specified, removing level that maps
-        # columns from `values` to the actual values
-        if len(index) > 0 and len(values) == 1 and result.columns.nlevels > 1:
-            result.columns = result.columns.droplevel(int(margins))
 
         return result
 

--- a/modin/pandas/test/internals/test_repartition.py
+++ b/modin/pandas/test/internals/test_repartition.py
@@ -12,6 +12,7 @@
 # governing permissions and limitations under the License.
 
 import pytest
+import numpy as np
 
 import modin.pandas as pd
 from modin.config import NPartitions
@@ -46,15 +47,23 @@ def test_repartition(axis, dtype):
 
     if dtype == "DataFrame":
         results = {
-            None: (1, 1),
-            0: (1, 2),
-            1: (2, 1),
+            None: ([4, 0, 0, 0], [3, 0, 0, 0]),
+            0: ([4, 0, 0, 0], [2, 1]),
+            1: ([2, 2], [3, 0, 0, 0]),
         }
     else:
         results = {
-            None: (1, 1),
-            0: (1, 1),
-            1: (2, 1),
+            None: ([4, 0, 0, 0], [1]),
+            0: ([4, 0, 0, 0], [1]),
+            1: ([2, 2], [1]),
         }
 
-    assert obj._query_compiler._modin_frame._partitions.shape == results[axis]
+    # in some cases empty partitions aren't filtered so it's better to use
+    # `row_lengths` and `column_widths` to check the result of repartitioning
+    # than `._partitions.shape`.
+    assert np.array_equal(
+        obj._query_compiler._modin_frame.row_lengths, results[axis][0]
+    )
+    assert np.array_equal(
+        obj._query_compiler._modin_frame.column_widths, results[axis][1]
+    )

--- a/modin/pandas/test/internals/test_repartition.py
+++ b/modin/pandas/test/internals/test_repartition.py
@@ -12,7 +12,6 @@
 # governing permissions and limitations under the License.
 
 import pytest
-import numpy as np
 
 import modin.pandas as pd
 from modin.config import NPartitions
@@ -47,23 +46,15 @@ def test_repartition(axis, dtype):
 
     if dtype == "DataFrame":
         results = {
-            None: ([4, 0, 0, 0], [3, 0, 0, 0]),
-            0: ([4, 0, 0, 0], [2, 1]),
-            1: ([2, 2], [3, 0, 0, 0]),
+            None: (1, 1),
+            0: (1, 2),
+            1: (2, 1),
         }
     else:
         results = {
-            None: ([4, 0, 0, 0], [1]),
-            0: ([4, 0, 0, 0], [1]),
-            1: ([2, 2], [1]),
+            None: (1, 1),
+            0: (1, 1),
+            1: (2, 1),
         }
 
-    # in some cases empty partitions aren't filtered so it's better to use
-    # `row_lengths` and `column_widths` to check the result of repartitioning
-    # than `._partitions.shape`.
-    assert np.array_equal(
-        obj._query_compiler._modin_frame.row_lengths, results[axis][0]
-    )
-    assert np.array_equal(
-        obj._query_compiler._modin_frame.column_widths, results[axis][1]
-    )
+    assert obj._query_compiler._modin_frame._partitions.shape == results[axis]


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5557 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
