### PR TITLE
FIX-#4635: allow pass modin functions to `apply`

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -383,6 +383,11 @@ class DataFrame(BasePandasDataset):
         """
         Apply a function along an axis of the ``DataFrame``.
         """
+        if callable(func):
+            if func.__module__ == "modin.pandas.series":
+                func = getattr(pandas.Series, func.__name__)
+            elif func.__module__ in ("modin.pandas.dataframe", "modin.pandas.base"):
+                func = getattr(pandas.DataFrame, func.__name__)
         axis = self._get_axis_number(axis)
         query_compiler = super(DataFrame, self).apply(
             func,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -57,6 +57,7 @@ from .utils import (
     from_pandas,
     from_non_pandas,
     broadcast_item,
+    cast_function_modin2pandas,
     SET_DATAFRAME_ATTRIBUTE_WARNING,
 )
 from .iterator import PartitionIterator
@@ -383,11 +384,7 @@ class DataFrame(BasePandasDataset):
         """
         Apply a function along an axis of the ``DataFrame``.
         """
-        if callable(func):
-            if func.__module__ == "modin.pandas.series":
-                func = getattr(pandas.Series, func.__name__)
-            elif func.__module__ in ("modin.pandas.dataframe", "modin.pandas.base"):
-                func = getattr(pandas.DataFrame, func.__name__)
+        func = cast_function_modin2pandas(func)
         axis = self._get_axis_number(axis)
         query_compiler = super(DataFrame, self).apply(
             func,

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -36,6 +36,7 @@ from modin.utils import (
     wrap_into_list,
     MODIN_UNNAMED_SERIES_LABEL,
 )
+from modin.pandas.utils import cast_function_modin2pandas
 from modin.core.storage_formats.base.query_compiler import BaseQueryCompiler
 from modin.core.dataframe.algebra.default2pandas.groupby import GroupBy
 from modin.config import IsExperimental
@@ -433,11 +434,7 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def apply(self, func, *args, **kwargs):
-        if callable(func):
-            if func.__module__ == "modin.pandas.series":
-                func = getattr(pandas.Series, func.__name__)
-            elif func.__module__ in ("modin.pandas.dataframe", "modin.pandas.base"):
-                func = getattr(pandas.DataFrame, func.__name__)
+        func = cast_function_modin2pandas(func)
         if not isinstance(func, BuiltinFunctionType):
             func = wrap_udf_function(func)
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -433,6 +433,11 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def apply(self, func, *args, **kwargs):
+        if callable(func):
+            if func.__module__ == "modin.pandas.series":
+                func = getattr(pandas.Series, func.__name__)
+            elif func.__module__ in ("modin.pandas.dataframe", "modin.pandas.base"):
+                func = getattr(pandas.DataFrame, func.__name__)
         if not isinstance(func, BuiltinFunctionType):
             func = wrap_udf_function(func)
 

--- a/modin/pandas/resample.py
+++ b/modin/pandas/resample.py
@@ -21,6 +21,7 @@ from pandas._libs.lib import no_default
 from typing import Optional
 from modin.logging import ClassLogger
 from modin.utils import _inherit_docstrings
+from modin.pandas.utils import cast_function_modin2pandas
 
 
 @_inherit_docstrings(pandas.core.resample.Resampler)
@@ -142,6 +143,7 @@ class Resampler(ClassLogger):
         return group if self.axis == 0 else group.T
 
     def apply(self, func, *args, **kwargs):
+        func = cast_function_modin2pandas(func)
         from .dataframe import DataFrame
 
         if isinstance(self._dataframe, DataFrame):

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -637,6 +637,11 @@ class Series(BasePandasDataset):
         """
         Invoke function on values of Series.
         """
+        if callable(func):
+            if func.__module__ == "modin.pandas.series":
+                func = getattr(pandas.Series, func.__name__)
+            elif func.__module__ in ("modin.pandas.dataframe", "modin.pandas.base"):
+                func = getattr(pandas.DataFrame, func.__name__)
         self._validate_function(func)
         # apply and aggregate have slightly different behaviors, so we have to use
         # each one separately to determine the correct return type. In the case of

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -37,7 +37,7 @@ from modin.utils import (
 from modin.config import IsExperimental, PersistentPickle
 from .base import BasePandasDataset, _ATTRS_NO_LOOKUP
 from .iterator import PartitionIterator
-from .utils import from_pandas, is_scalar, _doc_binary_op
+from .utils import from_pandas, is_scalar, _doc_binary_op, cast_function_modin2pandas
 from .accessor import CachedAccessor, SparseAccessor
 
 
@@ -637,11 +637,7 @@ class Series(BasePandasDataset):
         """
         Invoke function on values of Series.
         """
-        if callable(func):
-            if func.__module__ == "modin.pandas.series":
-                func = getattr(pandas.Series, func.__name__)
-            elif func.__module__ in ("modin.pandas.dataframe", "modin.pandas.base"):
-                func = getattr(pandas.DataFrame, func.__name__)
+        func = cast_function_modin2pandas(func)
         self._validate_function(func)
         # apply and aggregate have slightly different behaviors, so we have to use
         # each one separately to determine the correct return type. In the case of

--- a/modin/pandas/test/dataframe/test_udf.py
+++ b/modin/pandas/test/dataframe/test_udf.py
@@ -245,6 +245,22 @@ def test_apply_udf(data, func):
     )
 
 
+def test_apply_modin_func_4635():
+    data = [1]
+    modin_df, pandas_df = create_test_dfs(data)
+    df_equals(modin_df.apply(pd.Series.sum), pandas_df.apply(pandas.Series.sum))
+
+    data = data = {"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]}
+    modin_df, pandas_df = create_test_dfs(data)
+    modin_df = modin_df.set_index(["a"])
+    pandas_df = pandas_df.set_index(["a"])
+
+    df_equals(
+        modin_df.groupby("a", group_keys=False).apply(pd.DataFrame.sample, n=1),
+        pandas_df.groupby("a", group_keys=False).apply(pandas.DataFrame.sample, n=1),
+    )
+
+
 def test_eval_df_use_case():
     frame_data = {"a": random_state.randn(10), "b": random_state.randn(10)}
     df = pandas.DataFrame(frame_data)

--- a/modin/pandas/test/dataframe/test_udf.py
+++ b/modin/pandas/test/dataframe/test_udf.py
@@ -250,7 +250,7 @@ def test_apply_modin_func_4635():
     modin_df, pandas_df = create_test_dfs(data)
     df_equals(modin_df.apply(pd.Series.sum), pandas_df.apply(pandas.Series.sum))
 
-    data = data = {"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]}
+    data = {"a": [1, 2, 3], "b": [1, 2, 3], "c": [1, 2, 3]}
     modin_df, pandas_df = create_test_dfs(data)
     modin_df = modin_df.set_index(["a"])
     pandas_df = pandas_df.set_index(["a"])

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -138,6 +138,29 @@ def from_dataframe(df):
     return DataFrame(query_compiler=FactoryDispatcher.from_dataframe(df))
 
 
+def cast_function_modin2pandas(func):
+    """
+    Replace Modin functions with pandas functions if `func` is callable.
+
+    Parameters
+    ----------
+    func : object
+
+    Returns
+    -------
+    object
+    """
+    if callable(func):
+        if func.__module__ == "modin.pandas.series":
+            func = getattr(pandas.Series, func.__name__)
+        elif func.__module__ in ("modin.pandas.dataframe", "modin.pandas.base"):
+            # FIXME: when the method is defined in `modin.pandas.base` file, then the
+            # type cannot be determined, in general there may be an error, but at the
+            # moment it is better.
+            func = getattr(pandas.DataFrame, func.__name__)
+    return func
+
+
 def is_scalar(obj):
     """
     Return True if given object is scalar.

--- a/modin/pandas/window.py
+++ b/modin/pandas/window.py
@@ -19,6 +19,7 @@ from pandas.core.dtypes.common import is_list_like
 
 from modin.logging import ClassLogger
 from modin.utils import _inherit_docstrings
+from modin.pandas.utils import cast_function_modin2pandas
 
 
 @_inherit_docstrings(pandas.core.window.rolling.Window)
@@ -224,6 +225,7 @@ class Rolling(ClassLogger):
         args=None,
         kwargs=None,
     ):
+        func = cast_function_modin2pandas(func)
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.rolling_apply(
                 self.axis,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4635 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
