### PR TITLE
PERF-#5690: move `read_callback` from dispatchers into parsers

### DIFF
--- a/modin/core/io/text/csv_dispatcher.py
+++ b/modin/core/io/text/csv_dispatcher.py
@@ -13,28 +13,8 @@
 
 """Module houses `CSVDispatcher` class, that is used for reading `.csv` files."""
 
-import pandas
-
 from modin.core.io.text.text_file_dispatcher import TextFileDispatcher
 
 
 class CSVDispatcher(TextFileDispatcher):
     """Class handles utils for reading `.csv` files."""
-
-    def read_callback(*args, **kwargs):
-        """
-        Parse data on each partition.
-
-        Parameters
-        ----------
-        *args : list
-            Positional arguments to be passed to the callback function.
-        **kwargs : dict
-            Keyword arguments to be passed to the callback function.
-
-        Returns
-        -------
-        pandas.DataFrame or pandas.io.parsers.TextParser
-            Function call result.
-        """
-        return pandas.read_csv(*args, **kwargs)

--- a/modin/core/io/text/custom_text_dispatcher.py
+++ b/modin/core/io/text/custom_text_dispatcher.py
@@ -23,8 +23,6 @@ from modin.config import NPartitions
 class CustomTextExperimentalDispatcher(TextFileDispatcher):
     """Class handles utils for reading custom text files."""
 
-    read_callback = None
-
     @classmethod
     def _read(cls, filepath_or_buffer, columns, custom_parser, **kwargs):
         r"""

--- a/modin/core/io/text/fwf_dispatcher.py
+++ b/modin/core/io/text/fwf_dispatcher.py
@@ -13,7 +13,6 @@
 
 """Module houses `FWFDispatcher` class, that is used for reading of tables with fixed-width formatted lines."""
 
-import pandas
 from typing import Optional, Union, Sequence, Tuple
 
 from modin.core.io.text.text_file_dispatcher import TextFileDispatcher
@@ -21,24 +20,6 @@ from modin.core.io.text.text_file_dispatcher import TextFileDispatcher
 
 class FWFDispatcher(TextFileDispatcher):
     """Class handles utils for reading of tables with fixed-width formatted lines."""
-
-    def read_callback(*args, **kwargs):
-        """
-        Parse data on each partition.
-
-        Parameters
-        ----------
-        *args : list
-            Positional arguments to be passed to the callback function.
-        **kwargs : dict
-            Keyword arguments to be passed to the callback function.
-
-        Returns
-        -------
-        pandas.DataFrame or pandas.io.parsers.TextFileReader
-            Function call result.
-        """
-        return pandas.read_fwf(*args, **kwargs)
 
     @classmethod
     def check_parameters_support(

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -42,10 +42,6 @@ IndexColType = Union[int, str, bool, Sequence[int], Sequence[str], None]
 class TextFileDispatcher(FileDispatcher):
     """Class handles utils for reading text formats files."""
 
-    # The variable allows to set a function with which one partition will be read;
-    # Used in dispatchers and parsers
-    read_callback = None
-
     @classmethod
     def get_path_or_buffer(cls, filepath_or_buffer):
         """
@@ -1033,7 +1029,6 @@ class TextFileDispatcher(FileDispatcher):
         if not use_modin_impl:
             return cls.single_worker_read(
                 filepath_or_buffer,
-                callback=cls.read_callback,
                 reason=fallback_reason,
                 **kwargs,
             )
@@ -1121,7 +1116,7 @@ class TextFileDispatcher(FileDispatcher):
             compression=compression_infered,
         )
         partition_ids, index_ids, dtypes_ids = cls._launch_tasks(
-            splits, callback=cls.read_callback, **partition_kwargs
+            splits, **partition_kwargs
         )
 
         new_query_compiler = cls._get_new_qc(

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -302,7 +302,27 @@ class PandasCSVParser(PandasParser):
     @staticmethod
     @doc(_doc_parse_func, parameters=_doc_parse_parameters_common)
     def parse(fname, **kwargs):
+        kwargs["callback"] = PandasCSVParser.read_callback
         return PandasParser.generic_parse(fname, **kwargs)
+
+    @staticmethod
+    def read_callback(*args, **kwargs):
+        """
+        Parse data on each partition.
+
+        Parameters
+        ----------
+        *args : list
+            Positional arguments to be passed to the callback function.
+        **kwargs : dict
+            Keyword arguments to be passed to the callback function.
+
+        Returns
+        -------
+        pandas.DataFrame or pandas.io.parsers.TextParser
+            Function call result.
+        """
+        return pandas.read_csv(*args, **kwargs)
 
 
 @doc(_doc_pandas_parser_class, data_type="multiple CSV files simultaneously")
@@ -401,7 +421,27 @@ class PandasFWFParser(PandasParser):
     @staticmethod
     @doc(_doc_parse_func, parameters=_doc_parse_parameters_common)
     def parse(fname, **kwargs):
+        kwargs["callback"] = PandasFWFParser.read_callback
         return PandasParser.generic_parse(fname, **kwargs)
+
+    @staticmethod
+    def read_callback(*args, **kwargs):
+        """
+        Parse data on each partition.
+
+        Parameters
+        ----------
+        *args : list
+            Positional arguments to be passed to the callback function.
+        **kwargs : dict
+            Keyword arguments to be passed to the callback function.
+
+        Returns
+        -------
+        pandas.DataFrame or pandas.io.parsers.TextFileReader
+            Function call result.
+        """
+        return pandas.read_fwf(*args, **kwargs)
 
 
 @doc(_doc_pandas_parser_class, data_type="excel files")


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5690 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
