### PR TITLE
FIX-#6035: Fall back to Pandas, when merging unsupported column types

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -29,6 +29,9 @@ from pandas.core.dtypes.common import (
     get_dtype,
     is_list_like,
     is_bool_dtype,
+    is_string_dtype,
+    is_any_int_dtype,
+    is_datetime64_dtype,
     is_categorical_dtype,
 )
 
@@ -955,6 +958,18 @@ class HdkOnNativeDataframe(PandasDataframe):
         orig_right_on = right_on
         left, left_on = check_cols_to_join("left_on", self, left_on)
         right, right_on = check_cols_to_join("right_on", other, right_on)
+        for left_col, right_col in zip(left_on, right_on):
+            left_dt = self._dtypes[left_col]
+            right_dt = other._dtypes[right_col]
+            if not (
+                (is_any_int_dtype(left_dt) and is_any_int_dtype(right_dt))
+                or (is_string_dtype(left_dt) and is_string_dtype(right_dt))
+                or (is_datetime64_dtype(left_dt) and is_datetime64_dtype(right_dt))
+                or (is_categorical_dtype(left_dt) and is_categorical_dtype(right_dt))
+            ):
+                raise NotImplementedError(
+                    f"Join on columns of '{left_dt}' and '{right_dt}' dtypes"
+                )
 
         # If either left_on or right_on has been changed, it means that there
         # are index columns in the list. Joining by index in this case.

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
@@ -25,6 +25,12 @@ import pandas
 from pandas import Timestamp
 from pandas.core.dtypes.common import get_dtype, is_string_dtype
 from pandas.core.arrays.arrow.extension_types import ArrowIntervalType
+from pandas.core.dtypes.common import (
+    is_string_dtype,
+    is_any_int_dtype,
+    is_datetime64_dtype,
+    is_categorical_dtype,
+)
 
 import pyarrow as pa
 from pyarrow.types import is_dictionary
@@ -334,18 +340,32 @@ def check_cols_to_join(what, df, col_names):
     Tuple[HdkOnNativeDataframe, list]
         The aligned data frame and column names.
     """
-    cols = df.columns
+
+    def check_dtype(name, dtype):
+        if not (
+            is_string_dtype(dtype)
+            or is_any_int_dtype(dtype)
+            or is_datetime64_dtype(dtype)
+            or is_categorical_dtype(dtype)
+        ):
+            raise NotImplementedError(f"Join on column '{name}' of type '{dtype}'")
+
+    dtypes = df.dtypes
     new_col_names = col_names
     for i, col in enumerate(col_names):
-        if col in cols:
+        dtype = dtypes.get(col, None)
+        if dtype is not None:
+            check_dtype(col, dtype)
             continue
+
         new_name = None
         if df._index_cols is not None:
             for c in df._index_cols:
                 if col == ColNameCodec.demangle_index_name(c):
                     new_name = c
+                    check_dtype(col, df._dtypes[c])
                     break
-        elif df.has_index_cache:
+        elif df.has_index_cache and df.index.name == col:
             new_name = f"__index__{0}_{col}"
             df = df._maybe_materialize_rowid()
         if new_name is None:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -1610,7 +1610,7 @@ class TestMerge:
             data2={"A": [1.0, 3.0] * 1000},
             on_columns="A",
             constructor_kwargs={"dtype": "category"},
-            comparator=lambda df1, df2: df1["A"].values == df2["A"].values,
+            comparator=lambda df1, df2: df_equals(df1.astype(float), df2.astype(float)),
         )
 
     def test_merge_date(self):

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -1588,6 +1588,52 @@ class TestMerge:
                 iterations=i,
             )
 
+    def test_merge_float(self):
+        def merge(df, df2, on_columns, **kwargs):
+            return df.merge(df2, on=on_columns)
+
+        run_and_compare(
+            merge,
+            data={"A": [1, 2] * 1000},
+            data2={"A": [1.0, 3.0] * 1000},
+            on_columns="A",
+            force_lazy=False,
+        )
+
+    def test_merge_categorical(self):
+        def merge(df, df2, on_columns, **kwargs):
+            return df.merge(df2, on=on_columns)
+
+        run_and_compare(
+            merge,
+            data={"A": [1, 2] * 1000},
+            data2={"A": [1.0, 3.0] * 1000},
+            on_columns="A",
+            constructor_kwargs={"dtype": "category"},
+            comparator=lambda df1, df2: df1["A"].values == df2["A"].values,
+        )
+
+    def test_merge_date(self):
+        def merge(df, df2, on_columns, **kwargs):
+            return df.merge(df2, on=on_columns)
+
+        run_and_compare(
+            merge,
+            data={
+                "A": [
+                    pd.Timestamp("2023-01-01"),
+                    pd.Timestamp("2023-01-02"),
+                ]
+            },
+            data2={
+                "A": [
+                    pd.Timestamp("2023-01-01"),
+                    pd.Timestamp("2023-01-03"),
+                ]
+            },
+            on_columns="A",
+        )
+
 
 class TestBinaryOp:
     data = {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6035 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
