### PR TITLE
FIX-#5819: Fix np.argmax/argmin on 1D arrays

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -638,6 +638,7 @@ jobs:
       - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_logic.py
       - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_linalg.py
       - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_indexing.py
+      - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_math.py
       - run: chmod +x ./.github/workflows/sql_server/set_up_sql_server.sh
       - run: ./.github/workflows/sql_server/set_up_sql_server.sh
       - run: mpiexec -n 1 python -m pytest modin/pandas/test/test_io.py --verbose
@@ -735,6 +736,7 @@ jobs:
       - run: python -m pytest -n 2 modin/numpy/test/test_array_logic.py
       - run: python -m pytest -n 2 modin/numpy/test/test_array_linalg.py
       - run: python -m pytest -n 2 modin/numpy/test/test_array_indexing.py
+      - run: python -m pytest -n 2 modin/numpy/test/test_array_math.py
       - run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
       - run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
       - run: python -m pytest -n 2 modin/pandas/test/test_general.py
@@ -871,6 +873,7 @@ jobs:
           - modin/numpy/test/test_array_logic.py
           - modin/numpy/test/test_array_linalg.py
           - modin/numpy/test/test_array_indexing.py
+          - modin/numpy/test/test_array_math.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
     name: test-windows

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -2179,9 +2179,9 @@ class array(object):
                 raise numpy.AxisError(1, 1)
             if self._query_compiler.isna().any(axis=1).any(axis=0).to_numpy()[0, 0]:
                 na_row_map = self._query_compiler.isna().any(axis=1)
-                result = na_row_map.idxmax().to_numpy()[0, 0]
+                result = na_row_map.idxmax()
             else:
-                result = self._query_compiler.idxmax(axis=1)
+                result = self._query_compiler.idxmax(axis=0)
             if keepdims:
                 if out is not None and out.shape != (1,):
                     raise ValueError(
@@ -2248,7 +2248,9 @@ class array(object):
                 raise numpy.AxisError(1, 1)
             if self._query_compiler.isna().any(axis=1).any(axis=0).to_numpy()[0, 0]:
                 na_row_map = self._query_compiler.isna().any(axis=1)
-                result = na_row_map.idxmax().to_numpy()[0, 0]
+                # numpy apparently considers nan to be the minimum value in an array if present
+                # therefore, we use idxmax on the mask array to identify where nans are
+                result = na_row_map.idxmax()
             else:
                 result = self._query_compiler.idxmin(axis=0)
             if keepdims:
@@ -2293,7 +2295,7 @@ class array(object):
         result = self._query_compiler.idxmin(axis=axis)
         na_mask = self._query_compiler.isna().any(axis=axis)
         if na_mask.any(axis=axis ^ 1).to_numpy()[0, 0]:
-            na_idxs = self._query_compiler.isna().idxmax(axis=axis)
+            na_idxs = self._query_compiler.isna().idxmin(axis=axis)
             result = na_mask.where(na_idxs, result)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -2295,7 +2295,7 @@ class array(object):
         result = self._query_compiler.idxmin(axis=axis)
         na_mask = self._query_compiler.isna().any(axis=axis)
         if na_mask.any(axis=axis ^ 1).to_numpy()[0, 0]:
-            na_idxs = self._query_compiler.isna().idxmin(axis=axis)
+            na_idxs = self._query_compiler.isna().idxmax(axis=axis)
             result = na_mask.where(na_idxs, result)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:

--- a/modin/numpy/test/test_array_math.py
+++ b/modin/numpy/test/test_array_math.py
@@ -16,19 +16,21 @@ import pytest
 
 import modin.numpy as np
 
+
 @pytest.mark.parametrize(
     "data",
-    [[3, 2, 1, 1],
-    [-87.434,-90.908, -87.152, -84.903],
-    [-87.434,-90.908, np.nan, -87.152, -84.903],
+    [
+        [3, 2, 1, 1],
+        [-87.434, -90.908, -87.152, -84.903],
+        [-87.434, -90.908, np.nan, -87.152, -84.903],
     ],
-    ids=["ints", "floats", "floats with nan"]
+    ids=["ints", "floats", "floats with nan"],
 )
 def test_argmax_argmin(data):
     numpy_result = numpy.argmax(numpy.array(data))
     modin_result = np.argmax(np.array(data))
     numpy.testing.assert_array_equal(modin_result, numpy_result)
-    
+
     numpy_result = numpy.argmin(numpy.array(data))
     modin_result = np.argmin(np.array(data))
     numpy.testing.assert_array_equal(modin_result, numpy_result)

--- a/modin/numpy/test/test_array_math.py
+++ b/modin/numpy/test/test_array_math.py
@@ -1,0 +1,34 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import numpy
+import pytest
+
+import modin.numpy as np
+
+@pytest.mark.parametrize(
+    "data",
+    [[3, 2, 1, 1],
+    [-87.434,-90.908, -87.152, -84.903],
+    [-87.434,-90.908, np.nan, -87.152, -84.903],
+    ],
+    ids=["ints", "floats", "floats with nan"]
+)
+def test_argmax_argmin(data):
+    numpy_result = numpy.argmax(numpy.array(data))
+    modin_result = np.argmax(np.array(data))
+    numpy.testing.assert_array_equal(modin_result, numpy_result)
+    
+    numpy_result = numpy.argmin(numpy.array(data))
+    modin_result = np.argmin(np.array(data))
+    numpy.testing.assert_array_equal(modin_result, numpy_result)

--- a/modin/numpy/test/test_array_math.py
+++ b/modin/numpy/test/test_array_math.py
@@ -26,11 +26,8 @@ import modin.numpy as np
     ],
     ids=["ints", "floats", "floats with nan"],
 )
-def test_argmax_argmin(data):
-    numpy_result = numpy.argmax(numpy.array(data))
-    modin_result = np.argmax(np.array(data))
-    numpy.testing.assert_array_equal(modin_result, numpy_result)
-
-    numpy_result = numpy.argmin(numpy.array(data))
-    modin_result = np.argmin(np.array(data))
+@pytest.mark.parametrize("op", ["argmin", "argmax"])
+def test_argmax_argmin(data, op):
+    numpy_result = getattr(numpy, op)(numpy.array(data))
+    modin_result = getattr(np, op)(np.array(data))
     numpy.testing.assert_array_equal(modin_result, numpy_result)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Fixes a bug where argmax/argmin on 1D arrays were giving incorrect results. There may still be bugs left over for 2D arrays, which we plan to address later with more comprehensive tests for our numpy API.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5819  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
