### PR TITLE
FEAT-#5816: Implement '.split' method for axis partitions

### DIFF
--- a/modin/core/dataframe/base/partitioning/axis_partition.py
+++ b/modin/core/dataframe/base/partitioning/axis_partition.py
@@ -123,12 +123,21 @@ class BaseDataframeAxisPartition(ABC):  # pragma: no cover
             extract_metadata = bool(self._PARTITIONS_METADATA_LEN)
 
         if extract_metadata:
+            # Here we recieve a 1D array of futures describing partitions and their metadata as:
+            # [object_id{partition_idx}, metadata{partition_idx}_{metadata_idx}, ...]
+            # Here's an example of such array:
+            # [
+            #  object_id1, metadata1_1, metadata1_2, ..., metadata1_PARTITIONS_METADATA_LEN,
+            #  object_id2, metadata2_1, ..., metadata2_PARTITIONS_METADATA_LEN,
+            #  ...
+            #  object_idN, metadataN_1, ..., metadataN_PARTITIONS_METADATA_LEN,
+            # ]
             return [
                 self.partition_type(*init_args)
                 for init_args in zip(
                     # `partition_type` consumes `(object_id, *metadata)`, thus adding `+1`
                     *[iter(partitions)]
-                    * (self._PARTITIONS_METADATA_LEN + 1)
+                    * (1 + self._PARTITIONS_METADATA_LEN)
                 )
             ]
         else:

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -142,7 +142,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
 
         Parameters
         ----------
-        split_func : callable(pandas.DataFrame, *args, **kwargs) -> list[pandas.DataFrame]
+        split_func : callable(pandas.DataFrame) -> list[pandas.DataFrame]
             A function that takes partition's content and split it into multiple chunks.
         num_splits : int
             The number of splits the `split_func` return.
@@ -194,12 +194,12 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         ----------
         axis : {0, 1}
             The axis to perform the function along.
-        split_func : callable(pandas.DataFrame, *args, **kwargs) -> list[pandas.DataFrame]
+        split_func : callable(pandas.DataFrame) -> list[pandas.DataFrame]
             The function to perform.
         f_args : list or tuple
-            Positional arguments to pass to ``split_func``.
+            Positional arguments to pass to `split_func`.
         f_kwargs : dict
-            Keyword arguments to pass to ``split_func``.
+            Keyword arguments to pass to `split_func`.
         num_splits : int
             The number of splits the `split_func` return.
         *partitions : iterable

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -155,6 +155,11 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
             the load on object storage as the remote function would return X times fewer futures
             (where X is the number of metadata values). Passing `False` makes sense for temporary
             results where you know for sure that the metadata will never be requested.
