### PR TITLE
PERF-#5660: Don't trigger axes computation when accessing cat.codes

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3394,10 +3394,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
             ser = df.iloc[:, 0]
             if ser.dtype != "category":
                 ser = ser.astype("category", copy=False)
-            return ser.cat.codes
+            return ser.cat.codes.to_frame(name=MODIN_UNNAMED_SERIES_LABEL)
 
-        res = self._modin_frame.apply_full_axis(axis=0, func=func)
-        return self.__constructor__(res)
+        res = self._modin_frame.apply_full_axis(
+            axis=0, func=func, new_columns=[MODIN_UNNAMED_SERIES_LABEL]
+        )
+        return self.__constructor__(res, shape_hint="column")
 
     # END Cat operations
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5660 <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
