### PR TITLE
FIX-#5891: BUG: HDK: Query execution fails because the query contains…

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -867,6 +867,20 @@ class HdkOnNativeDataframe(PandasDataframe):
             right_on
         ), "'left_on' and 'right_on' lengths don't match"
 
+        if other is self:
+            # To avoid the self-join failure - #5891
+            if isinstance(self._op, FrameNode):
+                other = self.copy()
+            else:
+                exprs = OrderedDict((c, self.ref(c)) for c in self._table_cols)
+                other = self.__constructor__(
+                    columns=self.columns,
+                    dtypes=self._dtypes_for_exprs(exprs),
+                    op=TransformNode(self, exprs),
+                    index_cols=self._index_cols,
+                    force_execution_mode=self._force_execution_mode,
+                )
+
         orig_left_on = left_on
         orig_right_on = right_on
         left, left_on = check_cols_to_join("left_on", self, left_on)

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -1513,13 +1513,17 @@ class TestMerge:
         )
 
     def test_self_merge(self):
-        def merge(df, lib, **kwargs):
-            return lib.merge(df, df)
+        def merge(df, lib, iterations, **kwargs):
+            for _ in range(iterations):
+                df = lib.merge(df, df)
+            return df
 
-        run_and_compare(
-            merge,
-            data={"a": [1]},
-        )
+        for i in range(1, 3):
+            run_and_compare(
+                merge,
+                data={"a": [1]},
+                iterations=i,
+            )
 
 
 class TestBinaryOp:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -1512,6 +1512,15 @@ class TestMerge:
             right_on=left_on,
         )
 
+    def test_self_merge(self):
+        def merge(df, lib, **kwargs):
+            return lib.merge(df, df)
+
+        run_and_compare(
+            merge,
+            data={"a": [1]},
+        )
+
 
 class TestBinaryOp:
     data = {


### PR DESCRIPTION
- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5891 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
