### PR TITLE
PERF-#5575: Don't trigger axes computation in `reset_index` function

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2684,13 +2684,13 @@ class PandasDataframe(ClassLogger):
         apply_func_args = None
         if pass_cols_to_partitions:
             apply_func_args = (
-                self._columns_cache
+                [self._columns_cache]
                 if self._columns_cache is not None
                 else self._partition_mgr_cls.get_indices(
                     axis=1,
                     partitions=self._partitions,
                     materialize=False,
-                )[1],
+                )[1]
             )
 
         new_partitions = self._partition_mgr_cls.broadcast_axis_partitions(

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2192,6 +2192,7 @@ class PandasDataframe(ClassLogger):
         dtypes=None,
         keep_partitioning=True,
         sync_labels=True,
+        pass_axis_lengths_to_partitions=False,
     ):
         """
         Perform a function across an entire axis.
@@ -2219,6 +2220,9 @@ class PandasDataframe(ClassLogger):
             Synchronize external indexes (`new_index`, `new_columns`) with internal indexes.
             This could be used when you're certain that the indices in partitions are equal to
             the provided hints in order to save time on syncing them.
+        pass_axis_lengths_to_partitions : bool, default: False
+            Whether pass partition lengths along `axis ^ 1` to the kernel `func`.
+            Note that `func` must be able to obtain `df, *axis_lengths`.
 
         Returns
         -------
@@ -2238,6 +2242,7 @@ class PandasDataframe(ClassLogger):
             other=None,
             keep_partitioning=keep_partitioning,
             sync_labels=sync_labels,
+            pass_axis_lengths_to_partitions=pass_axis_lengths_to_partitions,
         )
 
     @lazy_metadata_decorator(apply_axis="both")

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2681,6 +2681,18 @@ class PandasDataframe(ClassLogger):
                 axis ^ 1, numeric_indices
             ).keys()
 
+        apply_func_args = None
+        if pass_cols_to_partitions:
+            apply_func_args = (
+                self._columns_cache
+                if self._columns_cache is not None
+                else self._partition_mgr_cls.get_indices(
+                    axis=1,
+                    partitions=self._partitions,
+                    materialize=False,
+                )[1],
+            )
+
         new_partitions = self._partition_mgr_cls.broadcast_axis_partitions(
             axis=axis,
             left=self._partitions,
@@ -2689,7 +2701,7 @@ class PandasDataframe(ClassLogger):
             apply_indices=apply_indices,
             enumerate_partitions=enumerate_partitions,
             keep_partitioning=keep_partitioning,
-            pass_cols_to_partitions=pass_cols_to_partitions,
+            apply_func_args=apply_func_args,
         )
         kw = {"row_lengths": None, "column_widths": None}
         if dtypes == "copy":

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2663,7 +2663,7 @@ class PandasDataframe(ClassLogger):
             the provided hints in order to save time on syncing them.
         pass_cols_to_partitions : bool, default: False
             Whether pass columns into applied `func` or not.
-            Note that `func` must be able to obtain `*columns` arg.
+            Note that `func` must be able to obtain `df, *columns`.
 
         Returns
         -------

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2626,7 +2626,7 @@ class PandasDataframe(ClassLogger):
         dtypes=None,
         keep_partitioning=True,
         sync_labels=True,
-        give_columns=False,
+        pass_cols_to_partitions=False,
     ):
         """
         Broadcast partitions of `other` Modin DataFrame and apply a function along full axis.
@@ -2661,6 +2661,9 @@ class PandasDataframe(ClassLogger):
             Synchronize external indexes (`new_index`, `new_columns`) with internal indexes.
             This could be used when you're certain that the indices in partitions are equal to
             the provided hints in order to save time on syncing them.
+        pass_cols_to_partitions : bool, default: False
+            Whether pass columns into applied `func` or not.
+            Note that `func` must be able to obtain `*columns` arg.
 
         Returns
         -------
@@ -2686,7 +2689,7 @@ class PandasDataframe(ClassLogger):
             apply_indices=apply_indices,
             enumerate_partitions=enumerate_partitions,
             keep_partitioning=keep_partitioning,
-            give_columns=give_columns,
+            pass_cols_to_partitions=pass_cols_to_partitions,
         )
         # Index objects for new object creation. This is shorter than if..else
         kw = self.__make_init_labels_args(new_partitions, new_index, new_columns)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2662,7 +2662,7 @@ class PandasDataframe(ClassLogger):
             This could be used when you're certain that the indices in partitions are equal to
             the provided hints in order to save time on syncing them.
         pass_axis_lengths_to_partitions : bool, default: False
-            Whether pass columns into applied `func` or not.
+            Whether pass partition lengths along `axis ^ 1` to the kernel `func`.
             Note that `func` must be able to obtain `df, *axis_lengths`.
 
         Returns

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2619,6 +2619,7 @@ class PandasDataframe(ClassLogger):
         enumerate_partitions=False,
         dtypes=None,
         keep_partitioning=True,
