### PR TITLE
FIX-#5629: Make read_sql alias compatible with snowflake.

### DIFF
--- a/modin/db_conn.py
+++ b/modin/db_conn.py
@@ -136,7 +136,7 @@ class ModinDatabaseConnection:
         """
         # This query looks odd, but it works in both PostgreSQL and Microsoft
         # SQL, which doesn't let you use a "limit" clause to select 0 rows.
-        return f"SELECT * FROM ({query}) AS _ WHERE 1 = 0"
+        return f"SELECT * FROM ({query}) AS _MODIN_COUNT_QUERY WHERE 1 = 0"
 
     def row_count_query(self, query: str) -> str:
         """
@@ -151,7 +151,7 @@ class ModinDatabaseConnection:
         -------
         str
         """
-        return f"SELECT COUNT(*) FROM ({query}) AS _"
+        return f"SELECT COUNT(*) FROM ({query}) AS _MODIN_COUNT_QUERY"
 
     def partition_query(self, query: str, limit: int, offset: int) -> str:
         """
@@ -172,9 +172,10 @@ class ModinDatabaseConnection:
         """
         return (
             (
-                f"SELECT * FROM ({query}) AS _ ORDER BY(SELECT NULL)"
+                f"SELECT * FROM ({query}) AS _MODIN_COUNT_QUERY ORDER BY(SELECT NULL)"
                 + f" OFFSET {offset} ROWS FETCH NEXT {limit} ROWS ONLY"
             )
             if self._dialect_is_microsoft_sql()
-            else f"SELECT * FROM ({query}) AS _ LIMIT {limit} OFFSET {offset}"
+            else f"SELECT * FROM ({query}) AS _MODIN_COUNT_QUERY LIMIT "
+            + f"{limit} OFFSET {offset}"
         )


### PR DESCRIPTION
Not adding a test because setting up and maintaining a test snowflake account is too much effort. This fix works in practice.

Signed-off-by: mvashishtha <mahesh@ponder.io>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5629 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
