### PR TITLE
REFACTOR-#5923: add `pragma: no cover` for functions that used in `apply_full_axis`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2066,7 +2066,7 @@ class PandasDataframe(ClassLogger):
         # index and the column share the same name, when in actuality, the index's name should be
         # None. This fixes the indexes name beforehand in that case, so that the sort works.
 
-        def sort_function(df):
+        def sort_function(df):  # pragma: no cover
             index_renaming = None
             if any(name in df.columns for name in df.index.names):
                 index_renaming = df.index.names

--- a/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
@@ -176,7 +176,7 @@ class PandasOnDaskIO(BaseIO):
         kwargs["if_exists"] = "append"
         columns = qc.columns
 
-        def func(df):
+        def func(df):  # pragma: no cover
             """
             Override column names in the wrapped dataframe and convert it to SQL.
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -96,7 +96,7 @@ class PandasOnRayIO(RayIO):
         kwargs["if_exists"] = "append"
         columns = qc.columns
 
-        def func(df):
+        def func(df):  # pragma: no cover
             """
             Override column names in the wrapped dataframe and convert it to SQL.
 

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -101,7 +101,7 @@ class PandasOnUnidistIO(UnidistIO):
         kwargs["if_exists"] = "append"
         columns = qc.columns
 
-        def func(df):
+        def func(df):  # pragma: no cover
             """
             Override column names in the wrapped dataframe and convert it to SQL.
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -484,7 +484,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
             kwargs["sort"] = False
 
-            def map_func(left, right=right_pandas, kwargs=kwargs):
+            def map_func(left, right=right_pandas, kwargs=kwargs):  # pragma: no cover
                 return pandas.merge(left, right_pandas, **kwargs)
 
             # Want to ensure that these are python lists
@@ -604,7 +604,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if how in ["left", "inner"]:
             right_pandas = right.to_pandas()
 
-            def map_func(left, right=right_pandas, kwargs=kwargs):
+            def map_func(left, right=right_pandas, kwargs=kwargs):  # pragma: no cover
                 return pandas.DataFrame.join(left, right, **kwargs)
 
             new_self = self.__constructor__(
@@ -640,7 +640,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def reset_index(self, **kwargs):
         if self.lazy_execution:
 
-            def _reset(df, *axis_lengths, partition_idx):
+            def _reset(df, *axis_lengths, partition_idx):  # pragma: no cover
                 df = df.reset_index(**kwargs)
 
                 if isinstance(df.index, pandas.RangeIndex):
@@ -976,7 +976,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             New QueryCompiler containing the result of resample aggregation.
         """
 
-        def map_func(df, resample_kwargs=resample_kwargs):
+        def map_func(df, resample_kwargs=resample_kwargs):  # pragma: no cover
             """Resample time-series data of the passed frame and apply aggregation function on it."""
             if df_op is not None:
                 df = df_op(df)
@@ -1304,7 +1304,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             new_columns = None
             need_reindex = False
 
-        def map_func(df):
+        def map_func(df):  # pragma: no cover
             return pandas.DataFrame(df.unstack(level=level, fill_value=fill_value))
 
         def is_tree_like_or_1d(calc_index, valid_index):
@@ -1782,7 +1782,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     )
                     break
 
-        def describe_builder(df, internal_indices=[]):
+        def describe_builder(df, internal_indices=[]):  # pragma: no cover
             """Apply `describe` function to the subset of columns in a single partition."""
             # The index of the resulting dataframe is the same amongst all partitions
             # when dealing with the same data type. However, if we work with columns
@@ -1870,7 +1870,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if min_periods is None:
             min_periods = 1
 
-        def map_func(df):
+        def map_func(df):  # pragma: no cover
             """Compute covariance or correlation matrix for the passed frame."""
             df = df.to_numpy()
             n_rows = df.shape[0]
@@ -1925,7 +1925,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 else other.to_pandas()
             )
 
-        def map_func(df, other=other, squeeze_self=squeeze_self):
+        def map_func(df, other=other, squeeze_self=squeeze_self):  # pragma: no cover
             """Compute matrix multiplication of the passed frames."""
             result = df.squeeze(axis=1).dot(other) if squeeze_self else df.dot(other)
             if is_list_like(result):
@@ -1980,7 +1980,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             sorted in the given order.
         """
 
-        def map_func(df, n=n, keep=keep, columns=columns):
+        def map_func(df, n=n, keep=keep, columns=columns):  # pragma: no cover
             """Return first `N` rows of the sorted data for a single partition."""
             if columns is None:
                 return pandas.DataFrame(
@@ -2035,7 +2035,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def mode(self, **kwargs):
         axis = kwargs.get("axis", 0)
 
-        def mode_builder(df):
+        def mode_builder(df):  # pragma: no cover
             """Compute modes for a single partition."""
             result = pandas.DataFrame(df.mode(**kwargs))
             # We return a dataframe with the same shape as the input to ensure
@@ -2073,7 +2073,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 if full_axis:
                     value = value.to_pandas().squeeze(axis=1)
 
-                    def fillna_builder(series):
+                    def fillna_builder(series):  # pragma: no cover
                         # `limit` parameter works only on `Series` type, so we have to squeeze both objects to get
                         # correct behavior.
                         return series.squeeze(axis=1).fillna(value=value, **kwargs)
@@ -2360,7 +2360,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # __setitem__ methods
     def setitem_bool(self, row_loc, col_loc, item):
-        def _set_item(df, row_loc):
+        def _set_item(df, row_loc):  # pragma: no cover
             df = df.copy()
             df.loc[row_loc.squeeze(axis=1), col_loc] = item
             return df
@@ -2467,7 +2467,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             New QueryCompiler with updated `key` value.
         """
 
