### PR TITLE
FIX-#0000: Fix a typo in `expr.py`

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
@@ -89,7 +89,7 @@ def _agg_dtype(agg, dtype):
     elif agg in _aggs_with_float_result:
         return get_dtype(float)
     else:
-        raise NotImplementedError(f"unsupported aggreagte {agg}")
+        raise NotImplementedError(f"unsupported aggregate {agg}")
 
 
 _cmp_ops = {"eq", "ge", "gt", "le", "lt", "ne"}


### PR DESCRIPTION
Fixed typo
