### PR TITLE
FIX-#5988: BUG: Concatenation of frames with strings is not supported by HDK

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -37,6 +37,7 @@ from pandas.core.dtypes.common import (
     get_dtype,
     is_list_like,
     is_bool_dtype,
+    is_string_dtype,
     is_categorical_dtype,
 )
 from modin.error_message import ErrorMessage
@@ -998,6 +999,7 @@ class HdkOnNativeDataframe(PandasDataframe):
             len(other_modin_frames) == 0
             or len(self.columns) == 0
             or all(f._has_arrow_table() for f in ([self] + other_modin_frames))
+            or any(is_string_dtype(t) for t in self._dtypes)
             or any(len(f.columns) != len(self.columns) for f in other_modin_frames)
             or any(set(f._dtypes) != set(self._dtypes) for f in other_modin_frames)
         ):

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -775,6 +775,17 @@ class TestConcat:
 
         df_equals(ref, exp)
 
+    def test_concat_str(self):
+        def concat(df1, df2, lib, **kwargs):
+            return lib.concat([df1.dropna(), df2.dropna()]).astype(str)
+
+        run_and_compare(
+            concat,
+            data={"a": ["1", "2", "3"]},
+            data2={"a": ["4", "5", "6"]},
+            force_lazy=False,
+        )
+
 
 class TestGroupby:
     data = {


### PR DESCRIPTION
… by HDK

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5988 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
