### PR TITLE
TEST-#6020: exclude `_version.py` from coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -66,6 +66,8 @@ omit =
     modin/core/execution/ray/implementations/cudf_on_ray/series/*
     # Skip CLI part
     modin/__main__.py
+    # Skip third-party stuff
+    modin/_version.py
 parallel = True
 # The use of this feature is one of the recommendations of codecov if the
 # tests are run in different environments (for example, on different operating


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6020 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
