### PR TITLE
PERF-#5680: Don't trigger axes computation when doing binary operations

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -252,7 +252,7 @@ class Binary(Operator):
                         if (
                             len(self_columns) == 1
                             and len(other.columns) == 1
-                            and query_compiler.columns.equal(other.columns)
+                            and query_compiler.columns.equals(other.columns)
                         ):
                             shape_hint = "column"
                     return query_compiler.__constructor__(

--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -15,6 +15,7 @@
 
 import numpy as np
 import pandas
+from pandas.api.types import is_scalar
 
 from .operator import Operator
 
@@ -195,6 +196,7 @@ class Binary(Operator):
                 Result of binary function.
             """
             axis = kwargs.get("axis", 0)
+            shape_hint = None
             if isinstance(other, type(query_compiler)):
                 if broadcast:
                     assert (
@@ -206,6 +208,18 @@ class Binary(Operator):
                     # column or row as a single-column Modin DataFrame
                     if axis == 1:
                         other = other.transpose()
+
+                    if (
+                        query_compiler._modin_frame._columns_cache is not None
+                        and other._modin_frame._columns_cache is not None
+                    ):
+                        if (
+                            len(query_compiler.columns) == 1
+                            and len(other.columns) == 1
+                            and len(query_compiler.columns.difference(other.columns))
+                            == 0
+                        ):
+                            shape_hint = "column"
                     return query_compiler.__constructor__(
                         query_compiler._modin_frame.broadcast_apply(
                             axis,
@@ -216,7 +230,8 @@ class Binary(Operator):
                             join_type=join_type,
                             labels=labels,
                             dtypes=dtypes,
-                        )
+                        ),
+                        shape_hint=shape_hint,
                     )
                 else:
                     if (
@@ -230,13 +245,25 @@ class Binary(Operator):
                         elif infer_dtypes == "float":
                             dtypes = compute_dtypes_common_cast(query_compiler, other)
                             dtypes = dtypes.apply(coerce_int_to_float64)
+                    if (
+                        query_compiler._modin_frame._columns_cache is not None
+                        and other._modin_frame._columns_cache is not None
+                    ):
+                        if (
+                            len(query_compiler.columns) == 1
+                            and len(other.columns) == 1
+                            and len(query_compiler.columns.difference(other.columns))
+                            == 0
+                        ):
+                            shape_hint = "column"
                     return query_compiler.__constructor__(
                         query_compiler._modin_frame.n_ary_op(
                             lambda x, y: func(x, y, *args, **kwargs),
                             [other._modin_frame],
                             join_type=join_type,
                             dtypes=dtypes,
-                        )
+                        ),
+                        shape_hint=shape_hint,
                     )
             else:
                 # TODO: it's possible to chunk the `other` and broadcast them to partitions
@@ -250,10 +277,18 @@ class Binary(Operator):
                         dtypes=dtypes,
                     )
                 else:
+                    if (
+                        query_compiler._modin_frame._columns_cache is not None
+                        and len(query_compiler.columns) == 1
+                        and is_scalar(other)
+                    ):
+                        shape_hint = "column"
                     new_modin_frame = query_compiler._modin_frame.map(
                         lambda df: func(df, other, *args, **kwargs),
                         dtypes=dtypes,
                     )
-                return query_compiler.__constructor__(new_modin_frame)
+                return query_compiler.__constructor__(
+                    new_modin_frame, shape_hint=shape_hint
+                )
 
         return caller

--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -197,6 +197,7 @@ class Binary(Operator):
             """
             axis = kwargs.get("axis", 0)
             shape_hint = None
+            self_columns = query_compiler._modin_frame._columns_cache
             if isinstance(other, type(query_compiler)):
                 if broadcast:
                     assert (
@@ -210,14 +211,13 @@ class Binary(Operator):
                         other = other.transpose()
 
                     if (
-                        query_compiler._modin_frame._columns_cache is not None
+                        self_columns is not None
                         and other._modin_frame._columns_cache is not None
                     ):
                         if (
-                            len(query_compiler.columns) == 1
+                            len(self_columns) == 1
                             and len(other.columns) == 1
-                            and len(query_compiler.columns.difference(other.columns))
-                            == 0
+                            and self_columns.equals(other.columns)
                         ):
                             shape_hint = "column"
                     return query_compiler.__constructor__(
@@ -246,14 +246,13 @@ class Binary(Operator):
                             dtypes = compute_dtypes_common_cast(query_compiler, other)
                             dtypes = dtypes.apply(coerce_int_to_float64)
                     if (
-                        query_compiler._modin_frame._columns_cache is not None
+                        self_columns is not None
                         and other._modin_frame._columns_cache is not None
                     ):
                         if (
-                            len(query_compiler.columns) == 1
+                            len(self_columns) == 1
                             and len(other.columns) == 1
-                            and len(query_compiler.columns.difference(other.columns))
-                            == 0
+                            and query_compiler.columns.equal(other.columns)
                         ):
                             shape_hint = "column"
                     return query_compiler.__constructor__(
@@ -278,8 +277,8 @@ class Binary(Operator):
                     )
                 else:
                     if (
-                        query_compiler._modin_frame._columns_cache is not None
-                        and len(query_compiler.columns) == 1
+                        self_columns is not None
+                        and len(self_columns) == 1
                         and is_scalar(other)
                     ):
                         shape_hint = "column"


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5680  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
