### PR TITLE
FIX-#5454: add missed methods for `SeriesGroupBy`, `DataFrameGroupBy` objects

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -223,6 +223,20 @@ class DataFrameGroupBy(ClassLogger):
     def sem(self, ddof=1):
         return self._default_to_pandas(lambda df: df.sem(ddof=ddof))
 
+    def sample(self, n=None, frac=None, replace=False, weights=None, random_state=None):
+        return self._default_to_pandas(
+            lambda df: df.sample(
+                n=n,
+                frac=frac,
+                replace=replace,
+                weights=weights,
+                random_state=random_state,
+            )
+        )
+
+    def ewm(self, *args, **kwargs):
+        return self._default_to_pandas(lambda df: df.ewm(*args, **kwargs))
+
     def value_counts(
         self,
         subset=None,
@@ -1385,6 +1399,27 @@ class SeriesGroupBy(DataFrameGroupBy):
                 dropna=dropna,
             )
         )
+
+    @property
+    def is_monotonic_decreasing(self):
+        return self._default_to_pandas(lambda ser: ser.is_monotonic_decreasing)
+
+    @property
+    def is_monotonic_increasing(self):
+        return self._default_to_pandas(lambda ser: ser.is_monotonic_increasing)
+
+    def nlargest(self, n: int = 5, keep: str = "first") -> Series:
+        return self._default_to_pandas(lambda ser: ser.nlargest(n=n, keep=keep))
+
+    def nsmallest(self, n: int = 5, keep: str = "first") -> Series:
+        return self._default_to_pandas(lambda ser: ser.nsmallest(n=n, keep=keep))
+
+    def unique(self):
+        return self._default_to_pandas(lambda ser: ser.unique())
+
+    @property
+    def dtype(self):
+        return self._default_to_pandas(lambda ser: ser.dtype)
 
 
 if IsExperimental.get():

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -249,6 +249,21 @@ def test_series_str_api_equality():
     )
 
 
+@pytest.mark.parametrize("klass", ["SeriesGroupBy", "DataFrameGroupBy"])
+def test_series_groupby_api_equality(klass):
+    modin_dir = [obj for obj in dir(getattr(pd.groupby, klass)) if obj[0] != "_"]
+    pandas_dir = [obj for obj in dir(getattr(pandas.core.groupby, klass)) if obj[0] != "_"]
+
+    missing_from_modin = set(pandas_dir) - set(modin_dir)
+    assert not len(missing_from_modin), "Differences found in API: {}".format(
+        len(missing_from_modin)
+    )
+    extra_in_modin = set(modin_dir) - set(pandas_dir)
+    assert not len(extra_in_modin), "Differences found in API: {}".format(
+        extra_in_modin
+    )
+
+
 def test_series_api_equality():
     modin_dir = [obj for obj in dir(pd.Series) if obj[0] != "_"]
     pandas_dir = [obj for obj in dir(pandas.Series) if obj[0] != "_"]

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -252,7 +252,9 @@ def test_series_str_api_equality():
 @pytest.mark.parametrize("klass", ["SeriesGroupBy", "DataFrameGroupBy"])
 def test_series_groupby_api_equality(klass):
     modin_dir = [obj for obj in dir(getattr(pd.groupby, klass)) if obj[0] != "_"]
-    pandas_dir = [obj for obj in dir(getattr(pandas.core.groupby, klass)) if obj[0] != "_"]
+    pandas_dir = [
+        obj for obj in dir(getattr(pandas.core.groupby, klass)) if obj[0] != "_"
+    ]
 
     missing_from_modin = set(pandas_dir) - set(modin_dir)
     assert not len(missing_from_modin), "Differences found in API: {}".format(

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -137,6 +137,10 @@ def test_mixed_dtypes_groupby(as_index):
             lambda df: df.sem(),
             modin_df_almost_equals_pandas,
         )
+        eval_general(
+            modin_groupby, pandas_groupby, lambda df: df.sample(random_state=1)
+        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.ewm(com=0.5).std())
         eval_shift(modin_groupby, pandas_groupby)
         eval_mean(modin_groupby, pandas_groupby)
         eval_any(modin_groupby, pandas_groupby)
@@ -902,6 +906,20 @@ def test_series_groupby(by, as_index_series_or_dataframe):
             lambda df: df.sem(),
             modin_df_almost_equals_pandas,
         )
+        eval_general(
+            modin_groupby, pandas_groupby, lambda df: df.sample(random_state=1)
+        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.ewm(com=0.5).std())
+        eval_general(
+            modin_groupby, pandas_groupby, lambda df: df.is_monotonic_decreasing
+        )
+        eval_general(
+            modin_groupby, pandas_groupby, lambda df: df.is_monotonic_increasing
+        )
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.nlargest())
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.nsmallest())
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.unique())
+        eval_general(modin_groupby, pandas_groupby, lambda df: df.dtype)
         eval_mean(modin_groupby, pandas_groupby)
         eval_any(modin_groupby, pandas_groupby)
         eval_min(modin_groupby, pandas_groupby)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5454 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
