### PR TITLE
FIX-#5373: Fix Series.shift() for named Series

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2811,7 +2811,7 @@ class BasePandasDataset(ClassLogger):
         filled_df = (
             self.__constructor__(index=fill_index, columns=fill_columns)
             if isinstance(self, DataFrame)
-            else self.__constructor__(index=fill_index)
+            else self.__constructor__(index=fill_index, name=self.name)
         )
         if fill_value is not None:
             filled_df.fillna(fill_value, inplace=True)

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1403,7 +1403,7 @@ class Series(BasePandasDataset):
 
         if axis == "index" or axis == 0:
             if abs(periods) >= len(self.index):
-                return self.__constructor__(dtype=self.dtype)
+                return self.__constructor__(dtype=self.dtype, name=self.name)
             else:
                 new_df = self.iloc[:-periods] if periods > 0 else self.iloc[-periods:]
                 new_df.index = (

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3093,8 +3093,9 @@ def test_skew(data, skipna):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("index", ["default", "ndarray", "has_duplicates"])
 @pytest.mark.parametrize("periods", [0, 1, -1, 10, -10, 1000000000, -1000000000])
-def test_shift_slice_shift(data, index, periods):
-    modin_series, pandas_series = create_test_series(data)
+@pytest.mark.parametrize("name", [None, "foo"])
+def test_shift_slice_shift(data, index, periods, name):
+    modin_series, pandas_series = create_test_series(data, name=name)
     if index == "ndarray":
         data_column_length = len(data[next(iter(data))])
         modin_series.index = pandas_series.index = np.arange(2, data_column_length + 2)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Keep `Series.name` intact when shifting.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5373 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
