### PR TITLE
REFACTOR-#0000: remove code duplication for `to_*` functions

### DIFF
--- a/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
@@ -13,10 +13,6 @@
 
 """Module houses class that implements ``BaseIO`` using Dask as an execution engine."""
 
-import os
-
-import pandas
-
 from modin.core.io import BaseIO
 from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.core.execution.dask.implementations.pandas_on_dask.dataframe import (
@@ -55,139 +51,28 @@ class PandasOnDaskIO(BaseIO):
         frame_cls=PandasOnDaskDataframe,
         frame_partition_cls=PandasOnDaskDataframePartition,
         query_compiler_cls=PandasQueryCompiler,
+        base_io=BaseIO,
     )
 
-    def __make_read(*classes, build_args=build_args):  # noqa: GL08
+    def __make_read(*classes, build_args=build_args):
         # used to reduce code duplication
         return type("", (DaskWrapper, *classes), build_args).read
+
+    def __make_to_method(*classes, build_args=build_args):
+        # used to reduce code duplication
+        return type("", (DaskWrapper, *classes), build_args)._to_method
 
     read_csv = __make_read(PandasCSVParser, CSVDispatcher)
     read_fwf = __make_read(PandasFWFParser, FWFDispatcher)
     read_json = __make_read(PandasJSONParser, JSONDispatcher)
     read_parquet = __make_read(PandasParquetParser, ParquetDispatcher)
+    to_parquet = __make_to_method(ParquetDispatcher)
     # Blocked on pandas-dev/pandas#12236. It is faster to default to pandas.
     # read_hdf = __make_read(PandasHDFParser, HDFReader)
     read_feather = __make_read(PandasFeatherParser, FeatherDispatcher)
     read_sql = __make_read(PandasSQLParser, SQLDispatcher)
+    to_sql = __make_to_method(SQLDispatcher)
     read_excel = __make_read(PandasExcelParser, ExcelDispatcher)
 
     del __make_read  # to not pollute class namespace
