### PR TITLE
PERF-#5705: Preserve metadata when applying `Series.cat.codes`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2199,6 +2199,8 @@ class PandasDataframe(ClassLogger):
         func,
         new_index=None,
         new_columns=None,
+        new_row_lengths=None,
+        new_column_widths=None,
         apply_indices=None,
         enumerate_partitions: bool = False,
         dtypes=None,
@@ -2221,6 +2223,12 @@ class PandasDataframe(ClassLogger):
         new_columns : list-like, optional
             The columns of the result. We may know this in
             advance, and if not provided it must be computed.
+        new_row_lengths : list, optional
+            The length of each partition in the rows. The "height" of
+            each of the block partitions. Is computed if not provided.
+        new_column_widths : list, optional
+            The width of each partition in the columns. The "width" of
+            each of the block partitions. Is computed if not provided.
         apply_indices : list-like, default: None
             Indices of `axis ^ 1` to apply function over.
         enumerate_partitions : bool, default: False
@@ -2255,6 +2263,8 @@ class PandasDataframe(ClassLogger):
             func=func,
             new_index=new_index,
             new_columns=new_columns,
+            new_row_lengths=new_row_lengths,
+            new_column_widths=new_column_widths,
             apply_indices=apply_indices,
             enumerate_partitions=enumerate_partitions,
             dtypes=dtypes,
@@ -2649,6 +2659,8 @@ class PandasDataframe(ClassLogger):
         other,
         new_index=None,
         new_columns=None,
+        new_row_lengths=None,
+        new_column_widths=None,
         apply_indices=None,
         enumerate_partitions=False,
         dtypes=None,
@@ -2673,6 +2685,12 @@ class PandasDataframe(ClassLogger):
         new_columns : list-like, optional
             Columns of the result. We may know this in
             advance, and if not provided it must be computed.
+        new_row_lengths : list, optional
+            The length of each partition in the rows. The "height" of
+            each of the block partitions. Is computed if not provided.
+        new_column_widths : list, optional
+            The width of each partition in the columns. The "width" of
+            each of the block partitions. Is computed if not provided.
         apply_indices : list-like, default: None
             Indices of `axis ^ 1` to apply function over.
         enumerate_partitions : bool, default: False
@@ -2736,7 +2754,7 @@ class PandasDataframe(ClassLogger):
             keep_partitioning=keep_partitioning,
             apply_func_args=apply_func_args,
         )
-        kw = {"row_lengths": None, "column_widths": None}
+        kw = {"row_lengths": new_row_lengths, "column_widths": new_column_widths}
         if dtypes == "copy":
             kw["dtypes"] = self._dtypes
         elif dtypes is not None:

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3428,7 +3428,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
             return ser.cat.codes.to_frame(name=MODIN_UNNAMED_SERIES_LABEL)
 
         res = self._modin_frame.apply_full_axis(
-            axis=0, func=func, new_columns=[MODIN_UNNAMED_SERIES_LABEL]
+            axis=0,
+            func=func,
+            new_index=self._modin_frame._index_cache,
+            new_columns=[MODIN_UNNAMED_SERIES_LABEL],
+            new_row_lengths=self._modin_frame._row_lengths_cache,
+            new_column_widths=self._modin_frame._column_widths_cache,
         )
         return self.__constructor__(res, shape_hint="column")
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3427,13 +3427,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 ser = ser.astype("category", copy=False)
             return ser.cat.codes.to_frame(name=MODIN_UNNAMED_SERIES_LABEL)
 
-        res = self._modin_frame.apply_full_axis(
-            axis=0,
-            func=func,
-            new_index=self._modin_frame._index_cache,
-            new_columns=[MODIN_UNNAMED_SERIES_LABEL],
-            new_row_lengths=self._modin_frame._row_lengths_cache,
-            new_column_widths=self._modin_frame._column_widths_cache,
+        res = self._modin_frame.fold(
+            axis=0, func=func, new_columns=[MODIN_UNNAMED_SERIES_LABEL]
         )
         return self.__constructor__(res, shape_hint="column")
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5705  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
