### PR TITLE
FEAT-#5620: Synchronize parameters of `apply_full_axis` with `broadcast_apply_full_axis`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2189,6 +2189,8 @@ class PandasDataframe(ClassLogger):
         func,
         new_index=None,
         new_columns=None,
+        apply_indices=None,
+        enumerate_partitions: bool = False,
         dtypes=None,
         keep_partitioning=True,
         sync_labels=True,
@@ -2209,6 +2211,11 @@ class PandasDataframe(ClassLogger):
         new_columns : list-like, optional
             The columns of the result. We may know this in
             advance, and if not provided it must be computed.
+        apply_indices : list-like, default: None
+            Indices of `axis ^ 1` to apply function over.
+        enumerate_partitions : bool, default: False
+            Whether pass partition index into applied `func` or not.
+            Note that `func` must be able to obtain `partition_idx` kwarg.
         dtypes : list-like, optional
             The data types of the result. This is an optimization
             because there are functions that always result in a particular data
@@ -2238,6 +2245,8 @@ class PandasDataframe(ClassLogger):
             func=func,
             new_index=new_index,
             new_columns=new_columns,
+            apply_indices=apply_indices,
+            enumerate_partitions=enumerate_partitions,
             dtypes=dtypes,
             other=None,
             keep_partitioning=keep_partitioning,

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -562,7 +562,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 new_columns = None
 
             return self.__constructor__(
-                self._modin_frame.broadcast_apply_full_axis(
+                self._modin_frame.apply_full_axis(
                     axis=1,
                     func=_reset,
                     other=None,

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -565,7 +565,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 self._modin_frame.apply_full_axis(
                     axis=1,
                     func=_reset,
-                    other=None,
                     enumerate_partitions=True,
                     new_columns=new_columns,
                     sync_labels=False,

--- a/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -238,7 +238,7 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
             df.to_pickle(**kwargs)
             return pandas.DataFrame()
 
-        result = qc._modin_frame.broadcast_apply_full_axis(
+        result = qc._modin_frame.apply_full_axis(
             1, func, other=None, new_index=[], new_columns=[], enumerate_partitions=True
         )
         result.to_pandas()

--- a/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -239,7 +239,7 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
             return pandas.DataFrame()
 
         result = qc._modin_frame.apply_full_axis(
-            1, func, other=None, new_index=[], new_columns=[], enumerate_partitions=True
+            1, func, new_index=[], new_columns=[], enumerate_partitions=True
         )
         result.to_pandas()
 

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -243,7 +243,7 @@ class ExperimentalPandasOnUnidistIO(PandasOnUnidistIO):
             df.to_pickle(**kwargs)
             return pandas.DataFrame()
 
-        result = qc._modin_frame.broadcast_apply_full_axis(
+        result = qc._modin_frame.apply_full_axis(
             1, func, other=None, new_index=[], new_columns=[], enumerate_partitions=True
         )
         result.to_pandas()

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -244,7 +244,7 @@ class ExperimentalPandasOnUnidistIO(PandasOnUnidistIO):
             return pandas.DataFrame()
 
         result = qc._modin_frame.apply_full_axis(
-            1, func, other=None, new_index=[], new_columns=[], enumerate_partitions=True
+            1, func, new_index=[], new_columns=[], enumerate_partitions=True
         )
         result.to_pandas()
 


### PR DESCRIPTION
## What do these changes do?

Add parameters 
- apply_indices
- enumerate_partitions
to `apply_full_axis` function in `modin/core/dataframe/pandas/dataframe/dataframe.py` to match with the parameters of the function `broadcast_apply_full_axis`.

- [x] first commit message and PR title follow format outlined [here]
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5620 
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date