-
-    @staticmethod
-    def _to_parquet_check_support(kwargs):
-        """
-        Check if parallel version of `to_parquet` could be used.
-
-        Parameters
-        ----------
-        kwargs : dict
-            Keyword arguments passed to `.to_parquet()`.
-
-        Returns
-        -------
-        bool
-            Whether parallel version of `to_parquet` is applicable.
-        """
-        path = kwargs["path"]
-        compression = kwargs["compression"]
-        if not isinstance(path, str):
-            return False
-        if any((path.endswith(ext) for ext in [".gz", ".bz2", ".zip", ".xz"])):
-            return False
-        if compression is None or not compression == "snappy":
-            return False
-        return True
-
-    @classmethod
-    def to_parquet(cls, qc, **kwargs):
-        """
-        Write a ``DataFrame`` to the binary parquet format.
-
-        Parameters
-        ----------
-        qc : BaseQueryCompiler
-            The query compiler of the Modin dataframe that we want to run `to_parquet` on.
-        **kwargs : dict
-            Parameters for `pandas.to_parquet(**kwargs)`.
-        """
-        if not cls._to_parquet_check_support(kwargs):
-            return BaseIO.to_parquet(qc, **kwargs)
-
-        output_path = kwargs["path"]
-        os.makedirs(output_path, exist_ok=True)
-
-        def func(df, **kw):
-            """
-            Dump a chunk of rows as parquet, then save them to target maintaining order.
-
-            Parameters
-            ----------
-            df : pandas.DataFrame
-                A chunk of rows to write to a parquet file.
-            **kw : dict
-                Arguments to pass to ``pandas.to_parquet(**kwargs)`` plus an extra argument
-                `partition_idx` serving as chunk index to maintain rows order.
-            """
-            compression = kwargs["compression"]
-            partition_idx = kw["partition_idx"]
-            kwargs[
-                "path"
-            ] = f"{output_path}/part-{partition_idx:04d}.{compression}.parquet"
-            df.to_parquet(**kwargs)
-            return pandas.DataFrame()
-
-        # Ensure that the metadata is synchronized
-        qc._modin_frame._propagate_index_objs(axis=None)
-        result = qc._modin_frame._partition_mgr_cls.map_axis_partitions(
-            axis=1,
-            partitions=qc._modin_frame._partitions,
-            map_func=func,
-            keep_partitioning=True,
-            lengths=None,
-            enumerate_partitions=True,
-        )
-        DaskWrapper.materialize(
-            [part.list_of_blocks[0] for row in result for part in row]
-        )
-
-    @classmethod
-    def to_sql(cls, qc, **kwargs):
-        """
-        Write records stored in the `qc` to a SQL database.
-
-        Parameters
-        ----------
-        qc : BaseQueryCompiler
-            The query compiler of the Modin dataframe that we want to run ``to_sql`` on.
-        **kwargs : dict
-            Parameters for ``pandas.to_sql(**kwargs)``.
-        """
-        # we first insert an empty DF in order to create the full table in the database
-        # This also helps to validate the input against pandas
-        # we would like to_sql() to complete only when all rows have been inserted into the database
-        # since the mapping operation is non-blocking, each partition will return an empty DF
-        # so at the end, the blocking operation will be this empty DF to_pandas
-
-        empty_df = qc.getitem_row_array([0]).to_pandas().head(0)
-        empty_df.to_sql(**kwargs)
-        # so each partition will append its respective DF
-        kwargs["if_exists"] = "append"
-        columns = qc.columns
-
-        def func(df):  # pragma: no cover
-            """
-            Override column names in the wrapped dataframe and convert it to SQL.
-
-            Notes
-            -----
-            This function returns an empty ``pandas.DataFrame`` because ``apply_full_axis``
-            expects a Frame object as a result of operation (and ``to_sql`` has no dataframe result).
-            """
-            df.columns = columns
-            df.to_sql(**kwargs)
-            return pandas.DataFrame()
-
-        # Ensure that the metadata is synchronized
-        qc._modin_frame._propagate_index_objs(axis=None)
-        result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
-        result._partition_mgr_cls.wait_partitions(result._partitions.flatten())
+    del __make_to_method  # to not pollute class namespace

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -14,7 +14,6 @@
 """The module holds the factory which performs I/O using pandas on unidist."""
 
 import io
-import os
 
 import pandas
 
@@ -52,65 +51,31 @@ class PandasOnUnidistIO(UnidistIO):
         frame_partition_cls=PandasOnUnidistDataframePartition,
         query_compiler_cls=PandasQueryCompiler,
         frame_cls=PandasOnUnidistDataframe,
+        base_io=UnidistIO,
     )
 
-    def __make_read(*classes, build_args=build_args):  # noqa: GL08
+    def __make_read(*classes, build_args=build_args):
         # used to reduce code duplication
         return type("", (UnidistWrapper, *classes), build_args).read
+
+    def __make_to_method(*classes, build_args=build_args):
+        # used to reduce code duplication
+        return type("", (UnidistWrapper, *classes), build_args)._to_method
 
     read_csv = __make_read(PandasCSVParser, CSVDispatcher)
     read_fwf = __make_read(PandasFWFParser, FWFDispatcher)
     read_json = __make_read(PandasJSONParser, JSONDispatcher)
     read_parquet = __make_read(PandasParquetParser, ParquetDispatcher)
+    to_parquet = __make_to_method(ParquetDispatcher)
     # Blocked on pandas-dev/pandas#12236. It is faster to default to pandas.
     # read_hdf = __make_read(PandasHDFParser, HDFReader)
     read_feather = __make_read(PandasFeatherParser, FeatherDispatcher)
     read_sql = __make_read(PandasSQLParser, SQLDispatcher)
+    to_sql = __make_to_method(SQLDispatcher)
     read_excel = __make_read(PandasExcelParser, ExcelDispatcher)
 
     del __make_read  # to not pollute class namespace
