### PR TITLE
FIX-#5720: Ensure that modin.numpy.array's propagate NaN values when computing mean

### DIFF
--- a/modin/numpy/test/test_array_axis_functions.py
+++ b/modin/numpy/test/test_array_axis_functions.py
@@ -420,6 +420,19 @@ def test_mean():
     modin_result = modin_arr.mean(where=modin_where)
     numpy_result = numpy_arr.mean(where=numpy_where)
     assert modin_result == numpy_result
+    # Test NA propagation
+    numpy_arr = numpy.array([[1, 2], [3, 4], [5, numpy.nan]])
+    modin_arr = np.array([[1, 2], [3, 4], [5, np.nan]])
+    assert numpy.isnan(modin_arr.mean())
+    numpy.testing.assert_array_equal(
+        numpy_arr.mean(axis=1), modin_arr.mean(axis=1)._to_numpy()
+    )
+    numpy.testing.assert_array_equal(
+        numpy_arr.mean(axis=0), modin_arr.mean(axis=0)._to_numpy()
+    )
+    numpy_where = numpy.array([[True, True], [True, True], [True, False]])
+    modin_where = np.array(numpy_where)
+    assert modin_arr.mean(where=modin_where) == numpy_arr.mean(where=numpy_where)
 
 
 def test_prod():


### PR DESCRIPTION


<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5720 ? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
