### PR TITLE
FIX-#5650: Restore the right dtype for applying Series.cat

### DIFF
--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -45,7 +45,12 @@ modin.utils._make_api_url = _saving_make_api_url
 
 import modin  # noqa: E402
 import modin.config  # noqa: E402
-from modin.config import IsExperimental, TestRayClient  # noqa: E402
+from modin.config import (  # noqa: E402
+    NPartitions,
+    MinPartitionSize,
+    IsExperimental,
+    TestRayClient,
+)
 import uuid  # noqa: E402
 
 from modin.core.storage_formats import (  # noqa: E402
@@ -533,6 +538,22 @@ def TestReadGlobCSVFixture():
 @pytest.fixture
 def get_generated_doc_urls():
     return lambda: _generated_doc_urls
+
+
+@pytest.fixture
+def set_num_partitions(request):
+    old_num_partitions = NPartitions.get()
+    NPartitions.put(request.param)
+    yield
+    NPartitions.put(old_num_partitions)
+
+
+@pytest.fixture
+def set_min_partition_size(request):
+    old_min_partition_size = MinPartitionSize.get()
+    MinPartitionSize.put(request.param)
+    yield
+    MinPartitionSize.put(old_min_partition_size)
 
 
 ray_client_server = None

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3391,7 +3391,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
             # if the dfs have categorical columns
             # so we intentionaly restore the right dtype.
             # TODO: revert the change when https://github.com/pandas-dev/pandas/issues/51362 is fixed.
-            ser = df.astype("category", copy=False).iloc[:, 0]
+            ser = df.iloc[:, 0]
+            if ser.dtype != "category":
+                ser = ser.astype("category", copy=False)
             return ser.cat.codes
 
         res = self._modin_frame.apply_full_axis(axis=0, func=func)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4334,6 +4334,21 @@ def test_cat_codes(data):
 
 
 @pytest.mark.parametrize(
+    "set_min_partition_size",
+    [1, 2],
+    ids=["four_partitions", "two_partitions"],
+    indirect=True,
+)
+def test_cat_codes_issue5650(set_min_partition_size):
+    data = {"name": ["abc", "def", "ghi", "jkl"]}
+    pandas_df = pandas.DataFrame(data)
+    pandas_df = pandas_df.astype("category")
+    modin_df = pd.DataFrame(data)
+    modin_df = modin_df.astype("category")
+    eval_general(modin_df, pandas_df, lambda df: df["name"].cat.codes)
+
+
+@pytest.mark.parametrize(
     "data", test_data_categorical_values, ids=test_data_categorical_keys
 )
 @pytest.mark.parametrize("inplace", [True, False])

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -113,14 +113,6 @@ def validate_partitions_cache(df):
             assert df._partitions[i, j].width() == column_widths[j]
 
 
-@pytest.fixture
-def set_num_partitions(request):
-    old_num_partitions = NPartitions.get()
-    NPartitions.put(request.param)
-    yield
-    NPartitions.put(old_num_partitions)
-
-
 def test_aligning_blocks():
     # Test problem when modin frames have the same number of rows, but different
     # blocks (partition.list_of_blocks). See #2322 for details


### PR DESCRIPTION
Signed-off-by: Igoshev, Iaroslav <iaroslav.igoshev@intel.com>

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5650  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