-
-    @classmethod
-    def to_sql(cls, qc, **kwargs):
-        """
-        Write records stored in the `qc` to a SQL database.
-
-        Parameters
-        ----------
-        qc : BaseQueryCompiler
-            The query compiler of the Modin dataframe that we want to run ``to_sql`` on.
-        **kwargs : dict
-            Parameters for ``pandas.to_sql(**kwargs)``.
-        """
-        # we first insert an empty DF in order to create the full table in the database
-        # This also helps to validate the input against pandas
-        # we would like to_sql() to complete only when all rows have been inserted into the database
-        # since the mapping operation is non-blocking, each partition will return an empty DF
-        # so at the end, the blocking operation will be this empty DF to_pandas
-
-        empty_df = qc.getitem_row_array([0]).to_pandas().head(0)
-        empty_df.to_sql(**kwargs)
-        # so each partition will append its respective DF
-        kwargs["if_exists"] = "append"
-        columns = qc.columns
-
-        def func(df):  # pragma: no cover
-            """
-            Override column names in the wrapped dataframe and convert it to SQL.
-
-            Notes
-            -----
-            This function returns an empty ``pandas.DataFrame`` because ``apply_full_axis``
-            expects a Frame object as a result of operation (and ``to_sql`` has no dataframe result).
-            """
-            df.columns = columns
-            df.to_sql(**kwargs)
-            return pandas.DataFrame()
-
-        # Ensure that the metadata is synchronized
-        qc._modin_frame._propagate_index_objs(axis=None)
-        result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
-        result._partition_mgr_cls.wait_partitions(result._partitions.flatten())
+    del __make_to_method  # to not pollute class namespace
 
     @staticmethod
     def _to_csv_check_support(kwargs):
@@ -232,82 +197,6 @@ class PandasOnUnidistIO(UnidistIO):
             lengths=None,
             enumerate_partitions=True,
             max_retries=0,
-        )
-        # pending completion
-        qc._modin_frame._partition_mgr_cls.wait_partitions(result.flatten())
-
-    @staticmethod
-    def _to_parquet_check_support(kwargs):
-        """
-        Check if parallel version of `to_parquet` could be used.
-
-        Parameters
-        ----------
-        kwargs : dict
-            Keyword arguments passed to `.to_parquet()`.
-
-        Returns
-        -------
-        bool
-            Whether parallel version of `to_parquet` is applicable.
-        """
-        path = kwargs["path"]
-        compression = kwargs["compression"]
-        if not isinstance(path, str):
-            return False
-        if any((path.endswith(ext) for ext in [".gz", ".bz2", ".zip", ".xz"])):
-            return False
-        if compression is None or not compression == "snappy":
-            return False
-        return True
-
-    @classmethod
-    def to_parquet(cls, qc, **kwargs):
-        """
-        Write a ``DataFrame`` to the binary parquet format.
-
-        Parameters
-        ----------
-        qc : BaseQueryCompiler
-            The query compiler of the Modin dataframe that we want to run `to_parquet` on.
-        **kwargs : dict
-            Parameters for `pandas.to_parquet(**kwargs)`.
-        """
-        if not cls._to_parquet_check_support(kwargs):
-            return UnidistIO.to_parquet(qc, **kwargs)
-
-        output_path = kwargs["path"]
-        os.makedirs(output_path, exist_ok=True)
-
-        def func(df, **kw):
-            """
-            Dump a chunk of rows as parquet, then save them to target maintaining order.
-
-            Parameters
-            ----------
-            df : pandas.DataFrame
-                A chunk of rows to write to a parquet file.
-            **kw : dict
-                Arguments to pass to ``pandas.to_parquet(**kwargs)`` plus an extra argument
-                `partition_idx` serving as chunk index to maintain rows order.
-            """
-            compression = kwargs["compression"]
-            partition_idx = kw["partition_idx"]
-            kwargs[
-                "path"
-            ] = f"{output_path}/part-{partition_idx:04d}.{compression}.parquet"
-            df.to_parquet(**kwargs)
-            return pandas.DataFrame()
-
-        # Ensure that the metadata is synchronized
-        qc._modin_frame._propagate_index_objs(axis=None)
-        result = qc._modin_frame._partition_mgr_cls.map_axis_partitions(
-            axis=1,
-            partitions=qc._modin_frame._partitions,
-            map_func=func,
-            keep_partitioning=True,
-            lengths=None,
-            enumerate_partitions=True,
         )
         # pending completion
         qc._modin_frame._partition_mgr_cls.wait_partitions(result.flatten())

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -22,6 +22,7 @@ from fsspec.core import url_to_fs
 from fsspec.spec import AbstractBufferedFile
 import numpy as np
 from pandas.io.common import stringify_path
