### PR TITLE
REFACTOR-#0000: use `pure=True` by default for `DaskWrapper.deploy`

### DIFF
--- a/modin/core/execution/dask/common/engine_wrapper.py
+++ b/modin/core/execution/dask/common/engine_wrapper.py
@@ -49,7 +49,7 @@ class DaskWrapper:
         f_args=None,
         f_kwargs=None,
         num_returns=1,
-        pure=True,
+        pure=False,
     ):
         """
         Deploy a function in a worker process.

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
@@ -96,7 +96,6 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
                 func=apply_list_of_funcs,
                 f_args=(call_queue, self._data),
                 num_returns=2,
-                pure=False,
             )
         else:
             # We handle `len(call_queue) == 1` in a different way because
@@ -107,7 +106,6 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
                 f_args=(self._data, func, *f_args),
                 f_kwargs=f_kwargs,
                 num_returns=2,
-                pure=False,
             )
             self._is_debug(log) and log.debug(f"SUBMIT::_apply_func::{self._identity}")
         self._is_debug(log) and log.debug(f"EXIT::Partition.apply::{self._identity}")
@@ -130,7 +128,6 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
                 func=apply_list_of_funcs,
                 f_args=(call_queue, self._data),
                 num_returns=2,
-                pure=False,
             )
         else:
             # We handle `len(call_queue) == 1` in a different way because
@@ -142,7 +139,6 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
                 f_args=(self._data, func, *f_args),
                 f_kwargs=f_kwargs,
                 num_returns=2,
-                pure=False,
             )
         self._data = futures[0]
         self._ip_cache = futures[1]

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -206,7 +206,6 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
                 "manual_partition": manual_partition,
             },
             num_returns=result_num_splits * 4,
-            pure=False,
         )
 
     @classmethod
@@ -263,7 +262,6 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
                 *partitions,
             ),
             num_returns=num_splits * 4,
-            pure=False,
         )
 
     def _wrap_partitions(self, partitions):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
