### PR TITLE
PERF-#5657: Don't trigger axes computation when accessing `.str.*` methods

### DIFF
--- a/modin/core/dataframe/algebra/map.py
+++ b/modin/core/dataframe/algebra/map.py
@@ -43,10 +43,12 @@ class Map(Operator):
 
         def caller(query_compiler, *args, **kwargs):
             """Execute Map function against passed query compiler."""
+            shape_hint = call_kwds.pop("shape_hint", None)
             return query_compiler.__constructor__(
                 query_compiler._modin_frame.map(
                     lambda x: function(x, *args, **kwargs), *call_args, **call_kwds
-                )
+                ),
+                shape_hint=shape_hint,
             )
 
         return caller

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1479,25 +1479,37 @@ class PandasQueryCompiler(BaseQueryCompiler):
         qc.columns = get_group_names(regex)
         return qc
 
-    str_replace = Map.register(_str_map("replace"), dtypes="copy")
-    str_rfind = Map.register(_str_map("rfind"), dtypes="copy")
-    str_rindex = Map.register(_str_map("rindex"), dtypes="copy")
-    str_rjust = Map.register(_str_map("rjust"), dtypes="copy")
-    str_rpartition = Map.register(_str_map("rpartition"), dtypes="copy")
-    str_rsplit = Map.register(_str_map("rsplit"), dtypes="copy")
-    str_rstrip = Map.register(_str_map("rstrip"), dtypes="copy")
-    str_slice = Map.register(_str_map("slice"), dtypes="copy")
-    str_slice_replace = Map.register(_str_map("slice_replace"), dtypes="copy")
-    str_split = Map.register(_str_map("split"), dtypes="copy")
-    str_startswith = Map.register(_str_map("startswith"), dtypes=np.bool_)
-    str_strip = Map.register(_str_map("strip"), dtypes="copy")
-    str_swapcase = Map.register(_str_map("swapcase"), dtypes="copy")
-    str_title = Map.register(_str_map("title"), dtypes="copy")
-    str_translate = Map.register(_str_map("translate"), dtypes="copy")
-    str_upper = Map.register(_str_map("upper"), dtypes="copy")
-    str_wrap = Map.register(_str_map("wrap"), dtypes="copy")
-    str_zfill = Map.register(_str_map("zfill"), dtypes="copy")
-    str___getitem__ = Map.register(_str_map("__getitem__"), dtypes="copy")
+    str_replace = Map.register(_str_map("replace"), dtypes="copy", shape_hint="column")
+    str_rfind = Map.register(_str_map("rfind"), dtypes="copy", shape_hint="column")
+    str_rindex = Map.register(_str_map("rindex"), dtypes="copy", shape_hint="column")
+    str_rjust = Map.register(_str_map("rjust"), dtypes="copy", shape_hint="column")
+    str_rpartition = Map.register(
+        _str_map("rpartition"), dtypes="copy", shape_hint="column"
+    )
+    str_rsplit = Map.register(_str_map("rsplit"), dtypes="copy", shape_hint="column")
+    str_rstrip = Map.register(_str_map("rstrip"), dtypes="copy", shape_hint="column")
+    str_slice = Map.register(_str_map("slice"), dtypes="copy", shape_hint="column")
+    str_slice_replace = Map.register(
+        _str_map("slice_replace"), dtypes="copy", shape_hint="column"
+    )
+    str_split = Map.register(_str_map("split"), dtypes="copy", shape_hint="column")
+    str_startswith = Map.register(
+        _str_map("startswith"), dtypes=np.bool_, shape_hint="column"
+    )
+    str_strip = Map.register(_str_map("strip"), dtypes="copy", shape_hint="column")
+    str_swapcase = Map.register(
+        _str_map("swapcase"), dtypes="copy", shape_hint="column"
+    )
+    str_title = Map.register(_str_map("title"), dtypes="copy", shape_hint="column")
+    str_translate = Map.register(
+        _str_map("translate"), dtypes="copy", shape_hint="column"
+    )
+    str_upper = Map.register(_str_map("upper"), dtypes="copy", shape_hint="column")
+    str_wrap = Map.register(_str_map("wrap"), dtypes="copy", shape_hint="column")
+    str_zfill = Map.register(_str_map("zfill"), dtypes="copy", shape_hint="column")
+    str___getitem__ = Map.register(
+        _str_map("__getitem__"), dtypes="copy", shape_hint="column"
+    )
 
     # END String map partitions operations
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5657  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
