### PR TITLE
TEST-#5897: Add more robust tests for numpy API

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -640,6 +640,7 @@ jobs:
       - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_linalg.py
       - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_indexing.py
       - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_math.py
+      - run: mpiexec -n 1 python -m pytest modin/numpy/test/test_array_shaping.py
       - run: chmod +x ./.github/workflows/sql_server/set_up_sql_server.sh
       - run: ./.github/workflows/sql_server/set_up_sql_server.sh
       - run: mpiexec -n 1 python -m pytest modin/pandas/test/test_io.py --verbose
@@ -738,6 +739,7 @@ jobs:
       - run: python -m pytest -n 2 modin/numpy/test/test_array_linalg.py
       - run: python -m pytest -n 2 modin/numpy/test/test_array_indexing.py
       - run: python -m pytest -n 2 modin/numpy/test/test_array_math.py
+      - run: python -m pytest -n 2 modin/numpy/test/test_array_shaping.py
       - run: python -m pytest -n 2 modin/pandas/test/test_groupby.py
       - run: python -m pytest -n 2 modin/pandas/test/test_reshape.py
       - run: python -m pytest -n 2 modin/pandas/test/test_general.py
@@ -875,6 +877,7 @@ jobs:
           - modin/numpy/test/test_array_linalg.py
           - modin/numpy/test/test_array_indexing.py
           - modin/numpy/test/test_array_math.py
+          - modin/numpy/test/test_array_shaping.py
     env:
       MODIN_ENGINE: ${{matrix.engine}}
     name: test-windows

--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -62,6 +62,8 @@ jobs:
           python -m pytest modin/numpy/test/test_array_logic.py
           python -m pytest modin/numpy/test/test_array_linalg.py
           python -m pytest modin/numpy/test/test_array_indexing.py
+          python -m pytest modin/numpy/test/test_array_math.py
+          python -m pytest modin/numpy/test/test_array_shaping.py
           python -m pytest modin/pandas/test/test_rolling.py
           python -m pytest modin/pandas/test/test_concat.py
           python -m pytest modin/pandas/test/test_groupby.py
@@ -135,6 +137,8 @@ jobs:
           - modin/numpy/test/test_array_logic.py
           - modin/numpy/test/test_array_linalg.py
           - modin/numpy/test/test_array_indexing.py
+          - modin/numpy/test/test_array_math.py
+          - modin/numpy/test/test_array_shaping.py
           - modin/pandas/test/test_rolling.py
           - modin/pandas/test/test_concat.py
           - modin/pandas/test/test_groupby.py

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -402,7 +402,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
 
         Returns
         -------
-        numpy array.
+        NumPy array.
         """
         return self.force_materialization().list_of_block_partitions[0].to_numpy()
 

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -396,6 +396,16 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         """
         return self.force_materialization().list_of_block_partitions[0].to_pandas()
 
+    def to_numpy(self):
+        """
+        Convert the data in this partition to a ``numpy.array``.
+
+        Returns
+        -------
+        numpy array.
+        """
+        return self.force_materialization().list_of_block_partitions[0].to_numpy()
+
     _length_cache = None
 
     def length(self):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -409,6 +409,16 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         """
         return self.force_materialization().list_of_block_partitions[0].to_pandas()
 
+    def to_numpy(self):
+        """
+        Convert the data in this partition to a ``numpy.array``.
+
+        Returns
+        -------
+        numpy array.
+        """
+        return self.force_materialization().list_of_block_partitions[0].to_numpy()
+
     _length_cache = None
 
     def length(self):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -415,7 +415,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
 
         Returns
         -------
-        numpy array.
+        NumPy array.
         """
         return self.force_materialization().list_of_block_partitions[0].to_numpy()
 

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -407,7 +407,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
 
         Returns
         -------
-        numpy array.
+        NumPy array.
         """
         return self.force_materialization().list_of_block_partitions[0].to_numpy()
 

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -401,6 +401,16 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         """
         return self.force_materialization().list_of_block_partitions[0].to_pandas()
 
+    def to_numpy(self):
+        """
+        Convert the data in this partition to a ``numpy.array``.
+
+        Returns
+        -------
+        numpy array.
+        """
+        return self.force_materialization().list_of_block_partitions[0].to_numpy()
+
     _length_cache = None
 
     def length(self):

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -1135,9 +1135,7 @@ class array(object):
             raise ValueError(
                 f"all the input arrays must have same number of dimensions, but the array at index 0 has 1 dimension(s) and the array at index 1 has {values._ndim} dimension(s)"
             )