+        give_columns=False,
     ):
         """
         Broadcast partitions of `other` Modin DataFrame and apply a function along full axis.
@@ -2674,6 +2675,7 @@ class PandasDataframe(ClassLogger):
             apply_indices=apply_indices,
             enumerate_partitions=enumerate_partitions,
             keep_partitioning=keep_partitioning,
+            give_columns=give_columns,
         )
         # Index objects for new object creation. This is shorter than if..else
         kw = self.__make_init_labels_args(new_partitions, new_index, new_columns)

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -315,7 +315,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         ----------
         materialize : bool, default: True
             Whether to forcibly materialize the result into an integer. If ``False``
-            was specified may return a future of the result if it hasn't been
+            was specified, may return a future of the result if it hasn't been
             materialized yet.
 
         Returns
@@ -335,7 +335,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         ----------
         materialize : bool, default: True
             Whether to forcibly materialize the result into an integer. If ``False``
-            was specified may return a future of the result if it hasn't been
+            was specified, may return a future of the result if it hasn't been
             materialized yet.
 
         Returns

--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -307,26 +307,40 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         """
         return width_fn_pandas
 
-    def length(self):
+    def length(self, materialize=True):
         """
         Get the length of the object wrapped by this partition.
 
+        Parameters
+        ----------
+        materialize : bool, default: True
+            Whether to forcibly materialize the result into an integer. If ``False``
+            was specified may return a future of the result if it hasn't been
+            materialized yet.
+
         Returns
         -------
-        int
+        int or its Future
             The length of the object.
         """
         if self._length_cache is None:
             self._length_cache = self.apply(self._length_extraction_fn()).get()
         return self._length_cache
 
-    def width(self):
+    def width(self, materialize=True):
         """
         Get the width of the object wrapped by the partition.
 
+        Parameters
+        ----------
+        materialize : bool, default: True
+            Whether to forcibly materialize the result into an integer. If ``False``
+            was specified may return a future of the result if it hasn't been
+            materialized yet.
+
         Returns
         -------
-        int
+        int or its Future
             The width of the object.
         """
         if self._width_cache is None:

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -445,7 +445,6 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         else:
             num_splits = NPartitions.get()
         preprocessed_map_func = cls.preprocess_func(apply_func)
-
         left_partitions = cls.axis_partition(left, axis)
         right_partitions = None if right is None else cls.axis_partition(right, axis)
         # For mapping across the entire axis, we don't maintain partitioning because we

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -444,10 +444,10 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
         give_columns = kwargs.pop("give_columns", False)
         if give_columns:
-            index_func = lambda df: df.columns  # noqa: E731
-            func = cls.preprocess_func(index_func)
-            new_idx = [idx.apply(func) for idx in left[0]]
-            columns_idx = [index._data for index in new_idx]
+            column_func = lambda df: df.columns  # noqa: E731
+            func = cls.preprocess_func(column_func)
+            partition_cols = [part.apply(func) for part in left[0]]
+            column_refs = [col.list_of_blocks[0] for col in partition_cols]
 
         left_partitions = cls.axis_partition(left, axis)
         right_partitions = None if right is None else cls.axis_partition(right, axis)