+import pandas
 from packaging import version
 
 from modin.core.storage_formats.pandas.utils import compute_chunksize
@@ -678,3 +679,79 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         ]
 
         return cls.build_query_compiler(dataset, columns, index_columns, **kwargs)
+
+    @staticmethod
+    def _to_parquet_check_support(kwargs):
+        """
+        Check if parallel version of `to_parquet` could be used.
+
+        Parameters
+        ----------
+        kwargs : dict
+            Keyword arguments passed to `.to_parquet()`.
+
+        Returns
+        -------
+        bool
+            Whether parallel version of `to_parquet` is applicable.
+        """
+        path = kwargs["path"]
+        compression = kwargs["compression"]
+        if not isinstance(path, str):
+            return False
+        if any((path.endswith(ext) for ext in [".gz", ".bz2", ".zip", ".xz"])):
+            return False
+        if compression is None or not compression == "snappy":
+            return False
+        return True
+
+    @classmethod
+    def _to_method(cls, qc, **kwargs):
+        """
+        Write a ``DataFrame`` to the binary parquet format.
+
+        Parameters
+        ----------
+        qc : BaseQueryCompiler
+            The query compiler of the Modin dataframe that we want to run `to_parquet` on.
+        **kwargs : dict
+            Parameters for `pandas.to_parquet(**kwargs)`.
+        """
+        if not cls._to_parquet_check_support(kwargs):
+            return cls.base_io.to_parquet(qc, **kwargs)
+
+        output_path = kwargs["path"]
+        os.makedirs(output_path, exist_ok=True)
+
+        def func(df, **kw):  # pragma: no cover
+            """
+            Dump a chunk of rows as parquet, then save them to target maintaining order.
+
+            Parameters
+            ----------
+            df : pandas.DataFrame
+                A chunk of rows to write to a parquet file.
+            **kw : dict
+                Arguments to pass to ``pandas.to_parquet(**kwargs)`` plus an extra argument
+                `partition_idx` serving as chunk index to maintain rows order.
+            """
+            compression = kwargs["compression"]
+            partition_idx = kw["partition_idx"]
+            kwargs[
+                "path"
+            ] = f"{output_path}/part-{partition_idx:04d}.{compression}.parquet"
+            df.to_parquet(**kwargs)
+            return pandas.DataFrame()
+
+        # Ensure that the metadata is synchronized
+        qc._modin_frame._propagate_index_objs(axis=None)
+        result = qc._modin_frame._partition_mgr_cls.map_axis_partitions(
+            axis=1,
+            partitions=qc._modin_frame._partitions,
+            map_func=func,
+            keep_partitioning=True,
+            lengths=None,
+            enumerate_partitions=True,
+        )
+        # pending completion
+        qc._modin_frame._partition_mgr_cls.wait_partitions(result.flatten())

--- a/modin/core/io/sql/sql_dispatcher.py
+++ b/modin/core/io/sql/sql_dispatcher.py
@@ -109,3 +109,45 @@ class SQLDispatcher(FileDispatcher):
         new_frame = cls.frame_cls(np.array(partition_ids), new_index, cols_names)
         new_frame.synchronize_labels(axis=0)
         return cls.query_compiler_cls(new_frame)
