### PR TITLE
FIX-#5561: CalciteSerializer does not support unsigned integers

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_serializer.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_serializer.py
@@ -42,7 +42,6 @@ def _warn_if_unsigned(dtype):  # noqa: GL08
         ErrorMessage.single_warning(
             "HDK does not support unsigned integer types, such types will be rounded up to the signed equivalent."
         )
-    return True
 
 
 class CalciteSerializer:
@@ -330,7 +329,7 @@ class CalciteSerializer:
         tuple
         """
         try:
-            assert _warn_if_unsigned(int_type)
+            _warn_if_unsigned(int_type)
             return self._INT_OPTS[int_type]
         except KeyError:
             raise NotImplementedError(f"Unsupported integer type {int_type.__name__}")
@@ -349,7 +348,7 @@ class CalciteSerializer:
         dict
             Serialized data type.
         """
-        assert _warn_if_unsigned(dtype)
+        _warn_if_unsigned(dtype)
         return {"type": self._DTYPE_STRINGS[dtype.name], "nullable": True}
 
     def serialize_input_idx(self, expr):

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_serializer.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_serializer.py
@@ -38,7 +38,7 @@ import numpy as np
 
 
 def _warn_if_unsigned(dtype):  # noqa: GL08
-    if dtype in (np.uint8, np.uint16, np.uint32, np.uint64):
+    if np.issubdtype(dtype, np.unsignedinteger):
         ErrorMessage.single_warning(
             "HDK does not support unsigned integer types, such types will be rounded up to the signed equivalent."
         )
@@ -277,7 +277,7 @@ class CalciteSerializer:
                 "type_scale": -2147483648,
                 "type_precision": len(literal.val),
             }
