### PR TITLE
FIX-#5767: cast `pathlib.Path` to str for `read_parquet`

### DIFF
--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -16,12 +16,12 @@
 import os
 import re
 import json
-import pathlib
 
 import fsspec
 from fsspec.core import url_to_fs
 from fsspec.spec import AbstractBufferedFile
 import numpy as np
+from pandas.io.common import stringify_path
 from packaging import version
 
 from modin.core.storage_formats.pandas.utils import compute_chunksize
@@ -613,8 +613,7 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         ParquetFile API is used. Please refer to the documentation here
         https://arrow.apache.org/docs/python/parquet.html
         """
-        if isinstance(path, pathlib.Path):
-            path = str(path)
+        path = stringify_path(path)
         if isinstance(path, list):
             # TODO(https://github.com/modin-project/modin/issues/5723): read all
             # files in parallel.

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -16,6 +16,7 @@
 import os
 import re
 import json
+import pathlib
 
 import fsspec
 from fsspec.core import url_to_fs
@@ -612,6 +613,8 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         ParquetFile API is used. Please refer to the documentation here
         https://arrow.apache.org/docs/python/parquet.html
         """
+        if isinstance(path, pathlib.Path):
+            path = str(path)
         if isinstance(path, list):
             # TODO(https://github.com/modin-project/modin/issues/5723): read all
             # files in parallel.

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1656,6 +1656,17 @@ class TestParquet:
 
             df_equals(test_df, read_df)
 
+    def test_read_parquet_5767(self, engine):
+        test_df = pandas.DataFrame({"a": [1, 2, 3, 4], "b": [1, 1, 2, 2]})
+        file_name = "modin_issue#0000.parquet"
+        with tempfile.TemporaryDirectory() as directory:
+            path = f"{directory}/data"
+            os.makedirs(path)
+            test_df.to_parquet(path + file_name, engine=engine, partition_cols=["b"])
+            read_df = pd.read_parquet(Path(path + file_name))
+        # both Modin and pandas read column "b" as a category
+        df_equals(test_df, read_df.astype("int64"))
+
     def test_read_parquet_s3_with_column_partitioning(self, engine):
         # This test case comes from
         # https://github.com/modin-project/modin/issues/4636


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5767 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