+
+    @classmethod
+    def _to_method(cls, qc, **kwargs):
+        """
+        Write records stored in the `qc` to a SQL database.
+
+        Parameters
+        ----------
+        qc : BaseQueryCompiler
+            The query compiler of the Modin dataframe that we want to run ``to_sql`` on.
+        **kwargs : dict
+            Parameters for ``pandas.to_sql(**kwargs)``.
+        """
+        # we first insert an empty DF in order to create the full table in the database
+        # This also helps to validate the input against pandas
+        # we would like to_sql() to complete only when all rows have been inserted into the database
+        # since the mapping operation is non-blocking, each partition will return an empty DF
+        # so at the end, the blocking operation will be this empty DF to_pandas
+
+        empty_df = qc.getitem_row_array([0]).to_pandas().head(0)
+        empty_df.to_sql(**kwargs)
+        # so each partition will append its respective DF
+        kwargs["if_exists"] = "append"
+        columns = qc.columns
+
+        def func(df):  # pragma: no cover
+            """
+            Override column names in the wrapped dataframe and convert it to SQL.
+
+            Notes
+            -----
+            This function returns an empty ``pandas.DataFrame`` because ``apply_full_axis``
+            expects a Frame object as a result of operation (and ``to_sql`` has no dataframe result).
+            """
+            df.columns = columns
+            df.to_sql(**kwargs)
+            return pandas.DataFrame()
+
+        # Ensure that the metadata is synchronized
+        qc._modin_frame._propagate_index_objs(axis=None)
+        result = qc._modin_frame.apply_full_axis(1, func, new_index=[], new_columns=[])
+        result._partition_mgr_cls.wait_partitions(result._partitions.flatten())

--- a/modin/experimental/core/execution/dask/implementations/pandas_on_dask/io/io.py
+++ b/modin/experimental/core/execution/dask/implementations/pandas_on_dask/io/io.py
@@ -18,10 +18,6 @@ Any function or class can be considered experimental API if it is not strictly r
 Query Compiler API, even if it is only extending the API.
 """
 
-import warnings
-
-import pandas
-
 from modin.core.storage_formats.pandas.parsers import (
     PandasCSVGlobParser,
     ExperimentalPandasPickleParser,
@@ -60,65 +56,23 @@ class ExperimentalPandasOnDaskIO(PandasOnDaskIO):
         base_io=PandasOnDaskIO,
     )
 
-    def __make_read(*classes, build_args=build_args):  # noqa: GL08
+    def __make_read(*classes, build_args=build_args):
         # used to reduce code duplication
         return type("", (DaskWrapper, *classes), build_args).read
 
-    read_csv_glob = __make_read(PandasCSVGlobParser, CSVGlobDispatcher)
+    def __make_to_method(*classes, build_args=build_args):
+        # used to reduce code duplication
+        return type("", (DaskWrapper, *classes), build_args)._to_method
 
+    read_csv_glob = __make_read(PandasCSVGlobParser, CSVGlobDispatcher)
     read_pickle_distributed = __make_read(
         ExperimentalPandasPickleParser, ExperimentalPickleDispatcher
     )
-
+    to_pickle_distributed = __make_to_method(ExperimentalPickleDispatcher)
     read_custom_text = __make_read(
         ExperimentalCustomTextParser, ExperimentalCustomTextDispatcher
     )
-
     read_sql = __make_read(ExperimentalSQLDispatcher)
 
     del __make_read  # to not pollute class namespace
-
-    @classmethod
-    def to_pickle_distributed(cls, qc, **kwargs):
-        """
-        When `*` in the filename all partitions are written to their own separate file.
-
-        The filenames is determined as follows:
-        - if `*` in the filename then it will be replaced by the increasing sequence 0, 1, 2, …
-        - if `*` is not the filename, then will be used default implementation.
-
-        Examples #1: 4 partitions and input filename="partition*.pkl.gz", then filenames will be:
-        `partition0.pkl.gz`, `partition1.pkl.gz`, `partition2.pkl.gz`, `partition3.pkl.gz`.
-
-        Parameters
-        ----------
-        qc : BaseQueryCompiler
-            The query compiler of the Modin dataframe that we want
-            to run ``to_pickle_distributed`` on.
-        **kwargs : dict
-            Parameters for ``pandas.to_pickle(**kwargs)``.
-        """
-        if not (
-            isinstance(kwargs["filepath_or_buffer"], str)
-            and "*" in kwargs["filepath_or_buffer"]
-        ) or not isinstance(qc, PandasQueryCompiler):
-            warnings.warn("Defaulting to Modin core implementation")
-            return PandasOnDaskIO.to_pickle(qc, **kwargs)
-
-        def func(df, **kw):  # pragma: no cover
-            idx = str(kw["partition_idx"])
-            # dask doesn't make a copy of kwargs on serialization;
-            # so take a copy ourselves, otherwise the error is:
-            #  kwargs["path"] = kwargs.pop("filepath_or_buffer").replace("*", idx)
-            #  KeyError: 'filepath_or_buffer'
-            dask_kwargs = dict(kwargs)
-            dask_kwargs["path"] = dask_kwargs.pop("filepath_or_buffer").replace(
-                "*", idx
-            )
-            df.to_pickle(**dask_kwargs)
-            return pandas.DataFrame()
-
-        result = qc._modin_frame.apply_full_axis(
-            1, func, new_index=[], new_columns=[], enumerate_partitions=True
-        )
-        result._partition_mgr_cls.wait_partitions(result._partitions.flatten())
+    del __make_to_method  # to not pollute class namespace

--- a/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/experimental/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -18,9 +18,6 @@ Any function or class can be considered experimental API if it is not strictly r
 Query Compiler API, even if it is only extending the API.
 """
 
