### PR TITLE
REFACTOR-#5286: remove docstrings from public Series' methods as they are inheriting from pandas

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -67,9 +67,7 @@ from .groupby import DataFrameGroupBy
 from .accessor import CachedAccessor, SparseFrameAccessor
 
 
-@_inherit_docstrings(
-    pandas.DataFrame, excluded=[pandas.DataFrame.__init__], apilink="pandas.DataFrame"
-)
+@_inherit_docstrings(pandas.DataFrame, excluded=[pandas.DataFrame.__init__])
 class DataFrame(BasePandasDataset):
     """
     Modin distributed representation of ``pandas.DataFrame``.
@@ -309,10 +307,7 @@ class DataFrame(BasePandasDataset):
 
     def drop_duplicates(
         self, subset=None, keep="first", inplace=False, ignore_index=False
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return ``DataFrame`` with duplicate rows removed.
-        """
+    ):
         return super(DataFrame, self).drop_duplicates(
             subset=subset, keep=keep, inplace=inplace, ignore_index=ignore_index
         )
@@ -353,6 +348,54 @@ class DataFrame(BasePandasDataset):
         Return a tuple representing the dimensionality of the ``DataFrame``.
         """
         return len(self.index), len(self.columns)
+
+    abs = BasePandasDataset._get_abs()
+    align = BasePandasDataset._get_align()
+    all = BasePandasDataset._get_all()
+    any = BasePandasDataset._get_any()
+    asfreq = BasePandasDataset._get_asfreq()
+    asof = BasePandasDataset._get_asof()
+    astype = BasePandasDataset._get_astype()
+    at = BasePandasDataset._get_at()
+    at_time = BasePandasDataset._get_at_time()
+    between_time = BasePandasDataset._get_between_time()
+    bfill = BasePandasDataset._get_bfill()
+    backfill = BasePandasDataset._get_bfill()
+    bool = BasePandasDataset._get_bool()
+    clip = BasePandasDataset._get_clip()
+    combine = BasePandasDataset._get_combine()
+    combine_first = BasePandasDataset._get_combine_first()
+    copy = BasePandasDataset._get_copy()
+    count = BasePandasDataset._get_count()
+    cummax = BasePandasDataset._get_cummax()
+    cummin = BasePandasDataset._get_cummin()
+    cumprod = BasePandasDataset._get_cumprod()
+    cumsum = BasePandasDataset._get_cumsum()
+    describe = BasePandasDataset._get_describe()
+    diff = BasePandasDataset._get_diff()
+    drop = BasePandasDataset._get_drop()
+    dropna = BasePandasDataset._get_dropna()
+    droplevel = BasePandasDataset._get_droplevel()
+    eq = BasePandasDataset._get_eq()
+    explode = BasePandasDataset._get_explode()
+    ewm = BasePandasDataset._get_ewm()
+    expanding = BasePandasDataset._get_expanding()
+    ffill = BasePandasDataset._get_ffill()
+    pad = BasePandasDataset._get_ffill()
+    fillna = BasePandasDataset._get_fillna()
+    filter = BasePandasDataset._get_filter()
+    first = BasePandasDataset._get_first()
+    first_valid_index = BasePandasDataset._get_first_valid_index()
+    floordiv = BasePandasDataset._get_floordiv()
+    convert_dtypes = BasePandasDataset._get_convert_dtypes()
+    ge = BasePandasDataset._get_ge()
+    get = BasePandasDataset._get_get()
+    gt = BasePandasDataset._get_gt()
+    head = BasePandasDataset._get_head()
+    iat = BasePandasDataset._get_iat()
+    idxmax = BasePandasDataset._get_idxmax()
+    idxmin = BasePandasDataset._get_idxmin()
+    infer_objects = BasePandasDataset._get_infer_objects()
 
     def add_prefix(self, prefix):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -203,12 +203,7 @@ class Series(BasePandasDataset):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).__rand__(new_other)
 
-    # add `_inherit_docstrings` decorator to force method link addition.
-    @_inherit_docstrings(pandas.Series.__array__, apilink="pandas.Series.__array__")
-    def __array__(self, dtype=None):  # noqa: PR01, RT01, D200
-        """
-        Return the values as a NumPy array.
-        """
+    def __array__(self, dtype=None):
         return super(Series, self).__array__(dtype).flatten()
 
     def __contains__(self, key):
@@ -485,10 +480,7 @@ class Series(BasePandasDataset):
     __itruediv__ = __truediv__
 
     @property
-    def values(self):  # noqa: RT01, D200
-        """
-        Return Series as ndarray or ndarray-like depending on the dtype.
-        """
+    def values(self):
         import modin.pandas as pd
 
         if isinstance(
@@ -505,48 +497,29 @@ class Series(BasePandasDataset):
             data = pd.Categorical(data, dtype=self.dtype)
         return data
 
-    def add(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return Addition of series and other, element-wise (binary operator add).
-        """
+    def add(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).add(
             new_other, level=level, fill_value=fill_value, axis=axis
         )
 
