### PR TITLE
REFACTOR-#5875: use default implementations for dt methods from the base query compiler

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -792,21 +792,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # END Transpose
 
     # TreeReduce operations
-
-    def is_monotonic_decreasing(self):
-        def is_monotonic_decreasing(df):
-            """Check whether data in the passed frame is monotonic decreasing."""
-            return pandas.DataFrame([df.squeeze(axis=1).is_monotonic_decreasing])
-
-        return self.default_to_pandas(is_monotonic_decreasing)
-
-    def is_monotonic_increasing(self):
-        def is_monotonic_increasing(df):
-            """Check whether data in the passed frame is monotonic increasing."""
-            return pandas.DataFrame([df.squeeze(axis=1).is_monotonic_increasing])
-
-        return self.default_to_pandas(is_monotonic_increasing)
-
     count = TreeReduce.register(pandas.DataFrame.count, pandas.DataFrame.sum)
     sum = TreeReduce.register(pandas.DataFrame.sum)
     prod = TreeReduce.register(pandas.DataFrame.prod)
@@ -1649,19 +1634,6 @@ class PandasQueryCompiler(BaseQueryCompiler):
     dt_is_leap_year = Map.register(_dt_prop_map("is_leap_year"), dtypes=np.bool_)
     dt_daysinmonth = Map.register(_dt_prop_map("daysinmonth"), dtypes=np.int64)
     dt_days_in_month = Map.register(_dt_prop_map("days_in_month"), dtypes=np.int64)
-
-    def dt_tz(self):
-        def datetime_tz(df):
-            return pandas.DataFrame([df.squeeze(axis=1).dt.tz])
-
-        return self.default_to_pandas(datetime_tz)
-
-    def dt_freq(self):
-        def datetime_freq(df):
-            return pandas.DataFrame([df.squeeze(axis=1).dt.freq])
-
-        return self.default_to_pandas(datetime_freq)
-
     dt_asfreq = Map.register(_dt_func_map("asfreq"))
     dt_to_period = Map.register(_dt_func_map("to_period"))
     dt_to_pydatetime = Map.register(_dt_func_map("to_pydatetime"), dtypes=np.object_)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5875 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
