### PR TITLE
FIX-#5862: fix Inline strong start-string without end-string for read_custom_text

### DIFF
--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -114,7 +114,7 @@ def read_custom_text(
     nrows: Optional[int] = None,
     is_quoting=True,
 ):
-    """
+    r"""
     Load custom text data from file.
 
     Parameters

--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -121,10 +121,10 @@ def read_custom_text(
     ----------
     filepath_or_buffer : str
         File path where the custom text data will be loaded from.
-    columns : list or callable(file-like object, **kwargs) -> list
+    columns : list or callable(file-like object, \*\*kwargs) -> list
         Column names of list type or callable that create column names from opened file
         and passed `kwargs`.
-    custom_parser : callable(file-like object, **kwargs) -> pandas.DataFrame
+    custom_parser : callable(file-like object, \*\*kwargs) -> pandas.DataFrame
         Function that takes as input a part of the `filepath_or_buffer` file loaded into
         memory in file-like object form.
     compression : {'infer', 'gzip', 'bz2', 'zip', 'xz', None}, default: 'infer'


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Such changes have already been in Modin. For example, in `PandasDataframePartitionManager.n_ary_operation`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5862 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