-    def radd(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return Addition of series and other, element-wise (binary operator radd).
-        """
+    def radd(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).radd(
             new_other, level=level, fill_value=fill_value, axis=axis
         )
 
-    def add_prefix(self, prefix):  # noqa: PR01, RT01, D200
-        """
-        Prefix labels with string `prefix`.
-        """
+    def add_prefix(self, prefix):
         return self.__constructor__(
             query_compiler=self._query_compiler.add_prefix(prefix, axis=0)
         )
 
-    def add_suffix(self, suffix):  # noqa: PR01, RT01, D200
-        """
-        Suffix labels with string `suffix`.
-        """
+    def add_suffix(self, suffix):
         return self.__constructor__(
             query_compiler=self._query_compiler.add_suffix(suffix, axis=0)
         )
 
-    def append(
-        self, to_append, ignore_index=False, verify_integrity=False
-    ):  # noqa: PR01, RT01, D200
-        """
-        Concatenate two or more Series.
-        """
+    def append(self, to_append, ignore_index=False, verify_integrity=False):
         from .dataframe import DataFrame
 
         bad_type_msg = (
@@ -617,11 +590,7 @@ class Series(BasePandasDataset):
         else:
             return self.__constructor__(query_compiler=query_compiler)
 
-    def aggregate(self, func=None, axis=0, *args, **kwargs):  # noqa: PR01, RT01, D200
-        """
-        Aggregate using one or more operations over the specified axis.
-        """
-
+    def aggregate(self, func=None, axis=0, *args, **kwargs):
         def error_raiser(msg, exception):
             """Convert passed exception to the same type as pandas do and raise it."""
             # HACK: to concord with pandas error types by replacing all of the
@@ -634,12 +603,7 @@ class Series(BasePandasDataset):
 
     agg = aggregate
 
-    def apply(
-        self, func, convert_dtype=True, args=(), **kwargs
-    ):  # noqa: PR01, RT01, D200
-        """
-        Invoke function on values of Series.
-        """
+    def apply(self, func, convert_dtype=True, args=(), **kwargs):
         self._validate_function(func)
         # apply and aggregate have slightly different behaviors, so we have to use
         # each one separately to determine the correct return type. In the case of
@@ -719,50 +683,32 @@ class Series(BasePandasDataset):
             return result.to_pandas().squeeze()
         return result
 
-    def argmax(self, axis=None, skipna=True, *args, **kwargs):  # noqa: PR01, RT01, D200
-        """
-        Return int position of the largest value in the Series.
-        """
+    def argmax(self, axis=None, skipna=True, *args, **kwargs):
         result = self.idxmax(axis=axis, skipna=skipna, *args, **kwargs)
         if np.isnan(result) or result is pandas.NA:
             result = -1
         return result
 
-    def argmin(self, axis=None, skipna=True, *args, **kwargs):  # noqa: PR01, RT01, D200
-        """
-        Return int position of the smallest value in the Series.
-        """
+    def argmin(self, axis=None, skipna=True, *args, **kwargs):
         result = self.idxmin(axis=axis, skipna=skipna, *args, **kwargs)
         if np.isnan(result) or result is pandas.NA:
             result = -1
         return result
 
-    def argsort(self, axis=0, kind="quicksort", order=None):  # noqa: PR01, RT01, D200
-        """
-        Return the integer indices that would sort the Series values.
-        """
+    def argsort(self, axis=0, kind="quicksort", order=None):
         return self._default_to_pandas(
             pandas.Series.argsort, axis=axis, kind=kind, order=order
         )
 
-    def autocorr(self, lag=1):  # noqa: PR01, RT01, D200
-        """
-        Compute the lag-N autocorrelation.
-        """
+    def autocorr(self, lag=1):
         return self.corr(self.shift(lag))
 
-    def between(self, left, right, inclusive: str = "both"):  # noqa: PR01, RT01, D200
-        """
-        Return boolean Series equivalent to left <= series <= right.
-        """
+    def between(self, left, right, inclusive: str = "both"):
         return self._default_to_pandas(
             pandas.Series.between, left, right, inclusive=inclusive
         )
 
-    def combine(self, other, func, fill_value=None):  # noqa: PR01, RT01, D200
-        """
-        Combine the Series with a Series or scalar according to `func`.
-        """
+    def combine(self, other, func, fill_value=None):
         return super(Series, self).combine(
             other, lambda s1, s2: s1.combine(s2, func, fill_value=fill_value)
         )
@@ -774,10 +720,7 @@ class Series(BasePandasDataset):
         keep_shape: bool = False,
         keep_equal: bool = False,
         result_names: tuple = ("self", "other"),
-    ) -> "Series":  # noqa: PR01, RT01, D200
-        """
-        Compare to another Series and show the differences.
-        """
+    ) -> "Series":
         if not isinstance(other, Series):
             raise TypeError(f"Cannot compare Series to {type(other)}")
         result = self.to_frame().compare(
@@ -795,10 +738,7 @@ class Series(BasePandasDataset):
             result = result.squeeze().rename(None)
         return result
 
-    def corr(self, other, method="pearson", min_periods=None):  # noqa: PR01, RT01, D200
-        """
-        Compute correlation with `other` Series, excluding missing values.
-        """
+    def corr(self, other, method="pearson", min_periods=None):
         if method == "pearson":
             this, other = self.align(other, join="inner", copy=False)
             this = self.__constructor__(this)
@@ -850,18 +790,10 @@ class Series(BasePandasDataset):
             )
         )
 
-    def count(self, level=None):  # noqa: PR01, RT01, D200
-        """
-        Return number of non-NA/null observations in the Series.
-        """
+    def count(self, level=None):
         return super(Series, self).count(level=level)
 
-    def cov(
-        self, other, min_periods=None, ddof: Optional[int] = 1
-    ):  # noqa: PR01, RT01, D200
-        """
-        Compute covariance with Series, excluding missing values.
-        """
+    def cov(self, other, min_periods=None, ddof: Optional[int] = 1):
         this, other = self.align(other, join="inner", copy=False)
         this = self.__constructor__(this)
         other = self.__constructor__(other)
@@ -895,35 +827,21 @@ class Series(BasePandasDataset):
 
     def describe(
         self, percentiles=None, include=None, exclude=None, datetime_is_numeric=False
-    ):  # noqa: PR01, RT01, D200
-        """
-        Generate descriptive statistics.
-        """
+    ):
         # Pandas ignores the `include` and `exclude` for Series for some reason.
         return super(Series, self).describe(
             percentiles=percentiles, datetime_is_numeric=datetime_is_numeric
         )
 
-    def diff(self, periods=1):  # noqa: PR01, RT01, D200
-        """
-        First discrete difference of element.
-        """
+    def diff(self, periods=1):
         return super(Series, self).diff(periods=periods, axis=0)
 
-    def divmod(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return Integer division and modulo of series and `other`, element-wise (binary operator `divmod`).
-        """
+    def divmod(self, other, level=None, fill_value=None, axis=0):
         return self._default_to_pandas(
             pandas.Series.divmod, other, level=level, fill_value=fill_value, axis=axis
         )
 
-    def dot(self, other):  # noqa: PR01, RT01, D200
-        """
-        Compute the dot product between the Series and the columns of `other`.
-        """
+    def dot(self, other):
         if isinstance(other, BasePandasDataset):
             common = self.index.union(other.index)
             if len(common) > len(self.index) or len(common) > len(other.index):
@@ -958,56 +876,33 @@ class Series(BasePandasDataset):
             query_compiler=self._query_compiler.dot(other, squeeze_self=True)
         )
 