-        if (axis ^ 1 < len(values.shape)) and self.shape[axis ^ 1] != values.shape[
-            axis ^ 1
-        ]:
+        if (axis ^ 1 < values._ndim) and self.shape[axis ^ 1] != values.shape[axis ^ 1]:
             raise ValueError(
                 f"all the input array dimensions except for the concatenation axis must match exactly, but along dimension {axis ^ 1}, the array at index 0 has size {self.shape[axis^1]} and the array at index 1 has size {values.shape[axis^1]}"
             )

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -64,9 +64,9 @@ def check_kwargs(order="C", subok=True, keepdims=None, casting="same_kind", wher
 def check_can_broadcast_to_output(arr_in: "array", arr_out: "array"):
     if not isinstance(arr_out, array):
         raise TypeError("return arrays must be of modin.numpy.array type.")
-    # Broadcast is ok if both arrays have matching ndim + shape, OR
+    # Broadcasting is ok if both arrays have matching ndim + shape, OR
     # arr_in is 1xN or a 1D N-element array and arr_out is MxN.
-    # Note that 1xN arr_in cannot be broadcast into a 1D N-element arr_out.
+    # Note that 1xN arr_in cannot be broadcasted into a 1D N-element arr_out.
     #
     # This is slightly different from the rules for checking if two inputs
     # of a binary operation can be broadcasted together.
@@ -293,8 +293,6 @@ class array(object):
         """
         Check that the provided axis argument is valid on this array.
 
-        Raises numpy.AxisError if the axis is invalid.
-
         Parameters
         ----------
         axis : int, optional
@@ -304,6 +302,11 @@ class array(object):
         -------
         int, optional
             Axis to apply the function over (None, 0, or 1).
+        
+        Raises
+        -------
+        numpy.AxisError
+            if the axis is invalid.
         """
         if axis is not None and axis < 0:
             new_axis = axis + self._ndim

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -302,7 +302,7 @@ class array(object):
         -------
         int, optional
             Axis to apply the function over (None, 0, or 1).
-        
+
         Raises
         -------
         numpy.AxisError

--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -79,20 +79,26 @@ def check_can_broadcast_to_output(arr_in: "array", arr_out: "array"):
         )
         or (
             # Case 2b: both arrays are 2D, arr_in is 1xN and arr_out is MxN
-            arr_in._ndim == 2 and arr_out._ndim == 2
-            and arr_in.shape[0] == 1 and arr_in.shape[1] == arr_out.shape[1]
+            arr_in._ndim == 2
+            and arr_out._ndim == 2
+            and arr_in.shape[0] == 1
+            and arr_in.shape[1] == arr_out.shape[1]
         )
         or (
             # Case 2c: arr_in is 1D N-element, arr_out is MxN
-            arr_in._ndim == 1 and arr_out._ndim == 2
-            and arr_in.shape[0] == arr_out.shape[1] and arr_out.shape[0] == 1
+            arr_in._ndim == 1
+            and arr_out._ndim == 2
+            and arr_in.shape[0] == arr_out.shape[1]
+            and arr_out.shape[0] == 1
         )
     )
     # Case 2b would require duplicating the 1xN result M times to match the shape of out,
     # which we currently do not support. See GH#5831.
     if (
-        arr_in._ndim == 2 and arr_out._ndim == 2
-        and arr_in.shape[0] == 1 and arr_in.shape[1] == arr_out.shape[1]
+        arr_in._ndim == 2
+        and arr_out._ndim == 2
+        and arr_in.shape[0] == 1
+        and arr_in.shape[1] == arr_out.shape[1]
         and arr_in.shape[0] != 1
     ):
         raise NotImplementedError(
@@ -282,6 +288,31 @@ class array(object):
         for sib in self._siblings:
             sib._query_compiler = new_query_compiler
         old_query_compiler.free()
+
+    def _validate_axis(self, axis):
+        """
+        Check that the provided axis argument is valid on this array.
+
+        Raises numpy.AxisError if the axis is invalid.
+
+        Parameters
+        ----------
+        axis : int, optional
+            The axis argument passed to the function.
+
+        Returns
+        -------
+        int, optional
+            Axis to apply the function over (None, 0, or 1).
+        """
+        if axis is not None and axis < 0:
+            new_axis = axis + self._ndim
+            if self._ndim == 1 and new_axis != 0:
+                raise numpy.AxisError(axis, 1)
+            elif self._ndim == 2 and new_axis not in [0, 1]:
+                raise numpy.AxisError(axis, 2)
+            return new_axis
+        return axis
 
     def __array_ufunc__(self, ufunc, method, *inputs, **kwargs):
         ufunc_name = ufunc.__name__
@@ -497,20 +528,14 @@ class array(object):
         self, axis=None, dtype=None, out=None, keepdims=None, initial=None, where=True
     ):
         check_kwargs(keepdims=keepdims, where=where)
-        if axis is not None and axis < 0:
-            new_axis = axis + self._ndim
-            if self._ndim == 1 and new_axis != 0:
-                raise numpy.AxisError(axis, 1)
-            elif self._ndim == 2 and new_axis not in [0, 1]:
-                raise numpy.AxisError(axis, 2)
-            axis = new_axis
+        apply_axis = self._validate_axis(axis)
         truthy_where = bool(where)
         if initial is None and where is not True:
             raise ValueError(
                 "reduction operation 'maximum' does not have an identity, so to use a where mask one has to specify 'initial'"
             )
         if self._ndim == 1:
-            if axis == 1:
+            if apply_axis == 1:
                 raise numpy.AxisError(1, 1)
             target = where.where(self, initial) if isinstance(where, array) else self
             result = target._query_compiler.max(axis=0)
@@ -561,10 +586,10 @@ class array(object):
                 else:
                     return array([[initial]])
             return result if truthy_where else initial
-        if axis > 1:
+        if apply_axis > 1:
             raise numpy.AxisError(axis, 2)
         target = where.where(self, initial) if isinstance(where, array) else self
-        result = target._query_compiler.max(axis=axis)
+        result = target._query_compiler.max(axis=apply_axis)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             if initial is not None:
@@ -572,7 +597,7 @@ class array(object):
             else:
                 result = result.to_numpy()[0, 0]
             return result if truthy_where else initial
-        if not keepdims and axis != 1:
+        if not keepdims and apply_axis != 1:
             result = result.transpose()
         if initial is not None and out is not None:
             out._update_inplace((numpy.ones_like(out) * initial)._query_compiler)
@@ -593,19 +618,13 @@ class array(object):
     ):
         check_kwargs(keepdims=keepdims, where=where)
         truthy_where = bool(where)
-        if axis is not None and axis < 0:
-            new_axis = axis + self._ndim
-            if self._ndim == 1 and new_axis != 0:
-                raise numpy.AxisError(axis, 1)
-            elif self._ndim == 2 and new_axis not in [0, 1]:
-                raise numpy.AxisError(axis, 2)
-            axis = new_axis
+        apply_axis = self._validate_axis(axis)
         if initial is None and where is not True:
             raise ValueError(
                 "reduction operation 'minimum' does not have an identity, so to use a where mask one has to specify 'initial'"
             )
         if self._ndim == 1:
-            if axis == 1:
+            if apply_axis == 1:
                 raise numpy.AxisError(1, 1)
             target = where.where(self, initial) if isinstance(where, array) else self
             result = target._query_compiler.min(axis=0)
@@ -631,7 +650,7 @@ class array(object):
             else:
                 result = result.to_numpy()[0, 0]
             return result if truthy_where else initial
-        if axis is None:
+        if apply_axis is None:
             target = where.where(self, initial) if isinstance(where, array) else self
             result = target._query_compiler.min(axis=0).min(axis=1).to_numpy()[0, 0]
             if initial is not None:
@@ -656,10 +675,10 @@ class array(object):
                 else:
                     return array([[initial]])
             return result if truthy_where else initial
-        if axis > 1:
+        if apply_axis > 1:
             raise numpy.AxisError(axis, 2)
         target = where.where(self, initial) if isinstance(where, array) else self
-        result = target._query_compiler.min(axis=axis)
+        result = target._query_compiler.min(axis=apply_axis)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             if initial is not None:
@@ -667,7 +686,7 @@ class array(object):
             else:
                 result = result.to_numpy()[0, 0]
             return result if truthy_where else initial
