### PR TITLE
FIX-#5309: series iloc/loc raises IndexingError if a key is too long

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -288,7 +288,9 @@ class _LocationIndexerBase(ClassLogger):
                 if Ellipsis in key:
                     raise IndexingError(_one_ellipsis_message)
                 return self._validate_key_length(key)
-            raise IndexingError(f"Too many indexers: you're trying to pass {len(key)} indexers to the {type(self.df)} having only {self.df.ndim} dimensions.")
+            raise IndexingError(
+                f"Too many indexers: you're trying to pass {len(key)} indexers to the {type(self.df)} having only {self.df.ndim} dimensions."
+            )
         return key
 
     def __getitem__(self, key):  # pragma: no cover

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -288,7 +288,7 @@ class _LocationIndexerBase(ClassLogger):
                 if Ellipsis in key:
                     raise IndexingError(_one_ellipsis_message)
                 return self._validate_key_length(key)
-            raise IndexingError("Too many indexers")
+            raise IndexingError(f"Too many indexers: you're trying to pass {len(key)} indexers to the {type(self.df)} having only {self.df.ndim} dimensions.")
         return key
 
     def __getitem__(self, key):  # pragma: no cover

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -233,6 +233,8 @@ Location based indexing can only have [integer, integer slice (START point is
 INCLUDED, END point is EXCLUDED), listlike of integers, boolean array] types.
 """
 
+_one_ellipsis_message = "indexer may only contain one '...' entry"
+
 
 def _compute_ndim(row_loc, col_loc):
     """
@@ -276,6 +278,18 @@ class _LocationIndexerBase(ClassLogger):
     def __init__(self, modin_df):
         self.df = modin_df
         self.qc = modin_df._query_compiler
+
+    def _validate_key_length(self, key: tuple) -> tuple:
+        """Copied from pandas."""
+        if len(key) > self.df.ndim:
+            if key[0] is Ellipsis:
+                # e.g. Series.iloc[..., 3] reduces to just Series.iloc[3]
+                key = key[1:]
+                if Ellipsis in key:
+                    raise IndexingError(_one_ellipsis_message)
+                return self._validate_key_length(key)
+            raise IndexingError("Too many indexers")
+        return key
 
     def __getitem__(self, key):  # pragma: no cover
         """
@@ -632,7 +646,7 @@ class _LocIndexer(_LocationIndexerBase):
         """
         if self.df.empty:
             return self.df._default_to_pandas(lambda df: df.loc[key])
-
+        key = self._validate_key_length(key)
         if (
             isinstance(key, tuple)
             and len(key) == 2
@@ -987,6 +1001,7 @@ class _iLocIndexer(_LocationIndexerBase):
         """
         if self.df.empty:
             return self.df._default_to_pandas(lambda df: df.iloc[key])
+        key = self._validate_key_length(key)
         row_loc, col_loc, ndim = self._parse_row_and_column_locators(key)
         row_scalar = is_scalar(row_loc)
         col_scalar = is_scalar(col_loc)

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -646,7 +646,8 @@ class _LocIndexer(_LocationIndexerBase):
         """
         if self.df.empty:
             return self.df._default_to_pandas(lambda df: df.loc[key])
-        key = self._validate_key_length(key)
+        if isinstance(key, tuple):
+            key = self._validate_key_length(key)
         if (
             isinstance(key, tuple)
             and len(key) == 2
@@ -1001,7 +1002,8 @@ class _iLocIndexer(_LocationIndexerBase):
         """
         if self.df.empty:
             return self.df._default_to_pandas(lambda df: df.iloc[key])
-        key = self._validate_key_length(key)
+        if isinstance(key, tuple):
+            key = self._validate_key_length(key)
         row_loc, col_loc, ndim = self._parse_row_and_column_locators(key)
         row_scalar = is_scalar(row_loc)
         col_scalar = is_scalar(col_loc)

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -279,8 +279,8 @@ class _LocationIndexerBase(ClassLogger):
         self.df = modin_df
         self.qc = modin_df._query_compiler
 
-    def _validate_key_length(self, key: tuple) -> tuple:
-        """Copied from pandas."""
+    def _validate_key_length(self, key: tuple) -> tuple:  # noqa: GL08
+        # Implementation copied from pandas.
         if len(key) > self.df.ndim:
             if key[0] is Ellipsis:
                 # e.g. Series.iloc[..., 3] reduces to just Series.iloc[3]

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -832,6 +832,12 @@ def test_iloc_empty():
     df_equals(pandas_df, modin_df)
 
 
+def test_iloc_loc_key_length():
+    modin_ser, pandas_ser = pd.Series(0), pandas.Series(0)
+    eval_general(modin_ser, pandas_ser, lambda ser: ser.iloc[0, 0])
+    eval_general(modin_ser, pandas_ser, lambda ser: ser.loc[0, 0])
+
+
 def test_loc_series():
     md_df, pd_df = create_test_dfs({"a": [1, 2], "b": [3, 4]})
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -16,6 +16,7 @@ import numpy as np
 import json
 import pandas
 from pandas.errors import SpecificationError
+from pandas.core.indexing import IndexingError
 import matplotlib
 import modin.pandas as pd
 from numpy.testing import assert_array_equal
@@ -2010,6 +2011,8 @@ def test_iloc(request, data):
         modin_series.iloc[[1, 2]] = 42
         pandas_series.iloc[[1, 2]] = 42
         df_equals(modin_series, pandas_series)
+        with pytest.raises(IndexingError):
+            modin_series.iloc[1:, 1]
     else:
         with pytest.raises(IndexError):
             modin_series.iloc[0]

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2010,9 +2010,6 @@ def test_iloc(request, data):
         modin_series.iloc[[1, 2]] = 42
         pandas_series.iloc[[1, 2]] = 42
         df_equals(modin_series, pandas_series)
-
-        with pytest.raises(IndexError):
-            modin_series.iloc[1:, 1]
     else:
         with pytest.raises(IndexError):
             modin_series.iloc[0]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The current solution just copies the required function from pandas. It would be great to be able to reuse it directly from pandas, however it's not that easy as this function is a private class method used for indexing.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5309 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