-    def drop_duplicates(self, keep="first", inplace=False):  # noqa: PR01, RT01, D200
-        """
-        Return Series with duplicate values removed.
-        """
+    def drop_duplicates(self, keep="first", inplace=False):
         return super(Series, self).drop_duplicates(keep=keep, inplace=inplace)
 
-    def dropna(self, axis=0, inplace=False, how=None):  # noqa: PR01, RT01, D200
-        """
-        Return a new Series with missing values removed.
-        """
+    def dropna(self, axis=0, inplace=False, how=None):
         return super(Series, self).dropna(axis=axis, inplace=inplace)
 
-    def duplicated(self, keep="first"):  # noqa: PR01, RT01, D200
-        """
-        Indicate duplicate Series values.
-        """
+    def duplicated(self, keep="first"):
         return self.to_frame().duplicated(keep=keep)
 
-    def eq(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return Equal to of series and `other`, element-wise (binary operator `eq`).
-        """
+    def eq(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).eq(new_other, level=level, axis=axis)
 
-    def equals(self, other):  # noqa: PR01, RT01, D200
-        """
-        Test whether two objects contain the same elements.
-        """
+    def equals(self, other):
         return (
             self.name == other.name
             and self.index.equals(other.index)
             and self.eq(other).all()
         )
 
-    def explode(self, ignore_index: bool = False):  # noqa: PR01, RT01, D200
-        """
-        Transform each element of a list-like to a row.
-        """
+    def explode(self, ignore_index: bool = False):
         return super(Series, self).explode(
             MODIN_UNNAMED_SERIES_LABEL if self.name is None else self.name,
             ignore_index=ignore_index,
         )
 
-    def factorize(
-        self, sort=False, na_sentinel=no_default, use_na_sentinel=no_default
-    ):  # noqa: PR01, RT01, D200
-        """
-        Encode the object as an enumerated type or categorical variable.
-        """
+    def factorize(self, sort=False, na_sentinel=no_default, use_na_sentinel=no_default):
         return self._default_to_pandas(
             pandas.Series.factorize,
             sort=sort,
@@ -1023,10 +918,7 @@ class Series(BasePandasDataset):
         inplace=False,
         limit=None,
         downcast=None,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Fill NaNs inside of a Series object.
-        """
+    ):
         if isinstance(value, BasePandasDataset) and not isinstance(value, Series):
             raise TypeError(
                 '"value" parameter must be a scalar, dict or Series, but '
@@ -1043,21 +935,13 @@ class Series(BasePandasDataset):
             downcast=downcast,
         )
 
-    def floordiv(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Get Integer division of dataframe and `other`, element-wise (binary operator `floordiv`).
-        """
+    def floordiv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).floordiv(
             new_other, level=level, fill_value=None, axis=axis
         )
 
-    def ge(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return greater than or equal to of series and `other`, element-wise (binary operator `ge`).
-        """
+    def ge(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).ge(new_other, level=level, axis=axis)
 
@@ -1072,10 +956,7 @@ class Series(BasePandasDataset):
         squeeze=no_default,
         observed=False,
         dropna: bool = True,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Group Series using a mapper or by a Series of columns.
-        """
+    ):
         if squeeze is not no_default:
             warnings.warn(
                 (
@@ -1114,10 +995,7 @@ class Series(BasePandasDataset):
             dropna=dropna,
         )
 
-    def gt(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return greater than of series and `other`, element-wise (binary operator `gt`).
-        """
+    def gt(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).gt(new_other, level=level, axis=axis)
 
@@ -1133,10 +1011,7 @@ class Series(BasePandasDataset):
         figsize=None,
         bins=10,
         **kwds,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Draw histogram of the input series using matplotlib.
-        """
+    ):
         return self._default_to_pandas(
             pandas.Series.hist,
             by=by,
@@ -1151,18 +1026,12 @@ class Series(BasePandasDataset):
             **kwds,
         )
 
-    def idxmax(self, axis=0, skipna=True, *args, **kwargs):  # noqa: PR01, RT01, D200
-        """
-        Return the row label of the maximum value.
-        """
+    def idxmax(self, axis=0, skipna=True, *args, **kwargs):
         if skipna is None:
             skipna = True
         return super(Series, self).idxmax(axis=axis, skipna=skipna, *args, **kwargs)
 
-    def idxmin(self, axis=0, skipna=True, *args, **kwargs):  # noqa: PR01, RT01, D200
-        """
-        Return the row label of the minimum value.
-        """
+    def idxmin(self, axis=0, skipna=True, *args, **kwargs):
         if skipna is None:
             skipna = True
         return super(Series, self).idxmin(axis=axis, skipna=skipna, *args, **kwargs)
@@ -1194,10 +1063,7 @@ class Series(BasePandasDataset):
         limit_area=None,
         downcast=None,
         **kwargs,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Fill NaN values using an interpolation method.
-        """
+    ):
         return self._default_to_pandas(
             pandas.Series.interpolate,
             method=method,
@@ -1210,23 +1076,13 @@ class Series(BasePandasDataset):
             **kwargs,
         )
 