-        if not keepdims and axis != 1:
+        if not keepdims and apply_axis != 1:
             result = result.transpose()
         if initial is not None and out is not None:
             out._update_inplace((numpy.ones_like(out) * initial)._query_compiler)
@@ -1113,7 +1132,9 @@ class array(object):
             raise ValueError(
                 f"all the input arrays must have same number of dimensions, but the array at index 0 has 1 dimension(s) and the array at index 1 has {values._ndim} dimension(s)"
             )
-        if self.shape[axis ^ 1] != values.shape[axis ^ 1]:
+        if (axis ^ 1 < len(values.shape)) and self.shape[axis ^ 1] != values.shape[
+            axis ^ 1
+        ]:
             raise ValueError(
                 f"all the input array dimensions except for the concatenation axis must match exactly, but along dimension {axis ^ 1}, the array at index 0 has size {self.shape[axis^1]} and the array at index 1 has size {values.shape[axis^1]}"
             )
@@ -1149,7 +1170,7 @@ class array(object):
         if axis is not None and axis < 0:
             new_axis = axis + self._ndim
             if self._ndim == 1 and new_axis != 0:
-                raise IndexError()
+                raise IndexError
             elif self._ndim == 2 and new_axis not in [0, 1]:
                 raise IndexError
             axis = new_axis
@@ -1248,17 +1269,11 @@ class array(object):
         out_type = getattr(out_dtype, "type", out_dtype)
         if isinstance(where, array) and issubclass(out_type, numpy.integer):
             out_dtype = numpy.float64
-        if axis is not None and axis < 0:
-            new_axis = axis + self._ndim
-            if self._ndim == 1 and new_axis != 0:
-                raise numpy.AxisError(axis, 1)
-            elif self._ndim == 2 and new_axis not in [0, 1]:
-                raise numpy.AxisError(axis, 2)
-            axis = new_axis
+        apply_axis = self._validate_axis(axis)
         check_kwargs(keepdims=keepdims, where=where)
         truthy_where = bool(where)
         if self._ndim == 1:
-            if axis == 1:
+            if apply_axis == 1:
                 raise numpy.AxisError(1, 1)
             if isinstance(where, array):
                 result = self._compute_masked_variance(where, out_dtype, 0, ddof)
@@ -1279,7 +1294,7 @@ class array(object):
                     )
                 else:
                     return array([numpy.nan], dtype=out_dtype)
-        if axis is None:
+        if apply_axis is None:
             # If any of the (non-masked) elements of our array are `NaN`, we know that the
             # result of `mean` must be `NaN`. This is a fastpath to see if any unmasked elements
             # are `NaN`.
@@ -1345,18 +1360,18 @@ class array(object):
                 else:
                     return array([[numpy.nan]], dtype=out_dtype)
             return result if truthy_where else numpy.nan
-        if axis > 1:
+        if apply_axis > 1:
             raise numpy.AxisError(axis, 2)
         if isinstance(where, array):
-            result = self._compute_masked_variance(where, out_dtype, axis, ddof)
+            result = self._compute_masked_variance(where, out_dtype, apply_axis, ddof)
         else:
             result = self._query_compiler.astype(
                 {col_name: out_dtype for col_name in self._query_compiler.columns}
-            ).var(axis=axis, skipna=False, ddof=ddof)
+            ).var(axis=apply_axis, skipna=False, ddof=ddof)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             return result.to_numpy()[0, 0] if truthy_where else numpy.nan
-        if not keepdims and axis != 1:
+        if not keepdims and apply_axis != 1:
             result = result.transpose()
         if out is not None:
             out._query_compiler = (numpy.ones_like(out) * numpy.nan)._query_compiler
@@ -1396,17 +1411,11 @@ class array(object):
         out_type = getattr(out_dtype, "type", out_dtype)
         if isinstance(where, array) and issubclass(out_type, numpy.integer):
             out_dtype = numpy.float64
-        if axis is not None and axis < 0:
-            new_axis = axis + self._ndim
-            if self._ndim == 1 and new_axis != 0:
-                raise numpy.AxisError(axis, 1)
-            elif self._ndim == 2 and new_axis not in [0, 1]:
-                raise numpy.AxisError(axis, 2)
-            axis = new_axis
+        apply_axis = self._validate_axis(axis)
         check_kwargs(keepdims=keepdims, where=where)
         truthy_where = bool(where)
         if self._ndim == 1:
-            if axis == 1:
+            if apply_axis == 1:
                 raise numpy.AxisError(1, 1)
             if isinstance(where, array):
                 result = self._compute_masked_mean(where, out_dtype, 0)
@@ -1434,7 +1443,7 @@ class array(object):
             # we just want to ensure that `where=False` was not passed in, and if it was
             # we return `numpy.nan`, since that is what NumPy would do.
             return result.to_numpy()[0, 0] if where else numpy.nan
-        if axis is None:
+        if apply_axis is None:
             # If any of the (non-masked) elements of our array are `NaN`, we know that the
             # result of `mean` must be `NaN`. This is a fastpath to see if any unmasked elements
             # are `NaN`.
@@ -1487,18 +1496,18 @@ class array(object):
                 else:
                     return array([[numpy.nan]], dtype=out_dtype)
             return result if truthy_where else numpy.nan
-        if axis > 1:
+        if apply_axis > 1:
             raise numpy.AxisError(axis, 2)
         if isinstance(where, array):
-            result = self._compute_masked_mean(where, out_dtype, axis)
+            result = self._compute_masked_mean(where, out_dtype, apply_axis)
         else:
             result = self._query_compiler.astype(
                 {col_name: out_dtype for col_name in self._query_compiler.columns}
-            ).mean(axis=axis, skipna=False)
+            ).mean(axis=apply_axis, skipna=False)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             return result.to_numpy()[0, 0] if truthy_where else numpy.nan
-        if not keepdims and axis != 1:
+        if not keepdims and apply_axis != 1:
             result = result.transpose()
         if out is not None:
             out._update_inplace((numpy.ones_like(out) * numpy.nan)._query_compiler)
@@ -1678,16 +1687,10 @@ class array(object):
         )
         initial = 1 if initial is None else initial
         check_kwargs(keepdims=keepdims, where=where)
-        if axis is not None and axis < 0:
-            new_axis = axis + self._ndim
-            if self._ndim == 1 and new_axis != 0:
-                raise numpy.AxisError(axis, 1)
-            elif self._ndim == 2 and new_axis not in [0, 1]:
-                raise numpy.AxisError(axis, 2)
-            axis = new_axis
+        apply_axis = self._validate_axis(axis)
         truthy_where = bool(where)
         if self._ndim == 1:
