### PR TITLE
FIX-#4924: fix read_excel when header is None

### DIFF
--- a/modin/core/io/text/excel_dispatcher.py
+++ b/modin/core/io/text/excel_dispatcher.py
@@ -15,7 +15,6 @@
 
 import pandas
 import re
-import sys
 import warnings
 
 from modin.core.io.text.text_file_dispatcher import TextFileDispatcher
@@ -53,12 +52,6 @@ class ExcelDispatcher(TextFileDispatcher):
                 reason="Modin only implements parallel `read_excel` with `openpyxl` engine, "
                 + 'please specify `engine=None` or `engine="openpyxl"` to '
                 + "use Modin's parallel implementation.",
-                **kwargs
-            )
-        if sys.version_info < (3, 7):
-            return cls.single_worker_read(
-                io,
-                reason="Python 3.7 or higher required for parallel `read_excel`.",
                 **kwargs
             )
 
@@ -132,14 +125,27 @@ class ExcelDispatcher(TextFileDispatcher):
             while end_of_row_tag not in sheet_block:
                 sheet_block += f.read(EXCEL_READ_BLOCK_SIZE)
             idx_of_header_end = sheet_block.index(end_of_row_tag) + len(end_of_row_tag)
-            sheet_header = sheet_block[:idx_of_header_end]
-            # Reset the file pointer to begin at the end of the header information.
-            f.seek(idx_of_header_end)
+            sheet_header_with_first_row = sheet_block[:idx_of_header_end]
+
+            if not kwargs["header"] is None:
+                # Reset the file pointer to begin at the end of the header information.
+                f.seek(idx_of_header_end)
+                sheet_header = sheet_header_with_first_row
+            else:
+                start_of_row_tag = b"<row"
+                idx_of_header_start = sheet_block.index(start_of_row_tag)
+                sheet_header = sheet_block[:idx_of_header_start]
+                # Reset the file pointer to begin at the end of the header information.
+                f.seek(idx_of_header_start)
+
             kwargs["_header"] = sheet_header
             footer = b"</sheetData></worksheet>"
             # Use openpyxml to parse the data
             reader = WorksheetReader(
-                ws, BytesIO(sheet_header + footer), ex.shared_strings, False
+                ws,
+                BytesIO(sheet_header_with_first_row + footer),
+                ex.shared_strings,
+                False,
             )
             # Attach cells to the worksheet
             reader.bind_cells()
@@ -147,7 +153,10 @@ class ExcelDispatcher(TextFileDispatcher):
                 ws, kwargs.get("convert_float", True)
             )
             # Extract column names from parsed data.
-            column_names = pandas.Index(data[0])
+            if kwargs["header"] is None:
+                column_names = pandas.RangeIndex(len(data[0]))
+            else:
+                column_names = pandas.Index(data[0])
             index_col = kwargs.get("index_col", None)
             # Remove column names that are specified as `index_col`
             if index_col is not None:

--- a/modin/core/io/text/excel_dispatcher.py
+++ b/modin/core/io/text/excel_dispatcher.py
@@ -127,7 +127,7 @@ class ExcelDispatcher(TextFileDispatcher):
             idx_of_header_end = sheet_block.index(end_of_row_tag) + len(end_of_row_tag)
             sheet_header_with_first_row = sheet_block[:idx_of_header_end]
 
-            if not kwargs["header"] is None:
+            if kwargs["header"] is not None:
                 # Reset the file pointer to begin at the end of the header information.
                 f.seek(idx_of_header_end)
                 sheet_header = sheet_header_with_first_row

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1885,6 +1885,14 @@ class TestExcel:
             io="modin/pandas/test/data/every_other_row_nan.xlsx",
         )
 
+    @check_file_leaks
+    def test_read_excel_header_none(self):
+        eval_io(
+            fn_name="read_excel",
+            io="modin/pandas/test/data/every_other_row_nan.xlsx",
+            header=None,
+        )
+
     @pytest.mark.parametrize(
         "sheet_name",
         [


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4924 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