-    def isin(self, values):  # noqa: PR01, RT01, D200
-        """
-        Whether elements in `Series` are contained in `values`.
-        """
+    def isin(self, values):
         return super(Series, self).isin(values, shape_hint="column")
 
-    def item(self):  # noqa: RT01, D200
-        """
-        Return the first element of the underlying data as a Python scalar.
-        """
+    def item(self):
         return self[0]
 
-    def items(self):  # noqa: D200
-        """
-        Lazily iterate over (index, value) tuples.
-        """
-
+    def items(self):
         def item_builder(s):
             return s.name, s.squeeze()
 
@@ -1234,16 +1090,10 @@ class Series(BasePandasDataset):
         for v in partition_iterator:
             yield v
 
-    def iteritems(self):  # noqa: RT01, D200
-        """
-        Lazily iterate over (index, value) tuples.
-        """
+    def iteritems(self):
         return self.items()
 
-    def keys(self):  # noqa: RT01, D200
-        """
-        Return alias for index.
-        """
+    def keys(self):
         return self.index
 
     def kurt(
@@ -1253,33 +1103,21 @@ class Series(BasePandasDataset):
         level=None,
         numeric_only=None,
         **kwargs,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return unbiased kurtosis over requested axis.
-        """
+    ):
         axis = self._get_axis_number(axis)
         return super(Series, self).kurt(axis, skipna, level, numeric_only, **kwargs)
 
     kurtosis = kurt
 
-    def le(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return less than or equal to of series and `other`, element-wise (binary operator `le`).
-        """
+    def le(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).le(new_other, level=level, axis=axis)
 
-    def lt(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return less than of series and `other`, element-wise (binary operator `lt`).
-        """
+    def lt(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).lt(new_other, level=level, axis=axis)
 
-    def map(self, arg, na_action=None):  # noqa: PR01, RT01, D200
-        """
-        Map values of Series according to input correspondence.
-        """
+    def map(self, arg, na_action=None):
         if isinstance(arg, type(self)):
             # HACK: if we don't cast to pandas, then the execution engine will try to
             # propagate the distributed Series to workers and most likely would have
@@ -1302,7 +1140,6 @@ class Series(BasePandasDataset):
             )
         )
 
-    @_inherit_docstrings(pandas.Series.mask, apilink="pandas.Series.mask")
     def mask(
         self,
         cond,
@@ -1324,10 +1161,7 @@ class Series(BasePandasDataset):
             try_cast=try_cast,
         )
 
-    def memory_usage(self, index=True, deep=False):  # noqa: PR01, RT01, D200
-        """
-        Return the memory usage of the Series.
-        """
+    def memory_usage(self, index=True, deep=False):
         if index:
             result = self._reduce_dimension(
                 self._query_compiler.memory_usage(index=False, deep=deep)
@@ -1336,25 +1170,16 @@ class Series(BasePandasDataset):
             return result + index_value
         return super(Series, self).memory_usage(index=index, deep=deep)
 
-    def mod(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return Modulo of series and `other`, element-wise (binary operator `mod`).
-        """
+    def mod(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).mod(
             new_other, level=level, fill_value=None, axis=axis
         )
 
-    def mode(self, dropna=True):  # noqa: PR01, RT01, D200
-        """
-        Return the mode(s) of the Series.
-        """
+    def mode(self, dropna=True):
         return super(Series, self).mode(numeric_only=False, dropna=dropna)
 
-    def mul(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return multiplication of series and `other`, element-wise (binary operator `mul`).
-        """
+    def mul(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).mul(
             new_other, level=level, fill_value=None, axis=axis
@@ -1362,42 +1187,25 @@ class Series(BasePandasDataset):
 
     multiply = mul
 
-    def rmul(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return multiplication of series and `other`, element-wise (binary operator `mul`).
-        """
+    def rmul(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rmul(
             new_other, level=level, fill_value=None, axis=axis
         )
 
-    def ne(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return not equal to of series and `other`, element-wise (binary operator `ne`).
-        """
+    def ne(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).ne(new_other, level=level, axis=axis)
 
-    def nlargest(self, n=5, keep="first"):  # noqa: PR01, RT01, D200
-        """
-        Return the largest `n` elements.
-        """
+    def nlargest(self, n=5, keep="first"):
         return self._default_to_pandas(pandas.Series.nlargest, n=n, keep=keep)
 
-    def nsmallest(self, n=5, keep="first"):  # noqa: PR01, RT01, D200
-        """
-        Return the smallest `n` elements.
-        """
+    def nsmallest(self, n=5, keep="first"):
         return self.__constructor__(
             query_compiler=self._query_compiler.nsmallest(n=n, keep=keep)
         )
 
-    def slice_shift(self, periods=1, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Equivalent to `shift` without copying data.
-        """
+    def slice_shift(self, periods=1, axis=0):
         if periods == 0:
             return self.copy()
 
@@ -1417,20 +1225,12 @@ class Series(BasePandasDataset):
                 )
             )
 
-    def shift(
-        self, periods=1, freq=None, axis=0, fill_value=None
-    ):  # noqa: PR01, RT01, D200
-        """
-        Shift index by desired number of periods with an optional time `freq`.
-        """
+    def shift(self, periods=1, freq=None, axis=0, fill_value=None):
         return super(type(self), self).shift(
             periods=periods, freq=freq, axis=axis, fill_value=fill_value
         )
 
-    def unstack(self, level=-1, fill_value=None):  # noqa: PR01, RT01, D200
-        """
-        Unstack, also known as pivot, Series with MultiIndex to produce DataFrame.
-        """
+    def unstack(self, level=-1, fill_value=None):
         from .dataframe import DataFrame
 
         result = DataFrame(
@@ -1466,22 +1266,15 @@ class Series(BasePandasDataset):
         label=None,
         secondary_y=False,
         **kwds,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Make plot of Series.
-        """
+    ):
         return self._to_pandas().plot
 
-    def pow(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return exponential power of series and `other`, element-wise (binary operator `pow`).
-        """
+    def pow(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).pow(
             new_other, level=level, fill_value=None, axis=axis
         )
 
-    @_inherit_docstrings(pandas.Series.prod, apilink="pandas.Series.prod")
     def prod(
         self,
         axis=None,
@@ -1533,17 +1326,13 @@ class Series(BasePandasDataset):
 
     product = prod
 
-    def ravel(self, order="C"):  # noqa: PR01, RT01, D200
-        """
-        Return the flattened underlying data as an ndarray.
-        """
+    def ravel(self, order="C"):
         data = self._query_compiler.to_numpy().flatten(order=order)
         if isinstance(self.dtype, pandas.CategoricalDtype):
             data = pandas.Categorical(data, dtype=self.dtype)
 
         return data
 
-    @_inherit_docstrings(pandas.Series.reindex, apilink="pandas.Series.reindex")
     def reindex(self, *args, **kwargs):
         if args:
             if len(args) > 1:
@@ -1585,10 +1374,7 @@ class Series(BasePandasDataset):
         inplace=False,
         level=None,
         errors="ignore",
-    ):  # noqa: PR01, RT01, D200
-        """
-        Alter Series index labels or name.
-        """
+    ):
         non_mapping = is_scalar(index) or (
             is_list_like(index) and not is_dict_like(index)
         )
@@ -1606,10 +1392,7 @@ class Series(BasePandasDataset):
             result.name = self.name
             return result
 
-    def repeat(self, repeats, axis=None):  # noqa: PR01, RT01, D200
-        """
-        Repeat elements of a Series.
-        """
+    def repeat(self, repeats, axis=None):
         if (isinstance(repeats, int) and repeats == 0) or (
             is_list_like(repeats) and len(repeats) == 1 and repeats[0] == 0
         ):
@@ -1624,10 +1407,7 @@ class Series(BasePandasDataset):
         name=no_default,
         inplace=False,
         allow_duplicates=False,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Generate a new Series with the index reset.
-        """
+    ):
         if name is no_default:
             # For backwards compatibility, keep columns as [0] instead of
             #  [None] when self.name is None
@@ -1660,66 +1440,36 @@ class Series(BasePandasDataset):
                 names=None,
             )
 
-    def rdivmod(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return integer division and modulo of series and `other`, element-wise (binary operator `rdivmod`).
-        """
+    def rdivmod(self, other, level=None, fill_value=None, axis=0):
         return self._default_to_pandas(
             pandas.Series.rdivmod, other, level=level, fill_value=fill_value, axis=axis
         )
 
-    def rfloordiv(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return integer division of series and `other`, element-wise (binary operator `rfloordiv`).
-        """
+    def rfloordiv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rfloordiv(
             new_other, level=level, fill_value=None, axis=axis
         )
 
-    def rmod(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return modulo of series and `other`, element-wise (binary operator `rmod`).
-        """
+    def rmod(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rmod(
             new_other, level=level, fill_value=None, axis=axis
         )
 
-    def rpow(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return exponential power of series and `other`, element-wise (binary operator `rpow`).
-        """
+    def rpow(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rpow(
             new_other, level=level, fill_value=None, axis=axis
         )
 
-    def rsub(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return subtraction of series and `other`, element-wise (binary operator `rsub`).
-        """
+    def rsub(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rsub(
             new_other, level=level, fill_value=None, axis=axis
         )
 
-    def rtruediv(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return floating division of series and `other`, element-wise (binary operator `rtruediv`).
-        """
+    def rtruediv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rtruediv(
             new_other, level=level, fill_value=None, axis=axis
@@ -1727,10 +1477,7 @@ class Series(BasePandasDataset):
 
     rdiv = rtruediv
 
-    def quantile(self, q=0.5, interpolation="linear"):  # noqa: PR01, RT01, D200
-        """
-        Return value at the given quantile.
-        """
+    def quantile(self, q=0.5, interpolation="linear"):
         return super(Series, self).quantile(
             q=q,
             axis=0,
@@ -1739,10 +1486,7 @@ class Series(BasePandasDataset):
             method="single",
         )
 
-    def reorder_levels(self, order):  # noqa: PR01, RT01, D200
-        """
-        Rearrange index levels using input order.
-        """
+    def reorder_levels(self, order):
         return super(Series, self).reorder_levels(order)
 
     def replace(
@@ -1753,10 +1497,7 @@ class Series(BasePandasDataset):
         limit=None,
         regex=False,
         method: str | NoDefault = no_default,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Replace values given in `to_replace` with `value`.
-        """
+    ):
         inplace = validate_bool_kwarg(inplace, "inplace")
         new_query_compiler = self._query_compiler.replace(
             to_replace=to_replace,
@@ -1768,10 +1509,7 @@ class Series(BasePandasDataset):
         )
         return self._create_or_update_from_compiler(new_query_compiler, inplace)
 
-    def searchsorted(self, value, side="left", sorter=None):  # noqa: PR01, RT01, D200
-        """
-        Find indices where elements should be inserted to maintain order.
-        """
+    def searchsorted(self, value, side="left", sorter=None):
         searchsorted_qc = self._query_compiler
         if sorter is not None:
             # `iloc` method works slowly (https://github.com/modin-project/modin/issues/1903),
@@ -1810,10 +1548,7 @@ class Series(BasePandasDataset):
         na_position="last",
         ignore_index: bool = False,
         key: Optional[IndexKeyFunc] = None,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Sort by the values.
-        """
+    ):
         from .dataframe import DataFrame
 
         # When we convert to a DataFrame, the name is automatically converted to 0 if it
@@ -1839,10 +1574,7 @@ class Series(BasePandasDataset):
 
     sparse = CachedAccessor("sparse", SparseAccessor)
 
-    def squeeze(self, axis=None):  # noqa: PR01, RT01, D200
-        """
-        Squeeze 1 dimensional axis objects into scalars.
-        """
+    def squeeze(self, axis=None):
         if axis is not None:
             # Validate `axis`
             pandas.Series._get_axis_number(axis)
@@ -1851,10 +1583,7 @@ class Series(BasePandasDataset):
         else:
             return self.copy()
 
-    def sub(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
-        """
-        Return subtraction of Series and `other`, element-wise (binary operator `sub`).
-        """
+    def sub(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).sub(
             new_other, level=level, fill_value=None, axis=axis
@@ -1870,10 +1599,7 @@ class Series(BasePandasDataset):
         numeric_only=None,
         min_count=0,
         **kwargs,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return the sum of the values.
-        """
+    ):
         validate_bool_kwarg(skipna, "skipna", none_allowed=False)
         axis = self._get_axis_number(axis)
         if level is not None:
@@ -1917,30 +1643,16 @@ class Series(BasePandasDataset):
             )
         )
 
-    def swaplevel(self, i=-2, j=-1, copy=True):  # noqa: PR01, RT01, D200
-        """
-        Swap levels `i` and `j` in a `MultiIndex`.
-        """
+    def swaplevel(self, i=-2, j=-1, copy=True):
         return self._default_to_pandas("swaplevel", i=i, j=j, copy=copy)
 
-    def take(self, indices, axis=0, is_copy=None, **kwargs):  # noqa: PR01, RT01, D200
-        """
-        Return the elements in the given positional indices along an axis.
-        """
+    def take(self, indices, axis=0, is_copy=None, **kwargs):
         return super(Series, self).take(indices, axis=axis, is_copy=is_copy, **kwargs)
 
-    def to_dict(self, into=dict):  # pragma: no cover # noqa: PR01, RT01, D200
-        """
-        Convert Series to {label -> value} dict or dict-like object.
-        """
+    def to_dict(self, into=dict):
         return self._default_to_pandas("to_dict", into=into)
 
-    def to_frame(
-        self, name: Hashable = no_default
-    ) -> "DataFrame":  # noqa: PR01, RT01, D200
-        """
-        Convert Series to {label -> value} dict or dict-like object.
-        """
+    def to_frame(self, name: Hashable = no_default) -> "DataFrame":
         from .dataframe import DataFrame
 
         if name is None:
@@ -1952,18 +1664,10 @@ class Series(BasePandasDataset):
 
         return DataFrame(self_cp)
 
-    def to_list(self):  # noqa: RT01, D200
-        """
-        Return a list of the values.
-        """
+    def to_list(self):
         return self._default_to_pandas(pandas.Series.to_list)
 
-    def to_numpy(
-        self, dtype=None, copy=False, na_value=no_default, **kwargs
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return the NumPy ndarray representing the values in this Series or Index.
-        """
+    def to_numpy(self, dtype=None, copy=False, na_value=no_default, **kwargs):
         from modin.config import ExperimentalNumPyAPI
 
         if not ExperimentalNumPyAPI.get():
@@ -1985,10 +1689,7 @@ class Series(BasePandasDataset):
 
     # TODO(williamma12): When we implement to_timestamp, have this call the version
     # in base.py
-    def to_period(self, freq=None, copy=True):  # noqa: PR01, RT01, D200
-        """
-        Cast to PeriodArray/Index at a particular frequency.
-        """
+    def to_period(self, freq=None, copy=True):
         return self._default_to_pandas("to_period", freq=freq, copy=copy)
 
     def to_string(
@@ -2003,10 +1704,7 @@ class Series(BasePandasDataset):
         name=False,
         max_rows=None,
         min_rows=None,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Render a string representation of the Series.
-        """
+    ):
         return self._default_to_pandas(
             pandas.Series.to_string,
             buf=buf,
@@ -2022,26 +1720,15 @@ class Series(BasePandasDataset):
 
     # TODO(williamma12): When we implement to_timestamp, have this call the version
     # in base.py
-    def to_timestamp(self, freq=None, how="start", copy=True):  # noqa: PR01, RT01, D200
-        """
-        Cast to DatetimeIndex of Timestamps, at beginning of period.
-        """
+    def to_timestamp(self, freq=None, how="start", copy=True):
         return self._default_to_pandas("to_timestamp", freq=freq, how=how, copy=copy)
 
-    def transpose(self, *args, **kwargs):  # noqa: PR01, RT01, D200
-        """
-        Return the transpose, which is by definition `self`.
-        """
+    def transpose(self, *args, **kwargs):
         return self
 
     T = property(transpose)
 
-    def truediv(
-        self, other, level=None, fill_value=None, axis=0
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return floating division of series and `other`, element-wise (binary operator `truediv`).
-        """
+    def truediv(self, other, level=None, fill_value=None, axis=0):
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).truediv(
             new_other, level=level, fill_value=None, axis=axis
@@ -2049,28 +1736,17 @@ class Series(BasePandasDataset):
 
     div = divide = truediv
 
-    def truncate(
-        self, before=None, after=None, axis=None, copy=True
-    ):  # noqa: PR01, RT01, D200
-        """
-        Truncate a Series before and after some index value.
-        """
+    def truncate(self, before=None, after=None, axis=None, copy=True):
         return self._default_to_pandas(
             pandas.Series.truncate, before=before, after=after, axis=axis, copy=copy
         )
 
-    def unique(self):  # noqa: RT01, D200
-        """
-        Return unique values of Series object.
-        """
+    def unique(self):
         return self.__constructor__(
             query_compiler=self._query_compiler.unique()
         ).to_numpy()
 
-    def update(self, other):  # noqa: PR01, D200
-        """
-        Modify Series in place using values from passed Series.
-        """
+    def update(self, other):
         if not isinstance(other, Series):
             other = self.__constructor__(other)
         query_compiler = self._query_compiler.series_update(other._query_compiler)
@@ -2078,10 +1754,7 @@ class Series(BasePandasDataset):
 
     def value_counts(
         self, normalize=False, sort=True, ascending=False, bins=None, dropna=True
-    ):  # noqa: PR01, RT01, D200
-        """
-        Return a Series containing counts of unique values.
-        """
+    ):
         if bins is not None:
             # Potentially we could implement `cut` function from pandas API, which
             # bins values into intervals, and then we can just count them as regular values.
@@ -2105,10 +1778,7 @@ class Series(BasePandasDataset):
         counted_values._query_compiler.set_index_name(None)
         return counted_values
 
-    def view(self, dtype=None):  # noqa: PR01, RT01, D200
-        """
-        Create a new view of the Series.
-        """
+    def view(self, dtype=None):
         return self.__constructor__(
             query_compiler=self._query_compiler.series_view(dtype=dtype)
         )
@@ -2122,10 +1792,7 @@ class Series(BasePandasDataset):
         level=None,
         errors=no_default,
         try_cast=no_default,
-    ):  # noqa: PR01, RT01, D200
-        """
-        Replace values where the condition is False.
-        """
+    ):
         if isinstance(other, Series):
             other = to_pandas(other)
         return self._default_to_pandas(
@@ -2140,130 +1807,80 @@ class Series(BasePandasDataset):
         )
 
     @property
-    def attrs(self):  # noqa: RT01, D200
-        """
-        Return dictionary of global attributes of this dataset.
-        """
-
+    def attrs(self):
         def attrs(df):
             return df.attrs
 
         return self._default_to_pandas(attrs)
 
     @property
-    def array(self):  # noqa: RT01, D200
-        """
-        Return the ExtensionArray of the data backing this Series or Index.
-        """
-
+    def array(self):
         def array(df):
             return df.array
 
         return self._default_to_pandas(array)
 
     @property
-    def axes(self):  # noqa: RT01, D200
-        """
-        Return a list of the row axis labels.
-        """
+    def axes(self):
         return [self.index]
 
     @property
-    def cat(self):  # noqa: RT01, D200
-        """
-        Accessor object for categorical properties of the Series values.
-        """
+    def cat(self):
         from .series_utils import CategoryMethods
 
         return CategoryMethods(self)
 
     @property
-    def dt(self):  # noqa: RT01, D200
-        """
-        Accessor object for datetimelike properties of the Series values.
-        """
+    def dt(self):
         from .series_utils import DatetimeProperties
 
         return DatetimeProperties(self)
 
     @property
-    def dtype(self):  # noqa: RT01, D200
-        """
-        Return the dtype object of the underlying data.
-        """
+    def dtype(self):
         return self._query_compiler.dtypes.squeeze()
 
     dtypes = dtype
 
     @property
-    def empty(self):  # noqa: RT01, D200
-        """
-        Indicate whether Series is empty.
-        """
+    def empty(self):
         return len(self.index) == 0
 
     @property
-    def hasnans(self):  # noqa: RT01, D200
-        """
-        Return True if Series has any nans.
-        """
+    def hasnans(self):
         return self.isna().sum() > 0
 
     @property
-    def is_monotonic(self):  # noqa: RT01, D200
-        """
-        Return True if values in the Series are monotonic_increasing.
-        """
+    def is_monotonic(self):
         return self._reduce_dimension(self._query_compiler.is_monotonic_increasing())
 
     is_monotonic_increasing = is_monotonic
 
     @property
-    def is_monotonic_decreasing(self):  # noqa: RT01, D200
-        """
-        Return True if values in the Series are monotonic_decreasing.
-        """
+    def is_monotonic_decreasing(self):
         return self._reduce_dimension(self._query_compiler.is_monotonic_decreasing())
 
     @property
-    def is_unique(self):  # noqa: RT01, D200
-        """
-        Return True if values in the Series are unique.
-        """
+    def is_unique(self):
         return self.nunique(dropna=False) == len(self)
 
     @property
-    def nbytes(self):  # noqa: RT01, D200
-        """
-        Return the number of bytes in the underlying data.
-        """
+    def nbytes(self):
         return self.memory_usage(index=False)
 
     @property
-    def ndim(self):  # noqa: RT01, D200
-        """
-        Return the number of dimensions of the underlying data, by definition 1.
-        """
+    def ndim(self):
         return 1
 
-    def nunique(self, dropna=True):  # noqa: PR01, RT01, D200
-        """
-        Return number of unique elements in the object.
-        """
+    def nunique(self, dropna=True):
         return super(Series, self).nunique(dropna=dropna)
 
     @property
-    def shape(self):  # noqa: RT01, D200
-        """
-        Return a tuple of the shape of the underlying data.
-        """
+    def shape(self):
         return (len(self),)
 
     @property
-    def str(self):  # noqa: RT01, D200
-        """
-        Vectorized string functions for Series and Index.
-        """
+    def str(self):
         from .series_utils import StringMethods
 
         return StringMethods(self)

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -47,9 +47,7 @@ if TYPE_CHECKING:
     from .dataframe import DataFrame
 
 
-@_inherit_docstrings(
-    pandas.Series, excluded=[pandas.Series.__init__], apilink="pandas.Series"
-)
+@_inherit_docstrings(pandas.Series, excluded=[pandas.Series.__init__])
 class Series(BasePandasDataset):
     """
     Modin distributed representation of `pandas.Series`.
@@ -508,6 +506,55 @@ class Series(BasePandasDataset):
         return super(Series, new_self).radd(
             new_other, level=level, fill_value=fill_value, axis=axis
         )
+
+    abs = BasePandasDataset._get_abs()
+    align = BasePandasDataset._get_align()
+    all = BasePandasDataset._get_all()
+    any = BasePandasDataset._get_any()
+    asfreq = BasePandasDataset._get_asfreq()
+    asof = BasePandasDataset._get_asof()
+    astype = BasePandasDataset._get_astype()
+    at = BasePandasDataset._get_at()
+    at_time = BasePandasDataset._get_at_time()
+    between_time = BasePandasDataset._get_between_time()
+    bfill = BasePandasDataset._get_bfill()
+    backfill = BasePandasDataset._get_bfill()
+    bool = BasePandasDataset._get_bool()
+    clip = BasePandasDataset._get_clip()
+    combine = BasePandasDataset._get_combine()
+    combine_first = BasePandasDataset._get_combine_first()
+    copy = BasePandasDataset._get_copy()
+    count = BasePandasDataset._get_count()
+    cummax = BasePandasDataset._get_cummax()
+    cummin = BasePandasDataset._get_cummin()
+    cumprod = BasePandasDataset._get_cumprod()
+    cumsum = BasePandasDataset._get_cumsum()
+    describe = BasePandasDataset._get_describe()
+    diff = BasePandasDataset._get_diff()
+    drop = BasePandasDataset._get_drop()
+    dropna = BasePandasDataset._get_dropna()
+    droplevel = BasePandasDataset._get_droplevel()
+    drop_duplicates = BasePandasDataset._get_drop_duplicates()
+    eq = BasePandasDataset._get_eq()
+    explode = BasePandasDataset._get_explode()
+    ewm = BasePandasDataset._get_ewm()
+    expanding = BasePandasDataset._get_expanding()
+    ffill = BasePandasDataset._get_ffill()
+    pad = BasePandasDataset._get_ffill()
+    fillna = BasePandasDataset._get_fillna()
+    filter = BasePandasDataset._get_filter()
+    first = BasePandasDataset._get_first()
+    first_valid_index = BasePandasDataset._get_first_valid_index()
+    floordiv = BasePandasDataset._get_floordiv()
+    convert_dtypes = BasePandasDataset._get_convert_dtypes()
+    ge = BasePandasDataset._get_ge()
+    get = BasePandasDataset._get_get()
+    gt = BasePandasDataset._get_gt()
+    head = BasePandasDataset._get_head()
+    iat = BasePandasDataset._get_iat()
+    idxmax = BasePandasDataset._get_idxmax()
+    idxmin = BasePandasDataset._get_idxmin()
+    infer_objects = BasePandasDataset._get_infer_objects()
 
     def add_prefix(self, prefix):
         return self.__constructor__(

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -13,6 +13,7 @@
 
 import pandas
 import inspect
+import pytest
 import numpy as np
 
 import modin.pandas as pd
@@ -328,3 +329,15 @@ def test_series_api_equality():
             except IndexError:
                 pass
     assert not len(difference), "Extra params found in API: {}".format(difference)
+
+
+@pytest.mark.xfail(reason="New changes have not yet been made for all methods.")
+def test_series_public_api__doc__():
+    extra_methods = ["__array__"]
+    modin_dir = [obj for obj in dir(pd.Series) if obj[0] != "_"]
+    modin_dir.extend(extra_methods)
+    modin_dir.sort()
+    for method in modin_dir:
+        assert (
+            getattr(pd.Series, method).__doc__ == getattr(pandas.Series, method).__doc__
+        ), f"problem method: {method}"

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -352,12 +352,12 @@ def _replace_doc(
         setattr(
             parent_cls,
             attr_name,
-            property(target_obj.fget, target_obj.fset, target_obj.fdel, doc),
+            property(target_obj.fget, target_obj.fset, target_obj.fdel, doc or None),
         )
     else:
         if overwrite:
             target_obj.__doc_inherited__ = True  # type: ignore[attr-defined]
-        target_obj.__doc__ = doc
+        target_obj.__doc__ = doc or None
 
 
 def _inherit_docstrings(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5286 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