-            if axis == 1:
+            if apply_axis == 1:
                 raise numpy.AxisError(1, 1)
             target = where.where(self, 1) if isinstance(where, array) else self
             result = target._query_compiler.astype(
@@ -1712,7 +1715,7 @@ class array(object):
                 else:
                     return array([initial], dtype=out_dtype)
             return result.to_numpy()[0, 0] if truthy_where else initial
-        if axis is None:
+        if apply_axis is None:
             result = self
             if isinstance(where, array):
                 result = where.where(self, 1)
@@ -1747,17 +1750,17 @@ class array(object):
                 else:
                     return array([[initial]], dtype=out_dtype)
             return result if truthy_where else initial
-        if axis > 1:
+        if apply_axis > 1:
             raise numpy.AxisError(axis, 2)
         target = where.where(self, 1) if isinstance(where, array) else self
         result = target._query_compiler.astype(
             {col_name: out_dtype for col_name in target._query_compiler.columns}
-        ).prod(axis=axis, skipna=False)
+        ).prod(axis=apply_axis, skipna=False)
         result = result.mul(initial)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             return result.to_numpy()[0, 0] if truthy_where else initial
-        if not keepdims and axis != 1:
+        if not keepdims and apply_axis != 1:
             result = result.transpose()
         if initial is not None and out is not None:
             out._update_inplace(
@@ -1980,16 +1983,10 @@ class array(object):
         )
         initial = 0 if initial is None else initial
         check_kwargs(keepdims=keepdims, where=where)
-        if axis is not None and axis < 0:
-            new_axis = axis + self._ndim
-            if self._ndim == 1 and new_axis != 0:
-                raise numpy.AxisError(axis, 1)
-            elif self._ndim == 2 and new_axis not in [0, 1]:
-                raise numpy.AxisError(axis, 2)
-            axis = new_axis
+        apply_axis = self._validate_axis(axis)
         truthy_where = bool(where)
         if self._ndim == 1:
-            if axis == 1:
+            if apply_axis == 1:
                 raise numpy.AxisError(1, 1)
             target = where.where(self, 0) if isinstance(where, array) else self
             result = target._query_compiler.astype(
@@ -2014,7 +2011,7 @@ class array(object):
                 else:
                     return array([initial], dtype=out_dtype)
             return result.to_numpy()[0, 0] if truthy_where else initial
-        if axis is None:
+        if apply_axis is None:
             result = self
             if isinstance(where, array):
                 result = where.where(self, 0)
@@ -2047,17 +2044,17 @@ class array(object):
                 else:
                     return array([[initial]], dtype=out_dtype)
             return result if truthy_where else initial
-        if axis > 1:
+        if apply_axis > 1:
             raise numpy.AxisError(axis, 2)
         target = where.where(self, 0) if isinstance(where, array) else self
         result = target._query_compiler.astype(
             {col_name: out_dtype for col_name in target._query_compiler.columns}
-        ).sum(axis=axis, skipna=False)
+        ).sum(axis=apply_axis, skipna=False)
         result = result.add(initial)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             return result.to_numpy()[0, 0] if truthy_where else initial
