### PR TITLE
TEST-#5933: Add assert_array_equals utility to numpy tests

### DIFF
--- a/modin/numpy/test/test_array.py
+++ b/modin/numpy/test/test_array.py
@@ -16,6 +16,7 @@ import pytest
 import warnings
 
 import modin.numpy as np
+from .utils import assert_scalar_or_array_equal
 
 
 @pytest.fixture
@@ -73,8 +74,8 @@ def test_conversion():
     assert isinstance(df_converted, np.array)
     series_converted = try_convert_from_interoperable_type(series)
     assert isinstance(series_converted, np.array)
-    numpy.testing.assert_array_equal(df_converted._to_numpy(), df.to_numpy())
-    numpy.testing.assert_array_equal(series_converted._to_numpy(), series.to_numpy())
+    assert_scalar_or_array_equal(df_converted, df)
+    assert_scalar_or_array_equal(series_converted, series)
     pandas_df = df._to_pandas()
     pandas_series = series._to_pandas()
     pandas_converted = try_convert_from_interoperable_type(pandas_df)
@@ -138,11 +139,11 @@ def test_update_inplace():
     arr1 = np.array([1, 2, 3])
     arr2 = np.array(out, copy=False)
     np.add(arr1, arr1, out=out)
-    numpy.testing.assert_array_equal(out._to_numpy(), arr2._to_numpy())
+    assert_scalar_or_array_equal(out, arr2)
     out = np.array([1, 2, 3])
     arr2 = np.array(out, copy=False)
     np.add(arr1, arr1, out=out, where=False)
-    numpy.testing.assert_array_equal(out._to_numpy(), arr2._to_numpy())
+    assert_scalar_or_array_equal(out, arr2)
 
 
 @pytest.mark.parametrize(
@@ -160,7 +161,7 @@ def test_out_broadcast(data_out):
     modin_out, numpy_out = np.array(data_out), numpy.array(data_out)
     numpy.add(numpy.array(data1), numpy.array(data2), out=numpy_out)
     np.add(np.array(data1), np.array(data2), out=modin_out)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
 
 
 def test_out_broadcast_error():
@@ -200,13 +201,13 @@ def test_array_ufunc(size):
     # Test ufunc.__call__
     numpy_arr = numpy.random.randint(-100, 100, size=size)
     modin_arr = np.array(numpy_arr)
-    modin_result = numpy.sign(modin_arr)._to_numpy()
+    modin_result = numpy.sign(modin_arr)
     numpy_result = numpy.sign(numpy_arr)
-    numpy.testing.assert_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     # Test ufunc that we have support for.
-    modin_result = numpy.add(modin_arr, modin_arr)._to_numpy()
+    modin_result = numpy.add(modin_arr, modin_arr)
     numpy_result = numpy.add(numpy_arr, numpy_arr)
-    numpy.testing.assert_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     # Test ufunc that we have support for, but method that we do not implement.
     modin_result = numpy.add.reduce(modin_arr)
     numpy_result = numpy.add.reduce(numpy_arr)
@@ -220,13 +221,13 @@ def test_array_function(size):
     numpy_arr = numpy.random.randint(-100, 100, size=size)
     modin_arr = np.array(numpy_arr)
     # Test from array shaping
-    modin_result = numpy.ravel(modin_arr)._to_numpy()
+    modin_result = numpy.ravel(modin_arr)
     numpy_result = numpy.ravel(numpy_arr)
-    numpy.testing.assert_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     # Test from array creation
-    modin_result = numpy.zeros_like(modin_arr)._to_numpy()
+    modin_result = numpy.zeros_like(modin_arr)
     numpy_result = numpy.zeros_like(numpy_arr)
-    numpy.testing.assert_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     # Test from math
     modin_result = numpy.sum(modin_arr)
     numpy_result = numpy.sum(numpy_arr)
@@ -247,54 +248,46 @@ def test_array_where():
         warnings.filterwarnings("ignore", message="Distributing")
         modin_result = (modin_flat_arr <= 0).where(x=4, y=5)
     numpy_result = numpy.where(numpy_flat_arr <= 0, 4, 5)
-    numpy.testing.assert_array_equal(numpy_result, modin_result._to_numpy())
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_flat_bool_arr = modin_flat_arr <= 0
     numpy_flat_bool_arr = numpy_flat_arr <= 0
     modin_result = modin_flat_bool_arr.where(x=5, y=modin_flat_arr)
     numpy_result = numpy.where(numpy_flat_bool_arr, 5, numpy_flat_arr)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_flat_bool_arr.where(x=modin_flat_arr, y=5)
     numpy_result = numpy.where(numpy_flat_bool_arr, numpy_flat_arr, 5)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_flat_bool_arr.where(x=modin_flat_arr, y=(-1 * modin_flat_arr))
     numpy_result = numpy.where(
         numpy_flat_bool_arr, numpy_flat_arr, (-1 * numpy_flat_arr)
     )
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     numpy_arr = numpy_flat_arr.reshape((10, 10))
     modin_arr = np.array(numpy_arr)
     modin_bool_arr = modin_arr > 0
     numpy_bool_arr = numpy_arr > 0
     modin_result = modin_bool_arr.where(modin_arr, 10 * modin_arr)
     numpy_result = numpy.where(numpy_bool_arr, numpy_arr, 10 * numpy_arr)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 def test_flatten():
     numpy_flat_arr = numpy.random.randint(-100, 100, size=100)
     modin_flat_arr = np.array(numpy_flat_arr)
-    numpy.testing.assert_array_equal(
-        numpy_flat_arr.flatten(), modin_flat_arr.flatten()._to_numpy()
-    )
+    assert_scalar_or_array_equal(modin_flat_arr.flatten(), numpy_flat_arr.flatten())
     numpy_arr = numpy_flat_arr.reshape((10, 10))
     modin_arr = np.array(numpy_arr)
-    numpy.testing.assert_array_equal(
-        numpy_arr.flatten(), modin_arr.flatten()._to_numpy()
-    )
+    assert_scalar_or_array_equal(modin_arr.flatten(), numpy_arr.flatten())
 
 
 def test_transpose():
     numpy_flat_arr = numpy.random.randint(-100, 100, size=100)
     modin_flat_arr = np.array(numpy_flat_arr)
-    numpy.testing.assert_array_equal(
-        numpy_flat_arr.transpose(), modin_flat_arr.transpose()._to_numpy()
-    )
+    assert_scalar_or_array_equal(modin_flat_arr.transpose(), numpy_flat_arr.transpose())
     numpy_arr = numpy_flat_arr.reshape((10, 10))
     modin_arr = np.array(numpy_arr)
-    numpy.testing.assert_array_equal(
-        numpy_arr.transpose(), modin_arr.transpose()._to_numpy()
-    )
-    numpy.testing.assert_array_equal(numpy_arr.T, modin_arr.T._to_numpy())
+    assert_scalar_or_array_equal(modin_arr.transpose(), numpy_arr.transpose())
+    assert_scalar_or_array_equal(modin_arr.T, numpy_arr.T)
 
 
 def test_astype():
@@ -303,19 +296,19 @@ def test_astype():
     modin_result = modin_arr.astype(numpy.float64)
     numpy_result = numpy_arr.astype(numpy.float64)
     assert modin_result.dtype == numpy_result.dtype
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.astype(str)
     numpy_result = numpy_arr.astype(str)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_arr, numpy_arr)
     modin_result = modin_arr.astype(str, copy=False)
     numpy_result = numpy_arr.astype(str, copy=False)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_arr, numpy_arr)
     modin_result = modin_arr.astype(numpy.float64, copy=False)
     numpy_result = numpy_arr.astype(numpy.float64, copy=False)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_arr, numpy_arr)
 
 
 def test_set_shape():
