### PR TITLE
FEAT-#4624: add `to_parquet` parallel implementation for Dask

### DIFF
--- a/docs/supported_apis/dataframe_supported.rst
+++ b/docs/supported_apis/dataframe_supported.rst
@@ -427,15 +427,13 @@ default to pandas.
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
 | ``to_orc``                 | `to_orc`_                 | D                      |                                                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
-| ``to_parquet``             | `to_parquet`_             | P                      | **Dask**: Defaults to Pandas implementation and    |
-|                            |                           |                        | writes a  single output file.                      |
-|                            |                           |                        | **Ray**: Parallel implementation only if path      |
-|                            |                           |                        | parameter is a string; does not end with ".gz",    |
-|                            |                           |                        | ".bz2", ".zip", or ".xz"; and compression parameter|
-|                            |                           |                        | is not ``None`` or "snappy". In these cases, the   |
-|                            |                           |                        | ``path`` parameter specifies a directory where     |
-|                            |                           |                        | one file is written per row partition of the Modin |
-|                            |                           |                        | dataframe.                                         |
+| ``to_parquet``             | `to_parquet`_             | P                      | **Ray/Dask/Unidist**: Parallel implementation only |
+|                            |                           |                        | if path parameter is a string; does not end with   |
+|                            |                           |                        | ".gz", ".bz2", ".zip", or ".xz"; and compression   |
+|                            |                           |                        | parameter is not ``None`` or "snappy". In these    |
+|                            |                           |                        | cases, the ``path`` parameter specifies a directory|
+|                            |                           |                        | where one file is written per row partition of the |
+|                            |                           |                        | Modin dataframe.                                   |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
 | ``to_period``              | `to_period`_              | D                      |                                                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Let's think about code duplication after a new release.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4624 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