-        def setitem_builder(df, internal_indices=[]):
+        def setitem_builder(df, internal_indices=[]):  # pragma: no cover
             """
             Set the row/column to the `value` in a single partition.
 
@@ -2569,7 +2569,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 )
             return result
 
-        def _compute_duplicated(df):
+        def _compute_duplicated(df):  # pragma: no cover
             result = df.duplicated(**kwargs)
             if isinstance(result, pandas.Series):
                 result = result.to_frame(
@@ -2609,7 +2609,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             value.columns = [column]
             return self.insert_item(axis=1, loc=loc, value=value, how=None)
 
-        def insert(df, internal_indices=[]):
+        def insert(df, internal_indices=[]):  # pragma: no cover
             """
             Insert new column to the partition.
 
@@ -2700,7 +2700,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if "axis" not in kwargs:
             kwargs["axis"] = axis
 
-        def dict_apply_builder(df, func_dict={}):
+        def dict_apply_builder(df, func_dict={}):  # pragma: no cover
             # Sometimes `apply` can return a `Series`, but we require that internally
             # all objects are `DataFrame`s.
             return pandas.DataFrame(df.apply(func_dict, *args, **kwargs))
@@ -3323,7 +3323,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if len_values == 0:
             len_values = len(self.columns.drop(unique_keys))
 
-        def applyier(df, other):
+        def applyier(df, other):  # pragma: no cover
             """
             Build pivot table for a single partition.
 
@@ -3393,7 +3393,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         elif not is_list_like(columns):
             columns = [columns]
 
-        def map_fn(df):
+        def map_fn(df):  # pragma: no cover
             cols_to_encode = df.columns.intersection(columns)
             return pandas.get_dummies(df, columns=cols_to_encode, **kwargs)
 

--- a/modin/experimental/batch/pipeline.py
+++ b/modin/experimental/batch/pipeline.py
@@ -258,7 +258,7 @@ class PandasQueryPipeline(object):
                 )
                 new_dfs = []
 
-                def mask_partition(df, i):
+                def mask_partition(df, i):  # pragma: no cover
                     new_length = len(df.index) // self.num_partitions
                     if i == self.num_partitions - 1:
                         return df.iloc[i * new_length :]

--- a/modin/experimental/core/execution/dask/implementations/pandas_on_dask/io/io.py
+++ b/modin/experimental/core/execution/dask/implementations/pandas_on_dask/io/io.py
@@ -105,7 +105,7 @@ class ExperimentalPandasOnDaskIO(PandasOnDaskIO):
             warnings.warn("Defaulting to Modin core implementation")
             return PandasOnDaskIO.to_pickle(qc, **kwargs)
 
-        def func(df, **kw):
+        def func(df, **kw):  # pragma: no cover
             idx = str(kw["partition_idx"])
             # dask doesn't make a copy of kwargs on serialization;
             # so take a copy ourselves, otherwise the error is:

--- a/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -103,7 +103,7 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
             warnings.warn("Defaulting to Modin core implementation")
             return PandasOnRayIO.to_pickle(qc, **kwargs)
 
-        def func(df, **kw):
+        def func(df, **kw):  # pragma: no cover
             idx = str(kw["partition_idx"])
             kwargs["path"] = kwargs.pop("filepath_or_buffer").replace("*", idx)
             df.to_pickle(**kwargs)

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -105,7 +105,7 @@ class ExperimentalPandasOnUnidistIO(PandasOnUnidistIO):
             warnings.warn("Defaulting to Modin core implementation")
             return PandasOnUnidistIO.to_pickle(qc, **kwargs)
 
-        def func(df, **kw):
+        def func(df, **kw):  # pragma: no cover
             idx = str(kw["partition_idx"])
             kwargs["path"] = kwargs.pop("filepath_or_buffer").replace("*", idx)
             df.to_pickle(**kwargs)

--- a/modin/experimental/core/io/sql/utils.py
+++ b/modin/experimental/core/io/sql/utils.py
@@ -233,7 +233,7 @@ def get_query_info(sql, con, partition_column):
     return list(cols.keys()), query
 
 
-def query_put_bounders(query, partition_column, start, end):
+def query_put_bounders(query, partition_column, start, end):  # pragma: no cover
     """
     Put partition boundaries into the query.
 
@@ -285,7 +285,7 @@ def read_sql_with_offset(
     parse_dates=None,
     columns=None,
     chunksize=None,
-):
+):  # pragma: no cover
     """
     Read a chunk of SQL query or table into a pandas DataFrame.
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This will allow us to get more accurate coverage numbers.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5923 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
