### PR TITLE
TEST-#4261: test rolling with axis=1, win_type=, and center=True

### DIFF
--- a/modin/pandas/test/test_rolling.py
+++ b/modin/pandas/test/test_rolling.py
@@ -71,14 +71,10 @@ def test_dataframe(data, window, min_periods, win_type, axis):
     )
     # Testing of Window class
     if win_type is not None:
-        # TODO(https://github.com/modin-project/modin/issues/4261): Once pandas
-        # allows rolling with (axis=1, win_type=, center=True), test that, as
-        # well.
-        if axis == 0:
-            df_equals(pandas_rolled.mean(), modin_rolled.mean())
-            df_equals(modin_rolled.sum(), pandas_rolled.sum())
-            df_equals(modin_rolled.var(ddof=0), pandas_rolled.var(ddof=0))
-            df_equals(modin_rolled.std(ddof=0), pandas_rolled.std(ddof=0))
+        df_equals(pandas_rolled.mean(), modin_rolled.mean())
+        df_equals(modin_rolled.sum(), pandas_rolled.sum())
+        df_equals(modin_rolled.var(ddof=0), pandas_rolled.var(ddof=0))
+        df_equals(modin_rolled.std(ddof=0), pandas_rolled.std(ddof=0))
     # Testing of Rolling class
     else:
         df_equals(modin_rolled.count(), pandas_rolled.count())


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4261 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
