### PR TITLE
FIX-#5781: Fix sort in descending order for columns with highly dense values

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/utils.py
+++ b/modin/core/dataframe/pandas/dataframe/utils.py
@@ -261,7 +261,7 @@ def split_partitions_using_pivots_for_sort(
         # When we only have one unique value in our pivots, `np.digitize` assumes that the pivots
         # are sorted in ascending order, and gives us results based off of that assumption - so if
         # we actually want to sort in descending order, we need to swap the new indices.
-        if not ascending and len(np.unique(pivots)) == 1 and len(pivots) != 1:
+        if not ascending and len(np.unique(pivots)) == 1:
             groupby_col = len(pivots) - groupby_col
     else:
         groupby_col = np.searchsorted(pivots, cols_to_digitize.squeeze(), side="right")

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -583,7 +583,9 @@ def test_sort_values_descending_with_only_two_bins():
     if StorageFormat.get() == "Pandas":
         assert modin_df._query_compiler._modin_frame._partitions.shape == (2, 1)
 
-    eval_general(modin_df, pandas_df, lambda df: df.sort_values(by="a"))
+    eval_general(
+        modin_df, pandas_df, lambda df: df.sort_values(by="a", ascending=False)
+    )
 
 
 def test_sort_overpartitioned_df():

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -572,6 +572,19 @@ def test_sort_values(
     )
 
 
+def test_sort_values_descending_with_only_two_bins():
+    # test case from https://github.com/modin-project/modin/issues/5781
+    part1 = pd.DataFrame({"a": [1, 2, 3, 4]})
+    part2 = pd.DataFrame({"a": [5, 6, 7, 8]})
+
+    modin_df = pd.concat([part1, part2])
+    pandas_df = modin_df._to_pandas()
+
+    assert modin_df._query_compiler._modin_frame._partitions.shape == (2, 1)
+
+    eval_general(modin_df, pandas_df, lambda df: df.sort_values(by="a"))
+
+
 def test_sort_overpartitioned_df():
     # First we test when the final df will have only 1 row and column partition.
     data = [[4, 5, 6], [1, 2, 3]]

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -37,7 +37,7 @@ from modin.pandas.test.utils import (
     extra_test_parameters,
     default_to_pandas_ignore_string,
 )
-from modin.config import NPartitions, Engine
+from modin.config import NPartitions, Engine, StorageFormat
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 
 NPartitions.put(4)
@@ -580,7 +580,8 @@ def test_sort_values_descending_with_only_two_bins():
     modin_df = pd.concat([part1, part2])
     pandas_df = modin_df._to_pandas()
 
-    assert modin_df._query_compiler._modin_frame._partitions.shape == (2, 1)
+    if StorageFormat.get() == "Pandas":
+        assert modin_df._query_compiler._modin_frame._partitions.shape == (2, 1)
 
     eval_general(modin_df, pandas_df, lambda df: df.sort_values(by="a"))
 

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -831,7 +831,7 @@ def test_split_partitions_kernel(
         else:
             # Check that each part is in the range of 'bound[i + 1] <= part <= bound[i]'
             # Example, if the `pivots` were [2, 5] and the min/max values for the colum are min=0, max=10
-            # Then each part satisfies: 10 <= part[0] <= 5; 5 <= part[1] <= 2; 2 <= part[2] <= 0
+            # Then each part satisfies: 5 <= part[0] <= 10; 2 <= part[1] <= 5; 0 <= part[2] <= 2
             assert (
                 (part[col_name] <= bounds[idx]) & (part[col_name] >= bounds[idx + 1])
             ).all()

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -833,5 +833,5 @@ def test_split_partitions_kernel(
             # Example, if the `pivots` were [2, 5] and the min/max values for the colum are min=0, max=10
             # Then each part satisfies: 5 <= part[0] <= 10; 2 <= part[1] <= 5; 0 <= part[2] <= 2
             assert (
-                (part[col_name] <= bounds[idx]) & (part[col_name] >= bounds[idx + 1])
+                (bounds[idx + 1] <= part[col_name]) & (part[col_name] <= bounds[idx])
             ).all()


### PR DESCRIPTION

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5781 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
