### PR TITLE
REFACTOR-#5796: reuse _apply_func, _apply_list_of_funcs, _get_index_and_columns_size functions

### DIFF
--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -287,7 +287,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 (
                     self._length_cache,
                     self._width_cache,
-                ) = self._get_index_and_columns.remote(self._data)
+                ) = self._get_index_and_columns_size.remote(self._data)
         if isinstance(self._length_cache, ObjectIDType) and materialize:
             self._length_cache = RayWrapper.materialize(self._length_cache)
         return self._length_cache
@@ -315,7 +315,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 (
                     self._length_cache,
                     self._width_cache,
-                ) = self._get_index_and_columns.remote(self._data)
+                ) = self._get_index_and_columns_size.remote(self._data)
         if isinstance(self._width_cache, ObjectIDType) and materialize:
             self._width_cache = RayWrapper.materialize(self._width_cache)
         return self._width_cache

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -21,8 +21,11 @@ from modin.core.execution.ray.common import RayWrapper
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from modin.pandas.indexing import compute_sliced_len
 from modin.logging import get_logger
-
-compute_sliced_len = ray.remote(compute_sliced_len)
+from modin.core.execution.utils import (
+    _get_index_and_columns_size,
+    get_apply_func,
+    get_apply_list_of_funcs,
+)
 
 
 class PandasOnRayDataframePartition(PandasDataframePartition):
