### PR TITLE
FIX-#5545: Align error-handling logic with pandas for `groupby.skew`

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2733,7 +2733,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
             # The equation for the 'skew' was taken directly from pandas:
             # https://github.com/pandas-dev/pandas/blob/8dab54d6573f7186ff0c3b6364d5e4dd635ff3e7/pandas/core/nanops.py#L1226
-            skew_res = (count * (count - 1) ** 0.5 / (count - 2)) * (m3 / m2**1.5)
+            with np.errstate(invalid="ignore", divide="ignore"):
+                skew_res = (count * (count - 1) ** 0.5 / (count - 2)) * (m3 / m2**1.5)
+
+            # Setting dummy values for invalid results in accordance with pandas
+            skew_res[m2 == 0] = 0
+            skew_res[count < 3] = np.nan
             return skew_res
 
         result = GroupByReduce.register(


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The PR aligns modin's behavior with pandas' logic on how to behave on invalid results for `groupby.skew`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5545 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

`groupby.skew()` performance hasn't changed significantly:

<details><summary>ASV benchmarks</summary>

Steps to run the benchmarks were taken from #5318

```
       before           after         ratio
     [53d9096d]       [959a3eac]
     <master>       <issue-5545>
         338±30ms         358±20ms     1.06  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1000000, 32], 'huge_amount_groups', 6)
        1.64±0.2s       1.74±0.06s     1.06  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1000000, 256], 'huge_amount_groups', 6)
        1.79±0.1s       1.89±0.08s     1.06  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([10000000, 32], 100, 6)
         871±20ms         915±50ms     1.05  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([5000, 5000], 'huge_amount_groups', 6)
          383±6ms          402±8ms     1.05  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([5000, 5000], 100)
         196±20ms         205±20ms     1.04  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1000000, 32], 100, 6)
         790±20ms         818±30ms     1.04  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([5000, 5000], 'huge_amount_groups')
         189±10ms         196±20ms     1.03  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1000000, 32], 100)
       1.92±0.07s       1.93±0.07s     1.01  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([10000000, 32], 'huge_amount_groups')
       1.34±0.03s       1.34±0.02s     1.00  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([1000000, 256], 100, 6)
         474±20ms         472±20ms     1.00  benchmarks.TimeGroupByMultiColumn.time_groupby_agg_skew([5000, 5000], 100, 6)
       1.70±0.06s       1.67±0.06s     0.98  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([10000000, 32], 100)
       1.25±0.05s       1.23±0.03s     0.98  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1000000, 256], 100)
       1.52±0.07s       1.48±0.04s     0.97  benchmarks.TimeGroupByDefaultAggregations.time_groupby_skew([1000000, 256], 'huge_amount_groups')

BENCHMARKS NOT SIGNIFICANTLY CHANGED.
```

</details>
