### PR TITLE
FEAT-#5754: Add np.linalg operations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -633,6 +633,7 @@ jobs:
       - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_arithmetic.py
       - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_axis_functions.py
       - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_logic.py
+      - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_linalg.py
       - run: chmod +x ./.github/workflows/sql_server/set_up_sql_server.sh
       - run: ./.github/workflows/sql_server/set_up_sql_server.sh
       - run: mpiexec -n 1 python -m pytest modin/pandas/test/test_io.py --verbose
@@ -728,6 +729,7 @@ jobs:
       - run: python -m pytest -n 2 modin/numpy/test/test_array_arithmetic.py
       - run: python -m pytest -n 2 modin/numpy/test/test_array_axis_functions.py
       - run: python -m pytest -n 2 modin/numpy/test/test_array_logic.py
+      - run: python -m pytest -n 2 modin/numpy/test/test_array_linalg.py
       - run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
       - run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
       - run: python -m pytest -n 2 modin/pandas/test/test_general.py
@@ -862,6 +864,7 @@ jobs:
           - modin/numpy/test/test_array_axis_functions.py
           - modin/numpy/test/test_array_arithmetic.py
           - modin/numpy/test/test_array_logic.py
+          - modin/numpy/test/test_array_linalg.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
     name: test-windows

--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -60,6 +60,7 @@ jobs:
           python -m pytest modin/numpy/test/test_array_arithmetic.py
           python -m pytest modin/numpy/test/test_array_axis_functions.py
           python -m pytest modin/numpy/test/test_array_logic.py
+          python -m pytest modin/numpy/test/test_array_linalg.py
           python -m pytest modin/pandas/test/test_rolling.py
           python -m pytest modin/pandas/test/test_concat.py
           python -m pytest modin/pandas/test/test_groupby.py
@@ -131,6 +132,7 @@ jobs:
           - modin/numpy/test/test_array_arithmetic.py
           - modin/numpy/test/test_array_axis_functions.py
           - modin/numpy/test/test_array_logic.py
+          - modin/numpy/test/test_array_linalg.py
           - modin/pandas/test/test_rolling.py
           - modin/pandas/test/test_concat.py
           - modin/pandas/test/test_groupby.py

