### PR TITLE
FIX-#5889: HDK: Combine multiple lazy concat operations into a single one and replace recursion with iteration

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -998,7 +998,8 @@ class HdkOnNativeDataframe(PandasDataframe):
         # slowly and supports only numeric column types.
         # See https://github.com/intel-ai/hdk/issues/182
         # To work around this issue, perform concatenation
-        # with arrow.
+        # with arrow. The arrow-based concatenation is also
+        # performed if all the frames have an arrow table.
         if (
             len(other_modin_frames) == 0
             or len(self.columns) == 0

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -1227,7 +1227,9 @@ class HdkOnNativeDataframe(PandasDataframe):
                     if not frame._has_arrow_table():
                         frame._execute()
                     if not frame._has_arrow_table():
-                        raise NotImplementedError("PyArrow tables concatenation")
+                        raise NotImplementedError(
+                            "PyArrow tables concatenation without any PyArrow table"
+                        )
                     self.table = frame._partitions[0][0].arrow_table
                 else:
                     self.table = frame_to_table[frame]
@@ -2159,7 +2161,11 @@ class HdkOnNativeDataframe(PandasDataframe):
                 result = frame()
             elif isinstance(frame._op, FrameNode):
                 if frame._partitions.size == 0:
-                    result = pyarrow.Table.from_pandas(pd.DataFrame({}))
+                    result = pyarrow.Table.from_pandas(
+                        pd.DataFrame(
+                            index=frame._index_cache, columns=frame._columns_cache
+                        )
+                    )
                 else:
                     assert frame._partitions.size == 1
                     result = frame._partitions[0][0].get()

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/df_algebra.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/df_algebra.py
@@ -721,6 +721,12 @@ class UnionNode(DFAlgNode):
     ----------
     frames : list of DFAlgNode
         Input frames.
+    join : str
+        Either outer or inner.
+    sort : bool
+        Sort columns.
+    ignore_index : bool
+        Ignore index columns.
 
     Attributes
     ----------
@@ -728,8 +734,11 @@ class UnionNode(DFAlgNode):
         Input frames.
     """
 
-    def __init__(self, frames):
+    def __init__(self, frames, join, sort, ignore_index):
         self.input = frames
+        self.join = join
+        self.sort = sort
+        self.ignore_index = ignore_index
 
     def copy(self):
         """

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -20,7 +20,7 @@ import numpy as np
 from modin.core.dataframe.pandas.partitioning.partition_manager import (
     PandasDataframePartitionManager,
 )
-from ..dataframe.utils import ColNameCodec, mangle_index_names
+from ..dataframe.utils import ColNameCodec
 from ..partitioning.partition import HdkOnNativeDataframePartition
 from ..db_worker import DbWorker
 from ..calcite_builder import CalciteBuilder
@@ -296,7 +296,7 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
                                 if frame.has_materialized_index
                                 else [None]
                             )
-                            idx_names = mangle_index_names(idx_names)
+                            idx_names = ColNameCodec.mangle_index_names(idx_names)
                             obj = pyarrow.table(
                                 {n: [] for n in idx_names},
                                 schema=pyarrow.schema(

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -20,7 +20,7 @@ import numpy as np
 from modin.core.dataframe.pandas.partitioning.partition_manager import (
     PandasDataframePartitionManager,
 )
-from ..dataframe.utils import ColNameCodec
+from ..dataframe.utils import ColNameCodec, mangle_index_names
 from ..partitioning.partition import HdkOnNativeDataframePartition
 from ..db_worker import DbWorker
 from ..calcite_builder import CalciteBuilder
@@ -296,7 +296,7 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
                                 if frame.has_materialized_index
                                 else [None]
                             )
-                            idx_names = frame._mangle_index_names(idx_names)
+                            idx_names = mangle_index_names(idx_names)
                             obj = pyarrow.table(
                                 {n: [] for n in idx_names},
                                 schema=pyarrow.schema(

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -800,6 +800,19 @@ class TestConcat:
             force_lazy=False,
         )
 
+    # RecursionError in case of concatenation of big number of frames
+    def test_issue_5889(self):
+        with ensure_clean(".csv") as file:
+            pandas.DataFrame({"a": [1, 2, 3, 4]}).to_csv(file, index=False)
+
+            def test_concat(lib, n_concats, **kwargs):
+                df = lib.read_csv(file)
+                for _ in range(n_concats):
+                    df = lib.concat([df, lib.read_csv(file)])
+                return df
+
+            run_and_compare(test_concat, data={}, n_concats=500)
+
 
 class TestGroupby:
     data = {

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -805,13 +805,16 @@ class TestConcat:
         with ensure_clean(".csv") as file:
             pandas.DataFrame({"a": [1, 2, 3, 4]}).to_csv(file, index=False)
 
-            def test_concat(lib, n_concats, **kwargs):
+            def test_concat(lib, n_concats, sort_last, **kwargs):
                 df = lib.read_csv(file)
                 for _ in range(n_concats):
                     df = lib.concat([df, lib.read_csv(file)])
+                if sort_last:
+                    df = lib.concat([df, lib.read_csv(file)], sort=True)
                 return df
 
-            run_and_compare(test_concat, data={}, n_concats=500)
+            run_and_compare(test_concat, data={}, n_concats=500, sort_last=False)
+            run_and_compare(test_concat, data={}, n_concats=2, sort_last=True)
 
 
 class TestGroupby:


### PR DESCRIPTION
1. If all frames are either FrameNode(materialized frame) or UnionNode, containing only FrameNodes and having the same concatenation options, put all frames into a single UnionNode. It allows to concatenate multiple frames with arrow in a single batch operation.
2. Use iteration instead of recursion for lazy frames materialization.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5889 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
