### PR TITLE
TEST-#0000: use custom Distributed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -692,6 +692,8 @@ jobs:
           # we set use-only-tar-bz2 to false in order for conda to properly find new packages to be installed
           # for more info see https://github.com/conda-incubator/setup-miniconda/issues/264
           use-only-tar-bz2: false
+      - name: Install custom Distributed
+        run: pip install git+https://github.com/anmyachev/distributed.git@get-computation-code
       - name: Conda environment
         run: |
           conda info


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

In the custom version of this `Distributed`, we remove the call of `self._get_computation_code()`, which is called in `submit->_graph_to_futures`. `_get_computation_code` takes about 75% of the total call time of `submit` function and it looks like it's just collecting additional information that might not be collected in a non-debug mode. With this change, Dask tests are faster than Ray tests. It is interesting to try to propose to implement a mechanism that disables the call to this function in `Distributed` library itself.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
