### PR TITLE
FIX-#5723: Attempt to read list of parquet files in one go.

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1356,6 +1356,20 @@ class TestParquet:
                 columns=columns,
             )
 
+    def test_read_parquet_list_of_files_5698(self, engine, make_parquet_file):
+        with ensure_clean(".parquet") as f1, ensure_clean(
+            ".parquet"
+        ) as f2, ensure_clean(".parquet") as f3:
+            for f in [f1, f2, f3]:
+                make_parquet_file(filename=f)
+            eval_io(fn_name="read_parquet", path=[f1, f2, f3], engine=engine)
+
+    def test_empty_list(self, engine):
+        eval_io(fn_name="read_parquet", path=[], engine=engine)
+
+    def test_list_of_s3_file(self, engine):
+        raise NotImplementedError
+
     @pytest.mark.xfail(
         condition="config.getoption('--simulate-cloud').lower() != 'off'",
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
