### PR TITLE
REFACTOR-#6044: remove code duplication for `get_objects_from_partitions`

### DIFF
--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
@@ -33,33 +33,7 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
     _partition_class = PandasOnDaskDataframePartition
     _column_partitions_class = PandasOnDaskDataframeColumnPartition
     _row_partition_class = PandasOnDaskDataframeRowPartition
-
-    @classmethod
-    def get_objects_from_partitions(cls, partitions):
-        """
-        Get the objects wrapped by `partitions` in parallel.
-
-        This function assumes that each partition in `partitions` contains a single block.
-
-        Parameters
-        ----------
-        partitions : np.ndarray
-            NumPy array with ``PandasDataframePartition``-s.
-
-        Returns
-        -------
-        list
-            The objects wrapped by `partitions`.
-        """
-        for idx, part in enumerate(partitions):
-            if hasattr(part, "force_materialization"):
-                partitions[idx] = part.force_materialization()
-        assert all(
-            [len(partition.list_of_blocks) == 1 for partition in partitions]
-        ), "Implementation assumes that each partition contains a signle block."
-        return DaskWrapper.materialize(
-            [partition.list_of_blocks[0] for partition in partitions]
-        )
+    _execution_wrapper = DaskWrapper
 
     @classmethod
     def wait_partitions(cls, partitions):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -90,33 +90,7 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
     _partition_class = PandasOnRayDataframePartition
     _column_partitions_class = PandasOnRayDataframeColumnPartition
     _row_partition_class = PandasOnRayDataframeRowPartition
-
-    @classmethod
-    def get_objects_from_partitions(cls, partitions):
-        """
-        Get the objects wrapped by `partitions` in parallel.
-
-        This function assumes that each partition in `partitions` contains a single block.
-
-        Parameters
-        ----------
-        partitions : np.ndarray
-            NumPy array with ``PandasDataframePartition``-s.
-
-        Returns
-        -------
-        list
-            The objects wrapped by `partitions`.
-        """
-        for idx, part in enumerate(partitions):
-            if hasattr(part, "force_materialization"):
-                partitions[idx] = part.force_materialization()
-        assert all(
-            [len(partition.list_of_blocks) == 1 for partition in partitions]
-        ), "Implementation assumes that each partition contains a signle block."
-        return RayWrapper.materialize(
-            [partition.list_of_blocks[0] for partition in partitions]
-        )
+    _execution_wrapper = RayWrapper
 
     @classmethod
     def wait_partitions(cls, partitions):

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
@@ -90,33 +90,7 @@ class PandasOnUnidistDataframePartitionManager(GenericUnidistDataframePartitionM
     _partition_class = PandasOnUnidistDataframePartition
     _column_partitions_class = PandasOnUnidistDataframeColumnPartition
     _row_partition_class = PandasOnUnidistDataframeRowPartition
-
-    @classmethod
-    def get_objects_from_partitions(cls, partitions):
-        """
-        Get the objects wrapped by `partitions` in parallel.
-
-        This function assumes that each partition in `partitions` contains a single block.
-
-        Parameters
-        ----------
-        partitions : np.ndarray
-            NumPy array with ``PandasDataframePartition``-s.
-
-        Returns
-        -------
-        list
-            The objects wrapped by `partitions`.
-        """
-        for idx, part in enumerate(partitions):
-            if hasattr(part, "force_materialization"):
-                partitions[idx] = part.force_materialization()
-        assert all(
-            [len(partition.list_of_blocks) == 1 for partition in partitions]
-        ), "Implementation assumes that each partition contains a signle block."
-        return UnidistWrapper.materialize(
-            [partition.list_of_blocks[0] for partition in partitions]
-        )
+    _execution_wrapper = UnidistWrapper
 
     @classmethod
     def wait_partitions(cls, partitions):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6044 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
