### PR TITLE
PERF-#5778: Avoid extra materialization at range-based reshuffling

### DIFF
--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1598,10 +1598,6 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             ]
         ).T
         # We need to convert every partition that came from the splits into a full-axis column partition.
-        col_partitioning_func = np.vectorize(
-            lambda partition: cls._row_partition_class(partition)
-        )
-        split_row_partitions = col_partitioning_func(split_row_partitions)
         new_partitions = [
             [
                 cls._column_partitions_class(row_partition, full_axis=False).apply(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR removes unnecessary conversion to row partitions while reshuffling partitions.

Changes of our ASV benchmark:
```
MODIN_TEST_DATASET_SIZE="Big" asv continuous origin/master issue_5778 --launch-method=spawn -b TimeSortValues --no-only-changed -a repeat=5

All benchmarks:

       before           after         ratio
     [8d3db2b4]       [b50ee4e2]
     <issue_5778~1>       <issue_5778>
-       7.52±0.1s       1.15±0.04s     0.15  benchmarks.TimeSortValues.time_sort_values([1000000, 10], 1, True)
-       7.74±0.4s       1.17±0.03s     0.15  benchmarks.TimeSortValues.time_sort_values([1000000, 10], 2, True)

SOME BENCHMARKS HAVE CHANGED SIGNIFICANTLY.
PERFORMANCE INCREASED.
```

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5778 <!-- issue must be created for each patch -->
- [x] tests are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
