### PR TITLE
PERF-#5682: Don't trigger axes computation when calling `isin`

### DIFF
--- a/modin/core/dataframe/algebra/map.py
+++ b/modin/core/dataframe/algebra/map.py
@@ -43,7 +43,9 @@ class Map(Operator):
 
         def caller(query_compiler, *args, **kwargs):
             """Execute Map function against passed query compiler."""
-            shape_hint = call_kwds.pop("shape_hint", None)
+            shape_hint = call_kwds.pop("shape_hint", None) or kwargs.pop(
+                "shape_hint", None
+            )
             return query_compiler.__constructor__(
                 query_compiler._modin_frame.map(
                     lambda x: function(x, *args, **kwargs), *call_args, **call_kwds

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1346,6 +1346,9 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             Boolean mask for self of whether an element at the corresponding
             position is contained in `values`.
         """
+        # We drop `shape_hint` argument that may be passed from the API layer.
+        # BaseQC doesn't need to know how to handle it.
+        kwargs.pop("shape_hint", None)
         return DataFrameDefault.register(pandas.DataFrame.isin)(self, **kwargs)
 
     def isna(self):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1720,12 +1720,12 @@ class BasePandasDataset(ClassLogger):
             )
         )
 
-    def isin(self, values):  # noqa: PR01, RT01, D200
+    def isin(self, values, **kwargs):  # noqa: PR01, RT01, D200
         """
         Whether elements in `BasePandasDataset` are contained in `values`.
         """
         return self.__constructor__(
-            query_compiler=self._query_compiler.isin(values=values)
+            query_compiler=self._query_compiler.isin(values=values, **kwargs)
         )
 
     def isna(self):  # noqa: RT01, D200

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1259,6 +1259,12 @@ class DataFrame(BasePandasDataset):
             **kwargs,
         )
 
+    def isin(self, values):  # noqa: PR01, RT01, D200
+        """
+        Whether elements in `DataFrame` are contained in `values`.
+        """
+        return super(DataFrame, self).isin(values)
+
     def iterrows(self):  # noqa: D200
         """
         Iterate over ``DataFrame`` rows as (index, ``Series``) pairs.

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1196,6 +1196,12 @@ class Series(BasePandasDataset):
             **kwargs,
         )
 
+    def isin(self, values):  # noqa: PR01, RT01, D200
+        """
+        Whether elements in `Series` are contained in `values`.
+        """
+        return super(Series, self).isin(values, shape_hint="column")
+
     def item(self):  # noqa: RT01, D200
         """
         Return the first element of the underlying data as a Python scalar.


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5682  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
