### PR TITLE
FIX-#5859: Fix '.sort_values()' when there's only one row partition

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2048,6 +2048,10 @@ class PandasDataframe(ClassLogger):
                 f"Algebra sort only implemented row-wise. {axis.name} sort not implemented yet!"
             )
 
+        # If there's only one row partition can simply apply sorting row-wise without the need to reshuffle
+        if self._partitions.shape[0] == 1:
+            return self.apply_full_axis(axis=1, func=sort_function)
+
         # If this df is empty, we don't want to try and shuffle or sort.
         if len(self.axes[0]) == 0 or len(self.axes[1]) == 0:
             return self.copy()

--- a/modin/core/dataframe/pandas/dataframe/utils.py
+++ b/modin/core/dataframe/pandas/dataframe/utils.py
@@ -200,10 +200,10 @@ def pick_pivots_from_samples_for_sort(
     num_quantiles = ideal_num_new_partitions
     quantiles = [i / num_quantiles for i in range(1, num_quantiles)]
     # If we only desire 1 partition, we need to ensure that we're not trying to find quantiles
-    # from an empty list of pivots. We use `np.nan` as a dummy value.
+    # from an empty list of pivots.
     if len(quantiles) > 0:
         return _find_quantiles(all_pivots, quantiles, method)
-    return np.array([np.nan])
+    return np.array([])
 
 
 def split_partitions_using_pivots_for_sort(
@@ -242,6 +242,9 @@ def split_partitions_using_pivots_for_sort(
     tuple[pandas.DataFrame]
         A tuple of the splits from this partition.
     """
+    if len(pivots) == 0:
+        # We can return the dataframe with zero changes if there were no pivots passed
+        return (df,)
     # If `ascending=False` and we are dealing with a numeric dtype, we can pass in a reversed list
     # of pivots, and `np.digitize` will work correctly. For object dtypes, we use `np.searchsorted`
     # which breaks when we reverse the pivots.

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -591,6 +591,21 @@ def test_sort_values_descending_with_only_two_bins():
     )
 
 
+@pytest.mark.parametrize("ascending", [True, False])
+def test_sort_values_with_one_partition(ascending):
+    # Test case from https://github.com/modin-project/modin/issues/5859
+    modin_df, pandas_df = create_test_dfs(
+        np.array([["hello", "goodbye"], ["hello", "Hello"]])
+    )
+
+    if StorageFormat.get() == "Pandas":
+        assert modin_df._query_compiler._modin_frame._partitions.shape == (1, 1)
+
+    eval_general(
+        modin_df, pandas_df, lambda df: df.sort_values(by=1, ascending=ascending)
+    )
+
+
 def test_sort_overpartitioned_df():
     # First we test when the final df will have only 1 row and column partition.
     data = [[4, 5, 6], [1, 2, 3]]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR adds several safeguards allowing us not to fail on an empty pivots list in `.sort_by()`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5859 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
