### PR TITLE
FIX-#5794: Enable test_default test on the HDK engine and add to ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -502,6 +502,7 @@ jobs:
       - run: python -m pytest modin/pandas/test/test_series.py
       - run: python -m pytest modin/pandas/test/dataframe/test_map_metadata.py
       - run: python -m pytest modin/pandas/test/dataframe/test_window.py
+      - run: python -m pytest modin/pandas/test/dataframe/test_default.py
       - run: python examples/docker/modin-hdk/census-hdk.py examples/data/census_1k.csv -no-ml
       - run: python examples/docker/modin-hdk/nyc-taxi-hdk.py examples/data/nyc-taxi_1k.csv
       - run: |

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -28,6 +28,7 @@ from .utils import (
     check_join_supported,
     check_cols_to_join,
     get_data_for_join_by_index,
+    get_common_arrow_type,
 )
 from ..partitioning.partition_manager import HdkOnNativeDataframePartitionManager
 
@@ -1130,21 +1131,8 @@ class HdkOnNativeDataframe(PandasDataframe):
             key = (col_name, table_col_name)
             field = table.field(table_col_name)
             cur_field = col_fields.get(key, None)
-            if (
-                (cur_field is None)
-                or pyarrow.types.is_null(cur_field.type)
-                or (
-                    (not pyarrow.types.is_string(cur_field.type))
-                    and (not pyarrow.types.is_null(field.type))
-                    and (
-                        pyarrow.types.is_string(field.type)
-                        or (
-                            (field.type.bit_width == cur_field.type.bit_width)
-                            and pyarrow.types.is_floating(field.type)
-                        )
-                        or (field.type.bit_width > cur_field.type.bit_width)
-                    )
-                )
+            if cur_field is None or (
+                cur_field.type != get_common_arrow_type(cur_field.type, field.type)
             ):
                 col_fields[key] = field
 

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -1124,6 +1124,8 @@ class HdkOnNativeDataframe(PandasDataframe):
         frames: List[FrameData] = [FrameData(f) for f in [self] + other_modin_frames]
         col_fields: typing.OrderedDict[Tuple[str, str], pyarrow.Field] = OrderedDict()
 
+        # Add field to the col_fields dictionary. If the field is already exists, chose
+        # the most appropriate field, according to the fields type and bit_width.
         def add_col_field(table, col_name, table_col_name):
             key = (col_name, table_col_name)
             field = table.field(table_col_name)

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
@@ -379,6 +379,34 @@ def get_data_for_join_by_index(
     return index_cols, exprs, new_dtypes, merged.columns
 
 
+def get_common_arrow_type(t1: pa.lib.DataType, t2: pa.lib.DataType) -> pa.lib.DataType:
+    """
+    Get common arrow data type.
+
+    Parameters
+    ----------
+    t1 : pa.lib.DataType
+    t2 : pa.lib.DataType
+
+    Returns
+    -------
+    pa.lib.DataType
+    """
+    if pa.types.is_string(t1):
+        return t1
+    if pa.types.is_string(t2):
+        return t2
+    if pa.types.is_null(t1):
+        return t2
+    if pa.types.is_null(t2):
+        return t1
+    if t1.bit_width > t2.bit_width:
+        return t1
+    if t1.bit_width < t2.bit_width:
+        return t2
+    return t2 if pa.types.is_floating(t2) else t1
+
+
 def arrow_to_pandas(at: pa.Table) -> pd.DataFrame:
     """
     Convert the specified arrow table to pandas.

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition.py
@@ -85,6 +85,9 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
         assert isinstance(obj, pyarrow.Table)
         return arrow_to_pandas(obj)
 
+    def to_numpy(self, **kwargs):
+        return self.to_pandas().to_numpy(**kwargs)
+
     def get(self):
         """
         Get partition data.

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition.py
@@ -86,6 +86,18 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
         return arrow_to_pandas(obj)
 
     def to_numpy(self, **kwargs):
+        """
+        Transform to NumPy format.
+
+        Parameters
+        ----------
+        **kwargs : dict
+            Additional keyword arguments to be passed in ``to_numpy``.
+
+        Returns
+        -------
+        np.ndarray
+        """
         return self.to_pandas().to_numpy(**kwargs)
 
     def get(self):

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -116,7 +116,6 @@ def test_to_numpy(data):
     assert_array_equal(modin_df.values, pandas_df.values)
 
 
-@pytest.mark.skipif(StorageFormat.get() == "Hdk", reason="Not supported by HDK")
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_partition_to_numpy(data):
     frame = pd.DataFrame(data)

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -45,7 +45,7 @@ from modin.pandas.test.utils import (
     test_data_large_categorical_dataframe,
     default_to_pandas_ignore_string,
 )
-from modin.config import NPartitions
+from modin.config import NPartitions, StorageFormat
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 
 NPartitions.put(4)
@@ -116,6 +116,7 @@ def test_to_numpy(data):
     assert_array_equal(modin_df.values, pandas_df.values)
 
 
+@pytest.mark.skipif(StorageFormat.get() == "Hdk", reason="Not supported by HDK")
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_partition_to_numpy(data):
     frame = pd.DataFrame(data)
@@ -242,16 +243,28 @@ def test_corr(min_periods):
 @pytest.mark.parametrize("min_periods", [1, 3, 5])
 @pytest.mark.parametrize("ddof", [1, 2, 4])
 def test_cov(min_periods, ddof):
+    # Modin result may slightly differ from pandas result
+    # due to floating pointing arithmetic.
+    if StorageFormat.get() == "Hdk":
+
+        def comparator1(df1, df2):
+            modin_df_almost_equals_pandas(df1, df2, max_diff=0.11)
+
+        comparator2 = comparator1
+    else:
+        comparator1 = df_equals
+        comparator2 = modin_df_almost_equals_pandas
+
     eval_general(
         *create_test_dfs(test_data["int_data"]),
         lambda df: df.cov(min_periods=min_periods, ddof=ddof),
+        comparator=comparator1,
     )
-    # Modin result may slightly differ from pandas result
-    # due to floating pointing arithmetic.
+
     eval_general(
         *create_test_dfs(test_data["float_nan_data"]),
         lambda df: df.cov(min_periods=min_periods),
-        comparator=modin_df_almost_equals_pandas,
+        comparator=comparator2,
     )
 
 
@@ -472,13 +485,33 @@ def test_mad_level(level):
     "value_vars", [lambda df: df.columns[-1], lambda df: df.columns[-4:], None]
 )
 def test_melt(data, id_vars, value_vars):
+    if StorageFormat.get() == "Hdk":
+        # Drop NA and sort by all columns to make sure the order
+        # is identical to Pandas.
+        def melt(df, *args, **kwargs):
+            df = df.melt(*args, **kwargs).dropna()
+            return df.sort_values(df.columns.tolist())
+
+        # HDK has different values of category codes than Pandas.
+        # The default comparator fails for categorical dtypes.
+        def comparator(df1, df2):
+            assert all(df1.index == df2.index)
+            for c1, c2 in zip(df1.columns, df2.columns):
+                assert c1 == c2
+                assert all(df1[c1] == df2[c2])
+
+    else:
+
+        def melt(df, *args, **kwargs):
+            return df.melt(*args, **kwargs).sort_values(["variable", "value"])
+
+        comparator = df_equals
     eval_general(
         *create_test_dfs(data),
-        lambda df, *args, **kwargs: df.melt(*args, **kwargs)
-        .sort_values(["variable", "value"])
-        .reset_index(drop=True),
+        lambda df, *args, **kwargs: melt(df, *args, **kwargs).reset_index(drop=True),
         id_vars=id_vars,
         value_vars=value_vars,
+        comparator=comparator,
     )
 
 
@@ -1186,12 +1219,13 @@ def test_setattr_axes():
             # In BaseOnPython, setting columns raises a warning because get_axis
             #  defaults to pandas.
             warnings.simplefilter("error")
-        df.index = ["foo", "bar"]
-        df.columns = [9, 10]
+        if StorageFormat.get() != "Hdk":  # Not yet supported
+            df.index = ["foo", "bar"]
+            # Check that ensure_index was called
+            pandas.testing.assert_index_equal(df.index, pandas.Index(["foo", "bar"]))
 
-    # Check that ensure_index was called
-    pandas.testing.assert_index_equal(df.index, pandas.Index(["foo", "bar"]))
-    pandas.testing.assert_index_equal(df.columns, pandas.Index([9, 10]))
+        df.columns = [9, 10]
+        pandas.testing.assert_index_equal(df.columns, pandas.Index([9, 10]))
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -491,26 +491,16 @@ def test_melt(data, id_vars, value_vars):
             df = df.melt(*args, **kwargs).dropna()
             return df.sort_values(df.columns.tolist())
 
-        # HDK has different values of category codes than Pandas.
-        # The default comparator fails for categorical dtypes.
-        def comparator(df1, df2):
-            assert all(df1.index == df2.index)
-            for c1, c2 in zip(df1.columns, df2.columns):
-                assert c1 == c2
-                assert all(df1[c1] == df2[c2])
-
     else:
 
         def melt(df, *args, **kwargs):
             return df.melt(*args, **kwargs).sort_values(["variable", "value"])
 
-        comparator = df_equals
     eval_general(
         *create_test_dfs(data),
         lambda df, *args, **kwargs: melt(df, *args, **kwargs).reset_index(drop=True),
         id_vars=id_vars,
         value_vars=value_vars,
-        comparator=comparator,
     )
 
 

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -1219,7 +1219,7 @@ def test_setattr_axes():
             # In BaseOnPython, setting columns raises a warning because get_axis
             #  defaults to pandas.
             warnings.simplefilter("error")
-        if StorageFormat.get() != "Hdk":  # Not yet supported
+        if StorageFormat.get() != "Hdk":  # Not yet supported - #1766
             df.index = ["foo", "bar"]
             # Check that ensure_index was called
             pandas.testing.assert_index_equal(df.index, pandas.Index(["foo", "bar"]))

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -247,7 +247,7 @@ def test_cov(min_periods, ddof):
     if StorageFormat.get() == "Hdk":
 
         def comparator1(df1, df2):
-            modin_df_almost_equals_pandas(df1, df2, max_diff=0.11)
+            modin_df_almost_equals_pandas(df1, df2, max_diff=0.0002)
 
         comparator2 = comparator1
     else:

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -669,7 +669,7 @@ def df_equals(df1, df2):
             np.testing.assert_almost_equal(df1, df2)
 
 
-def modin_df_almost_equals_pandas(modin_df, pandas_df):
+def modin_df_almost_equals_pandas(modin_df, pandas_df, max_diff=0.0001):
     df_categories_equals(modin_df._to_pandas(), pandas_df)
 
     modin_df = to_pandas(modin_df)
@@ -685,7 +685,7 @@ def modin_df_almost_equals_pandas(modin_df, pandas_df):
         diff_max = diff_max.max()
     assert (
         modin_df.equals(pandas_df)
-        or diff_max < 0.0001
+        or diff_max < max_diff
         or (all(modin_df.isna().all()) and all(pandas_df.isna().all()))
     )
 

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -679,15 +679,22 @@ def modin_df_almost_equals_pandas(modin_df, pandas_df, max_diff=0.0001):
     if hasattr(pandas_df, "select_dtypes"):
         pandas_df = pandas_df.select_dtypes(exclude=["category"])
 
-    if modin_df.equals(pandas_df) or (
-        all(modin_df.isna().all()) and all(pandas_df.isna().all())
-    ):
+    if modin_df.equals(pandas_df):
+        return
+
+    isna = modin_df.isna().all()
+    if isinstance(isna, bool):
+        if isna:
+            assert pandas_df.isna().all()
+            return
+    elif isna.all():
+        assert pandas_df.isna().all().all()
         return
 
     diff = (modin_df - pandas_df).abs()
     diff /= pandas_df
     diff_max = diff.max() if isinstance(diff, pandas.Series) else diff.max().max()
-    assert diff_max < max_diff
+    assert diff_max < max_diff, f"{diff_max} >= {max_diff}"
 
 
 def try_modin_df_almost_equals_compare(df1, df2):

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -685,7 +685,7 @@ def modin_df_almost_equals_pandas(modin_df, pandas_df, max_diff=0.0001):
         return
 
     diff = (modin_df - pandas_df).abs()
-    diff /= modin_df.where(modin_df > pandas_df, pandas_df)
+    diff /= pandas_df
     diff_max = diff.max() if isinstance(diff, pandas.Series) else diff.max().max()
     assert diff_max < max_diff
 


### PR DESCRIPTION
Depends on:
FIX-https://github.com/modin-project/modin/issues/3925: Fixed AssertionError on columns and index drop
FIX-https://github.com/modin-project/modin/issues/5576: Enable test_join_sort test on the HDK engine and add to CI
FIX-https://github.com/modin-project/modin/issues/5566: Enable test_indexing test on the HDK engine and add to ci
FIX-https://github.com/modin-project/modin/issues/5580: BUG: 'AVG|SUM' is only valid on integer and floating point

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5794 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
