### PR TITLE
FEAT-#5880: add `to_sql` parallel implementation for Dask

### DIFF
--- a/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
@@ -148,3 +148,43 @@ class PandasOnDaskIO(BaseIO):
         DaskWrapper.materialize(
             [part.list_of_blocks[0] for row in result for part in row]
         )
+
+    @classmethod
+    def to_sql(cls, qc, **kwargs):
+        """
+        Write records stored in the `qc` to a SQL database.
+        Parameters
+        ----------
+        qc : BaseQueryCompiler
+            The query compiler of the Modin dataframe that we want to run ``to_sql`` on.
+        **kwargs : dict
+            Parameters for ``pandas.to_sql(**kwargs)``.
+        """
+        # we first insert an empty DF in order to create the full table in the database
+        # This also helps to validate the input against pandas
+        # we would like to_sql() to complete only when all rows have been inserted into the database
+        # since the mapping operation is non-blocking, each partition will return an empty DF
+        # so at the end, the blocking operation will be this empty DF to_pandas
+
+        empty_df = qc.getitem_row_array([0]).to_pandas().head(0)
+        empty_df.to_sql(**kwargs)
+        # so each partition will append its respective DF
+        kwargs["if_exists"] = "append"
+        columns = qc.columns
+
+        def func(df):
+            """
+            Override column names in the wrapped dataframe and convert it to SQL.
+            Notes
+            -----
+            This function returns an empty ``pandas.DataFrame`` because ``apply_full_axis``
+            expects a Frame object as a result of operation (and ``to_sql`` has no dataframe result).
+            """
+            df.columns = columns
+            df.to_sql(**kwargs)
+            return pandas.DataFrame()
+
+        # Ensure that the metadata is syncrhonized
+        qc._modin_frame._propagate_index_objs(axis=None)
+        result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
+        result._partition_mgr_cls.wait_partitions(result._partitions.flatten())

--- a/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
@@ -186,7 +186,7 @@ class PandasOnDaskIO(BaseIO):
             df.to_sql(**kwargs)
             return pandas.DataFrame()
 
-        # Ensure that the metadata is syncrhonized
+        # Ensure that the metadata is synchronized
         qc._modin_frame._propagate_index_objs(axis=None)
         result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
         result._partition_mgr_cls.wait_partitions(result._partitions.flatten())

--- a/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
@@ -153,6 +153,7 @@ class PandasOnDaskIO(BaseIO):
     def to_sql(cls, qc, **kwargs):
         """
         Write records stored in the `qc` to a SQL database.
+
         Parameters
         ----------
         qc : BaseQueryCompiler
@@ -175,6 +176,7 @@ class PandasOnDaskIO(BaseIO):
         def func(df):
             """
             Override column names in the wrapped dataframe and convert it to SQL.
+
             Notes
             -----
             This function returns an empty ``pandas.DataFrame`` because ``apply_full_axis``

--- a/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -109,7 +109,7 @@ class PandasOnRayIO(RayIO):
             df.to_sql(**kwargs)
             return pandas.DataFrame()
 
-        # Ensure that the metadata is syncrhonized
+        # Ensure that the metadata is synchronized
         qc._modin_frame._propagate_index_objs(axis=None)
         result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
         result._partition_mgr_cls.wait_partitions(result._partitions.flatten())

--- a/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -112,8 +112,7 @@ class PandasOnRayIO(RayIO):
         # Ensure that the metadata is syncrhonized
         qc._modin_frame._propagate_index_objs(axis=None)
         result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
-        # FIXME: we should be waiting for completion less expensievely, maybe use _modin_frame.materialize()?
-        result.to_pandas()  # blocking operation
+        result._partition_mgr_cls.wait_partitions(result._partitions.flatten())
 
     @staticmethod
     def _to_csv_check_support(kwargs):

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -114,7 +114,7 @@ class PandasOnUnidistIO(UnidistIO):
             df.to_sql(**kwargs)
             return pandas.DataFrame()
 
-        # Ensure that the metadata is syncrhonized
+        # Ensure that the metadata is synchronized
         qc._modin_frame._propagate_index_objs(axis=None)
         result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
         result._partition_mgr_cls.wait_partitions(result._partitions.flatten())

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -117,8 +117,7 @@ class PandasOnUnidistIO(UnidistIO):
         # Ensure that the metadata is syncrhonized
         qc._modin_frame._propagate_index_objs(axis=None)
         result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
-        # FIXME: we should be waiting for completion less expensievely, maybe use _modin_frame.materialize()?
-        result.to_pandas()  # blocking operation
+        result._partition_mgr_cls.wait_partitions(result._partitions.flatten())
 
     @staticmethod
     def _to_csv_check_support(kwargs):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Let's think about code duplication after a new release.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5880 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
