### PR TITLE
FIX-#5432: don't return None when `astype` used with `copy=False` parameter

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -991,6 +991,8 @@ class BasePandasDataset(ClassLogger):
                     if col_dtypes[col] != frame_dtypes[col]:
                         copy = True
                         break
+            else:
+                copy = True
 
         if copy:
             new_query_compiler = self._query_compiler.astype(col_dtypes, errors=errors)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -172,7 +172,8 @@ class DataFrame(BasePandasDataset):
             if index is not None:
                 self.set_axis(index, axis=0, inplace=True)
             if dtype is not None:
-                self.astype(dtype, copy=False)
+                casted_obj = self.astype(dtype, copy=False)
+                self._query_compiler = casted_obj._query_compiler
         # Check type of data and use appropriate constructor
         elif query_compiler is None:
             distributed_frame = from_non_pandas(data, index, columns, dtype)

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -505,13 +505,18 @@ def test_astype_errors(errors):
     eval_general(modin_df, pandas_df, lambda df: df.astype("int", errors=errors))
 
 
-def test_astype_copy():
+@pytest.mark.parametrize("has_dtypes", [False, True])
+def test_astype_copy(has_dtypes):
     data = [1]
     modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
+    if not has_dtypes:
+        modin_df._query_compiler._modin_frame._dtypes = None
     eval_general(modin_df, pandas_df, lambda df: df.astype(str, copy=False))
 
     # trivial case where copying can be avoided, behavior should match pandas
     s1 = pd.Series([1, 2])
+    if not has_dtypes:
+        modin_df._query_compiler._modin_frame._dtypes = None
     s2 = s1.astype("int64", copy=False)
     s2[0] = 10
     df_equals(s1, s2)

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -505,6 +505,18 @@ def test_astype_errors(errors):
     eval_general(modin_df, pandas_df, lambda df: df.astype("int", errors=errors))
 
 
+def test_astype_copy():
+    data = [1]
+    modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
+    eval_general(modin_df, pandas_df, lambda df: df.astype(str, copy=False))
+
+    # trivial case where copying can be avoided, behavior should match pandas
+    s1 = pd.Series([1, 2])
+    s2 = s1.astype("int64", copy=False)
+    s2[0] = 10
+    df_equals(s1, s2)
+
+
 @pytest.mark.parametrize("dtypes_are_dict", [True, False])
 def test_astype_dict_or_series_multiple_column_partitions(dtypes_are_dict):
     # Test astype with a dtypes dict that is complex in that:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5432 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
