### PR TITLE
FIX-#5580: BUG: 'AVG|SUM' is only valid on integer and floating point

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -2071,8 +2071,8 @@ class TestBadData:
             return getattr(df, operation)()
 
         for c in supported_codes:
-            run_and_compare(test, data={}, dtype_code=c, operation="sum")
-            run_and_compare(test, data={}, dtype_code=c, operation="mean")
+            for op in ("sum", "mean"):
+                run_and_compare(test, data={}, dtype_code=c, operation=op)
 
 
 class TestDropna:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -2061,6 +2061,19 @@ class TestBadData:
         df = pd.DataFrame({"A": [np.iinfo(np.int64).max - 1, 1]})
         assert df.astype(np.uint64).sum()[0] == np.iinfo(np.int64).max
 
+    def test_mean_sum(self):
+        all_codes = np.typecodes["All"]
+        exclude_codes = np.typecodes["Datetime"] + np.typecodes["Complex"] + "gSUVO"
+        supported_codes = set(all_codes) - set(exclude_codes)
+
+        def test(df, dtype_code, operation, **kwargs):
+            df = type(df)({"A": [0, 1], "B": [1, 0]}, dtype=np.dtype(dtype_code))
+            return getattr(df, operation)()
+
+        for c in supported_codes:
+            run_and_compare(test, data={}, dtype_code=c, operation="sum")
+            run_and_compare(test, data={}, dtype_code=c, operation="mean")
+
 
 class TestDropna:
     data = {

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -32,6 +32,8 @@ from pandas.core.common import is_bool_indexer
 from pandas.core.dtypes.common import is_list_like
 from functools import wraps
 
+import numpy as np
+
 
 def is_inoperable(value):
     """
@@ -797,8 +799,12 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         return self._modin_frame.dtypes
 
 
+_SUPPORTED_NUM_TYPE_CODES = set(np.typecodes["AllInteger"] + np.typecodes["Float"]) - {
+    np.dtype(np.float16).char
+}
+
+
 def _check_int_or_float(op, dtypes):  # noqa: GL08
-    codes = "bBhHiIlLqQpPfd"
     for t in dtypes:
-        if t.char not in codes:
+        if t.char not in _SUPPORTED_NUM_TYPE_CODES:
             raise NotImplementedError(f"Operation '{op}' on type '{t.name}'")

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -399,9 +399,11 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             raise NotImplementedError(
                 f"HDK's sum does not support such set of parameters: min_count={min_count}."
             )
+        _check_int_or_float("sum", self.dtypes)
         return self._agg("sum", **kwargs)
 
     def mean(self, **kwargs):
+        _check_int_or_float("mean", self.dtypes)
         return self._agg("mean", **kwargs)
 
     def nunique(self, axis=0, dropna=True):
@@ -793,3 +795,10 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
     @property
     def dtypes(self):
         return self._modin_frame.dtypes
+
+
+def _check_int_or_float(op, dtypes):  # noqa: GL08
+    codes = "bBhHiIlLqQpPfd"
+    for t in dtypes:
+        if t.char not in codes:
+            raise NotImplementedError(f"Operation '{op}' on type '{t.name}'")


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5580 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
