### PR TITLE
REFACTOR-#5863: remove `Engine.subscribe(_update_engine)` in DataFrame/Series constructors

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -52,14 +52,13 @@ from modin.utils import (
     MODIN_UNNAMED_SERIES_LABEL,
     try_cast_to_pandas,
 )
-from modin.config import Engine, IsExperimental, PersistentPickle
+from modin.config import IsExperimental, PersistentPickle
 from .utils import (
     from_pandas,
     from_non_pandas,
     broadcast_item,
     SET_DATAFRAME_ATTRIBUTE_WARNING,
 )
-from . import _update_engine
 from .iterator import PartitionIterator
 from .series import Series
 from .base import BasePandasDataset, _ATTRS_NO_LOOKUP
@@ -129,7 +128,6 @@ class DataFrame(BasePandasDataset):
         # Siblings are other dataframes that share the same query compiler. We
         # use this list to update inplace when there is a shallow copy.
         self._siblings = []
-        Engine.subscribe(_update_engine)
         if isinstance(data, (DataFrame, Series)):
             self._query_compiler = data._query_compiler.copy()
             if index is not None and any(i not in data.index for i in index):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -32,7 +32,6 @@ import warnings
 from modin.utils import (
     _inherit_docstrings,
     to_pandas,
-    Engine,
     MODIN_UNNAMED_SERIES_LABEL,
 )
 from modin.config import IsExperimental, PersistentPickle
@@ -40,7 +39,6 @@ from .base import BasePandasDataset, _ATTRS_NO_LOOKUP
 from .iterator import PartitionIterator
 from .utils import from_pandas, is_scalar, _doc_binary_op
 from .accessor import CachedAccessor, SparseAccessor
-from . import _update_engine
 
 
 if TYPE_CHECKING:
@@ -98,7 +96,6 @@ class Series(BasePandasDataset):
         # Siblings are other dataframes that share the same query compiler. We
         # use this list to update inplace when there is a shallow copy.
         self._siblings = []
-        Engine.subscribe(_update_engine)
         if isinstance(data, type(self)):
             query_compiler = data._query_compiler.copy()
             if index is not None:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5863 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
