### PR TITLE
FIX-#5761: Add _exp, _sqrt to query compiler

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1496,6 +1496,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
     _tanh = Map.register(
         lambda df, *args, **kwargs: pandas.DataFrame(np.tanh(df, *args, **kwargs))
     )  # Needed for numpy API
+    _sqrt = Map.register(
+        lambda df, *args, **kwargs: pandas.DataFrame(np.sqrt(df, *args, **kwargs))
+    )  # Needed for numpy API
+    _exp = Map.register(
+        lambda df, *args, **kwargs: pandas.DataFrame(np.exp(df, *args, **kwargs))
+    )  # Needed for numpy API
     negative = Map.register(pandas.DataFrame.__neg__)
     notna = Map.register(pandas.DataFrame.notna, dtypes=np.bool_)
     round = Map.register(pandas.DataFrame.round)

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -952,8 +952,26 @@ class array(object):
         subok=True,
     ):
         return self._unary_math_operator(
-            "rpow",
-            numpy.e,
+            "_exp",
+            out=out,
+            where=where,
+            casting=casting,
+            order=order,
+            dtype=dtype,
+            subok=subok,
+        )
+
+    def sqrt(
+        self,
+        out=None,
+        where=True,
+        casting="same_kind",
+        order="K",
+        dtype=None,
+        subok=True,
+    ):
+        return self._unary_math_operator(
+            "_sqrt",
             out=out,
             where=where,
             casting=casting,
@@ -1853,9 +1871,9 @@ class array(object):
             result = result.sum(axis=0)
         if axis is None:
             # Return a scalar
-            return result.pow(0.5).to_numpy()[0, 0]
+            return result._sqrt().to_numpy()[0, 0]
         else:
-            result = result.pow(0.5)
+            result = result._sqrt()
             # the DF may be transposed after processing through pandas
             # check query compiler shape to ensure this is a row vector (1xN) not column (Nx1)
             if len(result.index) != 1:

--- a/modin/numpy/math.py
+++ b/modin/numpy/math.py
@@ -432,7 +432,7 @@ def sqrt(
             dtype=dtype,
             subok=subok,
         )
-    return x.power(0.5, out, where, casting, order, dtype, subok)
+    return x.sqrt(out, where, casting, order, dtype, subok)
 
 
 def exp(

--- a/modin/numpy/test/test_array_arithmetic.py
+++ b/modin/numpy/test/test_array_arithmetic.py
@@ -64,7 +64,7 @@ def test_basic_arithmetic_with_broadcast(operand1_shape, operand2_shape, operato
 
 @pytest.mark.parametrize("operator", ["__pow__", "__floordiv__", "__mod__"])
 def test_arithmetic(operator):
-    """Test of operators that do not yet support broadcasting"""
+    """Test of operators that do not yet support broadcasting."""
     for size, textdim in ((100, "1D"), ((10, 10), "2D")):
         operand1 = numpy.random.randint(-100, 100, size=size)
         lower_bound = -100 if operator != "__pow__" else 0
@@ -136,16 +136,18 @@ def test_scalar_arithmetic(size):
     )
 
 
-def test_abs():
+@pytest.mark.parametrize("op_name", ["abs", "exp", "sqrt", "tanh"])
+def test_unary_arithmetic(op_name):
     numpy_flat_arr = numpy.random.randint(-100, 100, size=100)
     modin_flat_arr = np.array(numpy_flat_arr)
     numpy.testing.assert_array_equal(
-        numpy.abs(numpy_flat_arr), np.abs(modin_flat_arr)._to_numpy()
+        getattr(numpy, op_name)(numpy_flat_arr),
+        getattr(np, op_name)(modin_flat_arr)._to_numpy(),
     )
     numpy_arr = numpy_flat_arr.reshape((10, 10))
     modin_arr = np.array(numpy_arr)
     numpy.testing.assert_array_equal(
-        numpy.abs(numpy_arr), np.abs(modin_arr)._to_numpy()
+        getattr(numpy, op_name)(numpy_arr), getattr(np, op_name)(modin_arr)._to_numpy()
     )
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5761 ? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