@@ -44,6 +47,12 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
     """
 
     execution_wrapper = RayWrapper
+    _compute_sliced_len = ray.remote(compute_sliced_len)
+    _get_index_and_columns_size = ray.remote(num_returns=2)(_get_index_and_columns_size)
+    _apply_func = ray.remote(num_returns=4)(get_apply_func(get_node_ip_address))
+    _apply_list_of_funcs = ray.remote(num_returns=4)(
+        get_apply_list_of_funcs(get_node_ip_address, deserialize)
+    )
 
     def __init__(self, data, length=None, width=None, ip=None, call_queue=None):
         assert isinstance(data, ObjectIDType)
@@ -96,12 +105,14 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             self._is_debug(log) and log.debug(
                 f"SUBMIT::_apply_list_of_funcs::{self._identity}"
             )
-            result, length, width, ip = _apply_list_of_funcs.remote(call_queue, data)
+            result, length, width, ip = self._apply_list_of_funcs.remote(
+                call_queue, data
+            )
         else:
             # We handle `len(call_queue) == 1` in a different way because
             # this dramatically improves performance.
             func, f_args, f_kwargs = call_queue[0]
-            result, length, width, ip = _apply_func.remote(
+            result, length, width, ip = self._apply_func.remote(
                 data, func, *f_args, **f_kwargs
             )
             self._is_debug(log) and log.debug(f"SUBMIT::_apply_func::{self._identity}")
@@ -127,7 +138,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 new_length,
                 new_width,
                 self._ip_cache,
-            ) = _apply_list_of_funcs.remote(call_queue, data)
+            ) = self._apply_list_of_funcs.remote(call_queue, data)
         else:
             # We handle `len(call_queue) == 1` in a different way because
             # this dramatically improves performance.
@@ -138,7 +149,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 new_length,
                 new_width,
                 self._ip_cache,
-            ) = _apply_func.remote(data, func, *f_args, **f_kwargs)
+            ) = self._apply_func.remote(data, func, *f_args, **f_kwargs)
         self._is_debug(log) and log.debug(
             f"EXIT::Partition.drain_call_queue::{self._identity}"
         )
@@ -203,7 +214,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 # fast path - full axis take
                 new_obj._length_cache = self._length_cache
             else:
-                new_obj._length_cache = compute_sliced_len.remote(
+                new_obj._length_cache = self._compute_sliced_len.remote(
                     row_labels, self._length_cache
                 )
         if isinstance(col_labels, slice) and isinstance(
@@ -213,7 +224,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 # fast path - full axis take
                 new_obj._width_cache = self._width_cache
             else:
-                new_obj._width_cache = compute_sliced_len.remote(
+                new_obj._width_cache = self._compute_sliced_len.remote(
                     col_labels, self._width_cache
                 )
         self._is_debug(log) and log.debug(f"EXIT::Partition.mask::{self._identity}")
@@ -273,9 +284,10 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             if len(self.call_queue):
                 self.drain_call_queue()
             else:
-                self._length_cache, self._width_cache = _get_index_and_columns.remote(
-                    self._data
-                )
+                (
+                    self._length_cache,
+                    self._width_cache,
+                ) = self._get_index_and_columns.remote(self._data)
         if isinstance(self._length_cache, ObjectIDType) and materialize:
             self._length_cache = RayWrapper.materialize(self._length_cache)
         return self._length_cache
@@ -300,9 +312,10 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             if len(self.call_queue):
                 self.drain_call_queue()
             else:
-                self._length_cache, self._width_cache = _get_index_and_columns.remote(
-                    self._data
-                )
+                (
+                    self._length_cache,
+                    self._width_cache,
+                ) = self._get_index_and_columns.remote(self._data)
         if isinstance(self._width_cache, ObjectIDType) and materialize:
             self._width_cache = RayWrapper.materialize(self._width_cache)
         return self._width_cache
@@ -324,113 +337,3 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         if isinstance(self._ip_cache, ObjectIDType):
             self._ip_cache = RayWrapper.materialize(self._ip_cache)
         return self._ip_cache
-
-
-@ray.remote(num_returns=2)
-def _get_index_and_columns(df):
-    """
-    Get the number of rows and columns of a pandas DataFrame.
-
-    Parameters
-    ----------
-    df : pandas.DataFrame
-        A pandas DataFrame which dimensions are needed.
-
-    Returns
-    -------
-    int
-        The number of rows.
-    int
-        The number of columns.
-    """
-    return len(df.index), len(df.columns)
-
-
-@ray.remote(num_returns=4)
-def _apply_func(partition, func, *args, **kwargs):  # pragma: no cover
-    """
-    Execute a function on the partition in a worker process.
-
-    Parameters
-    ----------
-    partition : pandas.DataFrame
-        A pandas DataFrame the function needs to be executed on.
-    func : callable
-        The function to perform on the partition.
-    *args : list
-        Positional arguments to pass to ``func``.
-    **kwargs : dict
-        Keyword arguments to pass to ``func``.
-
-    Returns
-    -------
-    pandas.DataFrame
-        The resulting pandas DataFrame.
-    int
-        The number of rows of the resulting pandas DataFrame.
-    int
-        The number of columns of the resulting pandas DataFrame.
-    str
-        The node IP address of the worker process.
-
-    Notes
-    -----
-    Directly passing a call queue entry (i.e. a list of [func, args, kwargs]) instead of
-    destructuring it causes a performance penalty.
-    """
-    try:
-        result = func(partition, *args, **kwargs)
-    # Sometimes Arrow forces us to make a copy of an object before we operate on it. We
-    # don't want the error to propagate to the user, and we want to avoid copying unless
-    # we absolutely have to.
-    except ValueError:
-        result = func(partition.copy(), *args, **kwargs)
-    return (
-        result,
-        len(result) if hasattr(result, "__len__") else 0,
-        len(result.columns) if hasattr(result, "columns") else 0,
-        get_node_ip_address(),
-    )
-
-
-@ray.remote(num_returns=4)
-def _apply_list_of_funcs(call_queue, partition):  # pragma: no cover
-    """
-    Execute all operations stored in the call queue on the partition in a worker process.
-
-    Parameters
-    ----------
-    call_queue : list
-        A call queue that needs to be executed on the partition.
-    partition : pandas.DataFrame
-        A pandas DataFrame the call queue needs to be executed on.
-
-    Returns
-    -------
-    pandas.DataFrame
-        The resulting pandas DataFrame.
-    int
-        The number of rows of the resulting pandas DataFrame.
-    int
-        The number of columns of the resulting pandas DataFrame.
-    str
-        The node IP address of the worker process.
-    """
-    for func, f_args, f_kwargs in call_queue:
-        func = deserialize(func)
-        args = deserialize(f_args)
-        kwargs = deserialize(f_kwargs)
-        try:
-            partition = func(partition, *args, **kwargs)
-        # Sometimes Arrow forces us to make a copy of an object before we operate on it. We
-        # don't want the error to propagate to the user, and we want to avoid copying unless
-        # we absolutely have to.
-        except ValueError:
-            partition = func(partition.copy(), *args, **kwargs)
-
-    return (
-        partition,
-        len(partition) if hasattr(partition, "__len__") else 0,
-        len(partition.columns) if hasattr(partition, "columns") else 0,
-        get_node_ip_address(),
-    )

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -265,7 +265,7 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
                 (
                     self._length_cache,
                     self._width_cache,
-                ) = _get_index_and_columns_size.remote(self._data)
+                ) = self._get_index_and_columns_size.remote(self._data)
         if unidist.is_object_ref(self._length_cache) and materialize:
             self._length_cache = UnidistWrapper.materialize(self._length_cache)
         return self._length_cache
@@ -293,7 +293,7 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
                 (
                     self._length_cache,
                     self._width_cache,
-                ) = _get_index_and_columns_size.remote(self._data)
+                ) = self._get_index_and_columns_size.remote(self._data)
         if unidist.is_object_ref(self._width_cache) and materialize:
             self._width_cache = UnidistWrapper.materialize(self._width_cache)
         return self._width_cache

--- a/modin/core/execution/utils.py
+++ b/modin/core/execution/utils.py
@@ -1,0 +1,127 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""Contains utility functions for partitioning."""
+
+
+def _get_index_and_columns_size(df):  # pragma: no cover
+    """
+    Get the number of rows and columns of a pandas DataFrame.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        A pandas DataFrame which dimensions are needed.
+
+    Returns
+    -------
+    int
+        The number of rows.
+    int
+        The number of columns.
+    """
+    return len(df.index), len(df.columns)
+
+
+def get_apply_func(get_ip_callable):
+    def _apply_func(partition, func, *args, **kwargs):  # pragma: no cover
+        """
+        Execute a function on the partition in a worker process.
+
+        Parameters
+        ----------
+        partition : pandas.DataFrame
+            A pandas DataFrame the function needs to be executed on.
+        func : callable
+            The function to perform on the partition.
+        *args : list
+            Positional arguments to pass to ``func``.
+        **kwargs : dict
+            Keyword arguments to pass to ``func``.
+
+        Returns
+        -------
+        pandas.DataFrame
+            The resulting pandas DataFrame.
+        int
+            The number of rows of the resulting pandas DataFrame.
+        int
+            The number of columns of the resulting pandas DataFrame.
+        str
+            The node IP address of the worker process.
+
+        Notes
+        -----
+        Directly passing a call queue entry (i.e. a list of [func, args, kwargs]) instead of
+        destructuring it causes a performance penalty.
+        """
+        try:
+            result = func(partition, *args, **kwargs)
+        # Sometimes Arrow forces us to make a copy of an object before we operate on it. We
+        # don't want the error to propagate to the user, and we want to avoid copying unless
+        # we absolutely have to.
+        except ValueError:
+            result = func(partition.copy(), *args, **kwargs)
+        return (
+            result,
+            len(result) if hasattr(result, "__len__") else 0,
+            len(getattr(result, "columns", ())),
+            get_ip_callable(),
+        )
+
+    return _apply_func
+
+
+def get_apply_list_of_funcs(get_ip_callable, deserialize_callable):
+    def _apply_list_of_funcs(call_queue, partition):  # pragma: no cover
+        """
+        Execute all operations stored in the call queue on the partition in a worker process.
+
+        Parameters
+        ----------
+        call_queue : list
+            A call queue that needs to be executed on the partition.
+        partition : pandas.DataFrame
+            A pandas DataFrame the call queue needs to be executed on.
+
+        Returns
+        -------
+        pandas.DataFrame
+            The resulting pandas DataFrame.
+        int
+            The number of rows of the resulting pandas DataFrame.
+        int
+            The number of columns of the resulting pandas DataFrame.
+        str
+            The node IP address of the worker process.
+        """
+        for func, f_args, f_kwargs in call_queue:
+            func = deserialize_callable(func)
+            args = deserialize_callable(f_args)
+            kwargs = deserialize_callable(f_kwargs)
+            try:
+                partition = func(partition, *args, **kwargs)
+            # Sometimes Arrow forces us to make a copy of an object before we operate on it. We
+            # don't want the error to propagate to the user, and we want to avoid copying unless
+            # we absolutely have to.
+            except ValueError:
+                partition = func(partition.copy(), *args, **kwargs)
+
+        return (
+            partition,
+            len(partition) if hasattr(partition, "__len__") else 0,
+            len(partition.columns) if hasattr(partition, "columns") else 0,
+            get_ip_callable(),
+        )
+
+    return _apply_list_of_funcs


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The above functions are transferred to `utils.py`, from where they will be used by ray and unidist.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5796 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