-        if not keepdims and axis != 1:
+        if not keepdims and apply_axis != 1:
             result = result.transpose()
         if out is not None:
             out._update_inplace(
@@ -2076,16 +2073,10 @@ class array(object):
     def all(self, axis=None, out=None, keepdims=None, *, where=True):
         check_kwargs(keepdims=keepdims, where=where)
         truthy_where = bool(where)
-        if axis is not None and axis < 0:
-            new_axis = axis + self._ndim
-            if self._ndim == 1 and new_axis != 0:
-                raise numpy.AxisError(axis, 1)
-            elif self._ndim == 2 and new_axis not in [0, 1]:
-                raise numpy.AxisError(axis, 2)
-            axis = new_axis
+        apply_axis = self._validate_axis(axis)
         target = where.where(self, True) if isinstance(where, array) else self
         if self._ndim == 1:
-            if axis == 1:
+            if apply_axis == 1:
                 raise numpy.AxisError(1, 1)
             result = target._query_compiler.all(axis=0)
             if keepdims:
@@ -2100,7 +2091,7 @@ class array(object):
                 else:
                     return array([True], dtype=bool)
             return result.to_numpy()[0, 0] if truthy_where else True
-        if axis is None:
+        if apply_axis is None:
             result = target._query_compiler.all(axis=1).all(axis=0)
             if keepdims:
                 if out is not None and out.shape != (1, 1):
@@ -2118,14 +2109,14 @@ class array(object):
                 else:
                     return array([[True]], dtype=bool)
             return result.to_numpy()[0, 0] if truthy_where else True
-        if axis > 1:
+        if apply_axis > 1:
             raise numpy.AxisError(axis, 2)
-        result = target._query_compiler.all(axis=axis)
+        result = target._query_compiler.all(axis=apply_axis)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             result = result.to_numpy()[0, 0]
             return result if truthy_where else True
-        if not keepdims and axis != 1:
+        if not keepdims and apply_axis != 1:
             result = result.transpose()
         if truthy_where or out is not None:
             return fix_dtypes_and_determine_return(
@@ -2139,16 +2130,10 @@ class array(object):
     def any(self, axis=None, out=None, keepdims=None, *, where=True):
         check_kwargs(keepdims=keepdims, where=where)
         truthy_where = bool(where)
-        if axis is not None and axis < 0:
-            new_axis = axis + self._ndim
-            if self._ndim == 1 and new_axis != 0:
-                raise numpy.AxisError(axis, 1)
-            elif self._ndim == 2 and new_axis not in [0, 1]:
-                raise numpy.AxisError(axis, 2)
-            axis = new_axis
+        apply_axis = self._validate_axis(axis)
         target = where.where(self, False) if isinstance(where, array) else self
         if self._ndim == 1:
-            if axis == 1:
+            if apply_axis == 1:
                 raise numpy.AxisError(1, 1)
             result = target._query_compiler.any(axis=0)
             if keepdims:
@@ -2163,7 +2148,7 @@ class array(object):
                 else:
                     return array([False], dtype=bool)
             return result.to_numpy()[0, 0] if truthy_where else False
-        if axis is None:
+        if apply_axis is None:
             result = target._query_compiler.any(axis=1).any(axis=0)
             if keepdims:
                 if out is not None and out.shape != (1, 1):
@@ -2181,14 +2166,14 @@ class array(object):
                 else:
                     return array([[False]], dtype=bool)
             return result.to_numpy()[0, 0] if truthy_where else False
-        if axis > 1:
+        if apply_axis > 1:
             raise numpy.AxisError(axis, 2)
-        result = target._query_compiler.any(axis=axis)
+        result = target._query_compiler.any(axis=apply_axis)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             result = result.to_numpy()[0, 0]
             return result if truthy_where else False
-        if not keepdims and axis != 1:
+        if not keepdims and apply_axis != 1:
             result = result.transpose()
         if truthy_where or out is not None:
             return fix_dtypes_and_determine_return(
@@ -2201,15 +2186,9 @@ class array(object):
 
     def argmax(self, axis=None, out=None, keepdims=None):
         check_kwargs(keepdims=keepdims)
-        if axis is not None and axis < 0:
-            new_axis = axis + self._ndim
-            if self._ndim == 1 and new_axis != 0:
-                raise numpy.AxisError(axis, 1)
-            elif self._ndim == 2 and new_axis not in [0, 1]:
-                raise numpy.AxisError(axis, 2)
-            axis = new_axis
+        apply_axis = self._validate_axis(axis)
         if self._ndim == 1:
-            if axis == 1:
+            if apply_axis == 1:
                 raise numpy.AxisError(1, 1)
             if self._query_compiler.isna().any(axis=1).any(axis=0).to_numpy()[0, 0]:
                 na_row_map = self._query_compiler.isna().any(axis=1)
@@ -2225,7 +2204,7 @@ class array(object):
                     result, 1, numpy.int64, out, True
                 )
             return result.to_numpy()[0, 0]
-        if axis is None:
+        if apply_axis is None:
             if self._query_compiler.isna().any(axis=1).any(axis=0).to_numpy()[0, 0]:
                 na_row_map = self._query_compiler.isna().any(axis=1)
                 na_row = self._query_compiler.getitem_array(na_row_map)
@@ -2253,32 +2232,26 @@ class array(object):
                     True,
                 )
             return result
-        if axis > 1:
+        if apply_axis > 1:
             raise numpy.AxisError(axis, 2)
-        result = self._query_compiler.idxmax(axis=axis)
-        na_mask = self._query_compiler.isna().any(axis=axis)
-        if na_mask.any(axis=axis ^ 1).to_numpy()[0, 0]:
-            na_idxs = self._query_compiler.isna().idxmax(axis=axis)
+        result = self._query_compiler.idxmax(axis=apply_axis)
+        na_mask = self._query_compiler.isna().any(axis=apply_axis)
+        if na_mask.any(axis=apply_axis ^ 1).to_numpy()[0, 0]:
+            na_idxs = self._query_compiler.isna().idxmax(axis=apply_axis)
             result = na_mask.where(na_idxs, result)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             result = result.to_numpy()[0, 0]
             return result
-        if not keepdims and axis != 1:
+        if not keepdims and apply_axis != 1:
             result = result.transpose()
         return fix_dtypes_and_determine_return(result, new_ndim, numpy.int64, out, True)
 
     def argmin(self, axis=None, out=None, keepdims=None):
         check_kwargs(keepdims=keepdims)
-        if axis is not None and axis < 0:
-            new_axis = axis + self._ndim
-            if self._ndim == 1 and new_axis != 0:
-                raise numpy.AxisError(axis, 1)
-            elif self._ndim == 2 and new_axis not in [0, 1]:
-                raise numpy.AxisError(axis, 2)
-            axis = new_axis
+        apply_axis = self._validate_axis(axis)
         if self._ndim == 1:
-            if axis == 1:
+            if apply_axis == 1:
                 raise numpy.AxisError(1, 1)
             if self._query_compiler.isna().any(axis=1).any(axis=0).to_numpy()[0, 0]:
                 na_row_map = self._query_compiler.isna().any(axis=1)
@@ -2296,7 +2269,7 @@ class array(object):
                     result, 1, numpy.int64, out, True
                 )
             return result.to_numpy()[0, 0]
-        if axis is None:
+        if apply_axis is None:
             if self._query_compiler.isna().any(axis=1).any(axis=0).to_numpy()[0, 0]:
                 na_row_map = self._query_compiler.isna().any(axis=1)
                 na_row = self._query_compiler.getitem_array(na_row_map)
@@ -2324,18 +2297,18 @@ class array(object):
                     True,
                 )
             return result
-        if axis > 1:
+        if apply_axis > 1:
             raise numpy.AxisError(axis, 2)
-        result = self._query_compiler.idxmin(axis=axis)
-        na_mask = self._query_compiler.isna().any(axis=axis)
-        if na_mask.any(axis=axis ^ 1).to_numpy()[0, 0]:
-            na_idxs = self._query_compiler.isna().idxmax(axis=axis)
+        result = self._query_compiler.idxmin(axis=apply_axis)
+        na_mask = self._query_compiler.isna().any(axis=apply_axis)
+        if na_mask.any(axis=apply_axis ^ 1).to_numpy()[0, 0]:
+            na_idxs = self._query_compiler.isna().idxmax(axis=apply_axis)
             result = na_mask.where(na_idxs, result)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             result = result.to_numpy()[0, 0]
             return result
-        if not keepdims and axis != 1:
+        if not keepdims and apply_axis != 1:
             result = result.transpose()
         return fix_dtypes_and_determine_return(result, new_ndim, numpy.int64, out, True)
 
@@ -2531,12 +2504,12 @@ class array(object):
             raise ValueError(
                 f"cannot reshape array of size {prod(self._get_shape())} into {new_shape if isinstance(new_shape, tuple) else (new_shape,)}"
             )
-        if isinstance(new_shape, int):
+        if isinstance(new_shape, int) or len(new_shape) == 1:
             self._update_inplace(self.flatten()._query_compiler)
             self._ndim = 1
         else:
             raise NotImplementedError(
-                "Reshaping from a 2D object to a 2D object is not currently supported!"
+                "Modin numpy does not currently support reshaping to a 2D object"
             )
 
     shape = property(_get_shape, _set_shape)

--- a/modin/numpy/test/test_array.py
+++ b/modin/numpy/test/test_array.py
@@ -145,6 +145,54 @@ def test_update_inplace():
     numpy.testing.assert_array_equal(out._to_numpy(), arr2._to_numpy())
 
 
