### PR TITLE
TEST-#5826: remove `_propagate_index_objs` internal function usage from tests

### DIFF
--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -1659,13 +1659,17 @@ def test_reset_index_with_named_index(
     df_equals(modin_df, pandas_df)
     if test_async_reset_index:
         # The change in index is not automatically handled by Modin. See #3941.
-        modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+        modin_df.index = modin_df.index
+        modin_df._to_pandas()
+
         modin_df._query_compiler._modin_frame._index_cache = None
     df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
 
     if test_async_reset_index:
         # The change in index is not automatically handled by Modin. See #3941.
-        modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+        modin_df.index = modin_df.index
+        modin_df._to_pandas()
+
         modin_df._query_compiler._modin_frame._index_cache = None
     modin_df.reset_index(drop=True, inplace=True)
     pandas_df.reset_index(drop=True, inplace=True)
@@ -1676,7 +1680,9 @@ def test_reset_index_with_named_index(
     modin_df.index.name = pandas_df.index.name = index_name
     if test_async_reset_index:
         # The change in index is not automatically handled by Modin. See #3941.
-        modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+        modin_df.index = modin_df.index
+        modin_df._to_pandas()
+
         modin_df._query_compiler._modin_frame._index_cache = None
     df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
 
@@ -1697,7 +1703,9 @@ def test_reset_index_metadata_update(index, test_async_reset_index):
     modin_df.columns = pandas_df.columns = ["col1"]
     if test_async_reset_index:
         # The change in index is not automatically handled by Modin. See #3941.
-        modin_df._query_compiler._modin_frame._propagate_index_objs(axis=0)
+        modin_df.index = modin_df.index
+        modin_df._to_pandas()
+
         modin_df._query_compiler._modin_frame._index_cache = None
     eval_general(modin_df, pandas_df, lambda df: df.reset_index())
 

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -367,9 +367,12 @@ def test_merge_on_index(has_index_cache):
             assert modin_df2._query_compiler._modin_frame._index_cache is not None
         else:
             # Propagate deferred indices to partitions
-            modin_df1._query_compiler._modin_frame._propagate_index_objs(axis=0)
+            # The change in index is not automatically handled by Modin. See #3941.
+            modin_df1.index = modin_df1.index
+            modin_df1._to_pandas()
             modin_df1._query_compiler._modin_frame._index_cache = None
-            modin_df2._query_compiler._modin_frame._propagate_index_objs(axis=0)
+            modin_df2.index = modin_df2.index
+            modin_df2._to_pandas()
             modin_df2._query_compiler._modin_frame._index_cache = None
 
     for on in (


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5826 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