+
+        Returns
+        -------
+        list
+            List of wrapped remote partition objects.
         """
         f_args = tuple() if f_args is None else f_args
         f_kwargs = {} if f_kwargs is None else f_kwargs

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1581,7 +1581,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         # Convert our list of block partitions to row partitions. We need to create full-axis
         # row partitions since we need to send the whole partition to the split step as otherwise
         # we wouldn't know how to split the block partitions that don't contain the shuffling key.
-        row_partitions = [partition for partition in cls.row_partitions(partitions)]
+        row_partitions = cls.row_partitions(partitions)
         if len(pivots):
             # Gather together all of the sub-partitions
             split_row_partitions = np.array(

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1584,15 +1584,17 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         # Convert our list of block partitions to row partitions. We need to create full-axis
         # row partitions since we need to send the whole partition to the split step as otherwise
         # we wouldn't know how to split the block partitions that don't contain the shuffling key.
-        row_partitions = [
-            partition.force_materialization().list_of_block_partitions[0]
-            for partition in cls.row_partitions(partitions)
-        ]
+        row_partitions = [partition for partition in cls.row_partitions(partitions)]
         # Gather together all of the sub-partitions
         split_row_partitions = np.array(
             [
                 partition.split(
-                    shuffle_functions.split_function, len(pivots) + 1, pivots
+                    shuffle_functions.split_function,
+                    num_splits=len(pivots) + 1,
+                    f_args=(pivots,),
+                    # The partition's metadata will never be accessed for the split partitions,
+                    # thus no need to compute it.
+                    extract_metadata=False,
                 )
                 for partition in row_partitions
             ]

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -170,7 +170,9 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
                 *partitions,
             ),
             f_kwargs={"extract_metadata": extract_metadata},
-            num_returns=num_splits * 4 if extract_metadata else num_splits,
+            num_returns=num_splits * (1 + cls._PARTITIONS_METADATA_LEN)
+            if extract_metadata
+            else num_splits,
             pure=False,
         )
 
@@ -234,7 +236,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
                 "lengths": lengths,
                 "manual_partition": manual_partition,
             },
-            num_returns=result_num_splits * 4,
+            num_returns=result_num_splits * (1 + cls._PARTITIONS_METADATA_LEN),
             pure=False,
         )
 
@@ -291,7 +293,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
                 other_shape,
                 *partitions,
             ),
-            num_returns=num_splits * 4,
+            num_returns=num_splits * (1 + cls._PARTITIONS_METADATA_LEN),
             pure=False,
         )
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -165,7 +165,9 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         extract_metadata=False,
     ):
         return _deploy_ray_func.options(
-            num_returns=num_splits * 4 if extract_metadata else num_splits,
+            num_returns=num_splits * (1 + cls._PARTITIONS_METADATA_LEN)
+            if extract_metadata
+            else num_splits,
         ).remote(
             _DEPLOY_SPLIT_FUNC,
             axis,
@@ -224,7 +226,8 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             A list of ``ray.ObjectRef``-s.
         """
         return _deploy_ray_func.options(
-            num_returns=(num_splits if lengths is None else len(lengths)) * 4,
+            num_returns=(num_splits if lengths is None else len(lengths))
+            * (1 + cls._PARTITIONS_METADATA_LEN),
             **({"max_retries": max_retries} if max_retries is not None else {}),
         ).remote(
             _DEPLOY_AXIS_FUNC,
@@ -279,7 +282,9 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         list
             A list of ``ray.ObjectRef``-s.
         """
-        return _deploy_ray_func.options(num_returns=num_splits * 4).remote(
+        return _deploy_ray_func.options(
+            num_returns=num_splits * (1 + cls._PARTITIONS_METADATA_LEN)
+        ).remote(
             PandasDataframeAxisPartition.deploy_func_between_two_axis_partitions,
             axis,
             func,

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -560,13 +560,13 @@ def _deploy_ray_func(
         Positional arguments to pass to ``f_to_deploy``.
     f_kwargs : dict
         Keyword arguments to pass to ``f_to_deploy``.
-    extract_metadata : bool, default: True
-        Whether to return metadata (length, width, ip) of the result. Passing `False` may relax
-        the load on plasma storage as the remote function would return 4 times fewer futures.
-        Passing `False` makes sense for temporary results where you know for sure that the
-        metadata will never be requested.
     *args : list
         Positional arguments to pass to ``deployer``.
+    extract_metadata : bool, default: True
+        Whether to return metadata (length, width, ip) of the result. Passing `False` may relax
+        the load on object storage as the remote function would return 4 times fewer futures.
+        Passing `False` makes sense for temporary results where you know for sure that the
+        metadata will never be requested.
     **kwargs : dict
         Keyword arguments to pass to ``deployer``.
 

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -166,7 +166,9 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         extract_metadata=False,
     ):
         return _deploy_unidist_func.options(
-            num_returns=num_splits * 4 if extract_metadata else num_splits,
+            num_returns=num_splits * (1 + cls._PARTITIONS_METADATA_LEN)
+            if extract_metadata
+            else num_splits,
         ).remote(
             _DEPLOY_SPLIT_FUNC,
             axis,
@@ -225,7 +227,8 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
             A list of ``unidist.ObjectRef``-s.
         """
         return _deploy_unidist_func.options(
-            num_returns=(num_splits if lengths is None else len(lengths)) * 4,
+            num_returns=(num_splits if lengths is None else len(lengths))
+            * (1 + cls._PARTITIONS_METADATA_LEN),
             **({"max_retries": max_retries} if max_retries is not None else {}),
         ).remote(
             _DEPLOY_AXIS_FUNC,
@@ -280,7 +283,9 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         list
             A list of ``unidist.ObjectRef``-s.
         """
-        return _deploy_unidist_func.options(num_returns=num_splits * 4).remote(
+        return _deploy_unidist_func.options(
+            num_returns=num_splits * (1 + cls._PARTITIONS_METADATA_LEN)
+        ).remote(
             PandasDataframeAxisPartition.deploy_func_between_two_axis_partitions,
             axis,
             func,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The PR introduces an implementation of the `.split()` method for axis partitions, making it possible to avoid materialization of the virtual row partitions during reshuffling.

ASV results:
```
MODIN_TEST_DATASET_SIZE="Big" asv continuous origin/master HEAD --launch-method=spawn -b TimeSortValues --no-only-changed -a repeat=5

All benchmarks:

       before           after         ratio
     [cd7611cd]       [9316fbcc]
     <master>       <issue_5816>
       949±50ms         910±50ms     0.96  benchmarks.TimeSortValues.time_sort_values([1000000, 10], 10, False)
       947±40ms         898±20ms     0.95  benchmarks.TimeSortValues.time_sort_values([1000000, 10], 1, False)
       1.03±0.04s         909±60ms    ~0.89  benchmarks.TimeSortValues.time_sort_values([1000000, 10], 2, False)
```

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5816 <!-- issue must be created for each patch -->
- [x] tests are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
