### PR TITLE
FIX-#2850: use modin.pandas.Series instead of pandas.Series for `where` func

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -442,6 +442,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         assert isinstance(
             cond, type(self)
         ), "Must have the same QueryCompiler subclass to perform this operation"
+        # it's doesn't work if `other` is Series._query_compiler because
+        # `n_ary_op` performs columns copartition both for `cond` and `other`.
         if isinstance(other, type(self)):
             # Make sure to set join_type=None so the `where` result always has
             # the same row and column labels as `self`.

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -444,7 +444,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         ), "Must have the same QueryCompiler subclass to perform this operation"
         # it's doesn't work if `other` is Series._query_compiler because
         # `n_ary_op` performs columns copartition both for `cond` and `other`.
-        if isinstance(other, type(self)) and other.shape_hint is not None:
+        if isinstance(other, type(self)) and other._shape_hint is not None:
             other = other.to_pandas()
         if isinstance(other, type(self)):
             # Make sure to set join_type=None so the `where` result always has

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -444,6 +444,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
         ), "Must have the same QueryCompiler subclass to perform this operation"
         # it's doesn't work if `other` is Series._query_compiler because
         # `n_ary_op` performs columns copartition both for `cond` and `other`.
+        if isinstance(other, type(self)) and other.shape_hint is not None:
+            other = other.to_pandas()
         if isinstance(other, type(self)):
             # Make sure to set join_type=None so the `where` result always has
             # the same row and column labels as `self`.

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2509,7 +2509,7 @@ class DataFrame(BasePandasDataset):
         Replace values where the condition is False.
         """
         inplace = validate_bool_kwarg(inplace, "inplace")
-        if isinstance(other, pandas.Series) and axis is None:
+        if isinstance(other, Series) and axis is None:
             raise ValueError("Must specify axis=0 or 1")
         if level is not None:
             if isinstance(other, DataFrame):
@@ -2572,7 +2572,8 @@ class DataFrame(BasePandasDataset):
                     "No axis named NoDefault.no_default for object type DataFrame"
                 )
             axis = self._get_axis_number(axis)
-            if isinstance(other, pandas.Series):
+            if isinstance(other, Series):
+                other = other._to_pandas()
                 other = other.reindex(self.index if axis == 0 else self.columns)
             elif is_list_like(other):
                 index = self.index if axis == 0 else self.columns

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2573,8 +2573,10 @@ class DataFrame(BasePandasDataset):
                 )
             axis = self._get_axis_number(axis)
             if isinstance(other, Series):
-                other = other._to_pandas()
-                other = other.reindex(self.index if axis == 0 else self.columns)
+                other = other.reindex(self.index if axis == 0 else self.columns)._query_compiler
+                if other._shape_hint is None:
+                    # To make the query compiler recognizable as a Series at lower levels
+                    other._shape_hint = "column"
             elif is_list_like(other):
                 index = self.index if axis == 0 else self.columns
                 other = pandas.Series(other, index=index)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2573,7 +2573,9 @@ class DataFrame(BasePandasDataset):
                 )
             axis = self._get_axis_number(axis)
             if isinstance(other, Series):
-                other = other.reindex(self.index if axis == 0 else self.columns)._query_compiler
+                other = other.reindex(
+                    self.index if axis == 0 else self.columns
+                )._query_compiler
                 if other._shape_hint is None:
                     # To make the query compiler recognizable as a Series at lower levels
                     other._shape_hint = "column"

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -726,6 +726,13 @@ def test_where():
     modin_result = modin_df.where(modin_cond_df, -modin_df)
     assert all((to_pandas(modin_result) == pandas_result).all())
 
+    # test case when other is Series
+    other_data = random_state.randn(len(pandas_df))
+    modin_other, pandas_other = pd.Series(other_data), pandas.Series(other_data)
+    pandas_result = pandas_df.where(pandas_cond_df, pandas_other, axis=0)
+    modin_result = modin_df.where(modin_cond_df, modin_other, axis=0)
+    df_equals(modin_result, pandas_result)
+
     # Test that we choose the right values to replace when `other` == `True`
     # everywhere.
     other_data = np.full(shape=pandas_df.shape, fill_value=True)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3719,9 +3719,10 @@ def test_where():
     modin_result = modin_series.where(modin_cond_series, -modin_series)
     assert all((to_pandas(modin_result) == pandas_result))
 
-    other = pandas.Series(random_state.randn(100))
-    pandas_result = pandas_series.where(pandas_cond_series, other, axis=0)
-    modin_result = modin_series.where(modin_cond_series, other, axis=0)
+    other_data = random_state.randn(100)
+    modin_other, pandas_other = pd.Series(other_data), pandas.Series(other_data)
+    pandas_result = pandas_series.where(pandas_cond_series, pandas_other, axis=0)
+    modin_result = modin_series.where(modin_cond_series, modin_other, axis=0)
     assert all(to_pandas(modin_result) == pandas_result)
 
     pandas_result = pandas_series.where(pandas_series < 2, True)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2850 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
