### PR TITLE
REFACTOR-#5922: let `upload-coverage` action fail if there is no `.coverage` file

### DIFF
--- a/.github/workflows/upload-coverage/action.yml
+++ b/.github/workflows/upload-coverage/action.yml
@@ -7,9 +7,7 @@ runs:
   steps:
     - run: |
         COVERAGE_UUID=$(python3 -c "import uuid; print(uuid.uuid4())")
-        if [ -f .coverage ]; then
-          mv .coverage .coverage.${COVERAGE_UUID}
-        fi
+        mv .coverage .coverage.${COVERAGE_UUID}
       id: coverage-uuid
       shell: bash
     - uses: actions/upload-artifact@v3.1.2


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This will allow us to see if something goes wrong.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5922 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
