### PR TITLE
FIX-#5625: Fix set_index with modin series.

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2080,7 +2080,9 @@ class DataFrame(BasePandasDataset):
             else:
                 frame = self.copy()
             if not all(
-                isinstance(col, (pandas.Index, Series, np.ndarray, list, Iterator))
+                isinstance(
+                    col, (pandas.Index, pandas.Series, np.ndarray, list, Iterator)
+                )
                 for col in keys
             ):
                 if drop:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -50,6 +50,7 @@ from modin.utils import (
     to_pandas,
     hashable,
     MODIN_UNNAMED_SERIES_LABEL,
+    try_cast_to_pandas,
 )
 from modin.config import Engine, IsExperimental, PersistentPickle
 from .utils import (
@@ -2079,15 +2080,9 @@ class DataFrame(BasePandasDataset):
                 frame = self
             else:
                 frame = self.copy()
-            if not all(
-                isinstance(
-                    col, (pandas.Index, pandas.Series, np.ndarray, list, Iterator)
-                )
-                for col in keys
-            ):
-                if drop:
-                    keys = [frame.pop(k) if not is_list_like(k) else k for k in keys]
-                keys = [k._to_pandas() if isinstance(k, Series) else k for k in keys]
+            if drop:
+                keys = [k if is_list_like(k) else frame.pop(k) for k in keys]
+            keys = try_cast_to_pandas(keys)
             # These are single-threaded objects, so we might as well let pandas do the
             # calculation so that it matches.
             frame.index = (

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -314,8 +314,22 @@ def test_indexing_duplicate_axis(data):
         "series_of_integers",
     ],
 )
-def test_set_index(data, key_func):
-    eval_general(*create_test_dfs(data), lambda df: df.set_index(key_func(df)))
+@pytest.mark.parametrize(
+    "drop_kwargs",
+    [{"drop": True}, {"drop": False}, {}],
+    ids=["drop_True", "drop_False", "no_drop_param"],
+)
+def test_set_index(data, key_func, drop_kwargs, request):
+    if (
+        "list_of_index_and_first_column_name" in request.node.name
+        and "drop_False" in request.node.name
+    ):
+        pytest.xfail(
+            reason="KeyError: https://github.com/modin-project/modin/issues/5636"
+        )
+    eval_general(
+        *create_test_dfs(data), lambda df: df.set_index(key_func(df), **drop_kwargs)
+    )
 
 
 @pytest.mark.parametrize("index", ["a", ["a", ("b", "")]])

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -294,16 +294,28 @@ def test_indexing_duplicate_axis(data):
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_set_index(data):
-    modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)
-
-    modin_result = modin_df.set_index([modin_df.index, modin_df.columns[0]])
-    pandas_result = pandas_df.set_index([pandas_df.index, pandas_df.columns[0]])
-    df_equals(modin_result, pandas_result)
-
-    # test for the case from https://github.com/modin-project/modin/issues/4308
-    eval_general(modin_df, pandas_df, lambda df: df.set_index("inexistent_col"))
+@pytest.mark.parametrize(
+    "key_func",
+    [
+        # test for the case from https://github.com/modin-project/modin/issues/4308
+        "non_existing_column",
+        lambda df: df.columns[0],
+        lambda df: df.index,
+        lambda df: [df.index, df.columns[0]],
+        lambda df: pandas.Series(list(range(len(df.index))))
+        if isinstance(df, pandas.DataFrame)
+        else pd.Series(list(range(len(df)))),
+    ],
+    ids=[
+        "non_existing_column",
+        "first_column_name",
+        "original_index",
+        "list_of_index_and_first_column_name",
+        "series_of_integers",
+    ],
+)
+def test_set_index(data, key_func):
+    eval_general(*create_test_dfs(data), lambda df: df.set_index(key_func(df)))
 
 
 @pytest.mark.parametrize("index", ["a", ["a", ("b", "")]])

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2204,7 +2204,6 @@ def test_loc(data):
     data = np.arange(100)
     modin_series = pd.Series(data, index=index).sort_index()
     pandas_series = pandas.Series(data, index=index).sort_index()
-    # Using 'fmt: skip' below as 'black' and 'flake8' can't agree on how this should be formatted
     modin_result = modin_series.loc[
         (slice(None), 1),
     ]  # fmt: skip

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2204,6 +2204,7 @@ def test_loc(data):
     data = np.arange(100)
     modin_series = pd.Series(data, index=index).sort_index()
     pandas_series = pandas.Series(data, index=index).sort_index()
+    # Using 'fmt: skip' below as 'black' and 'flake8' can't agree on how this should be formatted
     modin_result = modin_series.loc[
         (slice(None), 1),
     ]  # fmt: skip


### PR DESCRIPTION
Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5625 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