+@pytest.mark.parametrize("data_out", [
+    numpy.zeros((1, 3)),
+    numpy.zeros((2, 3)),
+])
+def test_out_broadcast(data_out):
+    if data_out.shape == (2, 3):
+        pytest.xfail("broadcasting would require duplicating row: see GH#5819")
+    data1 = [[1, 2, 3]]
+    data2 = [7, 8, 9]
+    numpy_out = numpy.array(data_out)
+    numpy.add(numpy.array(data1), numpy.array(data2), out=numpy_out)
+    modin_out = np.array(data_out)
+    np.add(np.array(data1), np.array(data2), out=modin_out)
+    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+
+
+def test_out_broadcast_error():
+    with pytest.raises(ValueError):
+        # Incompatible dimensions between inputs
+        np.add(np.array([1, 2, 3]), np.array([[1, 2], [3, 4]]))
+
+    with pytest.raises(ValueError):
+        # Compatible input broadcast dimensions, but output array dimensions are wrong
+        out = np.array([0])
+        np.add(np.array([[1, 2], [3, 4]]), np.array([1, 2]), out=out)
+
+    with pytest.raises(ValueError):
+        # Compatible input broadcast dimensions, but output array dimensions are wrong
+        # (cannot broadcast a 2x2 result into a 1x2 array)
+        out = np.array([0, 0])
+        np.add(np.array([[1, 2], [3, 4]]), np.array([1, 2]), out=out)
+
+    with pytest.raises(ValueError):
+        # Compatible input broadcast dimensions, but output array dimensions are wrong
+        # (cannot broadcast 1x2 into 1D 2-element array)
+        out = np.array([0, 0])
+        np.add(np.array([[1, 2]]), np.array([1, 2]), out=out)
+
+    with pytest.raises(ValueError):
+        # Compatible input broadcast dimensions, but output array dimensions are wrong
+        # (cannot broadcast a 2x2 result into a 3x2 array)
+        # Technically, our error message here does not match numpy's exactly, as the
+        # numpy message will specify both input shapes, whereas we only specify the
+        # shape of the default broadcast between the two inputs
+        out = np.array([[0, 0], [0, 0], [0, 0]])
+        np.add(np.array([[1, 2], [3, 4]]), np.array([1, 2]), out=out)
+
+
 @pytest.mark.parametrize("size", [100, (2, 100), (100, 2), (1, 100), (100, 1)])
 def test_array_ufunc(size):
     # Test ufunc.__call__

--- a/modin/numpy/test/test_array.py
+++ b/modin/numpy/test/test_array.py
@@ -157,9 +157,8 @@ def test_out_broadcast(data_out):
         pytest.xfail("broadcasting would require duplicating row: see GH#5819")
     data1 = [[1, 2, 3]]
     data2 = [7, 8, 9]
-    numpy_out = numpy.array(data_out)
+    modin_out, numpy_out = np.array(data_out), numpy.array(data_out)
     numpy.add(numpy.array(data1), numpy.array(data2), out=numpy_out)
-    modin_out = np.array(data_out)
     np.add(np.array(data1), np.array(data2), out=modin_out)
     numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
 

--- a/modin/numpy/test/test_array.py
+++ b/modin/numpy/test/test_array.py
@@ -145,10 +145,13 @@ def test_update_inplace():
     numpy.testing.assert_array_equal(out._to_numpy(), arr2._to_numpy())
 
 
-@pytest.mark.parametrize("data_out", [
-    numpy.zeros((1, 3)),
-    numpy.zeros((2, 3)),
-])
+@pytest.mark.parametrize(
+    "data_out",
+    [
+        numpy.zeros((1, 3)),
+        numpy.zeros((2, 3)),
+    ],
+)
 def test_out_broadcast(data_out):
     if data_out.shape == (2, 3):
         pytest.xfail("broadcasting would require duplicating row: see GH#5819")
@@ -314,3 +317,15 @@ def test_astype():
     numpy_result = numpy_arr.astype(numpy.float64, copy=False)
     numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
     numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+
+
+def test_set_shape():
+    numpy_arr = numpy.array([[1, 2, 3], [4, 5, 6]])
+    numpy_arr.shape = (6,)
+    modin_arr = np.array([[1, 2, 3], [4, 5, 6]])
+    modin_arr.shape = (6,)
+    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+    modin_arr.shape = 6  # Same as using (6,)
+    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+    with pytest.raises(ValueError, match="cannot reshape"):
+        modin_arr.shape = (4,)

--- a/modin/numpy/test/test_array_arithmetic.py
+++ b/modin/numpy/test/test_array_arithmetic.py
@@ -21,10 +21,7 @@ import modin.numpy as np
     "operand1_shape",
     [
         100,
-        pytest.param(
-            (1, 100),
-            marks=pytest.mark.xfail(reason="broadcasting is broken: see GH#5894"),
-        ),
+        (1, 100),
         (3, 100),
     ],
 )
@@ -32,10 +29,7 @@ import modin.numpy as np
     "operand2_shape",
     [
         100,
-        pytest.param(
-            (1, 100),
-            marks=pytest.mark.xfail(reason="broadcasting is broken: see GH#5894"),
-        ),
+        (1, 100),
         (3, 100),
         1,
     ],
@@ -61,6 +55,9 @@ import modin.numpy as np
 )
 def test_basic_arithmetic_with_broadcast(operand1_shape, operand2_shape, operator):
     """Test of operators that support broadcasting."""
+    if operand1_shape == (1, 100) or operand2_shape == (1, 100):
+        # For some reason, marking the param with xfail leads to [XPASS(strict)] and a reported failure
+        pytest.xfail(reason="broadcasting is broken: see GH#5894")
     operand1 = numpy.random.randint(-100, 100, size=operand1_shape)
     operand2 = numpy.random.randint(-100, 100, size=operand2_shape)
     numpy_result = getattr(operand1, operator)(operand2)
