### PR TITLE
FIX-#6000: HDK: read_csv(): Do not parse dates, if the parse_dates argument is not specified

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -174,7 +174,9 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
                 else false_values,
                 # timestamp fields should be handled as strings if parse_dates
                 # didn't passed explicitly as an array or a dict
-                timestamp_parsers=[""] if isinstance(parse_dates, bool) else None,
+                timestamp_parsers=[""]
+                if parse_dates is None or isinstance(parse_dates, bool)
+                else None,
                 strings_can_be_null=None,
                 include_columns=usecols_md,
                 include_missing_columns=None,

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -319,6 +319,20 @@ class TestCSV:
         )
 
     @pytest.mark.parametrize("engine", [None, "arrow"])
+    @pytest.mark.parametrize("parse_dates", [None, True, False])
+    def test_read_csv_datetime_tz(self, engine, parse_dates):
+        with ensure_clean(".csv") as file:
+            with open(file, "w") as f:
+                f.write("test\n2023-01-01T00:00:00.000-07:00")
+
+            eval_io(
+                fn_name="read_csv",
+                filepath_or_buffer=file,
+                md_extra_kwargs={"engine": engine},
+                parse_dates=parse_dates,
+            )
+
+    @pytest.mark.parametrize("engine", [None, "arrow"])
     @pytest.mark.parametrize(
         "usecols",
         [


### PR DESCRIPTION
The read_cvs() method disables the timestamp fields parsing if the parse_dates argument is of type bool, however, the default value is None and, in this case, the parsing should also be disabled.

Note: dates without timezone are still parsed. See #3485.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6000 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
