### PR TITLE
FEAT-#5797: Add a QC method to reset to a positional index lazily.

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1150,6 +1150,17 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         """
         return DataFrameDefault.register(pandas.DataFrame.reset_index)(self, **kwargs)
 
+    def maybe_reset_index_to_positional(self):  # noqa: PR02
+        """
+        Reset the index to a positional index, if it is not already.
+
+        Returns
+        -------
+        BaseQueryCompiler
+            QueryCompiler with appropriate index.
+        """
+        return DataFrameDefault.register(pandas.DataFrame.reset_index)(self)
+
     def set_index_from_columns(
         self, keys: List[Hashable], drop: bool = True, append: bool = False
     ):

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1161,6 +1161,18 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         """
         return DataFrameDefault.register(pandas.DataFrame.reset_index)(self)
 
+    def maybe_reset_columns_to_positional(self):  # noqa: PR02
+        """
+        Reset the columns to a positional index, if it is not already.
+
+        Returns
+        -------
+        BaseQueryCompiler
+            QueryCompiler with appropriate columns.
+        """
+        self.columns = range(len(self.columns))
+        return self
+
     def set_index_from_columns(
         self, keys: List[Hashable], drop: bool = True, append: bool = False
     ):

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -741,8 +741,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if self.index.equals(pandas.RangeIndex(len(self.index))):
             return self
         return self.reset_index(drop=True)
-    
-    def maybe_reset_index_to_positional(self):
+
+    def maybe_reset_columns_to_positional(self):
         if self.columns.equals(pandas.RangeIndex(len(self.columns))):
             return self
         return super().maybe_reset_columns_to_positional()

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -741,6 +741,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if self.index.equals(pandas.RangeIndex(len(self.index))):
             return self
         return self.reset_index(drop=True)
+    
+    def maybe_reset_index_to_positional(self):
+        if self.columns.equals(pandas.RangeIndex(len(self.columns))):
+            return self
+        return super().maybe_reset_columns_to_positional()
 
     def set_index_from_columns(
         self, keys: List[Hashable], drop: bool = True, append: bool = False

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -737,6 +737,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
             )
         return new_self
 
+    def maybe_reset_index_to_positional(self):
+        if self.index.equals(pandas.RangeIndex(len(self.index))):
+            return self
+        return self.reset_index(drop=True)
+
     def set_index_from_columns(
         self, keys: List[Hashable], drop: bool = True, append: bool = False
     ):

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -179,13 +179,14 @@ class array(object):
 
             self._query_compiler = pd.DataFrame(arr)._query_compiler
             new_dtype = arr.dtype
-        # These two lines are necessary so that our query compiler does not keep track of indices
+        # These two calls are necessary so that our query compiler does not keep track of indices
         # and try to map like indices to like indices. (e.g. if we multiply two arrays that used
         # to be dataframes, and the dataframes had the same column names but ordered differently
         # we want to do a simple broadcast where we only consider position, as numpy would, rather
         # than pair columns with the same name and multiply them.)
-        self._query_compiler = self._query_compiler.maybe_reset_index_to_positional()
-        self._query_compiler.columns = range(len(self._query_compiler.columns))
+        self._query_compiler = (
+            self._query_compiler.maybe_reset_index_to_positional().maybe_reset_columns_to_positional()
+        )
         new_dtype = new_dtype if dtype is None else dtype
         cols_with_wrong_dtype = self._query_compiler.dtypes != new_dtype
         if cols_with_wrong_dtype.any():


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5797 ? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
