### PR TITLE
REFACTOR-#5786: align logging of Dask partitions with other executions

### DIFF
--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
@@ -19,6 +19,7 @@ from dask.distributed import wait
 
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from modin.pandas.indexing import compute_sliced_len
+from modin.logging import get_logger
 from modin.core.execution.dask.common import DaskWrapper
 
 
@@ -51,8 +52,16 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         self._length_cache = length
         self._width_cache = width
         self._ip_cache = ip
-        # TODO: align with other engines
-        self._identity
+
+        log = get_logger()
+        self._is_debug(log) and log.debug(
+            "Partition ID: {}, Height: {}, Width: {}, Node IP: {}".format(
+                self._identity,
+                str(self._length_cache),
+                str(self._width_cache),
+                str(self._ip_cache),
+            )
+        )
 
     def apply(self, func, *args, **kwargs):
         """
@@ -76,8 +85,13 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         -----
         The keyword arguments are sent as a dictionary.
         """
+        log = get_logger()
+        self._is_debug(log) and log.debug(f"ENTER::Partition.apply::{self._identity}")
         call_queue = self.call_queue + [[func, args, kwargs]]
         if len(call_queue) > 1:
+            self._is_debug(log) and log.debug(
+                f"SUBMIT::_apply_list_of_funcs::{self._identity}"
+            )
             futures = DaskWrapper.deploy(
                 func=apply_list_of_funcs,
                 f_args=(call_queue, self._data),
@@ -95,14 +109,23 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
                 num_returns=2,
                 pure=False,
             )
+            self._is_debug(log) and log.debug(f"SUBMIT::_apply_func::{self._identity}")
+        self._is_debug(log) and log.debug(f"EXIT::Partition.apply::{self._identity}")
         return self.__constructor__(futures[0], ip=futures[1])
 
     def drain_call_queue(self):
         """Execute all operations stored in the call queue on the object wrapped by this partition."""
+        log = get_logger()
+        self._is_debug(log) and log.debug(
+            f"ENTER::Partition.drain_call_queue::{self._identity}"
+        )
         if len(self.call_queue) == 0:
             return
         call_queue = self.call_queue
         if len(call_queue) > 1:
+            self._is_debug(log) and log.debug(
+                f"SUBMIT::_apply_list_of_funcs::{self._identity}"
+            )
             futures = DaskWrapper.deploy(
                 func=apply_list_of_funcs,
                 f_args=(call_queue, self._data),
@@ -113,6 +136,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
             # We handle `len(call_queue) == 1` in a different way because
             # this improves performance a bit.
             func, f_args, f_kwargs = call_queue[0]
+            self._is_debug(log) and log.debug(f"SUBMIT::_apply_func::{self._identity}")
             futures = DaskWrapper.deploy(
                 func=apply_func,
                 f_args=(self._data, func, *f_args),
@@ -122,6 +146,9 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
             )
         self._data = futures[0]
         self._ip_cache = futures[1]
+        self._is_debug(log) and log.debug(
+            f"EXIT::Partition.drain_call_queue::{self._identity}"
+        )
         self.call_queue = []
 
     def wait(self):
@@ -145,6 +172,8 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
         PandasOnDaskDataframePartition
             A new ``PandasOnDaskDataframePartition`` object.
         """
+        log = get_logger()
+        self._is_debug(log) and log.debug(f"ENTER::Partition.mask::{self._identity}")
         new_obj = super().mask(row_labels, col_labels)
         if isinstance(row_labels, slice) and isinstance(self._length_cache, Future):
             if row_labels == slice(None):
@@ -162,6 +191,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
                 new_obj._width_cache = DaskWrapper.deploy(
                     func=compute_sliced_len, f_args=(col_labels, self._width_cache)
                 )
+        self._is_debug(log) and log.debug(f"EXIT::Partition.mask::{self._identity}")
         return new_obj
 
     def __copy__(self):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5786 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