@@ -105,13 +102,13 @@ def test_basic_arithmetic_with_broadcast(operand1_shape, operand2_shape, operato
         "__le__",
         pytest.param(
             "__eq__",
-            pytest.mark.xfail(
+            marks=pytest.mark.xfail(
                 reason="numpy behavior on eq/ne is counterintuitive: see GH#5893"
             ),
         ),
         pytest.param(
             "__ne__",
-            pytest.mark.xfail(
+            marks=pytest.mark.xfail(
                 reason="numpy behavior on eq/ne is counterintuitive: see GH#5893"
             ),
         ),

--- a/modin/numpy/test/test_array_indexing.py
+++ b/modin/numpy/test/test_array_indexing.py
@@ -109,9 +109,8 @@ def test_getitem_nested():
 )
 def test_setitem_1d(index, value):
     data = [1, 2, 3, 4, 5]
-    numpy_arr = numpy.array(data)
+    modin_arr, numpy_arr = np.array(data), numpy.array(data)
     numpy_arr[index] = value
-    modin_arr = np.array(data)
     modin_arr[index] = value
     numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
 
@@ -144,8 +143,7 @@ def test_setitem_2d(index, value):
     if index == [2, 0]:
         pytest.xfail("indexing with unsorted list would fail: see GH#5886")
     data = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
-    numpy_arr = numpy.array(data)
+    modin_arr, numpy_arr = np.array(data), numpy.array(data)
     numpy_arr[index] = value
-    modin_arr = np.array(data)
     modin_arr[index] = value
     numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)

--- a/modin/numpy/test/test_array_indexing.py
+++ b/modin/numpy/test/test_array_indexing.py
@@ -91,3 +91,61 @@ def test_getitem_nested():
         assert modin_result.shape == numpy_result.shape
     else:
         assert modin_result == numpy_result
+
+
+@pytest.mark.parametrize(
+    ("index", "value"),
+    [
+        (0, 1),
+        (1, 1),
+        (-1, 1),  # Scalar indices
+        (slice(0, 1, 1), [7]),
+        (slice(1, -1, 1), [7, 8, 9]),  # Slices
+        (slice(0, 4, 1), 7),  # Slice with broadcast
+        ([0, 2], [7, 8]),
+        ([1, -1], [7, 8]),  # Lists
+    ],
+    ids=lambda i: f"{i}",
+)
+def test_setitem_1d(index, value):
+    data = [1, 2, 3, 4, 5]
+    numpy_arr = numpy.array(data)
+    numpy_arr[index] = value
+    modin_arr = np.array(data)
+    modin_arr[index] = value
+    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+
+
+def test_setitem_1d_error():
+    arr = np.array([1, 2, 3, 4, 5])
+    with pytest.raises(ValueError, match="could not broadcast"):
+        arr[0:5] = [1, 2]
+
+
+@pytest.mark.parametrize(
+    ("index", "value"),
+    [
+        (0, 1),
+        (1, 1),
+        (-1, 1),  # Scalar indices
+        (slice(0, 1, 1), [13]),  # arr[0:1:1] = [13]
+        (slice(1, -1, 1), [13]),  # arr[1:-1:1] = 13
+        (slice(None, None, None), [7]),  # arr[:] = [7]
+        (slice(None, 1, None), [7]),  # arr[:1] = [7]
+        (slice(0, 1, None), [7]),  # arr[0:1] = [7]
+        (slice(0, None, None), [7]),  # arr[0:] = [7]
+        ([0, 2], [[13, 14, 15], [16, 17, 18]]),
+        ([2, 0], [[13, 14, 15], [16, 17, 18]]),
+        ([1, -1], [[13, 14, 15], [16, 17, 18]]),  # Lists
+    ],
+    ids=lambda i: f"{i}",
+)
+def test_setitem_2d(index, value):
+    if index == [2, 0]:
+        pytest.xfail("indexing with unsorted list would fail: see GH#5886")
+    data = [[1, 2, 3], [4, 5, 6], [7, 8, 9], [10, 11, 12]]
+    numpy_arr = numpy.array(data)
+    numpy_arr[index] = value
+    modin_arr = np.array(data)
+    modin_arr[index] = value
+    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)

--- a/modin/numpy/test/test_array_linalg.py
+++ b/modin/numpy/test/test_array_linalg.py
@@ -50,6 +50,26 @@ def test_dot_2d():
     numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
 
 
+def test_dot_scalar():
+    x1 = numpy.random.randint(-100, 100, size=(100, 3))
+    x2 = numpy.random.randint(-100, 100)
+    numpy_result = numpy.dot(x1, x2)
+    x1 = np.array(x1)
+    modin_result = np.dot(x1, x2)
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+
+
+def test_matmul_scalar():
+    x1 = numpy.random.randint(-100, 100, size=(100, 3))
+    x2 = numpy.random.randint(-100, 100)
+    x1 = np.array(x1)
+    # Modin error message differs from numpy for readability; the original numpy error is:
+    # ValueError: matmul: Input operand 1 does not have enough dimensions (has 0, gufunc
+    # core with signature (n?,k),(k,m?)->(n?,m?) requires 1)
+    with pytest.raises(ValueError):
+        x1 @ x2
+
+
 def test_dot_broadcast():
     # 2D @ 1D
     x1 = numpy.random.randint(-100, 100, size=(100, 3))

--- a/modin/numpy/test/test_array_math.py
+++ b/modin/numpy/test/test_array_math.py
@@ -40,6 +40,7 @@ def test_rem_mod():
     numpy_result = numpy.remainder(a, b)
     modin_result = np.remainder(np.array(a), np.array(b))
     numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+
     numpy_result = numpy.mod(a, b)
     modin_result = np.mod(np.array(a), np.array(b))
     numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)

--- a/modin/numpy/test/test_array_math.py
+++ b/modin/numpy/test/test_array_math.py
@@ -31,3 +31,15 @@ def test_argmax_argmin(data, op):
     numpy_result = getattr(numpy, op)(numpy.array(data))
     modin_result = getattr(np, op)(np.array(data))
     numpy.testing.assert_array_equal(modin_result, numpy_result)
+
+
+def test_rem_mod():
+    """Tests remainder and mod, which, unlike the C/matlab equivalents, are identical in numpy."""
+    a = numpy.array([[2, -1], [10, -3]])
+    b = numpy.array(([-3, 3], [3, -7]))
+    numpy_result = numpy.remainder(a, b)
+    modin_result = np.remainder(np.array(a), np.array(b))
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    numpy_result = numpy.mod(a, b)
+    modin_result = np.mod(np.array(a), np.array(b))
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)

--- a/modin/numpy/test/test_array_shaping.py
+++ b/modin/numpy/test/test_array_shaping.py
@@ -47,9 +47,8 @@ def test_split_2d(axis):
     # Integer argument: split into N equal arrays along axis
     numpy_result = numpy.split(x, 2, axis=axis)
     modin_result = np.split(np.array(x), 2, axis=axis)
