### PR TITLE
PERF-#5710: Avoid re-putting a distributed Series to the engine's object store at `.isin()`

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1348,8 +1348,6 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             Boolean mask for self of whether an element at the corresponding
             position is contained in `values`.
         """
-        # We drop `shape_hint` argument that may be passed from the API layer.
-        # BaseQC doesn't need to know how to handle it.
         shape_hint = kwargs.pop("shape_hint", None)
         if isinstance(values, type(self)) and ignore_indices:
             # Pandas logic is that it ignores indexing if 'values' is a 1D object

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1404,12 +1404,37 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # Map partitions operations
     # These operations are operations that apply a function to every partition.
+    def isin(self, values, ignore_indices=False, shape_hint=None):
+        if isinstance(values, type(self)):
+            # HACK: if we won't cast to pandas then the execution engine will try to
+            # # propagate the distributed Series to workers and most likely would have
+            # some performance problems.
+            # TODO: A better way of doing so could be passing this `values` as a query compiler
+            # and broadcast accordingly.
+            values = values.to_pandas()
+            if ignore_indices:
+                # Pandas logic is that it ignores indexing if 'values' is a 1D object
+                values = values.squeeze(axis=1)
+
+        def isin_func(df, values):
+            if shape_hint == "column":
+                df = df.squeeze(axis=1)
+            res = df.isin(values)
+            if isinstance(res, pandas.Series):
+                res = res.to_frame(
+                    MODIN_UNNAMED_SERIES_LABEL if res.name is None else res.name
+                )
+            return res
+
+        return Map.register(isin_func, shape_hint=shape_hint, dtypes=np.bool_)(
+            self, values
+        )
+
     abs = Map.register(pandas.DataFrame.abs, dtypes="copy")
     applymap = Map.register(pandas.DataFrame.applymap)
     conj = Map.register(lambda df, *args, **kwargs: pandas.DataFrame(np.conj(df)))
     convert_dtypes = Map.register(pandas.DataFrame.convert_dtypes)
     invert = Map.register(pandas.DataFrame.__invert__, dtypes="copy")
-    isin = Map.register(pandas.DataFrame.isin, dtypes=np.bool_)
     isna = Map.register(pandas.DataFrame.isna, dtypes=np.bool_)
     _isfinite = Map.register(
         lambda df, *args, **kwargs: pandas.DataFrame(np.isfinite(df))

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1406,8 +1406,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # These operations are operations that apply a function to every partition.
     def isin(self, values, ignore_indices=False, shape_hint=None):
         if isinstance(values, type(self)):
-            # HACK: if we won't cast to pandas then the execution engine will try to
-            # # propagate the distributed Series to workers and most likely would have
+            # HACK: if we don't cast to pandas, then the execution engine will try to
+            # propagate the distributed Series to workers and most likely would have
             # some performance problems.
             # TODO: A better way of doing so could be passing this `values` as a query compiler
             # and broadcast accordingly.

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1724,8 +1724,14 @@ class BasePandasDataset(ClassLogger):
         """
         Whether elements in `BasePandasDataset` are contained in `values`.
         """
+        from .series import Series
+
+        ignore_indices = isinstance(values, Series)
+        values = getattr(values, "_query_compiler", values)
         return self.__constructor__(
-            query_compiler=self._query_compiler.isin(values=values, **kwargs)
+            query_compiler=self._query_compiler.isin(
+                values=values, ignore_indices=ignore_indices, **kwargs
+            )
         )
 
     def isna(self):  # noqa: RT01, D200

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -336,7 +336,7 @@ def test_isin(data):
     df_equals(modin_result, pandas_result)
 
 
-def test_isin_with_modin():
+def test_isin_with_modin_objects():
     modin_df1, pandas_df1 = create_test_dfs({"a": [1, 2], "b": [3, 4]})
     modin_series, pandas_series = pd.Series([1, 4, 5, 6]), pandas.Series([1, 4, 5, 6])
 

--- a/modin/pandas/test/dataframe/test_iter.py
+++ b/modin/pandas/test/dataframe/test_iter.py
@@ -28,6 +28,8 @@ from modin.pandas.test.utils import (
     test_data_values,
     test_data_keys,
     test_data,
+    create_test_dfs,
+    eval_general,
 )
 from modin.pandas.utils import SET_DATAFRAME_ATTRIBUTE_WARNING
 from modin.config import NPartitions
@@ -332,3 +334,37 @@ def test_isin(data):
     modin_result = modin_df.isin(val)
 
     df_equals(modin_result, pandas_result)
+
+
+def test_isin_with_modin():
+    modin_df1, pandas_df1 = create_test_dfs({"a": [1, 2], "b": [3, 4]})
+    modin_series, pandas_series = pd.Series([1, 4, 5, 6]), pandas.Series([1, 4, 5, 6])
+
+    eval_general(
+        (modin_df1, modin_series),
+        (pandas_df1, pandas_series),
+        lambda srs: srs[0].isin(srs[1]),
+    )
+
+    modin_df2 = modin_series.to_frame("a")
+    pandas_df2 = pandas_series.to_frame("a")
+
+    eval_general(
+        (modin_df1, modin_df2),
+        (pandas_df1, pandas_df2),
+        lambda srs: srs[0].isin(srs[1]),
+    )
+
+    # Check case when indices are not matching
+    modin_df1, pandas_df1 = create_test_dfs({"a": [1, 2], "b": [3, 4]}, index=[10, 11])
+
+    eval_general(
+        (modin_df1, modin_series),
+        (pandas_df1, pandas_series),
+        lambda srs: srs[0].isin(srs[1]),
+    )
+    eval_general(
+        (modin_df1, modin_df2),
+        (pandas_df1, pandas_df2),
+        lambda srs: srs[0].isin(srs[1]),
+    )

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2070,6 +2070,26 @@ def test_isin(data):
     df_equals(modin_result, pandas_result)
 
 
+def test_isin_with_series():
+    modin_series1, pandas_series1 = create_test_series([1, 2, 3])
+    modin_series2, pandas_series2 = create_test_series([1, 2, 3, 4, 5])
+
+    eval_general(
+        (modin_series1, modin_series2),
+        (pandas_series1, pandas_series2),
+        lambda srs: srs[0].isin(srs[1]),
+    )
+
+    # Verify that Series actualy behaves like Series and ignores unmatched indices on '.isin'
+    modin_series1, pandas_series1 = create_test_series([1, 2, 3], index=[10, 11, 12])
+
+    eval_general(
+        (modin_series1, modin_series2),
+        (pandas_series1, pandas_series2),
+        lambda srs: srs[0].isin(srs[1]),
+    )
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_isnull(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #5710 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
