### PR TITLE
DOCS-#5852: Add mention of `read_custom_text` experimental api in docs

### DIFF
--- a/docs/flow/modin/experimental/pandas.rst
+++ b/docs/flow/modin/experimental/pandas.rst
@@ -11,5 +11,6 @@ Experimental API Reference
 
 .. autofunction:: read_sql
 .. autofunction:: read_csv_glob
+.. autofunction:: read_custom_text
 .. autofunction:: read_pickle_distributed
 .. automethod:: modin.experimental.pandas.DataFrame.to_pickle_distributed

--- a/docs/usage_guide/advanced_usage/index.rst
+++ b/docs/usage_guide/advanced_usage/index.rst
@@ -30,6 +30,7 @@ Modin also supports these experimental APIs on top of pandas that are under acti
 
 - :py:func:`~modin.experimental.pandas.read_csv_glob` -- read multiple files in a directory
 - :py:func:`~modin.experimental.pandas.read_sql` -- add optional parameters for the database connection
+- :py:func:`~modin.experimental.pandas.read_custom_text` -- read custom text data from file
 - :py:func:`~modin.experimental.pandas.read_pickle_distributed`  -- read multiple files in a directory
 - :py:meth:`~modin.experimental.pandas.DataFrame.to_pickle_distributed` -- write to multiple files in a directory
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5852 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
