### PR TITLE
TEST-#6198: add `pragma: no cover` for unidist and ray utils that used in remote context

### DIFF
--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -249,7 +249,7 @@ def _get_object_store_memory() -> Optional[int]:
     return object_store_memory
 
 
-def deserialize(obj):
+def deserialize(obj):  # pragma: no cover
     """
     Deserialize a Ray object.
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -327,7 +327,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
 
 
 @ray.remote(num_returns=2)
-def _get_index_and_columns(df):
+def _get_index_and_columns(df):  # pragma: no cover
     """
     Get the number of rows and columns of a pandas DataFrame.
 

--- a/modin/core/execution/unidist/common/utils.py
+++ b/modin/core/execution/unidist/common/utils.py
@@ -51,7 +51,7 @@ def initialize_unidist():
     modin_cfg.NPartitions._put(num_cpus)
 
 
-def deserialize(obj):
+def deserialize(obj):  # pragma: no cover
     """
     Deserialize a unidist object.
 

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -303,7 +303,7 @@ class PandasOnUnidistDataframePartition(PandasDataframePartition):
 
 
 @unidist.remote(num_returns=2)
-def _get_index_and_columns_size(df):
+def _get_index_and_columns_size(df):  # pragma: no cover
     """
     Get the number of rows and columns of a pandas DataFrame.
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6198 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
