### PR TITLE
FIX-#5604: Fix dictionary groupby aggregation for a single col partition case

### DIFF
--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -518,7 +518,10 @@ class GroupByReduce(TreeReduce):
             elif grp_has_id_level:
                 # Adding the 'id' level to the aggregation keys so they match `grp_obj` columns
                 native_aggs_modified = {
-                    (cls.ID_LEVEL_NAME, *key): value
+                    (
+                        cls.ID_LEVEL_NAME,
+                        *(key if isinstance(key, tuple) else (key,)),
+                    ): value
                     for key, value in native_aggs.items()
                 }
                 native_agg_res = grp_obj.agg(native_aggs_modified)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1783,26 +1783,65 @@ def test_unknown_groupby(columns):
                 list(test_data_values[0].keys())[-2]: np.sum,
             }
         ),
-        lambda grp: grp.agg(
-            {
-                list(test_data_values[0].keys())[1]: [
-                    ("new_sum", "sum"),
-                    ("new_mean", "mean"),
-                ],
-                list(test_data_values[0].keys())[-2]: "skew",
-            }
+        pytest.param(
+            lambda grp: grp.agg(
+                {
+                    list(test_data_values[0].keys())[1]: [
+                        ("new_sum", "sum"),
+                        ("new_mean", "mean"),
+                    ],
+                    list(test_data_values[0].keys())[-2]: "skew",
+                }
+            ),
+            id="renaming_aggs_at_different_partitions",
         ),
-        lambda grp: grp.agg(
-            {
-                list(test_data_values[0].keys())[1]: "mean",
-                list(test_data_values[0].keys())[-2]: "skew",
-            }
+        pytest.param(
+            lambda grp: grp.agg(
+                {
+                    list(test_data_values[0].keys())[1]: [
+                        ("new_sum", "sum"),
+                        ("new_mean", "mean"),
+                    ],
+                    list(test_data_values[0].keys())[2]: "skew",
+                }
+            ),
+            id="renaming_aggs_at_same_partition",
         ),
-        lambda grp: grp.agg(
-            {
-                list(test_data_values[0].keys())[1]: "mean",
-                list(test_data_values[0].keys())[-2]: "sum",
-            }
+        pytest.param(
+            lambda grp: grp.agg(
+                {
+                    list(test_data_values[0].keys())[1]: "mean",
+                    list(test_data_values[0].keys())[-2]: "skew",
+                }
+            ),
+            id="custom_aggs_at_different_partitions",
+        ),
+        pytest.param(
+            lambda grp: grp.agg(
+                {
+                    list(test_data_values[0].keys())[1]: "mean",
+                    list(test_data_values[0].keys())[2]: "skew",
+                }
+            ),
+            id="custom_aggs_at_same_partition",
+        ),
+        pytest.param(
+            lambda grp: grp.agg(
+                {
+                    list(test_data_values[0].keys())[1]: "mean",
+                    list(test_data_values[0].keys())[-2]: "sum",
+                }
+            ),
+            id="native_and_custom_aggs_at_different_partitions",
+        ),
+        pytest.param(
+            lambda grp: grp.agg(
+                {
+                    list(test_data_values[0].keys())[1]: "mean",
+                    list(test_data_values[0].keys())[2]: "sum",
+                }
+            ),
+            id="native_and_custom_aggs_at_same_partition",
         ),
         pytest.param(
             lambda grp: grp.agg(


### PR DESCRIPTION
Signed-off-by: Dmitry Chigarev <dmitry.chigarev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5604 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
