### PR TITLE
FEAT-#6048: add `wait` method for Dask/Ray/Unidist wrappers

### DIFF
--- a/modin/core/execution/dask/common/engine_wrapper.py
+++ b/modin/core/execution/dask/common/engine_wrapper.py
@@ -16,6 +16,7 @@
 from collections import UserDict
 
 from distributed.client import default_client
+from dask.distributed import wait
 
 
 def _deploy_dask_func(func, *args, **kwargs):  # pragma: no cover
@@ -133,3 +134,16 @@ class DaskWrapper:
             data = UserDict(data)
         client = default_client()
         return client.scatter(data, **kwargs)
+
+    @classmethod
+    def wait(cls, obj_ids):
+        """
+        Wait on the objects without materializing them (blocking operation).
+
+        Parameters
+        ----------
+        obj_ids : list, scalar
+        """
+        if not isinstance(obj_ids, list):
+            obj_ids = [obj_ids]
+        wait(obj_ids, return_when="ALL_COMPLETED")

--- a/modin/core/execution/dask/common/engine_wrapper.py
+++ b/modin/core/execution/dask/common/engine_wrapper.py
@@ -136,14 +136,22 @@ class DaskWrapper:
         return client.scatter(data, **kwargs)
 
     @classmethod
-    def wait(cls, obj_ids):
+    def wait(cls, obj_ids, num_returns=None):
         """
         Wait on the objects without materializing them (blocking operation).
 
         Parameters
         ----------
         obj_ids : list, scalar
+        num_returns : int, optional
         """
         if not isinstance(obj_ids, list):
             obj_ids = [obj_ids]
-        wait(obj_ids, return_when="ALL_COMPLETED")
+        if num_returns is None:
+            num_returns = len(obj_ids)
+        if num_returns == len(obj_ids):
+            wait(obj_ids, return_when="ALL_COMPLETED")
+        else:
+            # Dask doesn't natively support `num_returns` as int
+            for _ in range(num_returns):
+                wait(obj_ids, return_when="FIRST_COMPLETED")

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition.py
@@ -15,7 +15,6 @@
 
 from distributed import Future
 from distributed.utils import get_ip
-from dask.distributed import wait
 
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from modin.pandas.indexing import compute_sliced_len
@@ -154,7 +153,7 @@ class PandasOnDaskDataframePartition(PandasDataframePartition):
     def wait(self):
         """Wait completing computations on the object wrapped by the partition."""
         self.drain_call_queue()
-        wait(self._data)
+        DaskWrapper.wait(self._data)
 
     def mask(self, row_labels, col_labels):
         """

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/partition_manager.py
@@ -13,8 +13,6 @@
 
 """Module houses class that implements ``PandasDataframePartitionManager``."""
 
-from dask.distributed import wait
-
 from modin.core.dataframe.pandas.partitioning.partition_manager import (
     PandasDataframePartitionManager,
 )
@@ -47,7 +45,6 @@ class PandasOnDaskDataframePartitionManager(PandasDataframePartitionManager):
         partitions : np.ndarray
             NumPy array with ``PandasDataframePartition``-s.
         """
