### PR TITLE
PERF-#5837: Defer index materialization for MapReduce implemented groupby

### DIFF
--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -272,7 +272,10 @@ class GroupByReduce(TreeReduce):
                 inplace=True,
             )
         # Result could not always be a frame, so wrapping it into DataFrame
-        return pandas.DataFrame(result)
+        result = pandas.DataFrame(result)
+        if result.index.name == MODIN_UNNAMED_SERIES_LABEL:
+            result.index.name = None
+        return result
 
     @classmethod
     def caller(
@@ -400,8 +403,6 @@ class GroupByReduce(TreeReduce):
         )
 
         result = query_compiler.__constructor__(new_modin_frame)
-        if result.index.name == MODIN_UNNAMED_SERIES_LABEL:
-            result.index.name = None
         return result
 
     @classmethod

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3215,6 +3215,9 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
         # that means that exception in `compute_groupby` was raised
         # in every partition, so we also should raise it
+        # TODO: we should be able to drop this logic with pandas 2.0 as it removes `numeric_only=None`
+        # parameter for groupby thus making the behavior of processing of non-numeric columns more
+        # predictable (we can decide whether to raise an exception before actually executing groupby)
         if len(result.columns) == 0 and len(self.columns) != 0:
             # determening type of raised exception by applying `aggfunc`
             # to empty DataFrame


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The PR moves index renaming from the main process to the kernel function which allows us to not materialize the index for renaming.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5837  <!-- issue must be created for each patch -->
- [x] tests are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