@@ -470,7 +470,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             [
                 left_partitions[i].apply(
                     preprocessed_map_func,
-                    *(columns_idx if give_columns else []),
+                    *(column_refs if give_columns else []),
                     **kw,
                     **({"partition_idx": idx} if enumerate_partitions else {}),
                     **kwargs,

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -878,7 +878,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             A pandas Index object. None if `materialize==False`.
         list of pandas.Index or list of futures
             The list of internal indices for each partition.
-            The list of futures if `materialize==False`.
+            The list of futures if `materialize==False` and `partitions` is not empty.
 
         Notes
         -----

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -857,7 +857,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             partition.wait()
 
     @classmethod
-    def get_indices(cls, axis, partitions, index_func=None, materialize=True):
+    def get_indices(cls, axis, partitions, index_func=None):
         """
         Get the internal indices stored in the partitions.
 
@@ -869,16 +869,13 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             NumPy array with PandasDataframePartition's.
         index_func : callable, default: None
             The function to be used to extract the indices.
-        materialize : bool, default: True
-            Whether materialize indices or not.
 
         Returns
         -------
-        pandas.Index or None
-            A pandas Index object. None if `materialize==False`.
-        list of pandas.Index or list of futures
+        pandas.Index
+            A pandas Index object.
+        list of pandas.Index
             The list of internal indices for each partition.
-            The list of futures if `materialize==False` and `partitions` is not empty.
 
         Notes
         -----
@@ -893,9 +890,6 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         target = partitions.T if axis == 0 else partitions
         if len(target):
             new_idx = [idx.apply(func) for idx in target[0]]
-            if not materialize:
-                refs = [part_of_index.list_of_blocks[0] for part_of_index in new_idx]
-                return None, refs
             new_idx = cls.get_objects_from_partitions(new_idx)
         else:
             new_idx = [pandas.Index([])]

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -424,9 +424,8 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             Note that `apply_func` must be able to accept `partition_idx` kwarg.
         lengths : list of ints, default: None
             The list of lengths to shuffle the object.
-        apply_func_args : bool, optional
-            Whether pass extra args to `func` or not.
-            Note that `func` must be able to obtain `df, *args`.
+        apply_func_args : list-like, optional
+            Positional arguments to pass to the `func`.
         **kwargs : dict
             Additional options that could be used by different engines.
 

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
@@ -236,12 +236,12 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         ----------
         materialize : bool, default: True
             Whether to forcibly materialize the result into an integer. If ``False``
-            was specified may return a future of the result if it hasn't been
+            was specified, may return a future of the result if it hasn't been
             materialized yet.
 
         Returns
         -------
-        int or its Future
+        int or distributed.Future
             The length of the object.
         """
         if self._length_cache is None:
@@ -258,12 +258,12 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         ----------
         materialize : bool, default: True
             Whether to forcibly materialize the result into an integer. If ``False``
-            was specified may return a future of the result if it hasn't been
+            was specified, may return a future of the result if it hasn't been
             materialized yet.
 
         Returns
         -------
-        int or its Future
+        int or distributed.Future
             The width of the object.
         """
         if self._width_cache is None:

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
@@ -228,33 +228,47 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         """
         return DaskWrapper.put(func, hash=False, broadcast=True)
 
-    def length(self):
+    def length(self, materialize=True):
         """
         Get the length of the object wrapped by this partition.
 
+        Parameters
+        ----------
+        materialize : bool, default: True
+            Whether to forcibly materialize the result into an integer. If ``False``
+            was specified may return a future of the result if it hasn't been
+            materialized yet.
+
         Returns
         -------
-        int
+        int or its Future
             The length of the object.
         """
         if self._length_cache is None:
             self._length_cache = self.apply(len)._data
-        if isinstance(self._length_cache, Future):
+        if isinstance(self._length_cache, Future) and materialize:
             self._length_cache = DaskWrapper.materialize(self._length_cache)
         return self._length_cache
 
-    def width(self):
+    def width(self, materialize=True):
         """
         Get the width of the object wrapped by the partition.
 
+        Parameters
+        ----------
+        materialize : bool, default: True
+            Whether to forcibly materialize the result into an integer. If ``False``
+            was specified may return a future of the result if it hasn't been
+            materialized yet.
+
         Returns
         -------
-        int
+        int or its Future
             The width of the object.
         """
         if self._width_cache is None:
             self._width_cache = self.apply(lambda df: len(df.columns))._data
-        if isinstance(self._width_cache, Future):
+        if isinstance(self._width_cache, Future) and materialize:
             self._width_cache = DaskWrapper.materialize(self._width_cache)
         return self._width_cache
 

--- a/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
@@ -186,7 +186,7 @@ class cuDFOnRayDataframePartition(PandasDataframePartition):
         ----------
         materialize : bool, default: True
             Whether to forcibly materialize the result into an integer. If ``False``
-            was specified may return a future of the result if it hasn't been
+            was specified, may return a future of the result if it hasn't been
             materialized yet.
 
         Returns
@@ -209,7 +209,7 @@ class cuDFOnRayDataframePartition(PandasDataframePartition):
         ----------
         materialize : bool, default: True
             Whether to forcibly materialize the result into an integer. If ``False``
-            was specified may return a future of the result if it hasn't been
+            was specified, may return a future of the result if it hasn't been
             materialized yet.
 
         Returns

--- a/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition.py
@@ -182,6 +182,13 @@ class cuDFOnRayDataframePartition(PandasDataframePartition):
         """
         Get the length of the object wrapped by this partition.
 
+        Parameters
+        ----------
+        materialize : bool, default: True
+            Whether to forcibly materialize the result into an integer. If ``False``
+            was specified may return a future of the result if it hasn't been
+            materialized yet.
+
         Returns
         -------
         int or ray.ObjectRef
@@ -197,6 +204,13 @@ class cuDFOnRayDataframePartition(PandasDataframePartition):
     def width(self, materialize=True):
         """
         Get the width of the object wrapped by this partition.
+
+        Parameters
+        ----------
+        materialize : bool, default: True
+            Whether to forcibly materialize the result into an integer. If ``False``
+            was specified may return a future of the result if it hasn't been
+            materialized yet.
 
         Returns
         -------

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -270,7 +270,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         ----------
         materialize : bool, default: True
             Whether to forcibly materialize the result into an integer. If ``False``
-            was specified may return a future of the result if it hasn't been
+            was specified, may return a future of the result if it hasn't been
             materialized yet.
 
         Returns
@@ -297,7 +297,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         ----------
         materialize : bool, default: True
             Whether to forcibly materialize the result into an integer. If ``False``
-            was specified may return a future of the result if it hasn't been
+            was specified, may return a future of the result if it hasn't been
             materialized yet.
 
         Returns

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -262,13 +262,20 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         """
         return ray.put(func)
 
-    def length(self):
+    def length(self, materialize=True):
         """
         Get the length of the object wrapped by this partition.
 
+        Parameters
+        ----------
+        materialize : bool, default: True
+            Whether to forcibly materialize the result into an integer. If ``False``
+            was specified may return a future of the result if it hasn't been
+            materialized yet.
+
         Returns
         -------
-        int
+        int or ray.ObjectRef
             The length of the object.
         """
         if self._length_cache is None:
@@ -278,17 +285,24 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 self._length_cache, self._width_cache = _get_index_and_columns.remote(
                     self._data
                 )
-        if isinstance(self._length_cache, ObjectIDType):
+        if isinstance(self._length_cache, ObjectIDType) and materialize:
             self._length_cache = RayWrapper.materialize(self._length_cache)
         return self._length_cache
 
-    def width(self):
+    def width(self, materialize=True):
         """
         Get the width of the object wrapped by the partition.
 
+        Parameters
+        ----------
+        materialize : bool, default: True
+            Whether to forcibly materialize the result into an integer. If ``False``
+            was specified may return a future of the result if it hasn't been
+            materialized yet.
+
         Returns
         -------
-        int
+        int or ray.ObjectRef
             The width of the object.
         """
         if self._width_cache is None:
@@ -298,7 +312,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 self._length_cache, self._width_cache = _get_index_and_columns.remote(
                     self._data
                 )
-        if isinstance(self._width_cache, ObjectIDType):
+        if isinstance(self._width_cache, ObjectIDType) and materialize:
             self._width_cache = RayWrapper.materialize(self._width_cache)
         return self._width_cache
 

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -237,13 +237,20 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
         """
         return unidist.put(func)
 
-    def length(self):
+    def length(self, materialize=True):
         """
         Get the length of the object wrapped by this partition.
 
+        Parameters
+        ----------
+        materialize : bool, default: True
+            Whether to forcibly materialize the result into an integer. If ``False``
+            was specified may return a future of the result if it hasn't been
+            materialized yet.
+
         Returns
         -------
-        int
+        int or its Future
             The length of the object.
         """
         if self._length_cache is None:
@@ -254,17 +261,24 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
                     self._length_cache,
                     self._width_cache,
                 ) = _get_index_and_columns_size.remote(self._data)
-        if unidist.is_object_ref(self._length_cache):
+        if unidist.is_object_ref(self._length_cache) and materialize:
             self._length_cache = UnidistWrapper.materialize(self._length_cache)
         return self._length_cache
 
-    def width(self):
+    def width(self, materialize=True):
         """
         Get the width of the object wrapped by the partition.
 
+        Parameters
+        ----------
+        materialize : bool, default: True
+            Whether to forcibly materialize the result into an integer. If ``False``
+            was specified may return a future of the result if it hasn't been
+            materialized yet.
+
         Returns
         -------
-        int
+        int or its Future
             The width of the object.
         """
         if self._width_cache is None:
@@ -275,7 +289,7 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
                     self._length_cache,
                     self._width_cache,
                 ) = _get_index_and_columns_size.remote(self._data)