-        if type(literal.val) in type(self)._INT_OPTS.keys():
+        if type(literal.val) in self._INT_OPTS.keys():
             target_type, precision = self.opts_for_int_type(type(literal.val))
             return {
                 "literal": int(literal.val),
@@ -331,7 +331,7 @@ class CalciteSerializer:
         """
         try:
             assert _warn_if_unsigned(int_type)
-            return type(self)._INT_OPTS[int_type]
+            return self._INT_OPTS[int_type]
         except KeyError:
             raise NotImplementedError(f"Unsupported integer type {int_type.__name__}")
 
@@ -350,7 +350,7 @@ class CalciteSerializer:
             Serialized data type.
         """
         assert _warn_if_unsigned(dtype)
-        return {"type": type(self)._DTYPE_STRINGS[dtype.name], "nullable": True}
+        return {"type": self._DTYPE_STRINGS[dtype.name], "nullable": True}
 
     def serialize_input_idx(self, expr):
         """

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_serializer.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_serializer.py
@@ -32,8 +32,17 @@ from .calcite_algebra import (
     CalciteJoinNode,
     CalciteUnionNode,
 )
+from modin.error_message import ErrorMessage
 import json
 import numpy as np
+
+
+def _warn_if_unsigned(dtype):  # noqa: GL08
+    if dtype in (np.uint8, np.uint16, np.uint32, np.uint64):
+        ErrorMessage.single_warning(
+            "HDK does not support unsigned integer types, such types will be rounded up to the signed equivalent."
+        )
+    return True
 
 
 class CalciteSerializer:
@@ -45,14 +54,30 @@ class CalciteSerializer:
     a request in JSON format which can be fed to HDK.
     """
 
-    dtype_strings = {
+    _DTYPE_STRINGS = {
         "int8": "TINYINT",
         "int16": "SMALLINT",
         "int32": "INTEGER",
         "int64": "BIGINT",
+        "uint8": "SMALLINT",
+        "uint16": "INTEGER",
+        "uint32": "BIGINT",
+        "uint64": "BIGINT",
         "bool": "BOOLEAN",
         "float32": "FLOAT",
         "float64": "DOUBLE",
+    }
+
+    _INT_OPTS = {
+        np.int8: ("TINYINT", 3),
+        np.int16: ("SMALLINT", 5),
+        np.int32: ("INTEGER", 10),
+        np.int64: ("BIGINT", 19),
+        np.uint8: ("SMALLINT", 5),
+        np.uint16: ("INTEGER", 10),
+        np.uint32: ("BIGINT", 19),
+        np.uint64: ("BIGINT", 19),
+        int: ("BIGINT", 19),
     }
 
     def serialize(self, plan):
@@ -252,7 +277,7 @@ class CalciteSerializer:
                 "type_scale": -2147483648,
                 "type_precision": len(literal.val),
             }
-        if type(literal.val) in (int, np.int8, np.int16, np.int32, np.int64):
+        if type(literal.val) in type(self)._INT_OPTS.keys():
             target_type, precision = self.opts_for_int_type(type(literal.val))
             return {
                 "literal": int(literal.val),
@@ -304,15 +329,11 @@ class CalciteSerializer:
         -------
         tuple
         """
-        if int_type is np.int8:
-            return "TINYINT", 3
-        if int_type is np.int16:
-            return "SMALLINT", 5
-        if int_type is np.int32:
-            return "INTEGER", 10
-        if int_type in (np.int64, int):
-            return "BIGINT", 19
-        raise NotImplementedError(f"Unsupported integer type {int_type.__name__}")
+        try:
+            assert _warn_if_unsigned(int_type)
+            return type(self)._INT_OPTS[int_type]
+        except KeyError:
+            raise NotImplementedError(f"Unsupported integer type {int_type.__name__}")
 
     def serialize_dtype(self, dtype):
         """
@@ -328,7 +349,8 @@ class CalciteSerializer:
         dict
             Serialized data type.
         """
-        return {"type": type(self).dtype_strings[dtype.name], "nullable": True}
+        assert _warn_if_unsigned(dtype)
+        return {"type": type(self)._DTYPE_STRINGS[dtype.name], "nullable": True}
 
     def serialize_input_idx(self, expr):
         """

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
@@ -669,7 +669,21 @@ class LiteralExpr(BaseExpr):
 
     def __init__(self, val):
         assert val is None or isinstance(
-            val, (int, float, bool, str, np.int8, np.int16, np.int32, np.int64)
+            val,
+            (
+                int,
+                float,
+                bool,
+                str,
+                np.int8,
+                np.int16,
+                np.int32,
+                np.int64,
+                np.uint8,
+                np.uint16,
+                np.uint32,
+                np.uint64,
+            ),
         ), f"unsupported literal value {val} of type {type(val)}"
         self.val = val
         if val is None:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -2031,23 +2031,36 @@ class TestBadData:
     def test_uint_serialization(self):
         # Tests for CalciteSerializer.serialize_literal()
         df = pd.DataFrame({"A": [np.nan, 1]})
-        assert df.fillna(np.uint8(255)).sum()[0] == 256
-        assert df.fillna(np.uint16(65535)).sum()[0] == 65536
-        assert df.fillna(np.uint32(4_294_967_295)).sum()[0] == 4_294_967_296
         assert (
-            df.fillna(np.uint64(9_223_372_036_854_775_806)).sum()[0]
-            == 9_223_372_036_854_775_807
+            df.fillna(np.uint8(np.iinfo(np.uint8).max)).sum()[0]
+            == np.iinfo(np.uint8).max + 1
+        )
+        assert (
+            df.fillna(np.uint16(np.iinfo(np.uint16).max)).sum()[0]
+            == np.iinfo(np.uint16).max + 1
+        )
+        assert (
+            df.fillna(np.uint32(np.iinfo(np.uint32).max)).sum()[0]
+            == np.iinfo(np.uint32).max + 1
+        )
+        # HDK represents 'uint64' as 'int64' internally due to a lack of support
+        # for unsigned ints, that's why using 'int64.max' here
+        assert (
+            df.fillna(np.uint64(np.iinfo(np.int64).max - 1)).sum()[0]
+            == np.iinfo(np.int64).max
         )
 
         # Tests for CalciteSerializer.serialize_dtype()
-        df = pd.DataFrame({"A": [255, 1]})
-        assert df.astype(np.uint8).sum()[0] == 256
-        df = pd.DataFrame({"A": [65535, 1]})
-        assert df.astype(np.uint16).sum()[0] == 65536
-        df = pd.DataFrame({"A": [4_294_967_295, 1]})
-        assert df.astype(np.uint32).sum()[0] == 4_294_967_296
-        df = pd.DataFrame({"A": [9_223_372_036_854_775_806, 1]})
-        assert df.astype(np.uint64).sum()[0] == 9_223_372_036_854_775_807
+        df = pd.DataFrame({"A": [np.iinfo(np.uint8).max, 1]})
+        assert df.astype(np.uint8).sum()[0] == np.iinfo(np.uint8).max + 1
+        df = pd.DataFrame({"A": [np.iinfo(np.uint16).max, 1]})
+        assert df.astype(np.uint16).sum()[0] == np.iinfo(np.uint16).max + 1
+        df = pd.DataFrame({"A": [np.iinfo(np.uint32).max, 1]})
+        assert df.astype(np.uint32).sum()[0] == np.iinfo(np.uint32).max + 1
+        # HDK represents 'uint64' as 'int64' internally due to a lack of support
+        # for unsigned ints, that's why using 'int64.max' here
+        df = pd.DataFrame({"A": [np.iinfo(np.int64).max - 1, 1]})
+        assert df.astype(np.uint64).sum()[0] == np.iinfo(np.int64).max
 
 
 class TestDropna:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -2028,6 +2028,27 @@ class TestBadData:
             with ForceHdkImport(md_df):
                 pass
 
+    def test_uint_serialization(self):
+        # Tests for CalciteSerializer.serialize_literal()
+        df = pd.DataFrame({"A": [np.nan, 1]})
+        assert df.fillna(np.uint8(255)).sum()[0] == 256
+        assert df.fillna(np.uint16(65535)).sum()[0] == 65536
+        assert df.fillna(np.uint32(4_294_967_295)).sum()[0] == 4_294_967_296
+        assert (
+            df.fillna(np.uint64(9_223_372_036_854_775_806)).sum()[0]
+            == 9_223_372_036_854_775_807
+        )
+
+        # Tests for CalciteSerializer.serialize_dtype()
+        df = pd.DataFrame({"A": [255, 1]})
+        assert df.astype(np.uint8).sum()[0] == 256
+        df = pd.DataFrame({"A": [65535, 1]})
+        assert df.astype(np.uint16).sum()[0] == 65536
+        df = pd.DataFrame({"A": [4_294_967_295, 1]})
+        assert df.astype(np.uint32).sum()[0] == 4_294_967_296
+        df = pd.DataFrame({"A": [9_223_372_036_854_775_806, 1]})
+        assert df.astype(np.uint64).sum()[0] == 9_223_372_036_854_775_807
+
 
 class TestDropna:
     data = {


### PR DESCRIPTION
Signed-off-by: Andrey Pavlenko <andrey.a.pavlenko@gmail.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5561 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
