### PR TITLE
FIX-#5737: BUG: String columns are converted to Categorical, if exported from HDK

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -2302,13 +2302,16 @@ class HdkOnNativeDataframe(PandasDataframe):
             at = self._partitions[0][0].get()
             schema = at.schema
             cast = {
-                i: s[0].name
-                for i, s in enumerate(zip(schema, self._dtypes))
-                if is_dictionary(s[0].type) and not is_categorical_dtype(s[1])
+                idx: arrow_type.name
+                for idx, (arrow_type, pandas_type) in enumerate(
+                    zip(schema, self._dtypes)
+                )
+                if is_dictionary(arrow_type.type)
+                and not is_categorical_dtype(pandas_type)
             }
             if cast:
-                for i, n in cast.items():
-                    schema = schema.set(i, pyarrow.field(n, pyarrow.string()))
+                for idx, new_type in cast.items():
+                    schema = schema.set(idx, pyarrow.field(new_type, pyarrow.string()))
                 at = at.cast(schema)
             df = at.to_pandas()
         else:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -437,6 +437,14 @@ class TestMasks:
 
         run_and_compare(filter, data=self.data)
 
+    def test_filter_str_categorical(self):
+        def filter(df, **kwargs):
+            return df[df["A"] != ""]
+
+        data = {"A": ["A", "B", "C"]}
+        run_and_compare(filter, data=data)
+        run_and_compare(filter, data=data, constructor_kwargs={"dtype": "category"})
+
 
 class TestMultiIndex:
     data = {"a": np.arange(24), "b": np.arange(24)}

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/utils.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/utils.py
@@ -316,24 +316,4 @@ def run_and_compare(
             constructor_kwargs=constructor_kwargs,
             **kwargs,
         )
-
-        # Currently, strings are converted to categories when exported from HDK,
-        # this makes the equality comparison fail. Converting string cols back to
-        # their original dtypes until the issue is resolved:
-        # https://github.com/modin-project/modin/issues/2747
-        if isinstance(exp_res, pd.DataFrame):
-            external_dtypes = exp_res.dtypes
-            exp_res = try_cast_to_pandas(exp_res)
-            internal_dtypes = exp_res.dtypes
-
-            new_schema = {}
-            for col in exp_res.columns:
-                if (
-                    not isinstance(internal_dtypes[col], pandas.Series)
-                    and internal_dtypes[col] == "category"
-                    and external_dtypes[col] != "category"
-                ):
-                    new_schema[col] = external_dtypes[col]
-            exp_res = exp_res.astype(new_schema)
-
         comparator(ref_res, exp_res)

--- a/modin/experimental/sql/hdk/query.py
+++ b/modin/experimental/sql/hdk/query.py
@@ -74,7 +74,9 @@ def hdk_query(query: str, **kwargs) -> pd.DataFrame:
     schema = mdf._partitions[0][0].get().schema
     # HDK returns strings as dictionary. For the proper conversion to
     # Pandas, we need to replace dtypes of the corresponding columns.
-    if replace := [i for i, f in enumerate(schema) if pa.types.is_dictionary(f.type)]:
+    if replace := [
+        i for i, col in enumerate(schema) if pa.types.is_dictionary(col.type)
+    ]:
         dtypes = mdf._dtypes
         obj_type = get_dtype(object)
         for i in replace:

--- a/modin/experimental/sql/test/test_sql.py
+++ b/modin/experimental/sql/test/test_sql.py
@@ -81,10 +81,3 @@ def test_string_cast():
     mdf = pd.DataFrame(data)
     pdf = pandas.DataFrame(data)
     df_equals(pdf, query("SELECT * FROM df", df=mdf))
-
-    if cfg.StorageFormat.get() != "Hdk":
-        pytest.xfail(reason="dfsql does not preserve categorical dtypes")
-
-    mdf = pd.DataFrame(data, dtype="category")
-    pdf = pandas.DataFrame(data, dtype="category")
-    df_equals(pdf, query("SELECT * FROM df", df=mdf))

--- a/modin/experimental/sql/test/test_sql.py
+++ b/modin/experimental/sql/test/test_sql.py
@@ -11,9 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import pandas
 import modin.pandas as pd
 import modin.config as cfg
-from modin.pandas.test.utils import default_to_pandas_ignore_string
+from modin.pandas.test.utils import default_to_pandas_ignore_string, df_equals
 
 import io
 import pytest
@@ -71,3 +72,19 @@ def test_sql_extension():
     values_right = query_result.values
     assert values_left.shape == values_right.shape
     assert (values_left == values_right).all()
+
+
+def test_string_cast():
+    from modin.experimental.sql import query
+
+    data = {"A": ["A", "B", "C"], "B": ["A", "B", "C"]}
+    mdf = pd.DataFrame(data)
+    pdf = pandas.DataFrame(data)
+    df_equals(pdf, query("SELECT * FROM df", df=mdf))
+
+    if cfg.StorageFormat.get() != "Hdk":
+        pytest.xfail(reason="dfsql does not preserve categorical dtypes")
+
+    mdf = pd.DataFrame(data, dtype="category")
+    pdf = pandas.DataFrame(data, dtype="category")
+    df_equals(pdf, query("SELECT * FROM df", df=mdf))


### PR DESCRIPTION


- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5737 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