--- a/modin/numpy/__init__.py
+++ b/modin/numpy/__init__.py
@@ -53,6 +53,7 @@ from .math import (
     abs,
     add,
     divide,
+    dot,
     float_power,
     floor_divide,
     power,
@@ -90,6 +91,8 @@ from .constants import (
     pi,
 )
 
+from . import linalg
+
 
 def where(condition, x=None, y=None):
     if condition is True:
@@ -104,6 +107,7 @@ def where(condition, x=None, y=None):
 
 
 __all__ = [  # noqa: F405
+    "linalg",
     "array",
     "zeros_like",
     "ones_like",
@@ -135,6 +139,7 @@ __all__ = [  # noqa: F405
     "abs",
     "add",
     "divide",
+    "dot",
     "float_power",
     "floor_divide",
     "power",

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -1432,7 +1432,7 @@ class array(object):
         check_kwargs(keepdims=keepdims)
         if ord is not None and ord not in ("fro",):  # , numpy.inf, -numpy.inf, 0):
             raise NotImplementedError("unsupported ord argument for norm:", ord)
-        if axis < 0:
+        if isinstance(axis, int) and axis < 0:
             axis = self._ndim + axis
         apply_axis = axis or 0
         if apply_axis >= self._ndim or apply_axis < 0:

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -1417,7 +1417,7 @@ class array(object):
             result = self._query_compiler.dot(other._query_compiler)
             result_ndim = 1
         if out is not None:
-            out._query_compiler = result
+            out._update_inplace(result)
         return array(_query_compiler=result, _ndim=result_ndim)
 
     def __matmul__(self, other):

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -1395,6 +1395,7 @@ class array(object):
         if numpy.isscalar(other):
             # other is scalar -- result is an array
             result = self._query_compiler.mul(other)
+            result_ndim = self._ndim
         elif not isinstance(other, array):
             raise TypeError(
                 f"Unsupported operand type(s): '{type(self)}' and '{type(other)}'"
@@ -1408,23 +1409,33 @@ class array(object):
         elif self._ndim == 2 and other._ndim == 2:
             # both 2D arrays -- result is a 2D array
             result = self._query_compiler.dot(other._query_compiler)
+            result_ndim = 2
         elif self._ndim == 1 and other._ndim == 2:
-            result = self._query_compiler.dot(other._query_compiler)
+            result = self._query_compiler.dot(other._query_compiler, squeeze_self=True)
+            result_ndim = 1
         elif self._ndim == 2 and other._ndim == 1:
-            if other.shape[0] == 1:
-                result = self._query_compiler.dot(other._query_compiler.transpose())
-            else:
-                result = self._query_compiler.dot(other._query_compiler)
+            result = self._query_compiler.dot(other._query_compiler)
+            result_ndim = 1
         if out is not None:
             out._query_compiler = result
-        return array(_query_compiler=result)
+        return array(_query_compiler=result, _ndim=result_ndim)
+
+    def __matmul__(self, other):
+        if numpy.isscalar(other):
+            # numpy's original error message is something cryptic about a gufunc signature
+            raise ValueError(
+                "cannot call matmul with a scalar argument (use np.dot instead)"
+            )
+        return self.dot(other)
 
     def _norm(self, ord=None, axis=None, keepdims=False):
         check_kwargs(keepdims=keepdims)
         if ord is not None and ord not in ("fro",):  # , numpy.inf, -numpy.inf, 0):
             raise NotImplementedError("unsupported ord argument for norm:", ord)
+        if axis < 0:
+            axis = self._ndim + axis
         apply_axis = axis or 0
-        if apply_axis >= self._ndim:
+        if apply_axis >= self._ndim or apply_axis < 0:
             raise numpy.AxisError(apply_axis, self._ndim)
         result = self._query_compiler.applymap(lambda x: x**2)
         if self._ndim == 2:
@@ -1435,9 +1446,9 @@ class array(object):
             result = result.sum(axis=0)
         if axis is None:
             # Return a scalar
-            return numpy.sqrt(result.to_numpy()[0, 0])
+            return result.pow(0.5).to_numpy()[0, 0]
         else:
-            result = result.applymap(lambda x: numpy.sqrt(x))
+            result = result.applymap(lambda x: x**0.5)
             # the DF may be transposed after processing through pandas
             # check query compiler shape to ensure this is a row vector (1xN) not column (Nx1)
             if len(result.index) != 1:

--- a/modin/numpy/linalg.py
+++ b/modin/numpy/linalg.py
@@ -1,0 +1,26 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import numpy
+
+from .arr import array
+from .utils import try_convert_from_interoperable_type
+from modin.error_message import ErrorMessage
+
+
+def norm(x, ord=None, axis=None, keepdims=False):
+    x = try_convert_from_interoperable_type(x)
+    if not isinstance(x, array):
+        ErrorMessage.bad_type_for_numpy_op("linalg.norm", type(x))
+        return numpy.linalg.norm(x, ord=ord, axis=axis, keepdims=keepdims)
+    return x._norm(ord=ord, axis=axis, keepdims=keepdims)

--- a/modin/numpy/math.py
+++ b/modin/numpy/math.py
@@ -95,6 +95,14 @@ def divide(
     )
 
 
+def dot(a, b, out=None):
+    a = try_convert_from_interoperable_type(a)
+    if not isinstance(a, array):
+        ErrorMessage.bad_type_for_numpy_op("dot", type(a))
+        return numpy.dot(a, b, out=out)
+    return a.dot(b, out=out)
+
+
 def float_power(
     x1, x2, out=None, where=True, casting="same_kind", order="K", dtype=None, subok=True
 ):

--- a/modin/numpy/test/test_array_linalg.py
+++ b/modin/numpy/test/test_array_linalg.py
@@ -50,9 +50,27 @@ def test_dot_2d():
     numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
 
 
+def test_dot_broadcast():
+    # 2D @ 1D
+    x1 = numpy.random.randint(-100, 100, size=(100, 3))
+    x2 = numpy.random.randint(-100, 100, size=(3,))
+    numpy_result = numpy.dot(x1, x2)
+    x1, x2 = np.array(x1), np.array(x2)
+    modin_result = np.dot(x1, x2)
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+
+    # 1D @ 2D
+    x1 = numpy.random.randint(-100, 100, size=(100,))
+    x2 = numpy.random.randint(-100, 100, size=(100, 3))
+    numpy_result = numpy.dot(x1, x2)
+    x1, x2 = np.array(x1), np.array(x2)
+    modin_result = np.dot(x1, x2)
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+
+
 @pytest.mark.parametrize("axis", [None, 0, 1], ids=["axis=None", "axis=0", "axis=1"])
 def test_norm_fro_2d(axis):
-    x1 = numpy.random.randint(-100, 100, size=(100, 3))
+    x1 = numpy.random.randint(-10, 10, size=(100, 3))
     numpy_result = NLA.norm(x1, axis=axis)
     x1 = np.array(x1)
     modin_result = LA.norm(x1, axis=axis)
@@ -63,7 +81,7 @@ def test_norm_fro_2d(axis):
 
 
 def test_norm_fro_1d():
-    x1 = numpy.random.randint(-100, 100, size=100)
+    x1 = numpy.random.randint(-10, 10, size=100)
     numpy_result = NLA.norm(x1)
     x1 = np.array(x1)
     modin_result = LA.norm(x1)

--- a/modin/numpy/test/test_array_linalg.py
+++ b/modin/numpy/test/test_array_linalg.py
@@ -1,0 +1,70 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License
+
+
+import pytest
+import numpy
+import numpy.linalg as NLA
+
+import modin.pandas as pd
+import modin.numpy as np
+import modin.numpy.linalg as LA
+
+
+def test_dot_from_pandas_reindex():
+    # Reindexing the dataframe does not change the output of dot
+    # https://pandas.pydata.org/docs/reference/api/pandas.DataFrame.dot.html
+    df = pd.DataFrame([[0, 1, -2, -1], [1, 1, 1, 1]])
+    s = pd.Series([1, 1, 2, 1])
+    result1 = np.dot(df, s)
+    s2 = s.reindex([1, 0, 2, 3])
+    result2 = np.dot(df, s2)
+    numpy.testing.assert_array_equal(result1._to_numpy(), result2._to_numpy())
+
+
+def test_dot_1d():
+    x1 = numpy.random.randint(-100, 100, size=100)
+    x2 = numpy.random.randint(-100, 100, size=100)
+    numpy_result = numpy.dot(x1, x2)
+    x1, x2 = np.array(x1), np.array(x2)
+    modin_result = np.dot(x1, x2)
+    numpy.testing.assert_array_equal(modin_result, numpy_result)
+
+
+def test_dot_2d():
+    x1 = numpy.random.randint(-100, 100, size=(100, 3))
+    x2 = numpy.random.randint(-100, 100, size=(3, 50))
+    numpy_result = numpy.dot(x1, x2)
+    x1, x2 = np.array(x1), np.array(x2)
+    modin_result = np.dot(x1, x2)
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+
+
+@pytest.mark.parametrize("axis", [None, 0, 1], ids=["axis=None", "axis=0", "axis=1"])
+def test_norm_fro_2d(axis):
+    x1 = numpy.random.randint(-100, 100, size=(100, 3))
+    numpy_result = NLA.norm(x1, axis=axis)
+    x1 = np.array(x1)
+    modin_result = LA.norm(x1, axis=axis)
+    # Result may be a scalar
+    if isinstance(modin_result, np.array):
+        modin_result = modin_result._to_numpy()
+    numpy.testing.assert_array_equal(modin_result, numpy_result)
+
+
+def test_norm_fro_1d():
+    x1 = numpy.random.randint(-100, 100, size=100)
+    numpy_result = NLA.norm(x1)
+    x1 = np.array(x1)
+    modin_result = LA.norm(x1)
+    numpy.testing.assert_array_equal(modin_result, numpy_result)

--- a/modin/numpy/test/test_array_linalg.py
+++ b/modin/numpy/test/test_array_linalg.py
@@ -77,7 +77,7 @@ def test_norm_fro_2d(axis):
     # Result may be a scalar
     if isinstance(modin_result, np.array):
         modin_result = modin_result._to_numpy()
-    numpy.testing.assert_array_equal(modin_result, numpy_result)
+    numpy.testing.assert_allclose(modin_result, numpy_result, rtol=1e-12)
 
 
 def test_norm_fro_1d():
@@ -85,4 +85,4 @@ def test_norm_fro_1d():
     numpy_result = NLA.norm(x1)
     x1 = np.array(x1)
     modin_result = LA.norm(x1)
-    numpy.testing.assert_array_equal(modin_result, numpy_result)
+    numpy.testing.assert_allclose(modin_result, numpy_result, rtol=1e-12)

--- a/modin/numpy/test/test_array_linalg.py
+++ b/modin/numpy/test/test_array_linalg.py
@@ -9,7 +9,7 @@
 # Unless required by applicable law or agreed to in writing, software distributed under
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific language
-# governing permissions and limitations under the License
+# governing permissions and limitations under the License.
 
 
 import pytest


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
This PR adds support for `np.dot` and `np.linalg.norm`.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5754 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
