### PR TITLE
REFACTOR-#5830: rename experimental dispatchers and parsers

### DIFF
--- a/modin/core/io/__init__.py
+++ b/modin/core/io/__init__.py
@@ -19,7 +19,7 @@ from .text.csv_glob_dispatcher import CSVGlobDispatcher
 from .text.fwf_dispatcher import FWFDispatcher
 from .text.json_dispatcher import JSONDispatcher
 from .text.custom_text_dispatcher import (
-    CustomTextExperimentalDispatcher,
+    ExperimentalCustomTextDispatcher,
 )
 from .text.excel_dispatcher import ExcelDispatcher
 from .file_dispatcher import FileDispatcher
@@ -28,7 +28,7 @@ from .column_stores.parquet_dispatcher import ParquetDispatcher
 from .column_stores.hdf_dispatcher import HDFDispatcher
 from .column_stores.feather_dispatcher import FeatherDispatcher
 from .sql.sql_dispatcher import SQLDispatcher
-from .pickle.pickle_dispatcher import PickleExperimentalDispatcher
+from .pickle.pickle_dispatcher import ExperimentalPickleDispatcher
 
 __all__ = [
     "BaseIO",
@@ -43,6 +43,6 @@ __all__ = [
     "FeatherDispatcher",
     "SQLDispatcher",
     "ExcelDispatcher",
-    "PickleExperimentalDispatcher",
-    "CustomTextExperimentalDispatcher",
+    "ExperimentalPickleDispatcher",
+    "ExperimentalCustomTextDispatcher",
 ]

--- a/modin/core/io/pickle/pickle_dispatcher.py
+++ b/modin/core/io/pickle/pickle_dispatcher.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-"""Module houses ``PickleExperimentalDispatcher`` class that is used for reading `.pkl` files."""
+"""Module houses ``ExperimentalPickleDispatcher`` class that is used for reading `.pkl` files."""
 
 import glob
 import warnings
@@ -20,7 +20,7 @@ from modin.core.io.file_dispatcher import FileDispatcher
 from modin.config import NPartitions
 
 
-class PickleExperimentalDispatcher(FileDispatcher):
+class ExperimentalPickleDispatcher(FileDispatcher):
     """Class handles utils for reading pickle files."""
 
     @classmethod

--- a/modin/core/io/text/custom_text_dispatcher.py
+++ b/modin/core/io/text/custom_text_dispatcher.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-"""Module houses `CustomTextExperimentalDispatcher` class, that is used for reading custom text files."""
+"""Module houses `ExperimentalCustomTextDispatcher` class, that is used for reading custom text files."""
 
 import pandas
 
@@ -20,7 +20,7 @@ from modin.core.io.text.text_file_dispatcher import TextFileDispatcher
 from modin.config import NPartitions
 
 
-class CustomTextExperimentalDispatcher(TextFileDispatcher):
+class ExperimentalCustomTextDispatcher(TextFileDispatcher):
     """Class handles utils for reading custom text files."""
 
     @classmethod

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -412,7 +412,7 @@ class PandasCSVGlobParser(PandasCSVParser):
 
 
 @doc(_doc_pandas_parser_class, data_type="pickled pandas objects")
-class PandasPickleExperimentalParser(PandasParser):
+class ExperimentalPandasPickleParser(PandasParser):
     @staticmethod
     @doc(_doc_parse_func, parameters=_doc_parse_parameters_common)
     def parse(fname, **kwargs):
@@ -433,7 +433,7 @@ class PandasPickleExperimentalParser(PandasParser):
 
 
 @doc(_doc_pandas_parser_class, data_type="custom text")
-class CustomTextExperimentalParser(PandasParser):
+class ExperimentalCustomTextParser(PandasParser):
     @staticmethod
     @doc(_doc_parse_func, parameters=_doc_parse_parameters_common)
     def parse(fname, **kwargs):

--- a/modin/experimental/core/execution/dask/implementations/pandas_on_dask/io/io.py
+++ b/modin/experimental/core/execution/dask/implementations/pandas_on_dask/io/io.py
@@ -24,17 +24,17 @@ import pandas
 
 from modin.core.storage_formats.pandas.parsers import (
     PandasCSVGlobParser,
-    PandasPickleExperimentalParser,
-    CustomTextExperimentalParser,
+    ExperimentalPandasPickleParser,
+    ExperimentalCustomTextParser,
 )
 from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.core.execution.dask.implementations.pandas_on_dask.io import PandasOnDaskIO
 from modin.core.io import (
     CSVGlobDispatcher,
-    PickleExperimentalDispatcher,
-    CustomTextExperimentalDispatcher,
+    ExperimentalPickleDispatcher,
+    ExperimentalCustomTextDispatcher,
 )
-from modin.experimental.core.io import SQLExperimentalDispatcher
+from modin.experimental.core.io import ExperimentalSQLDispatcher
 
 from modin.core.execution.dask.implementations.pandas_on_dask.dataframe import (
     PandasOnDaskDataframe,
@@ -67,14 +67,14 @@ class ExperimentalPandasOnDaskIO(PandasOnDaskIO):
     read_csv_glob = __make_read(PandasCSVGlobParser, CSVGlobDispatcher)
 
     read_pickle_distributed = __make_read(
-        PandasPickleExperimentalParser, PickleExperimentalDispatcher
+        ExperimentalPandasPickleParser, ExperimentalPickleDispatcher
     )
 
     read_custom_text = __make_read(
-        CustomTextExperimentalParser, CustomTextExperimentalDispatcher
+        ExperimentalCustomTextParser, ExperimentalCustomTextDispatcher
     )
 
-    read_sql = __make_read(SQLExperimentalDispatcher)
+    read_sql = __make_read(ExperimentalSQLDispatcher)
 
     del __make_read  # to not pollute class namespace
 

--- a/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -23,17 +23,17 @@ import warnings
 
 from modin.core.storage_formats.pandas.parsers import (
     PandasCSVGlobParser,
-    PandasPickleExperimentalParser,
-    CustomTextExperimentalParser,
+    ExperimentalPandasPickleParser,
+    ExperimentalCustomTextParser,
 )
 from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.core.execution.ray.implementations.pandas_on_ray.io import PandasOnRayIO
 from modin.core.io import (
     CSVGlobDispatcher,
-    PickleExperimentalDispatcher,
-    CustomTextExperimentalDispatcher,
+    ExperimentalPickleDispatcher,
+    ExperimentalCustomTextDispatcher,
 )
-from modin.experimental.core.io import SQLExperimentalDispatcher
+from modin.experimental.core.io import ExperimentalSQLDispatcher
 from modin.core.execution.ray.implementations.pandas_on_ray.dataframe import (
     PandasOnRayDataframe,
 )
@@ -65,14 +65,14 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
     read_csv_glob = __make_read(PandasCSVGlobParser, CSVGlobDispatcher)
 
     read_pickle_distributed = __make_read(
-        PandasPickleExperimentalParser, PickleExperimentalDispatcher
+        ExperimentalPandasPickleParser, ExperimentalPickleDispatcher
     )
 
     read_custom_text = __make_read(
-        CustomTextExperimentalParser, CustomTextExperimentalDispatcher
+        ExperimentalCustomTextParser, ExperimentalCustomTextDispatcher
     )
 
-    read_sql = __make_read(SQLExperimentalDispatcher)
+    read_sql = __make_read(ExperimentalSQLDispatcher)
 
     del __make_read  # to not pollute class namespace
 

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -23,8 +23,8 @@ import warnings
 
 from modin.core.storage_formats.pandas.parsers import (
     PandasCSVGlobParser,
-    PandasPickleExperimentalParser,
-    CustomTextExperimentalParser,
+    ExperimentalPandasPickleParser,
+    ExperimentalCustomTextParser,
 )
 from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.core.execution.unidist.implementations.pandas_on_unidist.io import (
@@ -32,10 +32,10 @@ from modin.core.execution.unidist.implementations.pandas_on_unidist.io import (
 )
 from modin.core.io import (
     CSVGlobDispatcher,
-    PickleExperimentalDispatcher,
-    CustomTextExperimentalDispatcher,
+    ExperimentalPickleDispatcher,
+    ExperimentalCustomTextDispatcher,
 )
-from modin.experimental.core.io import SQLExperimentalDispatcher
+from modin.experimental.core.io import ExperimentalSQLDispatcher
 from modin.core.execution.unidist.implementations.pandas_on_unidist.dataframe import (
     PandasOnUnidistDataframe,
 )
@@ -67,14 +67,14 @@ class ExperimentalPandasOnUnidistIO(PandasOnUnidistIO):
     read_csv_glob = __make_read(PandasCSVGlobParser, CSVGlobDispatcher)
 
     read_pickle_distributed = __make_read(
-        PandasPickleExperimentalParser, PickleExperimentalDispatcher
+        ExperimentalPandasPickleParser, ExperimentalPickleDispatcher
     )
 
     read_custom_text = __make_read(
-        CustomTextExperimentalParser, CustomTextExperimentalDispatcher
+        ExperimentalCustomTextParser, ExperimentalCustomTextDispatcher
     )
 
-    read_sql = __make_read(SQLExperimentalDispatcher)
+    read_sql = __make_read(ExperimentalSQLDispatcher)
 
     del __make_read  # to not pollute class namespace
 

--- a/modin/experimental/core/io/__init__.py
+++ b/modin/experimental/core/io/__init__.py
@@ -13,8 +13,8 @@
 
 """Experimental IO functions implementations."""
 
-from .sql.sql_dispatcher import SQLExperimentalDispatcher
+from .sql.sql_dispatcher import ExperimentalSQLDispatcher
 
 __all__ = [
-    "SQLExperimentalDispatcher",
+    "ExperimentalSQLDispatcher",
 ]

--- a/modin/experimental/core/io/sql/sql_dispatcher.py
+++ b/modin/experimental/core/io/sql/sql_dispatcher.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-"""Module houses `SQLExperimentalDispatcher` class."""
+"""Module houses `ExperimentalSQLDispatcher` class."""
 
 import warnings
 
@@ -22,7 +22,7 @@ from modin.core.io import SQLDispatcher
 from modin.config import NPartitions
 
 
-class SQLExperimentalDispatcher(SQLDispatcher):
+class ExperimentalSQLDispatcher(SQLDispatcher):
     """Class handles experimental utils for reading SQL queries or database tables."""
 
     __read_sql_with_offset = None


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5830 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
