### PR TITLE
REFACTOR-#5703: align `DaskWrapper.deploy` behavior with others

### DIFF
--- a/modin/core/execution/dask/common/engine_wrapper.py
+++ b/modin/core/execution/dask/common/engine_wrapper.py
@@ -16,6 +16,27 @@
 from distributed.client import default_client
 
 
+def _deploy_dask_func(func, *args, **kwargs):  # pragma: no cover
+    """
+    Wrap `func` to ease calling it remotely.
+
+    Parameters
+    ----------
+    func : callable
+        A local function that we want to call remotely.
+    *args : iterable
+        Positional arguments to pass to `func` when calling remotely.
+    **kwargs : dict
+        Keyword arguments to pass to `func` when calling remotely.
+
+    Returns
+    -------
+    distributed.Future or list
+        Dask identifier of the result being put into distributed memory.
+    """
+    return func(*args, **kwargs)
+
+
 class DaskWrapper:
     """The class responsible for execution of remote operations."""
 
@@ -33,7 +54,7 @@ class DaskWrapper:
 
         Parameters
         ----------
-        func : callable
+        func : callable or distributed.Future
             Function to be deployed in a worker process.
         f_args : list or tuple, optional
             Positional arguments to pass to ``func``.
@@ -52,7 +73,13 @@ class DaskWrapper:
         client = default_client()
         args = [] if f_args is None else f_args
         kwargs = {} if f_kwargs is None else f_kwargs
-        remote_task_future = client.submit(func, *args, pure=pure, **kwargs)
+        if callable(func):
+            remote_task_future = client.submit(func, *args, pure=pure, **kwargs)
+        else:
+            # for the case where type(func) is distributed.Future
+            remote_task_future = client.submit(
+                _deploy_dask_func, func, *args, pure=pure, **kwargs
+            )
         if num_returns != 1:
             return [
                 client.submit(lambda tup, i: tup[i], remote_task_future, i)

--- a/modin/core/execution/ray/common/engine_wrapper.py
+++ b/modin/core/execution/ray/common/engine_wrapper.py
@@ -54,7 +54,7 @@ class RayWrapper:
 
         Parameters
         ----------
-        func : callable
+        func : callable or ray.ObjectID
             The function to perform.
         f_args : list or tuple, optional
             Positional arguments to pass to ``func``.

--- a/modin/core/execution/unidist/common/engine_wrapper.py
+++ b/modin/core/execution/unidist/common/engine_wrapper.py
@@ -53,7 +53,7 @@ class UnidistWrapper:
 
         Parameters
         ----------
-        func : callable
+        func : callable or unidist.ObjectRef
             The function to perform.
         f_args : list or tuple, optional
             Positional arguments to pass to ``func``.


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Allows instead of a function to pass `distributed.Future` into `deploy` (`client.submit` doesn't support this out of the box). There are no tests for this, but it is planned to use for https://github.com/modin-project/modin/pull/5678.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5703 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
