### PR TITLE
TEST-#0000: correct behavior of CI for push action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ on:
 
 jobs:
   lint-black:
-    if: github.event_name == 'pull_request'
     name: lint (black)
     runs-on: ubuntu-latest
     steps:
@@ -36,7 +35,6 @@ jobs:
       - run: black --check --diff modin/ asv_bench/benchmarks scripts/doc_checker.py
 
   lint-mypy:
-    if: github.event_name == 'pull_request'
     name: lint (mypy)
     runs-on: ubuntu-latest
     steps:
@@ -148,7 +146,6 @@ jobs:
       - run: python scripts/doc_checker.py modin/logging
 
   lint-flake8:
-    if: github.event_name == 'pull_request'
     name: lint (flake8)
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

It turned out that the main jobs do not start if the jobs on which they depend are skipped. This is a hotfix, I think it's not a problem that we also run linters when pushing, since they are fast enough.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