-        wait(
-            [block for partition in partitions for block in partition.list_of_blocks],
-            return_when="ALL_COMPLETED",
+        DaskWrapper.wait(
+            [block for partition in partitions for block in partition.list_of_blocks]
         )

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -15,7 +15,6 @@
 
 from distributed import Future
 from distributed.utils import get_ip
-from dask.distributed import wait
 
 import pandas
 
@@ -225,7 +224,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
     def wait(self):
         """Wait completing computations on the object wrapped by the partition."""
         self.drain_call_queue()
-        wait(self.list_of_blocks)
+        DaskWrapper.wait(self.list_of_blocks)
 
 
 @_inherit_docstrings(PandasOnDaskDataframeVirtualPartition.__init__)

--- a/modin/core/execution/ray/common/engine_wrapper.py
+++ b/modin/core/execution/ray/common/engine_wrapper.py
@@ -110,6 +110,23 @@ class RayWrapper:
         """
         return ray.put(data, **kwargs)
 
+    @classmethod
+    def wait(cls, obj_ids):
+        """
+        Wait on the objects without materializing them (blocking operation).
+
+        ``ray.wait`` assumes a list of unique object references: see
+        https://github.com/modin-project/modin/issues/5045
+
+        Parameters
+        ----------
+        objs_ids : list, scalar
+        """
+        if not isinstance(obj_ids, list):
+            obj_ids = [obj_ids]
+        unique_ids = list(set(obj_ids))
+        ray.wait(unique_ids, num_returns=len(unique_ids))
+
 
 @ray.remote
 class SignalActor:  # pragma: no cover

--- a/modin/core/execution/ray/common/engine_wrapper.py
+++ b/modin/core/execution/ray/common/engine_wrapper.py
@@ -111,7 +111,7 @@ class RayWrapper:
         return ray.put(data, **kwargs)
 
     @classmethod
-    def wait(cls, obj_ids):
+    def wait(cls, obj_ids, num_returns=None):
         """
         Wait on the objects without materializing them (blocking operation).
 
@@ -121,10 +121,13 @@ class RayWrapper:
         Parameters
         ----------
         obj_ids : list, scalar
+        num_returns : int, optional
         """
         if not isinstance(obj_ids, list):
             obj_ids = [obj_ids]
         unique_ids = list(set(obj_ids))
+        if num_returns is None:
+            num_returns = len(unique_ids)
         ray.wait(unique_ids, num_returns=len(unique_ids))
 
 

--- a/modin/core/execution/ray/common/engine_wrapper.py
+++ b/modin/core/execution/ray/common/engine_wrapper.py
@@ -128,7 +128,7 @@ class RayWrapper:
         unique_ids = list(set(obj_ids))
         if num_returns is None:
             num_returns = len(unique_ids)
-        ray.wait(unique_ids, num_returns=len(unique_ids))
+        ray.wait(unique_ids, num_returns=num_returns)
 
 
 @ray.remote

--- a/modin/core/execution/ray/common/engine_wrapper.py
+++ b/modin/core/execution/ray/common/engine_wrapper.py
@@ -120,7 +120,7 @@ class RayWrapper:
 
         Parameters
         ----------
-        objs_ids : list, scalar
+        obj_ids : list, scalar
         """
         if not isinstance(obj_ids, list):
             obj_ids = [obj_ids]

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -287,26 +287,3 @@ def deserialize(obj):  # pragma: no cover
         return dict(zip(obj.keys(), RayWrapper.materialize(list(obj.values()))))
     else:
         return obj
-
-
-def wait(obj_ids):
-    """
-    Wrap ``ray.wait`` to handle duplicate object references.
-
-    ``ray.wait`` assumes a list of unique object references: see
-    https://github.com/modin-project/modin/issues/5045
-
-    Parameters
-    ----------
-    obj_ids : List[ObjectIDType]
-        The object IDs to wait on.
-
-    Returns
-    -------
-    Tuple[List[ObjectIDType], List[ObjectIDType]]
-        A list of object IDs that are ready, and a list of object IDs remaining (this
-        is the same as for ``ray.wait``). Unlike ``ray.wait``, the order of these IDs is not
-        guaranteed.
-    """
-    unique_ids = list(set(obj_ids))
-    return ray.wait(unique_ids, num_returns=len(unique_ids))

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -16,7 +16,7 @@
 import ray
 from ray.util import get_node_ip_address
 
-from modin.core.execution.ray.common.utils import deserialize, ObjectIDType, wait
+from modin.core.execution.ray.common.utils import deserialize, ObjectIDType
 from modin.core.execution.ray.common import RayWrapper
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from modin.pandas.indexing import compute_sliced_len
@@ -154,7 +154,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
     def wait(self):
         """Wait completing computations on the object wrapped by the partition."""
         self.drain_call_queue()
-        wait([self._data])
+        RayWrapper.wait(self._data)
 
     def __copy__(self):
         """

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -17,7 +17,6 @@ from modin.core.execution.ray.generic.partitioning import (
     GenericRayDataframePartitionManager,
 )
 from modin.core.execution.ray.common import RayWrapper
-from modin.core.execution.ray.common.utils import wait
 from .virtual_partition import (
     PandasOnRayDataframeColumnPartition,
     PandasOnRayDataframeRowPartition,
@@ -47,10 +46,9 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         partitions : np.ndarray
             NumPy array with ``PandasDataframePartition``-s.
         """
-        blocks = [
-            block for partition in partitions for block in partition.list_of_blocks
-        ]
-        wait(blocks)
+        RayWrapper.wait(
+            [block for partition in partitions for block in partition.list_of_blocks]
+        )
 
 
 def _make_wrapped_method(name: str):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -20,7 +20,7 @@ from ray.util import get_node_ip_address
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
-from modin.core.execution.ray.common.utils import deserialize, wait
+from modin.core.execution.ray.common.utils import deserialize
 from modin.core.execution.ray.common import RayWrapper
 from .partition import PandasOnRayDataframePartition
 from modin.utils import _inherit_docstrings
@@ -245,7 +245,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         """Wait completing computations on the object wrapped by the partition."""
         self.drain_call_queue()
         futures = self.list_of_blocks
-        wait(futures)
+        RayWrapper.wait(futures)
 
 
 @_inherit_docstrings(PandasOnRayDataframeVirtualPartition.__init__)

--- a/modin/core/execution/unidist/common/engine_wrapper.py
+++ b/modin/core/execution/unidist/common/engine_wrapper.py
@@ -109,6 +109,23 @@ class UnidistWrapper:
         """
         return unidist.put(data)
 
+    @classmethod
+    def wait(cls, obj_ids):
+        """
+        Wait on the objects without materializing them (blocking operation).
+
+        ``unidist.wait`` assumes a list of unique object references: see
+        https://github.com/modin-project/modin/issues/5045
+
+        Parameters
+        ----------
+        objs_ids : list, scalar
+        """
+        if not isinstance(obj_ids, list):
+            obj_ids = [obj_ids]
+        unique_ids = list(set(obj_ids))
+        unidist.wait(unique_ids, num_returns=len(unique_ids))
+
 
 @unidist.remote
 class SignalActor:  # pragma: no cover

--- a/modin/core/execution/unidist/common/engine_wrapper.py
+++ b/modin/core/execution/unidist/common/engine_wrapper.py
@@ -110,7 +110,7 @@ class UnidistWrapper:
         return unidist.put(data)
 
     @classmethod
-    def wait(cls, obj_ids):
+    def wait(cls, obj_ids, num_returns=None):
         """
         Wait on the objects without materializing them (blocking operation).
 
@@ -120,11 +120,14 @@ class UnidistWrapper:
         Parameters
         ----------
         obj_ids : list, scalar
+        num_returns : int, optional
         """
         if not isinstance(obj_ids, list):
             obj_ids = [obj_ids]
         unique_ids = list(set(obj_ids))
-        unidist.wait(unique_ids, num_returns=len(unique_ids))
+        if num_returns is None:
+            num_returns = len(unique_ids)
+        unidist.wait(unique_ids, num_returns=num_returns)
 
 
 @unidist.remote

--- a/modin/core/execution/unidist/common/engine_wrapper.py
+++ b/modin/core/execution/unidist/common/engine_wrapper.py
@@ -119,7 +119,7 @@ class UnidistWrapper:
 
         Parameters
         ----------
-        objs_ids : list, scalar
+        obj_ids : list, scalar
         """
         if not isinstance(obj_ids, list):
             obj_ids = [obj_ids]

--- a/modin/core/execution/unidist/common/utils.py
+++ b/modin/core/execution/unidist/common/utils.py
@@ -89,28 +89,3 @@ def deserialize(obj):  # pragma: no cover
         return dict(zip(obj.keys(), deserialize(tuple(obj.values()))))
     else:
         return obj
-
-
-def wait(obj_refs):
-    """
-    Wrap ``unidist.wait`` to handle duplicate object references.
-
-    Parameters
-    ----------
-    obj_refs : List[unidist.ObjectRef]
-        The object IDs to wait on.
-
-    Returns
-    -------
-    Tuple[List[ObjectRef], List[ObjectRef]]
-        A list of object refs that are ready, and a list of object refs remaining (this
-        is the same as for ``ray.wait``). Unlike ``ray.wait``, the order of these refs is not
-        guaranteed.
-
-    Notes
-    -----
-    ``ray.wait`` assumes a list of unique object references: see
-    https://github.com/modin-project/modin/issues/5045.
-    """
-    unique_refs = list(set(obj_refs))
-    return unidist.wait(unique_refs, num_returns=len(unique_refs))

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -16,7 +16,7 @@
 import unidist
 
 from modin.core.execution.unidist.common import UnidistWrapper
-from modin.core.execution.unidist.common.utils import deserialize, wait
+from modin.core.execution.unidist.common.utils import deserialize
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from modin.pandas.indexing import compute_sliced_len
 from modin.logging import get_logger
@@ -148,7 +148,7 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
     def wait(self):
         """Wait completing computations on the object wrapped by the partition."""
         self.drain_call_queue()
-        wait([self._data])
+        UnidistWrapper.wait(self._data)
 
     # If unidist has not been initialized yet by Modin,
     # unidist itself handles initialization when calling `unidist.put`,

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition_manager.py
@@ -17,7 +17,6 @@ from modin.core.execution.unidist.generic.partitioning import (
     GenericUnidistDataframePartitionManager,
 )
 from modin.core.execution.unidist.common import UnidistWrapper
-from modin.core.execution.unidist.common.utils import wait
 from .virtual_partition import (
     PandasOnUnidistDataframeColumnPartition,
     PandasOnUnidistDataframeRowPartition,
@@ -47,10 +46,9 @@ class PandasOnUnidistDataframePartitionManager(GenericUnidistDataframePartitionM
         partitions : np.ndarray
             NumPy array with ``PandasDataframePartition``-s.
         """
-        blocks = [
-            block for partition in partitions for block in partition.list_of_blocks
-        ]
-        wait(blocks)
+        UnidistWrapper.wait(
+            [block for partition in partitions for block in partition.list_of_blocks]
+        )
 
 
 def _make_wrapped_method(name: str):

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -19,7 +19,7 @@ import unidist
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
-from modin.core.execution.unidist.common.utils import deserialize, wait
+from modin.core.execution.unidist.common.utils import deserialize
 from modin.core.execution.unidist.common import UnidistWrapper
 from .partition import PandasOnUnidistDataframePartition
 from modin.utils import _inherit_docstrings
@@ -244,7 +244,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         """Wait completing computations on the object wrapped by the partition."""
         self.drain_call_queue()
         futures = self.list_of_blocks
-        wait(futures)
+        UnidistWrapper.wait(futures)
 
 
 @_inherit_docstrings(PandasOnUnidistDataframeVirtualPartition.__init__)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6048 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
