### PR TITLE
FEAT-#5901: add `read_fwf` parallel implementation for Dask

### DIFF
--- a/docs/supported_apis/io_supported.rst
+++ b/docs/supported_apis/io_supported.rst
@@ -31,6 +31,8 @@ default to pandas.
 |                    |                                 | ``escapechar``, ``doublequote``,                   |
 |                    |                                 | ``delim_whitespace``                               |
 +--------------------+---------------------------------+----------------------------------------------------+
+| `read_fwf`_        | Y                               |                                                    |
++--------------------+---------------------------------+----------------------------------------------------+
 | `read_table`_      | Y                               |                                                    |
 +--------------------+---------------------------------+----------------------------------------------------+
 | `read_parquet`_    | Y                               |                                                    |
@@ -60,6 +62,7 @@ default to pandas.
 +--------------------+---------------------------------+----------------------------------------------------+
 
 .. _`read_csv`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html#pandas.read_csv
+.. _`read_fwf`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_fwf.html#pandas.read_fwf
 .. _`read_table`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_table.html#pandas.read_table
 .. _`read_parquet`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_parquet.html#pandas.read_parquet
 .. _`read_json`: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_json.html#pandas.read_json

--- a/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
@@ -27,6 +27,7 @@ from modin.core.execution.dask.implementations.pandas_on_dask.partitioning impor
 )
 from modin.core.io import (
     CSVDispatcher,
+    FWFDispatcher,
     JSONDispatcher,
     ParquetDispatcher,
     FeatherDispatcher,
@@ -35,6 +36,7 @@ from modin.core.io import (
 )
 from modin.core.storage_formats.pandas.parsers import (
     PandasCSVParser,
+    PandasFWFParser,
     PandasJSONParser,
     PandasParquetParser,
     PandasFeatherParser,
@@ -56,6 +58,7 @@ class PandasOnDaskIO(BaseIO):
     )
 
     read_csv = type("", (DaskWrapper, PandasCSVParser, CSVDispatcher), build_args).read
+    read_fwf = type("", (DaskWrapper, PandasFWFParser, FWFDispatcher), build_args).read
     read_json = type(
         "", (DaskWrapper, PandasJSONParser, JSONDispatcher), build_args
     ).read


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5901 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
