### PR TITLE
FIX-#5714: BUG: Empty frames concatenation with inner join is not valid

### DIFF
--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -411,10 +411,7 @@ def concat(
             for obj in list_of_objs
             if (
                 isinstance(obj, (Series, pandas.Series))
-                or (
-                    isinstance(obj, (DataFrame, Series))
-                    and obj._query_compiler.lazy_execution
-                )
+                or (isinstance(obj, DataFrame) and obj._query_compiler.lazy_execution)
                 or sum(obj.shape) > 0
             )
         ]

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -361,13 +361,13 @@ def concat(
         )
     axis = pandas.DataFrame()._get_axis_number(axis)
     if isinstance(objs, dict):
-        list_of_objs = list(objs.values())
+        input_list_of_objs = list(objs.values())
     else:
-        list_of_objs = list(objs)
-    if len(list_of_objs) == 0:
+        input_list_of_objs = list(objs)
+    if len(input_list_of_objs) == 0:
         raise ValueError("No objects to concatenate")
 
-    list_of_objs = [obj for obj in list_of_objs if obj is not None]
+    list_of_objs = [obj for obj in input_list_of_objs if obj is not None]
 
     if len(list_of_objs) == 0:
         raise ValueError("All objects passed were None")
@@ -404,7 +404,21 @@ def concat(
                 sort=sort,
             )
         )
-    if join not in ["inner", "outer"]:
+    if join == "outer":
+        # Filter out empties
+        list_of_objs = [
+            obj
+            for obj in list_of_objs
+            if (
+                isinstance(obj, (Series, pandas.Series))
+                or (
+                    isinstance(obj, (DataFrame, Series))
+                    and obj._query_compiler.lazy_execution
+                )
+                or sum(obj.shape) > 0
+            )
+        ]
+    elif join != "inner":
         raise ValueError(
             "Only can inner (intersect) or outer (union) join the other axis"
         )
@@ -412,18 +426,12 @@ def concat(
     # dataframe to a series on axis=0, pandas ignores the name of the series,
     # and this check aims to mirror that (possibly buggy) functionality
     list_of_objs = [
-        obj
-        if isinstance(obj, DataFrame)
-        else DataFrame(obj.rename())
-        if isinstance(obj, (pandas.Series, Series)) and axis == 0
-        else DataFrame(obj)
-        for obj in list_of_objs
-    ]
-    list_of_objs = [
         obj._query_compiler
+        if isinstance(obj, DataFrame)
+        else DataFrame(obj.rename())._query_compiler
+        if isinstance(obj, (pandas.Series, Series)) and axis == 0
+        else DataFrame(obj)._query_compiler
         for obj in list_of_objs
-        if (not obj._query_compiler.lazy_execution and len(obj.index))
-        or len(obj.columns)
     ]
     if keys is not None:
         if all_series:
@@ -454,6 +462,14 @@ def concat(
         ).index
     else:
         new_idx = None
+
+    if len(list_of_objs) == 0:
+        return DataFrame(
+            index=input_list_of_objs[0].index.append(
+                [f.index for f in input_list_of_objs[1:]]
+            )
+        )
+
     new_query_compiler = list_of_objs[0].concat(
         axis,
         list_of_objs[1:],

--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -236,3 +236,26 @@ def test_sort_order(sort, join, axis):
         modin_concat,
     )
     assert list(pandas_concat.columns) == list(modin_concat.columns)
+
+
+@pytest.mark.parametrize(
+    "data1, index1, data2, index2",
+    [
+        (None, None, None, None),
+        (None, None, {"A": [1, 2, 3]}, pandas.Index([1, 2, 3], name="Test")),
+        ({"A": [1, 2, 3]}, pandas.Index([1, 2, 3], name="Test"), None, None),
+        ({"A": [1, 2, 3]}, None, None, None),
+        (None, None, {"A": [1, 2, 3]}, None),
+        (None, pandas.Index([1, 2, 3], name="Test"), None, None),
+        (None, None, None, pandas.Index([1, 2, 3], name="Test")),
+    ],
+)
+@pytest.mark.parametrize("axis", [0, 1])
+def test_concat_inner_empty(data1, index1, data2, index2, axis):
+    pdf1 = pandas.DataFrame(data1, index=index1)
+    pdf2 = pandas.DataFrame(data2, index=index2)
+    pdf = pandas.concat((pdf1, pdf2), axis=axis, join="inner")
+    mdf1 = pd.DataFrame(data1, index=index1)
+    mdf2 = pd.DataFrame(data2, index=index2)
+    mdf = pd.concat((mdf1, mdf2), axis=axis, join="inner")
+    df_equals(pdf, mdf)

--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -23,10 +23,13 @@ from .utils import (
     generate_multiindex_dfs,
     generate_none_dfs,
     create_test_dfs,
+    default_to_pandas_ignore_string,
 )
 from modin.config import NPartitions
 
 NPartitions.put(4)
+
+pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 
 
 def test_df_concat():
@@ -258,4 +261,13 @@ def test_concat_inner_empty(data1, index1, data2, index2, axis):
     mdf1 = pd.DataFrame(data1, index=index1)
     mdf2 = pd.DataFrame(data2, index=index2)
     mdf = pd.concat((mdf1, mdf2), axis=axis, join="inner")
+    df_equals(pdf, mdf)
+
+
+def test_concat_empty_df_series():
+    pdf = pandas.concat((pandas.DataFrame({"A": [1, 2, 3]}), pandas.Series()))
+    mdf = pd.concat((pd.DataFrame({"A": [1, 2, 3]}), pd.Series()))
+    df_equals(pdf, mdf)
+    pdf = pandas.concat((pandas.DataFrame(), pandas.Series([1, 2, 3])))
+    mdf = pd.concat((pd.DataFrame(), pd.Series([1, 2, 3])))
     df_equals(pdf, mdf)

--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -254,13 +254,14 @@ def test_sort_order(sort, join, axis):
     ],
 )
 @pytest.mark.parametrize("axis", [0, 1])
-def test_concat_inner_empty(data1, index1, data2, index2, axis):
+@pytest.mark.parametrize("join", ["inner", "outer"])
+def test_concat_empty(data1, index1, data2, index2, axis, join):
     pdf1 = pandas.DataFrame(data1, index=index1)
     pdf2 = pandas.DataFrame(data2, index=index2)
-    pdf = pandas.concat((pdf1, pdf2), axis=axis, join="inner")
+    pdf = pandas.concat((pdf1, pdf2), axis=axis, join=join)
     mdf1 = pd.DataFrame(data1, index=index1)
     mdf2 = pd.DataFrame(data2, index=index2)
-    mdf = pd.concat((mdf1, mdf2), axis=axis, join="inner")
+    mdf = pd.concat((mdf1, mdf2), axis=axis, join=join)
     df_equals(pdf, mdf)
 
 


### PR DESCRIPTION

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5714 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