@@ -323,8 +316,8 @@ def test_set_shape():
     numpy_arr.shape = (6,)
     modin_arr = np.array([[1, 2, 3], [4, 5, 6]])
     modin_arr.shape = (6,)
-    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+    assert_scalar_or_array_equal(modin_arr, numpy_arr)
     modin_arr.shape = 6  # Same as using (6,)
-    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+    assert_scalar_or_array_equal(modin_arr, numpy_arr)
     with pytest.raises(ValueError, match="cannot reshape"):
         modin_arr.shape = (4,)

--- a/modin/numpy/test/test_array_arithmetic.py
+++ b/modin/numpy/test/test_array_arithmetic.py
@@ -15,6 +15,7 @@ import numpy
 import pytest
 
 import modin.numpy as np
+from .utils import assert_scalar_or_array_equal
 
 
 @pytest.mark.parametrize(
@@ -67,8 +68,8 @@ def test_basic_arithmetic_with_broadcast(operand1_shape, operand2_shape, operato
     else:
         modin_result = getattr(np.array(operand1), operator)(np.array(operand2))
     if operator not in ["__truediv__", "__rtruediv__"]:
-        numpy.testing.assert_array_equal(
-            modin_result._to_numpy(),
+        assert_scalar_or_array_equal(
+            modin_result,
             numpy_result,
             err_msg=f"Binary Op {operator} failed.",
         )
@@ -148,16 +149,17 @@ def test_arithmetic(operator):
 def test_arithmetic_nans_and_zeros():
     numpy_arr1 = numpy.array([[1, 0, 3], [numpy.nan, 0, numpy.nan]])
     numpy_arr2 = numpy.array([1, 0, 0])
-    numpy.testing.assert_array_equal(
+    assert_scalar_or_array_equal(
+        (np.array(numpy_arr1) // np.array(numpy_arr2)),
         numpy_arr1 // numpy_arr2,
-        (np.array(numpy_arr1) // np.array(numpy_arr2))._to_numpy(),
     )
-    numpy.testing.assert_array_equal(
-        numpy.array([0]) // 0, (np.array([0]) // 0)._to_numpy()
+    assert_scalar_or_array_equal(
+        (np.array([0]) // 0),
+        numpy.array([0]) // 0,
     )
-    numpy.testing.assert_array_equal(
+    assert_scalar_or_array_equal(
+        (np.array([0], dtype=numpy.float64) // 0),
         numpy.array([0], dtype=numpy.float64) // 0,
-        (np.array([0], dtype=numpy.float64) // 0)._to_numpy(),
     )
 
 
@@ -166,39 +168,39 @@ def test_scalar_arithmetic(size):
     numpy_arr = numpy.random.randint(-100, 100, size=size)
     modin_arr = np.array(numpy_arr)
     scalar = numpy.random.randint(1, 100)
-    numpy.testing.assert_array_equal(
-        (scalar * modin_arr)._to_numpy(), scalar * numpy_arr, err_msg="__mul__ failed."
+    assert_scalar_or_array_equal(
+        (scalar * modin_arr), scalar * numpy_arr, err_msg="__mul__ failed."
     )
-    numpy.testing.assert_array_equal(
-        (modin_arr * scalar)._to_numpy(),
+    assert_scalar_or_array_equal(
+        (modin_arr * scalar),
         scalar * numpy_arr,
         err_msg="__rmul__ failed.",
     )
-    numpy.testing.assert_array_equal(
-        (scalar / modin_arr)._to_numpy(),
+    assert_scalar_or_array_equal(
+        (scalar / modin_arr),
         scalar / numpy_arr,
         err_msg="__rtruediv__ failed.",
     )
-    numpy.testing.assert_array_equal(
-        (modin_arr / scalar)._to_numpy(),
+    assert_scalar_or_array_equal(
+        (modin_arr / scalar),
         numpy_arr / scalar,
         err_msg="__truediv__ failed.",
     )
-    numpy.testing.assert_array_equal(
-        (scalar + modin_arr)._to_numpy(),
+    assert_scalar_or_array_equal(
+        (scalar + modin_arr),
         scalar + numpy_arr,
         err_msg="__radd__ failed.",
     )
-    numpy.testing.assert_array_equal(
-        (modin_arr + scalar)._to_numpy(), scalar + numpy_arr, err_msg="__add__ failed."
+    assert_scalar_or_array_equal(
+        (modin_arr + scalar), scalar + numpy_arr, err_msg="__add__ failed."
     )
-    numpy.testing.assert_array_equal(
-        (scalar - modin_arr)._to_numpy(),
+    assert_scalar_or_array_equal(
+        (scalar - modin_arr),
         scalar - numpy_arr,
         err_msg="__rsub__ failed.",
     )
-    numpy.testing.assert_array_equal(
-        (modin_arr - scalar)._to_numpy(), numpy_arr - scalar, err_msg="__sub__ failed."
+    assert_scalar_or_array_equal(
+        (modin_arr - scalar), numpy_arr - scalar, err_msg="__sub__ failed."
     )
 
 
@@ -206,27 +208,27 @@ def test_scalar_arithmetic(size):
 def test_unary_arithmetic(op_name):
     numpy_flat_arr = numpy.random.randint(-100, 100, size=100)
     modin_flat_arr = np.array(numpy_flat_arr)
-    numpy.testing.assert_array_equal(
+    assert_scalar_or_array_equal(
+        getattr(np, op_name)(modin_flat_arr),
         getattr(numpy, op_name)(numpy_flat_arr),
-        getattr(np, op_name)(modin_flat_arr)._to_numpy(),
     )
     numpy_arr = numpy_flat_arr.reshape((10, 10))
     modin_arr = np.array(numpy_arr)
-    numpy.testing.assert_array_equal(
-        getattr(numpy, op_name)(numpy_arr), getattr(np, op_name)(modin_arr)._to_numpy()
+    assert_scalar_or_array_equal(
+        getattr(np, op_name)(modin_arr), getattr(numpy, op_name)(numpy_arr)
     )
 
 
 def test_invert():
     numpy_flat_arr = numpy.random.randint(-100, 100, size=100)
     modin_flat_arr = np.array(numpy_flat_arr)
-    numpy.testing.assert_array_equal(~numpy_flat_arr, (~modin_flat_arr)._to_numpy())
+    assert_scalar_or_array_equal(~modin_flat_arr, ~numpy_flat_arr)
     numpy_arr = numpy_flat_arr.reshape((10, 10))
     modin_arr = np.array(numpy_arr)
-    numpy.testing.assert_array_equal(~numpy_arr, (~modin_arr)._to_numpy())
+    assert_scalar_or_array_equal(~modin_arr, ~numpy_arr)
     numpy_flat_arr = numpy.random.randint(-100, 100, size=100) < 0
     modin_flat_arr = np.array(numpy_flat_arr)
-    numpy.testing.assert_array_equal(~numpy_flat_arr, (~modin_flat_arr)._to_numpy())
+    assert_scalar_or_array_equal(~modin_flat_arr, ~numpy_flat_arr)
     numpy_arr = numpy_flat_arr.reshape((10, 10))
     modin_arr = np.array(numpy_arr)
-    numpy.testing.assert_array_equal(~numpy_arr, (~modin_arr)._to_numpy())
+    assert_scalar_or_array_equal(~modin_arr, ~numpy_arr)

--- a/modin/numpy/test/test_array_axis_functions.py
+++ b/modin/numpy/test/test_array_axis_functions.py
@@ -15,6 +15,7 @@ import numpy
 import pytest
 
 import modin.numpy as np
+from .utils import assert_scalar_or_array_equal
 
 
 def test_max():
@@ -34,7 +35,7 @@ def test_max():
     modin_result = modin_arr.max(keepdims=True)
     numpy_result = numpy_arr.max(keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     numpy_arr = numpy.array([1, 10000, 2, 3, 4, 5])
     modin_arr = np.array(numpy_arr)
     numpy_mask = numpy.array([True, False, True, True, True, True])
@@ -49,19 +50,19 @@ def test_max():
     modin_result = modin_arr.max(axis=0)
     numpy_result = numpy_arr.max(axis=0)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.max(axis=0, keepdims=True)
     numpy_result = numpy_arr.max(axis=0, keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.max(axis=1)
     numpy_result = numpy_arr.max(axis=1)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.max(axis=1, keepdims=True)
     numpy_result = numpy_arr.max(axis=1, keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.max(initial=200)
     numpy_result = numpy_arr.max(initial=200)
     assert modin_result == numpy_result
@@ -74,31 +75,31 @@ def test_max():
     numpy_out = modin_out._to_numpy()
     modin_result = modin_arr.max(out=modin_out, keepdims=True)
     numpy_result = numpy_arr.max(out=numpy_out, keepdims=True)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_arr = numpy.random.randint(-100, 100, size=(20, 20))
     modin_arr = np.array(numpy_arr)
     modin_result = modin_arr.max(axis=0, where=False, initial=4)
     numpy_result = numpy_arr.max(axis=0, where=False, initial=4)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.max(axis=0, where=False, initial=4, out=modin_out)
     numpy_result = numpy_arr.max(axis=0, where=False, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.max(axis=0, initial=4, out=modin_out)
     numpy_result = numpy_arr.max(axis=0, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.max(axis=1, initial=4, out=modin_out)
     numpy_result = numpy_arr.max(axis=1, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     numpy_where = numpy.full(20, False)
@@ -107,15 +108,15 @@ def test_max():
     modin_where = np.array(numpy_where)
     modin_result = modin_arr.max(axis=0, initial=4, out=modin_out, where=modin_where)
     numpy_result = numpy_arr.max(axis=0, initial=4, out=numpy_out, where=numpy_where)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_arr = numpy.array([[1, 10000, 2], [3, 4, 5]])
     modin_arr = np.array(numpy_arr)
     numpy_mask = numpy.array([[True, False, True], [True, True, True]])
     modin_mask = np.array(numpy_mask)
-    numpy.testing.assert_equal(
-        numpy_arr.max(where=numpy_mask, initial=5),
+    assert_scalar_or_array_equal(
         modin_arr.max(where=modin_mask, initial=5),
+        numpy_arr.max(where=numpy_mask, initial=5),
     )
 
 
@@ -136,7 +137,7 @@ def test_min():
     modin_result = modin_arr.min(keepdims=True)
     numpy_result = numpy_arr.min(keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     numpy_arr = numpy.array([1, -10000, 2, 3, 4, 5])
     modin_arr = np.array(numpy_arr)
     numpy_mask = numpy.array([True, False, True, True, True, True])
@@ -151,19 +152,19 @@ def test_min():
     modin_result = modin_arr.min(axis=0)
     numpy_result = numpy_arr.min(axis=0)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.min(axis=0, keepdims=True)
     numpy_result = numpy_arr.min(axis=0, keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.min(axis=1)
     numpy_result = numpy_arr.min(axis=1)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.min(axis=1, keepdims=True)
     numpy_result = numpy_arr.min(axis=1, keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.min(initial=-200)
     numpy_result = numpy_arr.min(initial=-200)
     assert modin_result == numpy_result
@@ -176,31 +177,31 @@ def test_min():
     numpy_out = modin_out._to_numpy()
     modin_result = modin_arr.min(out=modin_out, keepdims=True)
     numpy_result = numpy_arr.min(out=numpy_out, keepdims=True)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_arr = numpy.random.randint(-100, 100, size=(20, 20))
     modin_arr = np.array(numpy_arr)
     modin_result = modin_arr.min(axis=0, where=False, initial=4)
     numpy_result = numpy_arr.min(axis=0, where=False, initial=4)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.min(axis=0, where=False, initial=4, out=modin_out)
     numpy_result = numpy_arr.min(axis=0, where=False, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.min(axis=0, initial=4, out=modin_out)
     numpy_result = numpy_arr.min(axis=0, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.min(axis=1, initial=4, out=modin_out)
     numpy_result = numpy_arr.min(axis=1, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     numpy_where = numpy.full(20, False)
@@ -209,15 +210,15 @@ def test_min():
     modin_where = np.array(numpy_where)
     modin_result = modin_arr.min(axis=0, initial=4, out=modin_out, where=modin_where)
     numpy_result = numpy_arr.min(axis=0, initial=4, out=numpy_out, where=numpy_where)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_arr = numpy.array([[1, -10000, 2], [3, 4, 5]])
     modin_arr = np.array(numpy_arr)
     numpy_mask = numpy.array([[True, False, True], [True, True, True]])
     modin_mask = np.array(numpy_mask)
-    numpy.testing.assert_equal(
-        numpy_arr.min(where=numpy_mask, initial=5),
+    assert_scalar_or_array_equal(
         modin_arr.min(where=modin_mask, initial=5),
+        numpy_arr.min(where=numpy_mask, initial=5),
     )
 
 
@@ -238,7 +239,7 @@ def test_sum():
     modin_result = modin_arr.sum(keepdims=True)
     numpy_result = numpy_arr.sum(keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     numpy_arr = numpy.array([1, 10000, 2, 3, 4, 5])
     modin_arr = np.array(numpy_arr)
     numpy_mask = numpy.array([True, False, True, True, True, True])
@@ -251,19 +252,19 @@ def test_sum():
     modin_result = modin_arr.sum(axis=0)
     numpy_result = numpy_arr.sum(axis=0)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.sum(axis=0, keepdims=True)
     numpy_result = numpy_arr.sum(axis=0, keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.sum(axis=1)
     numpy_result = numpy_arr.sum(axis=1)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.sum(axis=1, keepdims=True)
     numpy_result = numpy_arr.sum(axis=1, keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.sum(initial=-200)
     numpy_result = numpy_arr.sum(initial=-200)
     assert modin_result == numpy_result
@@ -276,31 +277,31 @@ def test_sum():
     numpy_out = modin_out._to_numpy()
     modin_result = modin_arr.sum(out=modin_out, keepdims=True)
     numpy_result = numpy_arr.sum(out=numpy_out, keepdims=True)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_arr = numpy.random.randint(-100, 100, size=(20, 20))
     modin_arr = np.array(numpy_arr)
     modin_result = modin_arr.sum(axis=0, where=False, initial=4)
     numpy_result = numpy_arr.sum(axis=0, where=False, initial=4)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.sum(axis=0, where=False, initial=4, out=modin_out)
     numpy_result = numpy_arr.sum(axis=0, where=False, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.sum(axis=0, initial=4, out=modin_out)
     numpy_result = numpy_arr.sum(axis=0, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.sum(axis=1, initial=4, out=modin_out)
     numpy_result = numpy_arr.sum(axis=1, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     numpy_where = numpy.full(20, False)
@@ -309,8 +310,8 @@ def test_sum():
     modin_where = np.array(numpy_where)
     modin_result = modin_arr.sum(axis=0, initial=4, out=modin_out, where=modin_where)
     numpy_result = numpy_arr.sum(axis=0, initial=4, out=numpy_out, where=numpy_where)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_where = numpy.full(400, False)
     numpy_where[:200] = True
     numpy.random.shuffle(numpy_where)
@@ -323,11 +324,13 @@ def test_sum():
     numpy_arr = numpy.array([[1, 2], [3, 4], [5, numpy.nan]])
     modin_arr = np.array([[1, 2], [3, 4], [5, np.nan]])
     assert numpy.isnan(modin_arr.sum())
-    numpy.testing.assert_array_equal(
-        numpy_arr.sum(axis=1), modin_arr.sum(axis=1)._to_numpy()
+    assert_scalar_or_array_equal(
+        modin_arr.sum(axis=1),
+        numpy_arr.sum(axis=1),
     )
-    numpy.testing.assert_array_equal(
-        numpy_arr.sum(axis=0), modin_arr.sum(axis=0)._to_numpy()
+    assert_scalar_or_array_equal(
+        modin_arr.sum(axis=0),
+        numpy_arr.sum(axis=0),
     )
 
 
@@ -345,7 +348,7 @@ def test_mean():
     modin_result = modin_arr.mean(keepdims=True)
     numpy_result = numpy_arr.mean(keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     numpy_arr = numpy.array([1, 10000, 2, 3, 4, 5])
     modin_arr = np.array(numpy_arr)
     numpy_mask = numpy.array([True, False, True, True, True, True])
@@ -358,19 +361,19 @@ def test_mean():
     modin_result = modin_arr.mean(axis=0)
     numpy_result = numpy_arr.mean(axis=0)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.mean(axis=0, keepdims=True)
     numpy_result = numpy_arr.mean(axis=0, keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.mean(axis=1)
     numpy_result = numpy_arr.mean(axis=1)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.mean(axis=1, keepdims=True)
     numpy_result = numpy_arr.mean(axis=1, keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.mean()
     numpy_result = numpy_arr.mean()
     assert modin_result == numpy_result
@@ -380,28 +383,28 @@ def test_mean():
     numpy_out = modin_out._to_numpy()
     modin_result = modin_arr.mean(out=modin_out, keepdims=True)
     numpy_result = numpy_arr.mean(out=numpy_out, keepdims=True)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_arr = numpy.random.randint(-100, 100, size=(20, 20))
     modin_arr = np.array(numpy_arr)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.mean(axis=0, where=False, out=modin_out)
     numpy_result = numpy_arr.mean(axis=0, where=False, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.mean(axis=0, out=modin_out)
     numpy_result = numpy_arr.mean(axis=0, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.mean(axis=1, out=modin_out)
     numpy_result = numpy_arr.mean(axis=1, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     numpy_where = numpy.full(20, False)
@@ -410,8 +413,8 @@ def test_mean():
     modin_where = np.array(numpy_where)
     modin_result = modin_arr.mean(axis=0, out=modin_out, where=modin_where)
     numpy_result = numpy_arr.mean(axis=0, out=numpy_out, where=numpy_where)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_where = numpy.full(400, False)
     numpy_where[:200] = True
     numpy.random.shuffle(numpy_where)
@@ -424,11 +427,13 @@ def test_mean():
     numpy_arr = numpy.array([[1, 2], [3, 4], [5, numpy.nan]])
     modin_arr = np.array([[1, 2], [3, 4], [5, np.nan]])
     assert numpy.isnan(modin_arr.mean())
-    numpy.testing.assert_array_equal(
-        numpy_arr.mean(axis=1), modin_arr.mean(axis=1)._to_numpy()
+    assert_scalar_or_array_equal(
+        modin_arr.mean(axis=1),
+        numpy_arr.mean(axis=1),
     )
-    numpy.testing.assert_array_equal(
-        numpy_arr.mean(axis=0), modin_arr.mean(axis=0)._to_numpy()
+    assert_scalar_or_array_equal(
+        modin_arr.mean(axis=0),
+        numpy_arr.mean(axis=0),
     )
     numpy_where = numpy.array([[True, True], [True, True], [True, False]])
     modin_where = np.array(numpy_where)
@@ -452,7 +457,7 @@ def test_prod():
     modin_result = modin_arr.prod(keepdims=True)
     numpy_result = numpy_arr.prod(keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     numpy_arr = numpy.array([1, 10000, 2, 3, 4, 5])
     modin_arr = np.array(numpy_arr)
     numpy_mask = numpy.array([True, False, True, True, True, True])
@@ -465,19 +470,19 @@ def test_prod():
     modin_result = modin_arr.prod(axis=0)
     numpy_result = numpy_arr.prod(axis=0)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.prod(axis=0, keepdims=True)
     numpy_result = numpy_arr.prod(axis=0, keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.prod(axis=1)
     numpy_result = numpy_arr.prod(axis=1)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.prod(axis=1, keepdims=True)
     numpy_result = numpy_arr.prod(axis=1, keepdims=True)
     assert modin_result.shape == numpy_result.shape
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     modin_result = modin_arr.prod(initial=-200)
     numpy_result = numpy_arr.prod(initial=-200)
     assert modin_result == numpy_result
@@ -490,33 +495,33 @@ def test_prod():
     numpy_out = modin_out._to_numpy()
     modin_result = modin_arr.prod(out=modin_out, keepdims=True)
     numpy_result = numpy_arr.prod(out=numpy_out, keepdims=True)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_arr = numpy.random.randint(-100, 100, size=(20, 20))
     modin_arr = np.array(numpy_arr)
     modin_result = modin_arr.prod(axis=0, where=False, initial=4)
     numpy_result = numpy_arr.prod(axis=0, where=False, initial=4)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.prod(axis=0, where=False, initial=4, out=modin_out)
     numpy_result = numpy_arr.prod(axis=0, where=False, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_arr = numpy.random.randint(-100, 100, size=(20, 20))
     modin_arr = np.array(numpy_arr)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.prod(axis=0, initial=4, out=modin_out)
     numpy_result = numpy_arr.prod(axis=0, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     modin_result = modin_arr.prod(axis=1, initial=4, out=modin_out)
     numpy_result = numpy_arr.prod(axis=1, initial=4, out=numpy_out)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_out = numpy.ones(20)
     modin_out = np.array(numpy_out)
     numpy_where = numpy.full(20, False)
@@ -525,8 +530,8 @@ def test_prod():
     modin_where = np.array(numpy_where)
     modin_result = modin_arr.prod(axis=0, initial=4, out=modin_out, where=modin_where)
     numpy_result = numpy_arr.prod(axis=0, initial=4, out=numpy_out, where=numpy_where)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
-    numpy.testing.assert_array_equal(modin_out._to_numpy(), numpy_out)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_out, numpy_out)
     numpy_where = numpy.full(400, False)
     numpy_where[:200] = True
     numpy.random.shuffle(numpy_where)
@@ -539,9 +544,11 @@ def test_prod():
     numpy_arr = numpy.array([[1, 2], [3, 4], [5, numpy.nan]])
     modin_arr = np.array([[1, 2], [3, 4], [5, np.nan]])
     assert numpy.isnan(modin_arr.prod())
-    numpy.testing.assert_array_equal(
-        numpy_arr.prod(axis=1), modin_arr.prod(axis=1)._to_numpy()
+    assert_scalar_or_array_equal(
+        modin_arr.prod(axis=1),
+        numpy_arr.prod(axis=1),
     )
-    numpy.testing.assert_array_equal(
-        numpy_arr.prod(axis=0), modin_arr.prod(axis=0)._to_numpy()
+    assert_scalar_or_array_equal(
+        modin_arr.prod(axis=0),
+        numpy_arr.prod(axis=0),
     )

--- a/modin/numpy/test/test_array_creation.py
+++ b/modin/numpy/test/test_array_creation.py
@@ -14,45 +14,47 @@
 import numpy
 
 import modin.numpy as np
+from .utils import assert_scalar_or_array_equal
 
 
 def test_zeros_like():
     modin_arr = np.array([[1.0, 2.0], [3.0, 4.0]])
     numpy_arr = modin_arr._to_numpy()
-    numpy.testing.assert_array_equal(
-        numpy.zeros_like(numpy_arr), np.zeros_like(modin_arr)._to_numpy()
-    )
-    numpy.testing.assert_array_equal(
+    assert_scalar_or_array_equal(np.zeros_like(modin_arr), numpy.zeros_like(numpy_arr))
+    assert_scalar_or_array_equal(
+        np.zeros_like(modin_arr, dtype=numpy.int8),
         numpy.zeros_like(numpy_arr, dtype=numpy.int8),
-        np.zeros_like(modin_arr, dtype=numpy.int8)._to_numpy(),
     )
-    numpy.testing.assert_array_equal(
+    assert_scalar_or_array_equal(
+        np.zeros_like(modin_arr, shape=(10, 10)),
         numpy.zeros_like(numpy_arr, shape=(10, 10)),
-        np.zeros_like(modin_arr, shape=(10, 10))._to_numpy(),
     )
     modin_arr = np.array([[1, 2], [3, 4]])
     numpy_arr = modin_arr._to_numpy()
-    numpy.testing.assert_array_equal(
-        numpy.zeros_like(numpy_arr), np.zeros_like(modin_arr)._to_numpy()
+    assert_scalar_or_array_equal(
+        np.zeros_like(modin_arr),
+        numpy.zeros_like(numpy_arr),
     )
 
 
 def test_ones_like():
     modin_arr = np.array([[1.0, 2.0], [3.0, 4.0]])
     numpy_arr = modin_arr._to_numpy()
-    numpy.testing.assert_array_equal(
-        numpy.ones_like(numpy_arr), np.ones_like(modin_arr)._to_numpy()
+    assert_scalar_or_array_equal(
+        np.ones_like(modin_arr),
+        numpy.ones_like(numpy_arr),
     )
-    numpy.testing.assert_array_equal(
+    assert_scalar_or_array_equal(
+        np.ones_like(modin_arr, dtype=numpy.int8),
         numpy.ones_like(numpy_arr, dtype=numpy.int8),
-        np.ones_like(modin_arr, dtype=numpy.int8)._to_numpy(),
     )
-    numpy.testing.assert_array_equal(
+    assert_scalar_or_array_equal(
+        np.ones_like(modin_arr, shape=(10, 10)),
         numpy.ones_like(numpy_arr, shape=(10, 10)),
-        np.ones_like(modin_arr, shape=(10, 10))._to_numpy(),
     )
     modin_arr = np.array([[1, 2], [3, 4]])
     numpy_arr = modin_arr._to_numpy()
-    numpy.testing.assert_array_equal(
-        numpy.ones_like(numpy_arr), np.ones_like(modin_arr)._to_numpy()
+    assert_scalar_or_array_equal(
+        np.ones_like(modin_arr),
+        numpy.ones_like(numpy_arr),
     )

--- a/modin/numpy/test/test_array_indexing.py
+++ b/modin/numpy/test/test_array_indexing.py
@@ -16,6 +16,7 @@ import pytest
 from pandas.core.dtypes.common import is_list_like
 
 import modin.numpy as np
+from .utils import assert_scalar_or_array_equal
 
 
 @pytest.mark.parametrize(
@@ -36,7 +37,7 @@ def test_getitem_1d(index):
     numpy_result = numpy.array(data)[index]
     modin_result = np.array(data)[index]
     if is_list_like(numpy_result):
-        numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+        assert_scalar_or_array_equal(modin_result, numpy_result)
         assert modin_result.shape == numpy_result.shape
     else:
         assert modin_result == numpy_result
@@ -65,7 +66,7 @@ def test_getitem_2d(index):
     numpy_result = numpy.array(data)[index]
     modin_result = np.array(data)[index]
     if is_list_like(numpy_result):
-        numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+        assert_scalar_or_array_equal(modin_result, numpy_result)
         assert modin_result.shape == numpy_result.shape
     else:
         assert modin_result == numpy_result
@@ -77,7 +78,7 @@ def test_getitem_nested():
     numpy_result = numpy.array(data)[1:3][1]
     modin_result = np.array(data)[1:3][1]
     if is_list_like(numpy_result):
-        numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+        assert_scalar_or_array_equal(modin_result, numpy_result)
         assert modin_result.shape == numpy_result.shape
     else:
         assert (
@@ -87,7 +88,7 @@ def test_getitem_nested():
     numpy_result = numpy.array(data)[1][1]
     modin_result = np.array(data)[1][1]
     if is_list_like(numpy_result):
-        numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+        assert_scalar_or_array_equal(modin_result, numpy_result)
         assert modin_result.shape == numpy_result.shape
     else:
         assert modin_result == numpy_result
@@ -112,7 +113,7 @@ def test_setitem_1d(index, value):
     modin_arr, numpy_arr = np.array(data), numpy.array(data)
     numpy_arr[index] = value
     modin_arr[index] = value
-    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+    assert_scalar_or_array_equal(modin_arr, numpy_arr)
 
 
 def test_setitem_1d_error():
@@ -146,4 +147,4 @@ def test_setitem_2d(index, value):
     modin_arr, numpy_arr = np.array(data), numpy.array(data)
     numpy_arr[index] = value
     modin_arr[index] = value
-    numpy.testing.assert_array_equal(modin_arr._to_numpy(), numpy_arr)
+    assert_scalar_or_array_equal(modin_arr, numpy_arr)

--- a/modin/numpy/test/test_array_linalg.py
+++ b/modin/numpy/test/test_array_linalg.py
@@ -19,6 +19,7 @@ import numpy.linalg as NLA
 import modin.pandas as pd
 import modin.numpy as np
 import modin.numpy.linalg as LA
+from .utils import assert_scalar_or_array_equal
 
 
 def test_dot_from_pandas_reindex():
@@ -29,7 +30,7 @@ def test_dot_from_pandas_reindex():
     result1 = np.dot(df, s)
     s2 = s.reindex([1, 0, 2, 3])
     result2 = np.dot(df, s2)
-    numpy.testing.assert_array_equal(result1._to_numpy(), result2._to_numpy())
+    assert_scalar_or_array_equal(result1, result2)
 
 
 def test_dot_1d():
@@ -38,7 +39,7 @@ def test_dot_1d():
     numpy_result = numpy.dot(x1, x2)
     x1, x2 = np.array(x1), np.array(x2)
     modin_result = np.dot(x1, x2)
-    numpy.testing.assert_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 def test_dot_2d():
@@ -47,7 +48,7 @@ def test_dot_2d():
     numpy_result = numpy.dot(x1, x2)
     x1, x2 = np.array(x1), np.array(x2)
     modin_result = np.dot(x1, x2)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 def test_dot_scalar():
@@ -56,7 +57,7 @@ def test_dot_scalar():
     numpy_result = numpy.dot(x1, x2)
     x1 = np.array(x1)
     modin_result = np.dot(x1, x2)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 def test_matmul_scalar():
@@ -77,7 +78,7 @@ def test_dot_broadcast():
     numpy_result = numpy.dot(x1, x2)
     x1, x2 = np.array(x1), np.array(x2)
     modin_result = np.dot(x1, x2)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
     # 1D @ 2D
     x1 = numpy.random.randint(-100, 100, size=(100,))
@@ -85,7 +86,7 @@ def test_dot_broadcast():
     numpy_result = numpy.dot(x1, x2)
     x1, x2 = np.array(x1), np.array(x2)
     modin_result = np.dot(x1, x2)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 @pytest.mark.parametrize("axis", [None, 0, 1], ids=["axis=None", "axis=0", "axis=1"])

--- a/modin/numpy/test/test_array_logic.py
+++ b/modin/numpy/test/test_array_logic.py
@@ -15,6 +15,7 @@ import pytest
 import numpy
 
 import modin.numpy as np
+from .utils import assert_scalar_or_array_equal
 
 
 small_arr_c_2d = numpy.array(
@@ -41,10 +42,7 @@ def test_unary_with_axis(operand_shape, operator, axis):
     numpy_result = getattr(numpy, operator)(x1, axis=axis)
     x1 = np.array(x1)
     modin_result = getattr(np, operator)(x1, axis=axis)
-    # Result may be a scalar
-    if isinstance(modin_result, np.array):
-        modin_result = modin_result._to_numpy()
-    numpy.testing.assert_array_equal(
+    assert_scalar_or_array_equal(
         modin_result, numpy_result, err_msg=f"Unary operator {operator} failed."
     )
 
@@ -58,13 +56,13 @@ def test_all_any_where():
 
     where = np.array([[True, False], [False, False]])
     result = arr.all(where=where, axis=1)
-    numpy.testing.assert_array_equal(result, numpy.array([False, True]))
+    assert_scalar_or_array_equal(result, numpy.array([False, True]))
 
     # Results should contain vacuous Trues in the relevant shape
     result = arr.all(where=False, axis=1)
-    numpy.testing.assert_array_equal(result, numpy.array([True, True]))
+    assert_scalar_or_array_equal(result, numpy.array([True, True]))
     result = arr.all(where=False, axis=0)
-    numpy.testing.assert_array_equal(result, numpy.array([True, True]))
+    assert_scalar_or_array_equal(result, numpy.array([True, True]))
     assert bool(arr.all(where=False, axis=None))
 
     where = np.array([[True, False], [False, True]])
@@ -74,13 +72,13 @@ def test_all_any_where():
 
     where = np.array([[False, True], [False, False]])
     result = arr.any(where=where, axis=1)
-    numpy.testing.assert_array_equal(result, numpy.array([True, False]))
+    assert_scalar_or_array_equal(result, numpy.array([True, False]))
 
     # Results should contain vacuous Falses in the relevant shape
     result = arr.any(where=False, axis=1)
-    numpy.testing.assert_array_equal(result, numpy.array([False, False]))
+    assert_scalar_or_array_equal(result, numpy.array([False, False]))
     result = arr.any(where=False, axis=0)
-    numpy.testing.assert_array_equal(result, numpy.array([False, False]))
+    assert_scalar_or_array_equal(result, numpy.array([False, False]))
     assert not bool(arr.any(where=False, axis=None))
 
 
@@ -93,7 +91,7 @@ def test_unary_with_complex(data, operator):
     numpy_result = getattr(numpy, operator)(x1)
     x1 = np.array(x1)
     modin_result = getattr(np, operator)(x1)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 def test_isnat():
@@ -101,7 +99,7 @@ def test_isnat():
     numpy_result = numpy.isnat(x1)
     x1 = np.array(x1)
     modin_result = np.isnat(x1)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 @pytest.mark.parametrize("data", [small_arr_r_2d, small_arr_r_1d], ids=["2D", "1D"])
@@ -111,7 +109,7 @@ def test_unary_without_complex(data, operator):
     numpy_result = getattr(numpy, operator)(x1)
     x1 = np.array(x1)
     modin_result = getattr(np, operator)(x1)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 @pytest.mark.parametrize("data", [small_arr_r_2d, small_arr_r_1d], ids=["2D", "1D"])
@@ -120,7 +118,7 @@ def test_logical_not(data):
     numpy_result = numpy.logical_not(x1)
     x1 = np.array(x1)
     modin_result = np.logical_not(x1)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 @pytest.mark.parametrize("operand1_shape", [100, (3, 100)])
@@ -134,8 +132,6 @@ def test_logical_binops(operand1_shape, operand2_shape, operator):
     numpy_result = getattr(numpy, operator)(x1, x2)
     x1, x2 = np.array(x1), np.array(x2)
     modin_result = getattr(np, operator)(x1, x2)
-    numpy.testing.assert_array_equal(
-        modin_result._to_numpy(),
-        numpy_result,
-        err_msg=f"Logic binary operator {operator} failed.",
+    assert_scalar_or_array_equal(
+        modin_result, numpy_result, err_msg=f"Logic binary operator {operator} failed."
     )

--- a/modin/numpy/test/test_array_math.py
+++ b/modin/numpy/test/test_array_math.py
@@ -15,6 +15,7 @@ import numpy
 import pytest
 
 import modin.numpy as np
+from .utils import assert_scalar_or_array_equal
 
 
 @pytest.mark.parametrize(
@@ -30,7 +31,7 @@ import modin.numpy as np
 def test_argmax_argmin(data, op):
     numpy_result = getattr(numpy, op)(numpy.array(data))
     modin_result = getattr(np, op)(np.array(data))
-    numpy.testing.assert_array_equal(modin_result, numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 def test_rem_mod():
@@ -39,8 +40,8 @@ def test_rem_mod():
     b = numpy.array(([-3, 3], [3, -7]))
     numpy_result = numpy.remainder(a, b)
     modin_result = np.remainder(np.array(a), np.array(b))
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
     numpy_result = numpy.mod(a, b)
     modin_result = np.mod(np.array(a), np.array(b))
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)

--- a/modin/numpy/test/test_array_shaping.py
+++ b/modin/numpy/test/test_array_shaping.py
@@ -15,6 +15,7 @@ import numpy
 import pytest
 
 import modin.numpy as np
+from .utils import assert_scalar_or_array_equal
 
 
 @pytest.mark.parametrize("operand_shape", [100, (100, 3), (3, 100)])
@@ -22,7 +23,7 @@ def test_ravel(operand_shape):
     x = numpy.random.randint(-100, 100, size=operand_shape)
     numpy_result = numpy.ravel(x)
     modin_result = np.ravel(np.array(x))
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 @pytest.mark.parametrize("operand_shape", [100, (100, 3), (3, 100)])
@@ -38,7 +39,7 @@ def test_transpose(operand_shape):
     x = numpy.random.randint(-100, 100, size=operand_shape)
     numpy_result = numpy.transpose(x)
     modin_result = np.transpose(np.array(x))
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 @pytest.mark.parametrize("axis", [0, 1])
@@ -48,16 +49,15 @@ def test_split_2d(axis):
     numpy_result = numpy.split(x, 2, axis=axis)
     modin_result = np.split(np.array(x), 2, axis=axis)
     for modin_entry, numpy_entry in zip(modin_result, numpy_result):
-        numpy.testing.assert_array_equal(modin_entry._to_numpy(), numpy_entry)
+        assert_scalar_or_array_equal(modin_entry, numpy_entry)
     # List argument: split at specified indices
     idxs = [2, 3]
     numpy_result = numpy.split(x, idxs, axis=axis)
     modin_result = np.split(np.array(x), idxs, axis=axis)
-    for i in range(len(numpy_result)):
-        numpy.testing.assert_array_equal(modin_result[i]._to_numpy(), numpy_result[i])
+    for modin_entry, numpy_entry in zip(modin_result, numpy_result):
+        assert_scalar_or_array_equal(modin_entry, numpy_entry)
 
 
-@pytest.mark.xfail(reason="modin numpy does not natively support empty arrays")
 def test_split_2d_oob():
     # Supplying an index out of bounds results in an empty sub-array, for which modin
     # would return a numpy array by default
@@ -65,8 +65,8 @@ def test_split_2d_oob():
     idxs = [2, 3, 6]
     numpy_result = numpy.split(x, idxs)
     modin_result = np.split(np.array(x), idxs)
-    for i in range(len(numpy_result)):
-        numpy.testing.assert_array_equal(modin_result[i]._to_numpy(), numpy_result[i])
+    for modin_entry, numpy_entry in zip(modin_result, numpy_result):
+        assert_scalar_or_array_equal(modin_entry, numpy_entry)
 
 
 def test_split_2d_uneven():
@@ -83,13 +83,13 @@ def test_hstack():
     b = numpy.random.randint(-100, 100, size=(5, 2))
     numpy_result = numpy.hstack((a, b))
     modin_result = np.hstack((np.array(a), np.array(b)))
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
     # 1D arrays
     a = numpy.random.randint(-100, 100, size=(5,))
     b = numpy.random.randint(-100, 100, size=(3,))
     numpy_result = numpy.hstack((a, b))
     modin_result = np.hstack((np.array(a), np.array(b)))
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 def test_append():
@@ -97,11 +97,11 @@ def test_append():
     xs = [[1, 2, 3], [[4, 5, 6], [7, 8, 9]]]
     numpy_result = numpy.append(*xs)
     modin_result = np.append(*[np.array(x) for x in xs])
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
     numpy_result = numpy.append([[1, 2, 3], [4, 5, 6]], [[7, 8, 9]], axis=0)
     modin_result = np.append(np.array([[1, 2, 3], [4, 5, 6]]), [[7, 8, 9]], axis=0)
-    numpy.testing.assert_array_equal(modin_result._to_numpy(), numpy_result)
+    assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
 @pytest.mark.xfail(reason="append error checking is incorrect: see GH#5896")


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
