### PR TITLE
FIX-#5203: don't raise `AttributeError: 'list' object has no attribute '_query_compiler'` in `join` op

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -41,6 +41,7 @@ import numpy as np
 import sys
 from typing import IO, Optional, Union, Iterator, Hashable, Sequence
 import warnings
+from collections import abc
 
 import modin
 from modin.pandas import Categorical
@@ -1335,7 +1336,7 @@ class DataFrame(BasePandasDataset):
         """
         Join columns of another ``DataFrame``.
         """
-        if validate is not None:
+        if validate is not None or (on is not None and isinstance(other, abc.Iterable)):
             return self._default_to_pandas(
                 pandas.DataFrame.join,
                 other,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -41,7 +41,6 @@ import numpy as np
 import sys
 from typing import IO, Optional, Union, Iterator, Hashable, Sequence
 import warnings
-from collections import abc
 
 import modin
 from modin.pandas import Categorical
@@ -1336,7 +1335,11 @@ class DataFrame(BasePandasDataset):
         """
         Join columns of another ``DataFrame``.
         """
-        if validate is not None or (on is not None and isinstance(other, abc.Iterable)):
+        if on is not None and not isinstance(other, (Series, DataFrame)):
+            raise ValueError(
+                "Joining multiple DataFrames only supported for joining on index"
+            )
+        if validate is not None:
             return self._default_to_pandas(
                 pandas.DataFrame.join,
                 other,

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -167,14 +167,18 @@ def test_join(test_data, test_data2):
 
 
 def test_join_5203():
-    df1 = pd.DataFrame(np.ones([2, 4]), columns=["a", "b", "c", "d"])
-    df2 = pd.DataFrame(np.ones([2, 4]), columns=["a", "b", "c", "d"])
-    df3 = pd.DataFrame(np.ones([2, 4]), columns=["a", "b", "c", "d"])
-    with pytest.raises(
-        ValueError,
-        match="Joining multiple DataFrames only supported for joining on index",
-    ):
-        df1.join([df2, df3], how="inner", on="a")
+    data = np.ones([2, 4])
+    kwargs = {"columns": ["a", "b", "c", "d"]}
+    modin_dfs, pandas_dfs = [None] * 3, [None] * 3
+    for idx in range(len(modin_dfs)):
+        modin_dfs[idx], pandas_dfs[idx] = create_test_dfs(data, **kwargs)
+
+    for dfs in (modin_dfs, pandas_dfs):
+        with pytest.raises(
+            ValueError,
+            match="Joining multiple DataFrames only supported for joining on index",
+        ):
+            dfs[0].join([dfs[1], dfs[2]], how="inner", on="a")
 
 
 @pytest.mark.parametrize(

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -166,6 +166,17 @@ def test_join(test_data, test_data2):
         df_equals(modin_join, pandas_join)
 
 
+def test_join_5203():
+    df1 = pd.DataFrame(np.ones([2, 4]), columns=["a", "b", "c", "d"])
+    df2 = pd.DataFrame(np.ones([2, 4]), columns=["a", "b", "c", "d"])
+    df3 = pd.DataFrame(np.ones([2, 4]), columns=["a", "b", "c", "d"])
+    with pytest.raises(
+        ValueError,
+        match="Joining multiple DataFrames only supported for joining on index",
+    ):
+        df1.join([df2, df3], how="inner", on="a")
+
+
 @pytest.mark.parametrize(
     "test_data, test_data2",
     [


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5203 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