-import pandas
-import warnings
-
 from modin.core.storage_formats.pandas.parsers import (
     PandasCSVGlobParser,
     ExperimentalPandasPickleParser,
@@ -62,54 +59,19 @@ class ExperimentalPandasOnRayIO(PandasOnRayIO):
         # used to reduce code duplication
         return type("", (RayWrapper, *classes), build_args).read
 
-    read_csv_glob = __make_read(PandasCSVGlobParser, CSVGlobDispatcher)
+    def __make_to_method(*classes, build_args=build_args):
+        # used to reduce code duplication
+        return type("", (RayWrapper, *classes), build_args)._to_method
 
+    read_csv_glob = __make_read(PandasCSVGlobParser, CSVGlobDispatcher)
     read_pickle_distributed = __make_read(
         ExperimentalPandasPickleParser, ExperimentalPickleDispatcher
     )
-
+    to_pickle_distributed = __make_to_method(ExperimentalPickleDispatcher)
     read_custom_text = __make_read(
         ExperimentalCustomTextParser, ExperimentalCustomTextDispatcher
     )
-
     read_sql = __make_read(ExperimentalSQLDispatcher)
 
     del __make_read  # to not pollute class namespace
-
-    @classmethod
-    def to_pickle_distributed(cls, qc, **kwargs):
-        """
-        When `*` in the filename all partitions are written to their own separate file.
-
-        The filenames is determined as follows:
-        - if `*` in the filename then it will be replaced by the increasing sequence 0, 1, 2, …
-        - if `*` is not the filename, then will be used default implementation.
-
-        Examples #1: 4 partitions and input filename="partition*.pkl.gz", then filenames will be:
-        `partition0.pkl.gz`, `partition1.pkl.gz`, `partition2.pkl.gz`, `partition3.pkl.gz`.
-
-        Parameters
-        ----------
-        qc : BaseQueryCompiler
-            The query compiler of the Modin dataframe that we want
-            to run ``to_pickle_distributed`` on.
-        **kwargs : dict
-            Parameters for ``pandas.to_pickle(**kwargs)``.
-        """
-        if not (
-            isinstance(kwargs["filepath_or_buffer"], str)
-            and "*" in kwargs["filepath_or_buffer"]
-        ) or not isinstance(qc, PandasQueryCompiler):
-            warnings.warn("Defaulting to Modin core implementation")
-            return PandasOnRayIO.to_pickle(qc, **kwargs)
-
-        def func(df, **kw):  # pragma: no cover
-            idx = str(kw["partition_idx"])
-            kwargs["path"] = kwargs.pop("filepath_or_buffer").replace("*", idx)
-            df.to_pickle(**kwargs)
-            return pandas.DataFrame()
-
-        result = qc._modin_frame.apply_full_axis(
-            1, func, new_index=[], new_columns=[], enumerate_partitions=True
-        )
-        result._partition_mgr_cls.wait_partitions(result._partitions.flatten())
+    del __make_to_method  # to not pollute class namespace

--- a/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/experimental/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -18,9 +18,6 @@ Any function or class can be considered experimental API if it is not strictly r
 Query Compiler API, even if it is only extending the API.
 """
 
-import pandas
-import warnings
-
 from modin.core.storage_formats.pandas.parsers import (
     PandasCSVGlobParser,
     ExperimentalPandasPickleParser,
@@ -60,58 +57,23 @@ class ExperimentalPandasOnUnidistIO(PandasOnUnidistIO):
         base_io=PandasOnUnidistIO,
     )
 
-    def __make_read(*classes, build_args=build_args):  # noqa: GL08
+    def __make_read(*classes, build_args=build_args):
         # used to reduce code duplication
         return type("", (UnidistWrapper, *classes), build_args).read
 
-    read_csv_glob = __make_read(PandasCSVGlobParser, CSVGlobDispatcher)
+    def __make_to_method(*classes, build_args=build_args):
+        # used to reduce code duplication
+        return type("", (UnidistWrapper, *classes), build_args)._to_method
 
+    read_csv_glob = __make_read(PandasCSVGlobParser, CSVGlobDispatcher)
     read_pickle_distributed = __make_read(
         ExperimentalPandasPickleParser, ExperimentalPickleDispatcher
     )
-
+    to_pickle_distributed = __make_to_method(ExperimentalPickleDispatcher)
     read_custom_text = __make_read(
         ExperimentalCustomTextParser, ExperimentalCustomTextDispatcher
     )
-
     read_sql = __make_read(ExperimentalSQLDispatcher)
 
     del __make_read  # to not pollute class namespace
-
-    @classmethod
-    def to_pickle_distributed(cls, qc, **kwargs):
-        """
-        When `*` in the filename all partitions are written to their own separate file.
-
-        The filenames is determined as follows:
-        - if `*` in the filename then it will be replaced by the increasing sequence 0, 1, 2, …
-        - if `*` is not the filename, then will be used default implementation.
-
-        Examples #1: 4 partitions and input filename="partition*.pkl.gz", then filenames will be:
-        `partition0.pkl.gz`, `partition1.pkl.gz`, `partition2.pkl.gz`, `partition3.pkl.gz`.
-
-        Parameters
-        ----------
-        qc : BaseQueryCompiler
-            The query compiler of the Modin dataframe that we want
-            to run ``to_pickle_distributed`` on.
-        **kwargs : dict
-            Parameters for ``pandas.to_pickle(**kwargs)``.
-        """
-        if not (
-            isinstance(kwargs["filepath_or_buffer"], str)
-            and "*" in kwargs["filepath_or_buffer"]
-        ) or not isinstance(qc, PandasQueryCompiler):
-            warnings.warn("Defaulting to Modin core implementation")
-            return PandasOnUnidistIO.to_pickle(qc, **kwargs)
-
-        def func(df, **kw):  # pragma: no cover
-            idx = str(kw["partition_idx"])
-            kwargs["path"] = kwargs.pop("filepath_or_buffer").replace("*", idx)
-            df.to_pickle(**kwargs)
-            return pandas.DataFrame()
-
-        result = qc._modin_frame.apply_full_axis(
-            1, func, new_index=[], new_columns=[], enumerate_partitions=True
-        )
-        result._partition_mgr_cls.wait_partitions(result._partitions.flatten())
+    del __make_to_method  # to not pollute class namespace


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