-        if unidist.is_object_ref(self._width_cache):
+        if unidist.is_object_ref(self._width_cache) and materialize:
             self._width_cache = UnidistWrapper.materialize(self._width_cache)
         return self._width_cache
 

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -245,12 +245,12 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
         ----------
         materialize : bool, default: True
             Whether to forcibly materialize the result into an integer. If ``False``
-            was specified may return a future of the result if it hasn't been
+            was specified, may return a future of the result if it hasn't been
             materialized yet.
 
         Returns
         -------
-        int or its Future
+        int or unidist.ObjectRef
             The length of the object.
         """
         if self._length_cache is None:
@@ -273,12 +273,12 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
         ----------
         materialize : bool, default: True
             Whether to forcibly materialize the result into an integer. If ``False``
-            was specified may return a future of the result if it hasn't been
+            was specified, may return a future of the result if it hasn't been
             materialized yet.
 
         Returns
         -------
-        int or its Future
+        int or unidist.ObjectRef
             The width of the object.
         """
         if self._width_cache is None:

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -540,7 +540,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def reset_index(self, **kwargs):
         if self._modin_frame._index_cache is None:
 
-            def _reset(df, *columns_idx, partition_idx):
+            def _reset(df, *columns, partition_idx):
                 _kw = dict(kwargs)
                 if len(columns_idx) > 1 and partition_idx == 0:
                     old_cols = columns[0].append(columns[1:])

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -567,9 +567,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     func=_reset,
                     other=None,
                     enumerate_partitions=True,
-                    pass_axis_lengths_to_partitions=True,
                     new_columns=new_columns,
                     sync_labels=False,
+                    pass_axis_lengths_to_partitions=True,
                 )
             )
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -542,7 +542,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
             def _reset(df, *columns, partition_idx):
                 _kw = dict(kwargs)