-    # Cannot zip because modin array does not implement __iter__
-    for i in range(len(numpy_result)):
-        numpy.testing.assert_array_equal(modin_result[i]._to_numpy(), numpy_result[i])
+    for modin_entry, numpy_entry in zip(modin_result, numpy_result):
+        numpy.testing.assert_array_equal(modin_entry._to_numpy(), numpy_entry)
     # List argument: split at specified indices
     idxs = [2, 3]
     numpy_result = numpy.split(x, idxs, axis=axis)

--- a/modin/numpy/test/test_array_shaping.py
+++ b/modin/numpy/test/test_array_shaping.py
@@ -1,0 +1,106 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import numpy
+import pytest
+
+import modin.numpy as np
+
+
+@pytest.mark.parametrize("operand_shape", [100, (100, 3), (3, 100)])
+def test_ravel(operand_shape):
+    x = numpy.random.randint(-100, 100, size=operand_shape)
+    numpy_result = numpy.ravel(x)
+    modin_result = np.ravel(np.array(x))
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+
+
+@pytest.mark.parametrize("operand_shape", [100, (100, 3), (3, 100)])
+def test_shape(operand_shape):
+    x = numpy.random.randint(-100, 100, size=operand_shape)
+    numpy_result = numpy.shape(x)
+    modin_result = np.shape(np.array(x))
+    assert modin_result == numpy_result
+
+
+@pytest.mark.parametrize("operand_shape", [100, (100, 3), (3, 100)])
+def test_transpose(operand_shape):
+    x = numpy.random.randint(-100, 100, size=operand_shape)
+    numpy_result = numpy.transpose(x)
+    modin_result = np.transpose(np.array(x))
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+
+
+@pytest.mark.parametrize("axis", [0, 1])
+def test_split_2d(axis):
+    x = numpy.random.randint(-100, 100, size=(6, 4))
+    # Integer argument: split into N equal arrays along axis
+    numpy_result = numpy.split(x, 2, axis=axis)
+    modin_result = np.split(np.array(x), 2, axis=axis)
+    # Cannot zip because modin array does not implement __iter__
+    for i in range(len(numpy_result)):
+        numpy.testing.assert_array_equal(modin_result[i]._to_numpy(), numpy_result[i])
+    # List argument: split at specified indices
+    idxs = [2, 3]
+    numpy_result = numpy.split(x, idxs, axis=axis)
+    modin_result = np.split(np.array(x), idxs, axis=axis)
+    for i in range(len(numpy_result)):
+        numpy.testing.assert_array_equal(modin_result[i]._to_numpy(), numpy_result[i])
+
+
+@pytest.mark.xfail(reason="modin numpy does not natively support empty arrays")
+def test_split_2d_oob():
+    # Supplying an index out of bounds results in an empty sub-array, for which modin
+    # would return a numpy array by default
+    x = numpy.random.randint(-100, 100, size=(6, 4))
+    idxs = [2, 3, 6]
+    numpy_result = numpy.split(x, idxs)
+    modin_result = np.split(np.array(x), idxs)
+    for i in range(len(numpy_result)):
+        numpy.testing.assert_array_equal(modin_result[i]._to_numpy(), numpy_result[i])
+
+
+def test_split_2d_uneven():
+    x = np.array(numpy.random.randint(-100, 100, size=(3, 2)))
+    with pytest.raises(
+        ValueError, match="array split does not result in an equal division"
+    ):
+        np.split(x, 2)
+
+
+def test_hstack():
+    # 2D arrays
+    a = numpy.random.randint(-100, 100, size=(5, 3))
+    b = numpy.random.randint(-100, 100, size=(5, 2))
+    numpy_result = numpy.hstack((a, b))
+    modin_result = np.hstack((np.array(a), np.array(b)))
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    # 1D arrays
+    a = numpy.random.randint(-100, 100, size=(5,))
+    b = numpy.random.randint(-100, 100, size=(3,))
+    numpy_result = numpy.hstack((a, b))
+    modin_result = np.hstack((np.array(a), np.array(b)))
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+
+
+def test_append():
+    # Examples taken from numpy docs
+    xs = [[1, 2, 3], [[4, 5, 6], [7, 8, 9]]]
+    numpy_result = numpy.append(*xs)
+    modin_result = np.append(*[np.array(x) for x in xs])
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    numpy_result = numpy.append([[1, 2, 3], [4, 5, 6]], [[7, 8, 9]], axis=0)
+    modin_result = np.append(np.array([[1, 2, 3], [4, 5, 6]]), [[7, 8, 9]], axis=0)
+    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    with pytest.raises(ValueError):
+        np.append(np.array([[1, 2, 3], [4, 5, 6]]), np.array([7, 8, 9]), axis=0)

--- a/modin/numpy/test/test_array_shaping.py
+++ b/modin/numpy/test/test_array_shaping.py
@@ -102,5 +102,9 @@ def test_append():
     numpy_result = numpy.append([[1, 2, 3], [4, 5, 6]], [[7, 8, 9]], axis=0)
     modin_result = np.append(np.array([[1, 2, 3], [4, 5, 6]]), [[7, 8, 9]], axis=0)
     numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+
+
+@pytest.mark.xfail(reason="append error checking is incorrect: see GH#5896")
+def test_append_error():
     with pytest.raises(ValueError):
         np.append(np.array([[1, 2, 3], [4, 5, 6]]), np.array([7, 8, 9]), axis=0)

--- a/modin/numpy/test/test_array_shaping.py
+++ b/modin/numpy/test/test_array_shaping.py
@@ -99,6 +99,7 @@ def test_append():
     numpy_result = numpy.append(*xs)
     modin_result = np.append(*[np.array(x) for x in xs])
     numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+
     numpy_result = numpy.append([[1, 2, 3], [4, 5, 6]], [[7, 8, 9]], axis=0)
     modin_result = np.append(np.array([[1, 2, 3], [4, 5, 6]]), [[7, 8, 9]], axis=0)
     numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
This PR adds tests for several previously uncovered test cases in the numpy API.
<details>
<summary>New test cases:</summary>
- Error cases for improper broadcast dimensions
- Broadcasting with an `out` array specified
- Basic behavior for `__setitem__` and `_set_shape`
- Binary operations with a scalar argument
- remainder, mod, argmax, and argmin basic behavior
- shape, transpose, split, hstack, and append basic behavior
</details>

This PR also includes a few minor bugfixes related to broadcasting issues (I did not file issues for those), and adds xfail'd tests for the following:
- #5831
- #5886
- #5893
- #5894
- #5896

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5897 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
