### PR TITLE
FIX-#6196: Align `Series.cat` signatures with pandas

### DIFF
--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -18,8 +18,10 @@ Accessors: `Series.cat`, `Series.str`, `Series.dt`
 """
 from typing import TYPE_CHECKING
 import re
+
 import numpy as np
 import pandas
+import pandas._libs.lib as lib
 from modin.logging import ClassLogger
 from modin.utils import _inherit_docstrings
 
@@ -60,12 +62,12 @@ class CategoryMethods(ClassLogger):
     def codes(self):
         return self._Series(query_compiler=self._query_compiler.cat_codes())
 
-    def rename_categories(self, new_categories, inplace=False):
+    def rename_categories(self, new_categories, inplace=lib.no_default):
         return self._default_to_pandas(
             pandas.Series.cat.rename_categories, new_categories, inplace=inplace
         )
 
-    def reorder_categories(self, new_categories, ordered=None, inplace=False):
+    def reorder_categories(self, new_categories, ordered=None, inplace=lib.no_default):
         return self._default_to_pandas(
             pandas.Series.cat.reorder_categories,
             new_categories,
@@ -73,22 +75,24 @@ class CategoryMethods(ClassLogger):
             inplace=inplace,
         )
 
-    def add_categories(self, new_categories, inplace=False):
+    def add_categories(self, new_categories, inplace=lib.no_default):
         return self._default_to_pandas(
             pandas.Series.cat.add_categories, new_categories, inplace=inplace
         )
 
-    def remove_categories(self, removals, inplace=False):
+    def remove_categories(self, removals, inplace=lib.no_default):
         return self._default_to_pandas(
             pandas.Series.cat.remove_categories, removals, inplace=inplace
         )
 
-    def remove_unused_categories(self, inplace=False):
+    def remove_unused_categories(self, inplace=lib.no_default):
         return self._default_to_pandas(
             pandas.Series.cat.remove_unused_categories, inplace=inplace
         )
 
-    def set_categories(self, new_categories, ordered=None, rename=False, inplace=False):
+    def set_categories(
+        self, new_categories, ordered=None, rename=False, inplace=lib.no_default
+    ):
         return self._default_to_pandas(
             pandas.Series.cat.set_categories,
             new_categories,
@@ -97,10 +101,10 @@ class CategoryMethods(ClassLogger):
             inplace=inplace,
         )
 
-    def as_ordered(self, inplace=False):
+    def as_ordered(self, inplace=lib.no_default):
         return self._default_to_pandas(pandas.Series.cat.as_ordered, inplace=inplace)
 
-    def as_unordered(self, inplace=False):
+    def as_unordered(self, inplace=lib.no_default):
         return self._default_to_pandas(pandas.Series.cat.as_unordered, inplace=inplace)
 
     def _default_to_pandas(self, op, *args, **kwargs):

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -211,6 +211,9 @@ def test_series_cat_api_equality():
     assert not len(extra_in_modin), "Differences found in API: {}".format(
         extra_in_modin
     )
+    # all methods of `pandas.Series.cat` don't have any information about parameters,
+    # just method(*args, **kwargs)
+    assert_parameters_eq((pandas.core.arrays.Categorical, pd.Series.cat), modin_dir, [])
 
 
 @pytest.mark.parametrize("obj", ["DataFrame", "Series"])


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6196 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