-                if len(columns_idx) > 1 and partition_idx == 0:
+                if len(columns) > 1 and partition_idx == 0:
                     old_cols = columns[0].append(columns[1:])
                     new_cols = (
                         pandas.DataFrame(index=df.index, columns=old_cols)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -544,7 +544,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if self._modin_frame._index_cache is None:
 
             def _reset(df, *columns, partition_idx):
-                _kw = dict(kwargs)
+                kw = dict(kwargs)
                 if len(columns) > 0 and partition_idx == 0:
                     old_cols = columns[0].append(columns[1:])
                     new_cols = (
@@ -552,13 +552,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
                         .reset_index(**kwargs)
                         .columns
                     )
-                    cols_diff_len = len(new_cols) - len(old_cols)
+                    num_inserted_cols = len(new_cols) - len(old_cols)
 
                 if partition_idx != 0:
-                    _kw["drop"] = True
-                result = df.reset_index(**_kw)
+                    kw["drop"] = True
+                result = df.reset_index(**kw)
                 if len(columns) > 0 and partition_idx == 0:
-                    result.columns = new_cols[: len(df.columns) + cols_diff_len]
+                    result.columns = new_cols[: len(df.columns) + num_inserted_cols]
                 return result
 
             return self.__constructor__(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -538,6 +538,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
         return self.__constructor__(new_modin_frame)
 
     def reset_index(self, **kwargs):
+        if self._modin_frame._index_cache is None:
+            new_self = Map.register(
+                lambda df, *args, **kwargs: df.reset_index(**kwargs)
+            )(self, **kwargs)
+            return new_self
+
         allow_duplicates = kwargs.pop("allow_duplicates", no_default)
         names = kwargs.pop("names", None)
         if allow_duplicates not in (no_default, False) or names is not None:

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -556,7 +556,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     # depending on the column names, pandas may change the index name
                     # when setting it as a column. For example, `level_0` instead of `index`.
                     new_cols = (
-                        pandas.DataFrame(index=df.index, columns=old_cols)
+                        pandas.DataFrame(index=df.index[:1], columns=old_cols)
                         .reset_index(**kwargs)
                         .columns
                     )

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -564,7 +564,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     func=_reset,
                     other=None,
                     enumerate_partitions=True,
-                    give_columns=True,
+                    pass_cols_to_partitions=True,
                 )
             )
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -543,20 +543,20 @@ class PandasQueryCompiler(BaseQueryCompiler):
             def _reset(df, *columns_idx, partition_idx):
                 _kw = dict(kwargs)
                 if len(columns_idx) > 1 and partition_idx == 0:
