### PR TITLE
PERF-#5613: Optimize `duplicated` in case there is only one column partition

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2782,7 +2782,7 @@ class PandasDataframe(ClassLogger):
                         self._row_lengths_cache
                     ):
                         kw["row_lengths"] = self._row_lengths_cache
-                    elif len(new_index) == 1:
+                    elif len(new_index) == 1 and new_partitions.shape[0] == 1:
                         kw["row_lengths"] = [1]
             if kw["column_widths"] is None and new_columns is not None:
                 if axis == 1:
@@ -2795,7 +2795,7 @@ class PandasDataframe(ClassLogger):
                         new_columns
                     ) == sum(self._column_widths_cache):
                         kw["column_widths"] = self._column_widths_cache
-                    elif len(new_columns) == 1:
+                    elif len(new_columns) == 1 and new_partitions.shape[1] == 1:
                         kw["column_widths"] = [1]
 
         result = self.__constructor__(

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -204,13 +204,7 @@ class PandasDataframe(ClassLogger):
         self._dtypes = dtypes
 
         self._validate_axes_lengths()
-        if all(obj is not None for obj in (index, columns, row_lengths, column_widths)):
-            # this hint allows to filter empty partitions out without triggering metadata computation
-            # in order to avoid useless computation over empty partitions
-            compute_metadata = True
-        else:
-            compute_metadata = False
-        self._filter_empties(compute_metadata=compute_metadata)
+        self._filter_empties(compute_metadata=False)
 
     def _validate_axes_lengths(self):
         """Validate that labels are split correctly if split is known."""

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2476,41 +2476,44 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     def duplicated(self, **kwargs):
         def _compute_hash(df):
-            return df.apply(
+            result = df.apply(
                 lambda s: hashlib.new("md5", str(tuple(s)).encode()).hexdigest(), axis=1
-            ).to_frame()
+            )
+            if isinstance(result, pandas.Series):
+                result = result.to_frame(
+                    result.name
+                    if result.name is not None
+                    else MODIN_UNNAMED_SERIES_LABEL
+                )
+            return result
 
         def _compute_duplicated(df):
-            return df.duplicated(**kwargs).to_frame()
+            result = df.duplicated(**kwargs)
+            if isinstance(result, pandas.Series):
+                result = result.to_frame(
+                    result.name
+                    if result.name is not None
+                    else MODIN_UNNAMED_SERIES_LABEL
+                )
+            return result
 
-        new_index = self._modin_frame._index_cache
-        new_columns = [MODIN_UNNAMED_SERIES_LABEL]
-        new_row_lengths = self._modin_frame._row_lengths_cache
-        new_column_widths = [1]
         if len(self._modin_frame.column_widths) > 1:
             # if the number of columns (or column partitions) we are checking for duplicates is larger than 1,
             # we must first hash them to generate a single value that can be compared across rows.
-            hashed_modin_frame = self._modin_frame.apply_full_axis(
-                1,
-                _compute_hash,
-                new_index=new_index,
-                new_columns=new_columns,
-                new_row_lengths=new_row_lengths,
-                new_column_widths=new_column_widths,
-                keep_partitioning=False,
+            hashed_modin_frame = self._modin_frame.reduce(
+                axis=1,
+                function=_compute_hash,
                 dtypes=np.dtype("O"),
             )
         else:
             hashed_modin_frame = self._modin_frame
         new_modin_frame = hashed_modin_frame.apply_full_axis(
-            0,
-            _compute_duplicated,
-            new_index=new_index,
-            new_columns=new_columns,
-            new_row_lengths=new_row_lengths,
-            new_column_widths=new_column_widths,
-            keep_partitioning=False,
+            axis=0,
+            func=_compute_duplicated,
+            new_index=self._modin_frame._index_cache,
+            new_columns=[MODIN_UNNAMED_SERIES_LABEL],
             dtypes=np.bool_,
+            keep_partitioning=False,
         )
         return self.__constructor__(new_modin_frame, shape_hint="column")
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2497,7 +2497,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 )
             return result
 
-        if len(self._modin_frame.column_widths) > 1:
+        if self._modin_frame._partitions.shape[1] > 1:
             # if the number of columns (or column partitions) we are checking for duplicates is larger than 1,
             # we must first hash them to generate a single value that can be compared across rows.
             hashed_modin_frame = self._modin_frame.reduce(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2485,14 +2485,18 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
         new_index = self._modin_frame._index_cache
         new_columns = [MODIN_UNNAMED_SERIES_LABEL]
-        if len(self.columns) > 1:
-            # if the number of columns we are checking for duplicates is larger than 1,
-            # we must hash them to generate a single value that can be compared across rows.
+        new_row_lengths = self._modin_frame._row_lengths_cache
+        new_column_widths = [1]
+        if len(self._modin_frame.column_widths) > 1:
+            # if the number of columns (or column partitions) we are checking for duplicates is larger than 1,
+            # we must first hash them to generate a single value that can be compared across rows.
             hashed_modin_frame = self._modin_frame.apply_full_axis(
                 1,
                 _compute_hash,
                 new_index=new_index,
                 new_columns=new_columns,
+                new_row_lengths=new_row_lengths,
+                new_column_widths=new_column_widths,
                 keep_partitioning=False,
                 dtypes=np.dtype("O"),
             )
@@ -2503,6 +2507,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
             _compute_duplicated,
             new_index=new_index,
             new_columns=new_columns,
+            new_row_lengths=new_row_lengths,
+            new_column_widths=new_column_widths,
             keep_partitioning=False,
             dtypes=np.bool_,
         )

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -318,8 +318,6 @@ class DataFrame(BasePandasDataset):
         df = self[subset] if subset is not None else self
         new_qc = df._query_compiler.duplicated(keep=keep)
         duplicates = self._reduce_dimension(new_qc)
-        # remove Series name which was assigned automatically by .apply in QC
-        duplicates.name = None
         return duplicates
 
     @property


### PR DESCRIPTION

Signed-off-by: Igoshev, Iaroslav <iaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5613  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
