### PR TITLE
TEST-#6009: use `tmp_path` fixture instead of `ensure_clean_dir` as pandas 2.0.0 does

### DIFF
--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -506,13 +506,11 @@ def make_sql_connection():
     Yields:
         Factory that generates sql connection objects
     """
-    filenames = []
 
     def _sql_connection(filename, table=""):
         # Remove file if exists
         if os.path.exists(filename):
             os.remove(filename)
-        filenames.append(filename)
         # Create connection and, if needed, table
         conn = "sqlite:///{}".format(filename)
         if table:

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -41,7 +41,6 @@ Data parsing mechanism differs depending on the data format type:
 
 from collections import OrderedDict
 from io import BytesIO, TextIOWrapper, IOBase
-from pathlib import Path
 import fsspec
 import numpy as np
 import pandas
@@ -781,7 +780,7 @@ engine : str
         storage_options = kwargs.get("storage_options", {})
         chunks = []
         # `single_worker_read` just passes in a string path
-        if isinstance(files_for_parser, (str, Path)):
+        if isinstance(files_for_parser, str):
             return pandas.read_parquet(files_for_parser, engine=engine, **kwargs)
 
         for file_for_parser in files_for_parser:

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -41,6 +41,7 @@ Data parsing mechanism differs depending on the data format type:
 
 from collections import OrderedDict
 from io import BytesIO, TextIOWrapper, IOBase
+from pathlib import Path
 import fsspec
 import numpy as np
 import pandas
@@ -780,7 +781,7 @@ engine : str
         storage_options = kwargs.get("storage_options", {})
         chunks = []
         # `single_worker_read` just passes in a string path
-        if isinstance(files_for_parser, str):
+        if isinstance(files_for_parser, (str, Path)):
             return pandas.read_parquet(files_for_parser, engine=engine, **kwargs)
 
         for file_for_parser in files_for_parser:

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -12,13 +12,12 @@
 # governing permissions and limitations under the License.
 
 from contextlib import nullcontext
-import os
 import glob
 import json
 
 import numpy as np
 import pandas
-from pandas._testing import ensure_clean, ensure_clean_dir
+from pandas._testing import ensure_clean
 import pytest
 
 import modin.experimental.pandas as pd
@@ -37,30 +36,29 @@ from modin.pandas.test.utils import parse_dates_values_by_id, time_parsing_csv_p
     Engine.get() not in ("Ray", "Unidist", "Dask"),
     reason=f"{Engine.get()} does not have experimental API",
 )
-def test_from_sql_distributed(make_sql_connection):
-    with ensure_clean_dir() as dirname:
-        filename = "test_from_sql_distributed.db"
-        table = "test_from_sql_distributed"
-        conn = make_sql_connection(os.path.join(dirname, filename), table)
-        query = "select * from {0}".format(table)
+def test_from_sql_distributed(tmp_path, make_sql_connection):
+    filename = "test_from_sql_distributed.db"
+    table = "test_from_sql_distributed"
+    conn = make_sql_connection(tmp_path / filename, table)
+    query = "select * from {0}".format(table)
 
-        pandas_df = pandas.read_sql(query, conn)
-        modin_df_from_query = pd.read_sql(
-            query,
-            conn,
-            partition_column="col1",
-            lower_bound=0,
-            upper_bound=6,
-            max_sessions=2,
-        )
-        modin_df_from_table = pd.read_sql(
-            table,
-            conn,
-            partition_column="col1",
-            lower_bound=0,
-            upper_bound=6,
-            max_sessions=2,
-        )
+    pandas_df = pandas.read_sql(query, conn)
+    modin_df_from_query = pd.read_sql(
+        query,
+        conn,
+        partition_column="col1",
+        lower_bound=0,
+        upper_bound=6,
+        max_sessions=2,
+    )
+    modin_df_from_table = pd.read_sql(
+        table,
+        conn,
+        partition_column="col1",
+        lower_bound=0,
+        upper_bound=6,
+        max_sessions=2,
+    )
 
     df_equals(modin_df_from_query, pandas_df)
     df_equals(modin_df_from_table, pandas_df)
@@ -70,18 +68,17 @@ def test_from_sql_distributed(make_sql_connection):
     Engine.get() not in ("Ray", "Unidist", "Dask"),
     reason=f"{Engine.get()} does not have experimental API",
 )
-def test_from_sql_defaults(make_sql_connection):
-    with ensure_clean_dir() as dirname:
-        filename = "test_from_sql_distributed.db"
-        table = "test_from_sql_distributed"
-        conn = make_sql_connection(os.path.join(dirname, filename), table)
-        query = "select * from {0}".format(table)
+def test_from_sql_defaults(tmp_path, make_sql_connection):
+    filename = "test_from_sql_distributed.db"
+    table = "test_from_sql_distributed"
+    conn = make_sql_connection(tmp_path / filename, table)
+    query = "select * from {0}".format(table)
 
-        pandas_df = pandas.read_sql(query, conn)
-        with pytest.warns(UserWarning):
-            modin_df_from_query = pd.read_sql(query, conn)
-        with pytest.warns(UserWarning):
-            modin_df_from_table = pd.read_sql(table, conn)
+    pandas_df = pandas.read_sql(query, conn)
+    with pytest.warns(UserWarning):
+        modin_df_from_query = pd.read_sql(query, conn)
+    with pytest.warns(UserWarning):
+        modin_df_from_table = pd.read_sql(table, conn)
 
     df_equals(modin_df_from_query, pandas_df)
     df_equals(modin_df_from_table, pandas_df)
@@ -308,7 +305,7 @@ def test_read_custom_json_text(set_async_read_mode):
         )
         if AsyncReadMode.get():
             # If read operations are asynchronous, then the dataframes
-            # check should be inside `ensure_clean_dir` context
+            # check should be inside `ensure_clean` context
             # because the file may be deleted before actual reading starts
             df_equals(df1, df2)
     if not AsyncReadMode.get():
@@ -365,7 +362,7 @@ def test_read_evaluated_dict(set_async_read_mode):
         )
         if AsyncReadMode.get():
             # If read operations are asynchronous, then the dataframes
-            # check should be inside `ensure_clean_dir` context
+            # check should be inside `ensure_clean` context
             # because the file may be deleted before actual reading starts
             df_equals(df1, df2)
     if not AsyncReadMode.get():

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1725,7 +1725,7 @@ class TestParquet:
         with warns_that_defaulting_to_pandas():
             eval_io(
                 fn_name="read_parquet",
-                path=path / file_name,
+                path=str(path / file_name),
                 columns=["col_b"],
                 engine=engine,
                 filters=[[("col_a", "==", 1)]],

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -2502,7 +2502,11 @@ class TestStata:
     def test_to_stata(self, tmp_path):
         modin_df, pandas_df = create_test_dfs(TEST_DATA)
         eval_to_file(
-            modin_obj=modin_df, pandas_obj=pandas_df, fn="to_stata", extension="stata"
+            tmp_path,
+            modin_obj=modin_df,
+            pandas_obj=pandas_df,
+            fn="to_stata",
+            extension="stata",
         )
 
 
@@ -2555,6 +2559,7 @@ class TestFeather:
     def test_to_feather(self, tmp_path):
         modin_df, pandas_df = create_test_dfs(TEST_DATA)
         eval_to_file(
+            tmp_path,
             modin_obj=modin_df,
             pandas_obj=pandas_df,
             fn="to_feather",

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -12,6 +12,8 @@
 # governing permissions and limitations under the License.
 
 import re
+from pathlib import Path
+from typing import Union
 import pytest
 import numpy as np
 import math
@@ -1145,7 +1147,7 @@ def get_unique_filename(
     test_name: str = "test",
     kwargs: dict = {},
     extension: str = "csv",
-    data_dir: str = "",
+    data_dir: Union[str, Path] = "",
     suffix: str = "",
     debug_mode=False,
 ):
@@ -1159,7 +1161,7 @@ def get_unique_filename(
         Unique combiantion of test parameters for creation of unique name.
     extension: str
         Extension of unique file.
-    data_dir: str
+    data_dir: Union[str, Path]
         Data directory where test files will be created.
     suffix: str
         String to append to the resulted name.


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This is necessary step to migrate to pandas 2.0.0.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6009 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