-                    idx = columns_idx[0].append(columns_idx[1:])
-                    cols = (
-                        pandas.DataFrame(index=df.index, columns=idx)
+                    old_cols = columns[0].append(columns[1:])
+                    new_cols = (
+                        pandas.DataFrame(index=df.index, columns=old_cols)
                         .reset_index(**kwargs)
                         .columns
                     )
-                    len_new_cols = len(cols) - len(idx)
+                    cols_diff_len = len(new_cols) - len(old_cols)
 
                 if partition_idx != 0:
                     _kw["drop"] = True
-                res = df.reset_index(**_kw)
-                if len(columns_idx) > 1 and partition_idx == 0:
-                    res.columns = cols[: len(columns_idx[0]) + len_new_cols]
-                return res
+                result = df.reset_index(**_kw)
+                if len(columns) > 1 and partition_idx == 0:
+                    result.columns = new_cols[: len(columns[0]) + cols_diff_len]
+                return result
 
             return self.__constructor__(
                 self._modin_frame.broadcast_apply_full_axis(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -541,7 +541,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         return self.__constructor__(new_modin_frame)
 
     def reset_index(self, **kwargs):
-        if self._modin_frame._index_cache is None:
+        if self.lazy_execution:
 
             def _reset(df, *partition_columns, partition_idx):
                 kw = dict(kwargs)
@@ -583,15 +583,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 )
             )
 
-        # Error checking for matching pandas. Pandas does not allow you to
-        # insert a dropped index into a DataFrame if these columns already
-        # exist.
-        if (
-            not kwargs["drop"]
-            and not self.has_multiindex()
-            and all(n in self.columns for n in ["level_0", "index"])
-        ):
-            raise ValueError("cannot insert level_0, already exists")
         allow_duplicates = kwargs.pop("allow_duplicates", no_default)
         names = kwargs.pop("names", None)
         if allow_duplicates not in (no_default, False) or names is not None:

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -539,10 +539,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     def reset_index(self, **kwargs):
         if self._modin_frame._index_cache is None:
-            new_self = Map.register(
-                lambda df, *args, **kwargs: df.reset_index(**kwargs)
-            )(self, **kwargs)
-            return new_self
+            return self.__constructor__(
+                self._modin_frame.apply_full_axis(
+                    axis=0, func=lambda df: df.reset_index(**kwargs)
+                )
+            )
 
         allow_duplicates = kwargs.pop("allow_duplicates", no_default)
         names = kwargs.pop("names", None)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -545,7 +545,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
             def _reset(df, *columns, partition_idx):
                 _kw = dict(kwargs)
-                if len(columns) > 1 and partition_idx == 0:
+                if len(columns) > 0 and partition_idx == 0:
                     old_cols = columns[0].append(columns[1:])
                     new_cols = (
                         pandas.DataFrame(index=df.index, columns=old_cols)
@@ -557,8 +557,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 if partition_idx != 0:
                     _kw["drop"] = True
                 result = df.reset_index(**_kw)
-                if len(columns) > 1 and partition_idx == 0:
-                    result.columns = new_cols[: len(columns[0]) + cols_diff_len]
+                if len(columns) > 0 and partition_idx == 0:
+                    result.columns = new_cols[: len(df.columns) + cols_diff_len]
                 return result
 
             return self.__constructor__(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2389,6 +2389,16 @@ class BasePandasDataset(ClassLogger):
         Reset the index, or a level of it.
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
+        # Error checking for matching pandas. Pandas does not allow you to
+        # insert a dropped index into a DataFrame if these columns already
+        # exist.
+        if (
+            not drop
+            and not self._query_compiler.lazy_execution
+            and not self._query_compiler.has_multiindex()
+            and all(n in self.columns for n in ["level_0", "index"])
+        ):
+            raise ValueError("cannot insert level_0, already exists")
         new_query_compiler = self._query_compiler.reset_index(
             drop=drop,
             level=level,

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2393,7 +2393,8 @@ class BasePandasDataset(ClassLogger):
         # insert a dropped index into a DataFrame if these columns already
         # exist.
         if (
-            not drop
+            False  # have to avoid this check somehow
+            and not drop
             and not self._query_compiler.has_multiindex()
             and all(n in self.columns for n in ["level_0", "index"])
         ):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2389,25 +2389,14 @@ class BasePandasDataset(ClassLogger):
         Reset the index, or a level of it.
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        # Error checking for matching pandas. Pandas does not allow you to
-        # insert a dropped index into a DataFrame if these columns already
-        # exist.
-        if (
-            False  # have to avoid this check somehow
-            and not drop
-            and not self._query_compiler.has_multiindex()
-            and all(n in self.columns for n in ["level_0", "index"])
-        ):
-            raise ValueError("cannot insert level_0, already exists")
-        else:
-            new_query_compiler = self._query_compiler.reset_index(
-                drop=drop,
-                level=level,
-                col_level=col_level,
-                col_fill=col_fill,
-                allow_duplicates=allow_duplicates,
-                names=names,
-            )
+        new_query_compiler = self._query_compiler.reset_index(
+            drop=drop,
+            level=level,
+            col_level=col_level,
+            col_fill=col_fill,
+            allow_duplicates=allow_duplicates,
+            names=names,
+        )
         return self._create_or_update_from_compiler(new_query_compiler, inplace)
 
     def radd(

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1533,9 +1533,18 @@ def test_reset_index_with_named_index(index_levels_names_max_levels):
         else "NAME_OF_INDEX"
     )
     modin_df.index.name = pandas_df.index.name = index_name
+    modin_df._query_compiler._modin_frame.synchronize_labels(axis=0)
+    modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+    modin_df._query_compiler._modin_frame._index_cache = None
     df_equals(modin_df, pandas_df)
+    modin_df._query_compiler._modin_frame.synchronize_labels(axis=0)
+    modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+    modin_df._query_compiler._modin_frame._index_cache = None
     df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
 
+    modin_df._query_compiler._modin_frame.synchronize_labels(axis=0)
+    modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+    modin_df._query_compiler._modin_frame._index_cache = None
     modin_df.reset_index(drop=True, inplace=True)
     pandas_df.reset_index(drop=True, inplace=True)
     df_equals(modin_df, pandas_df)
@@ -1543,6 +1552,9 @@ def test_reset_index_with_named_index(index_levels_names_max_levels):
     modin_df = pd.DataFrame(test_data_values[0])
     pandas_df = pandas.DataFrame(test_data_values[0])
     modin_df.index.name = pandas_df.index.name = index_name
+    modin_df._query_compiler._modin_frame.synchronize_labels(axis=0)
+    modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+    modin_df._query_compiler._modin_frame._index_cache = None
     df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
 
 

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1251,15 +1251,12 @@ def test_reindex_multiindex():
     df_equals(modin_result, pandas_result)
 
 
-@pytest.mark.parametrize("use_get_indices", [False, True])
 @pytest.mark.parametrize("test_async_reset_index", [False, True])
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_reset_index(data, test_async_reset_index, use_get_indices):
+def test_reset_index(data, test_async_reset_index):
     modin_df, pandas_df = create_test_dfs(data)
     if test_async_reset_index:
         modin_df._query_compiler._modin_frame._index_cache = None
-        if use_get_indices:
-            modin_df._query_compiler._modin_frame._columns_cache = None
     modin_result = modin_df.reset_index(inplace=False)
     pandas_result = pandas_df.reset_index(inplace=False)
     df_equals(modin_result, pandas_result)
@@ -1268,8 +1265,6 @@ def test_reset_index(data, test_async_reset_index, use_get_indices):
     pd_df_cp = pandas_df.copy()
     if test_async_reset_index:
         modin_df._query_compiler._modin_frame._index_cache = None
-        if use_get_indices:
-            modin_df._query_compiler._modin_frame._columns_cache = None
     modin_df_cp.reset_index(inplace=True)
     pd_df_cp.reset_index(inplace=True)
     df_equals(modin_df_cp, pd_df_cp)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1557,13 +1557,13 @@ def test_reset_index_with_named_index(
     modin_df.index.name = pandas_df.index.name = index_name
     df_equals(modin_df, pandas_df)
     if test_async_reset_index:
-        # The change in index is not automatically handled by Modin.
+        # The change in index is not automatically handled by Modin. See #3941.
         modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
         modin_df._query_compiler._modin_frame._index_cache = None
     df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
 
     if test_async_reset_index:
-        # The change in index is not automatically handled by Modin.
+        # The change in index is not automatically handled by Modin. See #3941.
         modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
         modin_df._query_compiler._modin_frame._index_cache = None
     modin_df.reset_index(drop=True, inplace=True)
@@ -1574,7 +1574,7 @@ def test_reset_index_with_named_index(
     pandas_df = pandas.DataFrame(test_data_values[0])
     modin_df.index.name = pandas_df.index.name = index_name
     if test_async_reset_index:
-        # The change in index is not automatically handled by Modin.
+        # The change in index is not automatically handled by Modin. See #3941.
         modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
         modin_df._query_compiler._modin_frame._index_cache = None
     df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
@@ -1595,7 +1595,7 @@ def test_reset_index_metadata_update(index, test_async_reset_index):
     modin_df, pandas_df = create_test_dfs({"col0": [0, 1, 2, 3]}, index=index)
     modin_df.columns = pandas_df.columns = ["col1"]
     if test_async_reset_index:
-        # The change in index is not automatically handled by Modin.
+        # The change in index is not automatically handled by Modin. See #3941.
         modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
         modin_df._query_compiler._modin_frame._index_cache = None
     eval_general(modin_df, pandas_df, lambda df: df.reset_index())

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1251,12 +1251,15 @@ def test_reindex_multiindex():
     df_equals(modin_result, pandas_result)
 
 
+@pytest.mark.parametrize("use_get_indices", [False, True])
 @pytest.mark.parametrize("test_async_reset_index", [False, True])
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_reset_index(data, test_async_reset_index):
+def test_reset_index(data, test_async_reset_index, use_get_indices):
     modin_df, pandas_df = create_test_dfs(data)
     if test_async_reset_index:
         modin_df._query_compiler._modin_frame._index_cache = None
+        if use_get_indices:
+            modin_df._query_compiler._modin_frame._columns_cache = None
     modin_result = modin_df.reset_index(inplace=False)
     pandas_result = pandas_df.reset_index(inplace=False)
     df_equals(modin_result, pandas_result)
@@ -1265,6 +1268,8 @@ def test_reset_index(data, test_async_reset_index):
     pd_df_cp = pandas_df.copy()
     if test_async_reset_index:
         modin_df._query_compiler._modin_frame._index_cache = None
+        if use_get_indices:
+            modin_df._query_compiler._modin_frame._columns_cache = None
     modin_df_cp.reset_index(inplace=True)
     pd_df_cp.reset_index(inplace=True)
     df_equals(modin_df_cp, pd_df_cp)

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1251,17 +1251,20 @@ def test_reindex_multiindex():
     df_equals(modin_result, pandas_result)
 
 
+@pytest.mark.parametrize("test_async_reset_index", [False, True])
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_reset_index(data):
-    modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)
-
+def test_reset_index(data, test_async_reset_index):
+    modin_df, pandas_df = create_test_dfs(data)
+    if test_async_reset_index:
+        modin_df._query_compiler._modin_frame._index_cache = None
     modin_result = modin_df.reset_index(inplace=False)
     pandas_result = pandas_df.reset_index(inplace=False)
     df_equals(modin_result, pandas_result)
 
     modin_df_cp = modin_df.copy()
     pd_df_cp = pandas_df.copy()
+    if test_async_reset_index:
+        modin_df._query_compiler._modin_frame._index_cache = None
     modin_df_cp.reset_index(inplace=True)
     pd_df_cp.reset_index(inplace=True)
     df_equals(modin_df_cp, pd_df_cp)
@@ -1284,6 +1287,7 @@ def test_reset_index_multiindex_groupby(data):
     )
 
 
+@pytest.mark.parametrize("test_async_reset_index", [False, True])
 @pytest.mark.parametrize(
     "data",
     [
@@ -1372,6 +1376,7 @@ def test_reset_index_with_multi_index_no_drop(
     drop,
     multiindex_levels_names_max_levels,
     none_in_index_names,
+    test_async_reset_index,
 ):
     data_rows = len(data[list(data.keys())[0]])
     index = generate_multiindex(data_rows, nlevels=nlevels)
@@ -1429,9 +1434,12 @@ def test_reset_index_with_multi_index_no_drop(
         kwargs["col_level"] = col_level
     if col_fill != "no_col_fill":
         kwargs["col_fill"] = col_fill
+    if test_async_reset_index:
+        modin_df._query_compiler._modin_frame._index_cache = None
     eval_general(modin_df, pandas_df, lambda df: df.reset_index(**kwargs))
 
 
+@pytest.mark.parametrize("test_async_reset_index", [False, True])
 @pytest.mark.parametrize(
     "data",
     [
@@ -1507,7 +1515,12 @@ def test_reset_index_with_multi_index_no_drop(
     ],
 )
 def test_reset_index_with_multi_index_drop(
-    data, nlevels, level, multiindex_levels_names_max_levels, none_in_index_names
+    data,
+    nlevels,
+    level,
+    multiindex_levels_names_max_levels,
+    none_in_index_names,
+    test_async_reset_index,
 ):
     test_reset_index_with_multi_index_no_drop(
         data,
@@ -1519,11 +1532,15 @@ def test_reset_index_with_multi_index_drop(
         True,
         multiindex_levels_names_max_levels,
         none_in_index_names,
+        test_async_reset_index,
     )
 
 
+@pytest.mark.parametrize("test_async_reset_index", [False, True])
 @pytest.mark.parametrize("index_levels_names_max_levels", [0, 1, 2])
-def test_reset_index_with_named_index(index_levels_names_max_levels):
+def test_reset_index_with_named_index(
+    index_levels_names_max_levels, test_async_reset_index
+):
     modin_df = pd.DataFrame(test_data_values[0])
     pandas_df = pandas.DataFrame(test_data_values[0])
 
@@ -1533,18 +1550,17 @@ def test_reset_index_with_named_index(index_levels_names_max_levels):
         else "NAME_OF_INDEX"
     )
     modin_df.index.name = pandas_df.index.name = index_name
-    modin_df._query_compiler._modin_frame.synchronize_labels(axis=0)
-    modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
-    modin_df._query_compiler._modin_frame._index_cache = None
     df_equals(modin_df, pandas_df)
-    modin_df._query_compiler._modin_frame.synchronize_labels(axis=0)
-    modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
-    modin_df._query_compiler._modin_frame._index_cache = None
+    if test_async_reset_index:
+        # The change in index is not automatically handled by Modin.
+        modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+        modin_df._query_compiler._modin_frame._index_cache = None
     df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
 
-    modin_df._query_compiler._modin_frame.synchronize_labels(axis=0)
-    modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
-    modin_df._query_compiler._modin_frame._index_cache = None
+    if test_async_reset_index:
+        # The change in index is not automatically handled by Modin.
+        modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+        modin_df._query_compiler._modin_frame._index_cache = None
     modin_df.reset_index(drop=True, inplace=True)
     pandas_df.reset_index(drop=True, inplace=True)
     df_equals(modin_df, pandas_df)
@@ -1552,12 +1568,14 @@ def test_reset_index_with_named_index(index_levels_names_max_levels):
     modin_df = pd.DataFrame(test_data_values[0])
     pandas_df = pandas.DataFrame(test_data_values[0])
     modin_df.index.name = pandas_df.index.name = index_name
-    modin_df._query_compiler._modin_frame.synchronize_labels(axis=0)
-    modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
-    modin_df._query_compiler._modin_frame._index_cache = None
+    if test_async_reset_index:
+        # The change in index is not automatically handled by Modin.
+        modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+        modin_df._query_compiler._modin_frame._index_cache = None
     df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
 
 
+@pytest.mark.parametrize("test_async_reset_index", [False, True])
 @pytest.mark.parametrize(
     "index",
     [
@@ -1568,10 +1586,13 @@ def test_reset_index_with_named_index(index_levels_names_max_levels):
     ],
     ids=["index", "multiindex"],
 )
-def test_reset_index_metadata_update(index):
+def test_reset_index_metadata_update(index, test_async_reset_index):
     modin_df, pandas_df = create_test_dfs({"col0": [0, 1, 2, 3]}, index=index)
     modin_df.columns = pandas_df.columns = ["col1"]
-
+    if test_async_reset_index:
+        # The change in index is not automatically handled by Modin.
+        modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+        modin_df._query_compiler._modin_frame._index_cache = None
     eval_general(modin_df, pandas_df, lambda df: df.reset_index())
 
 


### PR DESCRIPTION
Signed-off-by: Anatoly Myachev <anatoly.myachev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5575 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
