### PR TITLE
PERF-#5808: Delay metadata computations for '.sort_values' result

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2274,9 +2274,9 @@ class PandasDataframe(ClassLogger):
             sort_function,
         )
         new_axes = (
-            [None, self._columns_cache]
+            [None, self.copy_columns_cache()]
             if axis == Axis.ROW_WISE
-            else [self._index_cache, None]
+            else [self.copy_index_cache(), None]
         )
         new_lengths = [None, None]
         if kwargs.get("ignore_index", False):
@@ -2285,7 +2285,7 @@ class PandasDataframe(ClassLogger):
         # We perform the final steps of the sort on full axis partitions, so we know that the
         # length of each partition is the full length of the dataframe.
         new_lengths[axis.value ^ 1] = (
-            [len(self.columns)] if self._columns_cache is not None else None
+            [len(self.columns)] if self.has_materialized_columns is not None else None
         )
         # Since the strategy to pick our pivots involves random sampling
         # we could end up picking poor pivots, leading to skew in our partitions.

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2167,10 +2167,7 @@ class PandasDataframe(ClassLogger):
         )
         new_lengths = [None, None]
         if kwargs.get("ignore_index", False):
-            old_axis_value = self.get_axis(axis.value)
-            new_axes[axis.value] = RangeIndex(len(old_axis_value)).set_names(
-                old_axis_value.names
-            )
+            new_axes[axis.value] = RangeIndex(len(self.get_axis(axis.value)))
 
         # We perform the final steps of the sort on full axis partitions, so we know that the
         # length of each partition is the full length of the dataframe.

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2285,7 +2285,7 @@ class PandasDataframe(ClassLogger):
         # We perform the final steps of the sort on full axis partitions, so we know that the
         # length of each partition is the full length of the dataframe.
         new_lengths[axis.value ^ 1] = (
-            [len(self.columns)] if self.has_materialized_columns is not None else None
+            [len(self.columns)] if self.has_materialized_columns else None
         )
         # Since the strategy to pick our pivots involves random sampling
         # we could end up picking poor pivots, leading to skew in our partitions.

--- a/modin/core/dataframe/pandas/dataframe/utils.py
+++ b/modin/core/dataframe/pandas/dataframe/utils.py
@@ -271,7 +271,8 @@ def split_partitions_using_pivots_for_sort(
             groupby_col = len(pivots) - groupby_col
     if len(non_na_rows) == 1:
         groups = [
-            pandas.DataFrame(columns=df.columns).astype(df.dtypes)
+            # taking an empty slice for an index's metadata
+            pandas.DataFrame(index=df.index[:0], columns=df.columns).astype(df.dtypes)
             if i != groupby_col
             else non_na_rows
             for i in range(len(pivots) + 1)
@@ -279,9 +280,11 @@ def split_partitions_using_pivots_for_sort(
     else:
         grouped = non_na_rows.groupby(groupby_col)
         groups = [
-            grouped.get_group(i)
-            if i in grouped.keys
-            else pandas.DataFrame(columns=df.columns).astype(df.dtypes)
+            grouped.get_group(i) if i in grouped.keys
+            # taking an empty slice for an index's metadata
+            else pandas.DataFrame(index=df.index[:0], columns=df.columns).astype(
+                df.dtypes
+            )
             for i in range(len(pivots) + 1)
         ]
     index_to_insert_na_vals = -1 if kwargs.get("na_position", "last") == "last" else 0

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -591,6 +591,31 @@ def test_sort_values_descending_with_only_two_bins():
     )
 
 
+@pytest.mark.parametrize("ignore_index", [True, False])
+def test_sort_values_preserve_index_names(ignore_index):
+    modin_df, pandas_df = create_test_dfs(
+        np.random.choice(128, 128, replace=False).reshape((128, 1))
+    )
+
+    pandas_df.index.names, pandas_df.columns.names = ["custom_name"], ["custom_name"]
+    modin_df.index.names, modin_df.columns.names = ["custom_name"], ["custom_name"]
+    # workaround for #1618 to actually propagate index change
+    modin_df.index = modin_df.index
+    modin_df.columns = modin_df.columns
+
+    def comparator(df1, df2):
+        assert df1.index.names == df2.index.names
+        assert df1.columns.names == df2.columns.names
+        df_equals(df1, df2)
+
+    eval_general(
+        modin_df,
+        pandas_df,
+        lambda df: df.sort_values(df.columns[0], ignore_index=ignore_index),
+        comparator=comparator,
+    )
+
+
 def test_sort_overpartitioned_df():
     # First we test when the final df will have only 1 row and column partition.
     data = [[4, 5, 6], [1, 2, 3]]

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -619,6 +619,10 @@ def test_sort_values_descending_with_only_two_bins():
     )
 
 
+@pytest.mark.skipif(
+    StorageFormat.get() == "Hdk",
+    reason="https://github.com/modin-project/modin/issues/3941",
+)
 @pytest.mark.parametrize("ignore_index", [True, False])
 def test_sort_values_preserve_index_names(ignore_index):
     modin_df, pandas_df = create_test_dfs(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR delays the resulting index computation by removing an explicit call of the `._compute_axis_labels_and_lengths`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5808 <!-- issue must be created for each patch -->
- [x] tests are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
