### PR TITLE
FIX-#5509: default to pandas for read_parquet if any additional kwargs are passed to the engine

### DIFF
--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -612,6 +612,14 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         ParquetFile API is used. Please refer to the documentation here
         https://arrow.apache.org/docs/python/parquet.html
         """
+        if any(arg not in ("storage_options", "use_nullable_dtypes") for arg in kwargs):
+            return cls.single_worker_read(
+                path,
+                engine=engine,
+                columns=columns,
+                reason="Parquet options that are not currently supported",
+                **kwargs,
+            )
         if isinstance(path, list):
             # TODO(https://github.com/modin-project/modin/issues/5723): read all
             # files in parallel.

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1656,6 +1656,21 @@ class TestParquet:
 
             df_equals(test_df, read_df)
 
+    def test_read_parquet_5509(self, engine):
+        test_df = pandas.DataFrame({"col_a": [1, 2, 3], "col_b": ["a", "b", "c"]})
+
+        with tempfile.TemporaryDirectory() as directory:
+            path = f"{directory}/data"
+            os.makedirs(path)
+            test_df.to_parquet(path + "/5509.parquet")
+            eval_io(
+                fn_name="read_parquet",
+                path=path + "/5509.parquet",
+                columns=["col_b"],
+                engine=engine,
+                filters=[[("col_a", "==", 1)]],
+            )
+
     def test_read_parquet_s3_with_column_partitioning(self, engine):
         # This test case comes from
         # https://github.com/modin-project/modin/issues/4636

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1663,13 +1663,14 @@ class TestParquet:
             path = f"{directory}/data"
             os.makedirs(path)
             test_df.to_parquet(path + "/5509.parquet")
-            eval_io(
-                fn_name="read_parquet",
-                path=path + "/5509.parquet",
-                columns=["col_b"],
-                engine=engine,
-                filters=[[("col_a", "==", 1)]],
-            )
+            with warns_that_defaulting_to_pandas():
+                eval_io(
+                    fn_name="read_parquet",
+                    path=path + "/5509.parquet",
+                    columns=["col_b"],
+                    engine=engine,
+                    filters=[[("col_a", "==", 1)]],
+                )
 
     def test_read_parquet_s3_with_column_partitioning(self, engine):
         # This test case comes from


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5509 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
