### PR TITLE
FIX-#3080: read_csv with OmniSci backend doesn't handle duplicated co…

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -300,6 +300,26 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
                 convert_options=co,
             )
 
+            col_names = at.column_names
+            col_counts = {}
+            for name in col_names:
+                col_counts[name] = 1 if name in col_counts else 0
+
+            if len(col_names) != len(col_counts):
+                for i, name in enumerate(col_names):
+                    count = col_counts[name]
+                    if count != 0:
+                        if count == 1:
+                            col_counts[name] = 2
+                        else:
+                            new_name = f"{name}.{count - 1}"
+                            while new_name in col_counts:
+                                new_name = f"{name}.{count}"
+                                count += 1
+                            col_counts[name] = count + 1
+                            col_names[i] = new_name
+                at = at.rename_columns(col_names)
+
             return cls.from_arrow(at)
         except (
             pa.ArrowNotImplementedError,

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -376,17 +376,6 @@ class TestCsv:
         names,
         encoding,
     ):
-        xfail_case = (
-            StorageFormat.get() == "Hdk"
-            and header is not None
-            and isinstance(skiprows, int)
-            and names is None
-            and nrows is None
-        )
-        if xfail_case:
-            pytest.xfail(
-                "read_csv fails because of duplicated columns names - issue #3080"
-            )
         if request.config.getoption(
             "--simulate-cloud"
         ).lower() != "off" and is_list_like(skiprows):
@@ -417,6 +406,7 @@ class TestCsv:
                     pytest.xfail(
                         "read_csv incorrect output with float data - issue #2634"
                     )
+
             eval_io(
                 fn_name="read_csv",
                 raising_exceptions=None,
@@ -491,10 +481,6 @@ class TestCsv:
             )
 
     def test_read_csv_mangle_dupe_cols(self):
-        if StorageFormat.get() == "Hdk":
-            pytest.xfail(
-                "processing of duplicated columns in HDK storage format is not supported yet - issue #3080"
-            )
         with ensure_clean() as unique_filename, pytest.warns(
             FutureWarning, match="'mangle_dupe_cols' keyword is deprecated"
         ):
@@ -733,6 +719,21 @@ class TestCsv:
                     escapechar=escapechar,
                     line_terminator=lineterminator,
                 )
+
+            if (
+                (StorageFormat.get() == "Hdk")
+                and (escapechar is not None)
+                and (lineterminator is None)
+                and (thousands is None)
+                and (decimal == ".")
+            ):
+                with open(unique_filename, "r") as f:
+                    if any(
+                        line.find(f',"{escapechar}') != -1 for _, line in enumerate(f)
+                    ):
+                        pytest.xfail(
+                            "Tests with this character sequence fail due to #5649"
+                        )
 
             eval_io(
                 raising_exceptions=None,
@@ -987,13 +988,6 @@ class TestCsv:
     @pytest.mark.parametrize("names", [list("XYZ"), None])
     @pytest.mark.parametrize("skiprows", [1, 2, 3, 4, None])
     def test_read_csv_skiprows_names(self, names, skiprows):
-        if StorageFormat.get() == "Hdk" and names is None and skiprows in [1, None]:
-            # If these conditions are satisfied, columns names will be inferred
-            # from the first row, that will contain duplicated values, that is
-            # not supported by  `HDK` storage format yet.
-            pytest.xfail(
-                "processing of duplicated columns in HDK storage format is not supported yet - issue #3080"
-            )
         eval_io(
             fn_name="read_csv",
             # read_csv kwargs


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #3080 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
