### PR TITLE
TEST-#5878: exclude modin/experimental/batch/test/ folder from computing coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -48,6 +48,7 @@ omit =
     modin/core/execution/dispatching/factories/test/*
     modin/experimental/cloud/test/*
     modin/experimental/pandas/test/*
+    modin/experimental/batch/test/*
     modin/experimental/core/execution/native/implementations/hdk_on_native/test/*
     # Plotting is not tested
     modin/pandas/plotting.py


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

We don't have to calculate test coverage for the test files themselves. This is also now causing the coverage percentage to fluctuate all the time.

<img width="954" alt="image" src="https://user-images.githubusercontent.com/45976948/228259288-dcc7731e-5853-465e-82af-7f482297d66c.png">


- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5878 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
