### PR TITLE
REFACTOR-#6062: Add query compiler interfaces for expanding methods

### DIFF
--- a/modin/core/dataframe/algebra/default2pandas/__init__.py
+++ b/modin/core/dataframe/algebra/default2pandas/__init__.py
@@ -19,7 +19,7 @@ from .series import SeriesDefault
 from .str import StrDefault
 from .binary import BinaryDefault
 from .resample import ResampleDefault
-from .rolling import RollingDefault
+from .rolling import RollingDefault, ExpandingDefault
 from .default import DefaultMethod
 from .cat import CatDefault
 from .groupby import GroupByDefault
@@ -32,6 +32,7 @@ __all__ = [
     "BinaryDefault",
     "ResampleDefault",
     "RollingDefault",
+    "ExpandingDefault",
     "DefaultMethod",
     "CatDefault",
     "GroupByDefault",

--- a/modin/core/dataframe/algebra/default2pandas/rolling.py
+++ b/modin/core/dataframe/algebra/default2pandas/rolling.py
@@ -15,7 +15,7 @@
 
 from .default import DefaultMethod
 
-   
+
 class RollingDefault(DefaultMethod):
     """Builder for default-to-pandas aggregation on a rolling window functions."""
 

--- a/modin/core/dataframe/algebra/default2pandas/rolling.py
+++ b/modin/core/dataframe/algebra/default2pandas/rolling.py
@@ -94,7 +94,7 @@ class ExpandingDefault(DefaultMethod):
 
         def fn(df, rolling_args, *args, **kwargs):
             """Create rolling window for the passed frame and execute specified `func` on it."""
-            roller = df.rolling(*rolling_args)
+            roller = df.expanding(*rolling_args)
 
             if type(func) == property:
                 return func.fget(roller)

--- a/modin/core/dataframe/algebra/default2pandas/rolling.py
+++ b/modin/core/dataframe/algebra/default2pandas/rolling.py
@@ -15,14 +15,14 @@
 
 from .default import DefaultMethod
 
+   
+class RollingDefault(DefaultMethod):
+    """Builder for default-to-pandas aggregation on a rolling window functions."""
 
-# FIXME: there is no sence of keeping `Rolling` and `RollingDefault` logic in a different
-# classes. They should be combined.
-class Rolling:
-    """Builder for aggregation on a rolling window functions."""
+    OBJECT_TYPE = "Rolling"
 
     @classmethod
-    def build_rolling(cls, func):
+    def _build_rolling(cls, func):
         """
         Build function that creates a rolling window and executes `func` on it.
 
@@ -48,12 +48,6 @@ class Rolling:
 
         return fn
 
-
-class RollingDefault(DefaultMethod):
-    """Builder for default-to-pandas aggregation on a rolling window functions."""
-
-    OBJECT_TYPE = "Rolling"
-
     @classmethod
     def register(cls, func, **kwargs):
         """
@@ -73,5 +67,60 @@ class RollingDefault(DefaultMethod):
             `func` on a rolling window.
         """
         return super().register(
-            Rolling.build_rolling(func), fn_name=func.__name__, **kwargs
+            cls._build_rolling(func), fn_name=func.__name__, **kwargs
+        )
+
+
+class ExpandingDefault(DefaultMethod):
+    """Builder for default-to-pandas aggregation on an expanding window functions."""
+
+    OBJECT_TYPE = "Expanding"
+
+    @classmethod
+    def _build_expanding(cls, func):
+        """
+        Build function that creates an expanding window and executes `func` on it.
+
+        Parameters
+        ----------
+        func : callable
+            Function to execute on a expanding window.
+
+        Returns
+        -------
+        callable
+            Function that takes pandas DataFrame and applies `func` on a expanding window.
+        """
+
+        def fn(df, rolling_args, *args, **kwargs):
+            """Create rolling window for the passed frame and execute specified `func` on it."""
+            roller = df.rolling(*rolling_args)
+
+            if type(func) == property:
+                return func.fget(roller)
+
+            return func(roller, *args, **kwargs)
+
+        return fn
+
+    @classmethod
+    def register(cls, func, **kwargs):
+        """
+        Build function that do fallback to pandas to apply `func` on a expanding window.
+
+        Parameters
+        ----------
+        func : callable
+            Function to execute on an expanding window.
+        **kwargs : kwargs
+            Additional arguments that will be passed to function builder.
+
+        Returns
+        -------
+        callable
+            Function that takes query compiler and defaults to pandas to apply aggregation
+            `func` on an expanding window.
+        """
+        return super().register(
+            cls._build_expanding(func), fn_name=func.__name__, **kwargs
         )

--- a/modin/core/storage_formats/base/doc_utils.py
+++ b/modin/core/storage_formats/base/doc_utils.py
@@ -535,6 +535,7 @@ doc_str_method = partial(
 
 
 def doc_window_method(
+    window_cls_name,
     result,
     refer_to,
     action=None,
@@ -543,10 +544,12 @@ def doc_window_method(
     build_rules="aggregation",
 ):
     """
-    Build decorator which adds docstring for the window method.
+    Build decorator which adds docstring for a window method.
 
     Parameters
     ----------
+    window_cls_name : str
+        The Window class the method is on.
     result : str
         The result of the method.
     refer_to : str
@@ -596,7 +599,12 @@ def doc_window_method(
     }
     if action is None:
         action = f"compute {result}"
-    window_args_name = "rolling_args" if win_type == "rolling window" else "window_args"
+    if win_type == "rolling window":
+        window_args_name = "rolling_args"
+    elif win_type == "expanding window":
+        window_args_name = "expanding_args"
+    else:
+        window_args_name = "window_args"
 
     # We need that `params` value ended with new line to have
     # an empty line between "parameters" and "return" sections
@@ -613,7 +621,7 @@ def doc_window_method(
         win_type=win_type,
         extra_params=params,
         build_rules=doc_build_rules.get(build_rules, build_rules),
-        refer_to=f"Rolling.{refer_to}",
+        refer_to=f"{window_cls_name}.{refer_to}",
         window_args_name=window_args_name,
     )
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -27,6 +27,7 @@ from modin.core.dataframe.algebra.default2pandas import (
     BinaryDefault,
     ResampleDefault,
     RollingDefault,
+    ExpandingDefault,
     CatDefault,
     GroupByDefault,
 )
@@ -5084,7 +5085,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         build_rules="udf_aggregation",
     )
     def expanding_aggregate(self, fold_axis, expanding_args, func, *args, **kwargs):
-        return RollingDefault.register(
+        return ExpandingDefault.register(
             pandas.core.window.expanding.Expanding.aggregate
         )(self, expanding_args, func, *args, **kwargs)
 
@@ -5098,7 +5099,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         **kwargs : dict""",
     )
     def expanding_sum(self, fold_axis, expanding_args, *args, **kwargs):
-        return RollingDefault.register(pandas.core.window.expanding.Expanding.sum)(
+        return ExpandingDefault.register(pandas.core.window.expanding.Expanding.sum)(
             self, expanding_args, *args, **kwargs
         )
 
@@ -5112,7 +5113,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         **kwargs : dict""",
     )
     def expanding_min(self, fold_axis, expanding_args, *args, **kwargs):
-        return RollingDefault.register(pandas.core.window.expanding.Expanding.min)(
+        return ExpandingDefault.register(pandas.core.window.expanding.Expanding.min)(
             self, expanding_args, *args, **kwargs
         )
 
@@ -5126,7 +5127,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         **kwargs : dict""",
     )
     def expanding_max(self, fold_axis, expanding_args, *args, **kwargs):
-        return RollingDefault.register(pandas.core.window.expanding.Expanding.max)(
+        return ExpandingDefault.register(pandas.core.window.expanding.Expanding.max)(
             self, expanding_args, *args, **kwargs
         )
 
@@ -5140,7 +5141,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         **kwargs : dict""",
     )
     def expanding_mean(self, fold_axis, expanding_args, *args, **kwargs):
-        return RollingDefault.register(pandas.core.window.expanding.Expanding.mean)(
+        return ExpandingDefault.register(pandas.core.window.expanding.Expanding.mean)(
             self, expanding_args, *args, **kwargs
         )
 
@@ -5155,7 +5156,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         **kwargs : dict""",
     )
     def expanding_var(self, fold_axis, expanding_args, ddof=1, *args, **kwargs):
-        return RollingDefault.register(pandas.core.window.expanding.Expanding.var)(
+        return ExpandingDefault.register(pandas.core.window.expanding.Expanding.var)(
             self, expanding_args, *args, **kwargs
         )
 
@@ -5170,7 +5171,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         **kwargs : dict""",
     )
     def expanding_std(self, fold_axis, expanding_args, ddof=1, *args, **kwargs):
-        return RollingDefault.register(pandas.core.window.expanding.Expanding.std)(
+        return ExpandingDefault.register(pandas.core.window.expanding.Expanding.std)(
             self, expanding_args, *args, **kwargs
         )
 
@@ -5185,7 +5186,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         **kwargs : dict""",
     )
     def expanding_count(self, fold_axis, expanding_args, ddof=1, *args, **kwargs):
-        return RollingDefault.register(pandas.core.window.expanding.Expanding.count)(
+        return ExpandingDefault.register(pandas.core.window.expanding.Expanding.count)(
             self, expanding_args, *args, **kwargs
         )
 
@@ -5203,7 +5204,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     def expanding_sem(
         self, fold_axis, expanding_args, ddof=1, numeric_only=False, *args, **kwargs
     ):
-        return RollingDefault.register(pandas.core.window.expanding.Expanding.sem)(
+        return ExpandingDefault.register(pandas.core.window.expanding.Expanding.sem)(
             self, expanding_args, ddof=ddof, numeric_only=numeric_only, *args, **kwargs
         )
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -4847,6 +4847,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     # from the API level, we should get rid of it (Modin issue #3108).
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="the result of passed functions",
         action="apply specified functions",
         refer_to="aggregate",
@@ -4865,6 +4866,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     # one of these should be removed (Modin issue #3107).
     @doc_utils.add_deprecation_warning(replacement_method="rolling_aggregate")
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="the result of passed function",
         action="apply specified function",
         refer_to="apply",
@@ -4895,6 +4897,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="correlation",
         refer_to="corr",
         params="""
@@ -4910,13 +4913,16 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             self, rolling_args, other, pairwise, *args, **kwargs
         )
 
-    @doc_utils.doc_window_method(result="number of non-NA values", refer_to="count")
+    @doc_utils.doc_window_method(
+        window_cls_name="Rolling", result="number of non-NA values", refer_to="count"
+    )
     def rolling_count(self, fold_axis, rolling_args):
         return RollingDefault.register(pandas.core.window.rolling.Rolling.count)(
             self, rolling_args
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="covariance",
         refer_to="cov",
         params="""
@@ -4933,7 +4939,10 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
-        result="unbiased kurtosis", refer_to="kurt", params="**kwargs : dict"
+        window_cls_name="Rolling",
+        result="unbiased kurtosis",
+        refer_to="kurt",
+        params="**kwargs : dict",
     )
     def rolling_kurt(self, fold_axis, rolling_args, **kwargs):
         return RollingDefault.register(pandas.core.window.rolling.Rolling.kurt)(
@@ -4941,6 +4950,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="maximum value",
         refer_to="max",
         params="""
@@ -4953,6 +4963,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="mean value",
         refer_to="mean",
         params="""
@@ -4965,7 +4976,10 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
-        result="median value", refer_to="median", params="**kwargs : dict"
+        window_cls_name="Rolling",
+        result="median value",
+        refer_to="median",
+        params="**kwargs : dict",
     )
     def rolling_median(self, fold_axis, rolling_args, **kwargs):
         return RollingDefault.register(pandas.core.window.rolling.Rolling.median)(
@@ -4973,6 +4987,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="minimum value",
         refer_to="min",
         params="""
@@ -4985,6 +5000,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="quantile",
         refer_to="quantile",
         params="""
@@ -5000,7 +5016,10 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
-        result="unbiased skewness", refer_to="skew", params="**kwargs : dict"
+        window_cls_name="Rolling",
+        result="unbiased skewness",
+        refer_to="skew",
+        params="**kwargs : dict",
     )
     def rolling_skew(self, fold_axis, rolling_args, **kwargs):
         return RollingDefault.register(pandas.core.window.rolling.Rolling.skew)(
@@ -5008,6 +5027,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="standard deviation",
         refer_to="std",
         params="""
@@ -5021,6 +5041,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="sum",
         refer_to="sum",
         params="""
@@ -5033,6 +5054,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         result="variance",
         refer_to="var",
         params="""
@@ -5049,49 +5071,140 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     # Begin Expanding methods
 
+    @doc_utils.doc_window_method(
+        window_cls_name="Expanding",
+        result="the result of passed functions",
+        action="apply specified functions",
+        refer_to="aggregate",
+        win_type="expanding window",
+        params="""
+        func : str, dict, callable(pandas.Series) -> scalar, or list of such
+        *args : iterable
+        **kwargs : dict""",
+        build_rules="udf_aggregation",
+    )
     def expanding_aggregate(self, fold_axis, expanding_args, func, *args, **kwargs):
         return RollingDefault.register(
             pandas.core.window.expanding.Expanding.aggregate
         )(self, expanding_args, func, *args, **kwargs)
 
+    @doc_utils.doc_window_method(
+        window_cls_name="Expanding",
+        result="sum",
+        refer_to="sum",
+        win_type="expanding window",
+        params="""
+        *args : iterable
+        **kwargs : dict""",
+    )
     def expanding_sum(self, fold_axis, expanding_args, *args, **kwargs):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.sum)(
             self, expanding_args, *args, **kwargs
         )
 
+    @doc_utils.doc_window_method(
+        window_cls_name="Expanding",
+        result="minimum value",
+        refer_to="min",
+        win_type="expanding window",
+        params="""
+        *args : iterable
+        **kwargs : dict""",
+    )
     def expanding_min(self, fold_axis, expanding_args, *args, **kwargs):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.min)(
             self, expanding_args, *args, **kwargs
         )
 
+    @doc_utils.doc_window_method(
+        window_cls_name="Expanding",
+        result="maximum value",
+        refer_to="max",
+        win_type="expanding window",
+        params="""
+        *args : iterable
+        **kwargs : dict""",
+    )
     def expanding_max(self, fold_axis, expanding_args, *args, **kwargs):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.max)(
             self, expanding_args, *args, **kwargs
         )
 
+    @doc_utils.doc_window_method(
+        window_cls_name="Expanding",
+        result="mean value",
+        refer_to="mean",
+        win_type="expanding window",
+        params="""
+        *args : iterable
+        **kwargs : dict""",
+    )
     def expanding_mean(self, fold_axis, expanding_args, *args, **kwargs):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.mean)(
             self, expanding_args, *args, **kwargs
         )
 
-    def expanding_var(self, fold_axis, expanding_args, *args, **kwargs):
+    @doc_utils.doc_window_method(
+        window_cls_name="Expanding",
+        result="variance",
+        refer_to="var",
+        win_type="expanding window",
+        params="""
+        ddof : int, default: 1
+        *args : iterable
+        **kwargs : dict""",
+    )
+    def expanding_var(self, fold_axis, expanding_args, ddof=1, *args, **kwargs):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.var)(
             self, expanding_args, *args, **kwargs
         )
 
-    def expanding_std(self, fold_axis, expanding_args, *args, **kwargs):
+    @doc_utils.doc_window_method(
+        window_cls_name="Expanding",
+        result="standard deviation",
+        refer_to="std",
+        win_type="expanding window",
+        params="""
+        ddof : int, default: 1
+        *args : iterable
+        **kwargs : dict""",
+    )
+    def expanding_std(self, fold_axis, expanding_args, ddof=1, *args, **kwargs):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.std)(
             self, expanding_args, *args, **kwargs
         )
 
-    def expanding_count(self, fold_axis, expanding_args, *args, **kwargs):
+    @doc_utils.doc_window_method(
+        window_cls_name="Expanding",
+        result="standard deviation",
+        refer_to="std",
+        win_type="expanding window",
+        params="""
+        ddof : int, default: 1
+        *args : iterable
+        **kwargs : dict""",
+    )
+    def expanding_count(self, fold_axis, expanding_args, ddof=1, *args, **kwargs):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.count)(
             self, expanding_args, *args, **kwargs
         )
 
-    def expanding_sem(self, fold_axis, expanding_args, *args, **kwargs):
+    @doc_utils.doc_window_method(
+        window_cls_name="Expanding",
+        result="unbiased standard error mean",
+        refer_to="std",
+        win_type="expanding window",
+        params="""
+        ddof : int, default: 1
+        numeric_only : bool, default: False
+        *args : iterable
+        **kwargs : dict""",
+    )
+    def expanding_sem(
+        self, fold_axis, expanding_args, ddof=1, numeric_only=False, *args, **kwargs
+    ):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.sem)(
-            self, expanding_args, *args, **kwargs
+            self, expanding_args, ddof=ddof, numeric_only=numeric_only, *args, **kwargs
         )
 
     # End of Expanding methods
@@ -5099,6 +5212,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     # Window methods
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         win_type="window of the specified type",
         result="mean",
         refer_to="mean",
@@ -5112,6 +5226,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         win_type="window of the specified type",
         result="standard deviation",
         refer_to="std",
@@ -5126,6 +5241,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         win_type="window of the specified type",
         result="sum",
         refer_to="sum",
@@ -5139,6 +5255,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_window_method(
+        window_cls_name="Rolling",
         win_type="window of the specified type",
         result="variance",
         refer_to="var",

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -5054,6 +5054,40 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             self, expanding_args, *args, **kwargs
         )
 
+    def expanding_min(self, fold_axis, expanding_args, *args, **kwargs):
+        return RollingDefault.register(pandas.core.window.expanding.Expanding.min)(
+            self, expanding_args, *args, **kwargs
+        )
+
+    def expanding_max(self, fold_axis, expanding_args, *args, **kwargs):
+        return RollingDefault.register(pandas.core.window.expanding.Expanding.max)(
+            self, expanding_args, *args, **kwargs
+        )
+    def expanding_mean(self, fold_axis, expanding_args, *args, **kwargs):
+        return RollingDefault.register(pandas.core.window.expanding.Expanding.mean)(
+            self, expanding_args, *args, **kwargs
+        )
+
+    def expanding_var(self, fold_axis, expanding_args, *args, **kwargs):
+        return RollingDefault.register(pandas.core.window.expanding.Expanding.var)(
+            self, expanding_args, *args, **kwargs
+        )
+
+    def expanding_std(self, fold_axis, expanding_args, *args, **kwargs):
+        return RollingDefault.register(pandas.core.window.expanding.Expanding.std)(
+            self, expanding_args, *args, **kwargs
+        )
+
+    def expanding_count(self, fold_axis, expanding_args, *args, **kwargs):
+        return RollingDefault.register(pandas.core.window.expanding.Expanding.count)(
+            self, expanding_args, *args, **kwargs
+        )
+
+    def expanding_sem(self, fold_axis, expanding_args, *args, **kwargs):
+        return RollingDefault.register(pandas.core.window.expanding.Expanding.sem)(
+            self, expanding_args, *args, **kwargs
+        )
+
     # End of Expanding methods
 
     # Window methods

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -5049,6 +5049,11 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     # Begin Expanding methods
 
+    def expanding_aggregate(self, fold_axis, expanding_args, func, *args, **kwargs):
+        return RollingDefault.register(
+            pandas.core.window.expanding.Expanding.aggregate
+        )(self, expanding_args, func, *args, **kwargs)
+
     def expanding_sum(self, fold_axis, expanding_args, *args, **kwargs):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.sum)(
             self, expanding_args, *args, **kwargs
@@ -5063,6 +5068,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.max)(
             self, expanding_args, *args, **kwargs
         )
+
     def expanding_mean(self, fold_axis, expanding_args, *args, **kwargs):
         return RollingDefault.register(pandas.core.window.expanding.Expanding.mean)(
             self, expanding_args, *args, **kwargs

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -5047,6 +5047,15 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     # End of Rolling methods
 
+    # Begin Expanding methods
+
+    def expanding_sum(self, fold_axis, expanding_args, *args, **kwargs):
+        return RollingDefault.register(pandas.core.window.expanding.Expanding.sum)(
+            self, expanding_args, *args, **kwargs
+        )
+
+    # End of Expanding methods
+
     # Window methods
 
     @doc_utils.doc_window_method(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1161,6 +1161,16 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def resample_quantile(self, resample_kwargs, q, **kwargs):
         return self._resample_func(resample_kwargs, "quantile", q=q, **kwargs)
 
+    def expanding_aggregate(self, axis, expanding_args, func, *args, **kwargs):
+        new_modin_frame = self._modin_frame.apply_full_axis(
+            axis,
+            lambda df: pandas.DataFrame(
+                df.expanding(*expanding_args).aggregate(func=func, *args, **kwargs)
+            ),
+            new_index=self.index,
+        )
+        return self.__constructor__(new_modin_frame)
+
     expanding_sum = Fold.register(
         lambda df, expanding_args, *args, **kwargs: pandas.DataFrame(
             df.expanding(*expanding_args).sum(*args, **kwargs)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1167,6 +1167,48 @@ class PandasQueryCompiler(BaseQueryCompiler):
         )
     )
 
+    expanding_min = Fold.register(
+        lambda df, expanding_args, *args, **kwargs: pandas.DataFrame(
+            df.expanding(*expanding_args).min(*args, **kwargs)
+        )
+    )
+
+    expanding_max = Fold.register(
+        lambda df, expanding_args, *args, **kwargs: pandas.DataFrame(
+            df.expanding(*expanding_args).max(*args, **kwargs)
+        )
+    )
+
+    expanding_mean = Fold.register(
+        lambda df, expanding_args, *args, **kwargs: pandas.DataFrame(
+            df.expanding(*expanding_args).mean(*args, **kwargs)
+        )
+    )
+
+    expanding_var = Fold.register(
+        lambda df, expanding_args, *args, **kwargs: pandas.DataFrame(
+            df.expanding(*expanding_args).var(*args, **kwargs)
+        )
+    )
+
+    expanding_std = Fold.register(
+        lambda df, expanding_args, *args, **kwargs: pandas.DataFrame(
+            df.expanding(*expanding_args).std(*args, **kwargs)
+        )
+    )
+
+    expanding_count = Fold.register(
+        lambda df, expanding_args, *args, **kwargs: pandas.DataFrame(
+            df.expanding(*expanding_args).count(*args, **kwargs)
+        )
+    )
+
+    expanding_sem = Fold.register(
+        lambda df, expanding_args, *args, **kwargs: pandas.DataFrame(
+            df.expanding(*expanding_args).sem(*args, **kwargs)
+        )
+    )
+
     window_mean = Fold.register(
         lambda df, rolling_args, *args, **kwargs: pandas.DataFrame(
             df.rolling(*rolling_args).mean(*args, **kwargs)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1161,6 +1161,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def resample_quantile(self, resample_kwargs, q, **kwargs):
         return self._resample_func(resample_kwargs, "quantile", q=q, **kwargs)
 
+    expanding_sum = Fold.register(
+        lambda df, expanding_args, *args, **kwargs: pandas.DataFrame(
+            df.expanding(*expanding_args).sum(*args, **kwargs)
+        )
+    )
+
     window_mean = Fold.register(
         lambda df, rolling_args, *args, **kwargs: pandas.DataFrame(
             df.rolling(*rolling_args).mean(*args, **kwargs)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1390,10 +1390,10 @@ class BasePandasDataset(ClassLogger):
             if is_integer(level):
                 level = index_columns[level]
             elif is_list_like(level):
-                level = [index_columns[l] if is_integer(l) else l for l in level]
+                level = [index_columns[c] if is_integer(c) else c for c in level]
             if is_list_like(level):
-                for l in level:
-                    index_columns.remove(l)
+                for c in level:
+                    index_columns.remove(c)
             else:
                 index_columns.remove(level)
             result = result.reset_index().drop(columns=[level]).set_index(index_columns)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -64,6 +64,7 @@ from modin import pandas as pd
 from modin.pandas.utils import is_scalar
 from modin.config import IsExperimental
 from modin.logging import disable_logging, ClassLogger
+from .window import Expanding
 
 # Similar to pandas, sentinel value to use as kwarg in place of None when None has
 # special meaning and needs to be distinguished from a user explicitly passing None.
@@ -1471,8 +1472,8 @@ class BasePandasDataset(ClassLogger):
         """
         Provide expanding window calculations.
         """
-        return self._default_to_pandas(
-            "expanding",
+        return Expanding(
+            self,
             min_periods=min_periods,
             center=center,
             axis=axis,

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1390,12 +1390,7 @@ class BasePandasDataset(ClassLogger):
             if is_integer(level):
                 level = index_columns[level]
             elif is_list_like(level):
-                level = [
-                    index_columns[l]
-                    if is_integer(l)
-                    else l
-                    for l in level
-                ]
+                level = [index_columns[l] if is_integer(l) else l for l in level]
             if is_list_like(level):
                 for l in level:
                     index_columns.remove(l)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -64,7 +64,6 @@ from modin import pandas as pd
 from modin.pandas.utils import is_scalar
 from modin.config import IsExperimental
 from modin.logging import disable_logging, ClassLogger
-from .window import Expanding
 
 # Similar to pandas, sentinel value to use as kwarg in place of None when None has
 # special meaning and needs to be distinguished from a user explicitly passing None.
@@ -1472,6 +1471,8 @@ class BasePandasDataset(ClassLogger):
         """
         Provide expanding window calculations.
         """
+        from .window import Expanding
+
         return Expanding(
             self,
             min_periods=min_periods,

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1384,12 +1384,26 @@ class BasePandasDataset(ClassLogger):
         Return `BasePandasDataset` with requested index / column level(s) removed.
         """
         axis = self._get_axis_number(axis)
-        new_axis = self.axes[axis].droplevel(level)
         result = self.copy()
         if axis == 0:
-            result.index = new_axis
+            index_columns = result.index.names.copy()
+            if is_integer(level):
+                level = index_columns[level]
+            elif is_list_like(level):
+                level = [
+                    index_columns[l]
+                    if is_integer(l)
+                    else l
+                    for l in level
+                ]
+            if is_list_like(level):
+                for l in level:
+                    index_columns.remove(l)
+            else:
+                index_columns.remove(level)
+            result = result.reset_index().drop(columns=[level]).set_index(index_columns)
         else:
-            result.columns = new_axis
+            raise NotImplementedError("'axis=1' is not supported yet")
         return result
 
     def drop_duplicates(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1384,21 +1384,12 @@ class BasePandasDataset(ClassLogger):
         Return `BasePandasDataset` with requested index / column level(s) removed.
         """
         axis = self._get_axis_number(axis)
+        new_axis = self.axes[axis].droplevel(level)
         result = self.copy()
         if axis == 0:
-            index_columns = result.index.names.copy()
-            if is_integer(level):
-                level = index_columns[level]
-            elif is_list_like(level):
-                level = [index_columns[c] if is_integer(c) else c for c in level]
-            if is_list_like(level):
-                for c in level:
-                    index_columns.remove(c)
-            else:
-                index_columns.remove(level)
-            result = result.reset_index().drop(columns=[level]).set_index(index_columns)
+            result.index = new_axis
         else:
-            raise NotImplementedError("'axis=1' is not supported yet")
+            result.columns = new_axis
         return result
 
     def drop_duplicates(

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -3152,9 +3152,13 @@ class DataFrame(BasePandasDataset):
         axis = self._get_axis_number(axis)
         renamed = self if inplace else self.copy()
         if axis == 0:
-            renamed.index = renamed.index.set_names(name)
+            if not is_list_like(name):
+                name = [name]
+            renamed = renamed.reset_index()
+            mapper = {n1:n2 for n1, n2 in zip(renamed.columns, list(name))}
+            renamed = renamed.rename(columns=mapper).set_index(list(name))
         else:
-            renamed.columns = renamed.columns.set_names(name)
+            raise NotImplementedError("'axis=1' is not supported yet")
         if not inplace:
             return renamed
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -3152,13 +3152,9 @@ class DataFrame(BasePandasDataset):
         axis = self._get_axis_number(axis)
         renamed = self if inplace else self.copy()
         if axis == 0:
-            if not is_list_like(name):
-                name = [name]
-            renamed = renamed.reset_index()
-            mapper = {n1: n2 for n1, n2 in zip(renamed.columns, list(name))}
-            renamed = renamed.rename(columns=mapper).set_index(list(name))
+            renamed.index = renamed.index.set_names(name)
         else:
-            raise NotImplementedError("'axis=1' is not supported yet")
+            renamed.columns = renamed.columns.set_names(name)
         if not inplace:
             return renamed
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -3155,7 +3155,7 @@ class DataFrame(BasePandasDataset):
             if not is_list_like(name):
                 name = [name]
             renamed = renamed.reset_index()
-            mapper = {n1:n2 for n1, n2 in zip(renamed.columns, list(name))}
+            mapper = {n1: n2 for n1, n2 in zip(renamed.columns, list(name))}
             renamed = renamed.rename(columns=mapper).set_index(list(name))
         else:
             raise NotImplementedError("'axis=1' is not supported yet")

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -63,7 +63,6 @@ pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
     "op, make_args",
     [
         ("align", lambda df: {"other": df}),
-        ("expanding", None),
         ("corrwith", lambda df: {"other": df}),
         ("ewm", lambda df: {"com": 0.5}),
         ("from_dict", lambda df: {"data": None}),

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -60,6 +60,7 @@ def test_top_level_api_equality():
         "warnings",
         "os",
         "series_utils",
+        "window",
     ]
 
     assert not len(

--- a/modin/pandas/test/test_expanding.py
+++ b/modin/pandas/test/test_expanding.py
@@ -39,27 +39,9 @@ def create_test_series(vals):
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("min_periods", [None, 5])
 @pytest.mark.parametrize("axis", [0, 1])
-def test_dataframe(data, min_periods, axis):
-    modin_df = pd.DataFrame(data)
-    pandas_df = pandas.DataFrame(data)
-    pandas_expanded = pandas_df.expanding(
-        min_periods=min_periods,
-        center=True,
-        axis=axis,
-    )
-    modin_expanded = modin_df.expanding(
-        min_periods=min_periods,
-        center=True,
-        axis=axis,
-    )
-
-    df_equals(modin_expanded.count(), pandas_expanded.count())
-    df_equals(modin_expanded.sum(), pandas_expanded.sum())
-    df_equals(modin_expanded.mean(), pandas_expanded.mean())
-    df_equals(modin_expanded.var(ddof=0), pandas_expanded.var(ddof=0))
-    df_equals(modin_expanded.std(ddof=0), pandas_expanded.std(ddof=0))
-    df_equals(modin_expanded.min(), pandas_expanded.min())
-    df_equals(modin_expanded.max(), pandas_expanded.max())
+@pytest.mark.parametrize("method, kwargs", [("count", {}), ("sum", {}), ("mean", {}), ("var", {"ddof": 0}), ("std", {"ddof": 0}), ("min", {}), ("max", {})])
+def test_dataframe(data, min_periods, axis, method, kwargs):
+    eval_general(*create_test_dfs(data), lambda df: getattr(df.expanding(min_periods=min_periods, center=True, axis=axis), method)(**kwargs))
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_expanding.py
+++ b/modin/pandas/test/test_expanding.py
@@ -1,0 +1,129 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pytest
+import numpy as np
+import pandas
+import modin.pandas as pd
+
+from .utils import (
+    df_equals,
+    test_data_values,
+    test_data_keys,
+    create_test_dfs,
+    default_to_pandas_ignore_string,
+)
+from modin.config import NPartitions
+
+NPartitions.put(4)
+
+
+def create_test_series(vals):
+    if isinstance(vals, dict):
+        modin_series = pd.Series(vals[next(iter(vals.keys()))])
+        pandas_series = pandas.Series(vals[next(iter(vals.keys()))])
+    else:
+        modin_series = pd.Series(vals)
+        pandas_series = pandas.Series(vals)
+    return modin_series, pandas_series
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize("min_periods", [None, 5])
+@pytest.mark.parametrize("axis", [0, 1])
+def test_dataframe(data, min_periods, axis):
+    modin_df = pd.DataFrame(data)
+    pandas_df = pandas.DataFrame(data)
+    pandas_expanded = pandas_df.expanding(
+        min_periods=min_periods,
+        center=True,
+        axis=axis,
+    )
+    modin_expanded = modin_df.expanding(
+        min_periods=min_periods,
+        center=True,
+        axis=axis,
+    )
+
+    df_equals(modin_expanded.count(), pandas_expanded.count())
+    df_equals(modin_expanded.sum(), pandas_expanded.sum())
+    df_equals(modin_expanded.mean(), pandas_expanded.mean())
+    df_equals(modin_expanded.var(ddof=0), pandas_expanded.var(ddof=0))
+    df_equals(modin_expanded.std(ddof=0), pandas_expanded.std(ddof=0))
+    df_equals(modin_expanded.min(), pandas_expanded.min())
+    df_equals(modin_expanded.max(), pandas_expanded.max())
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize("min_periods", [None, 5])
+def test_dataframe_agg(data, min_periods):
+    modin_df = pd.DataFrame(data)
+    pandas_df = pandas.DataFrame(data)
+    pandas_expanded = pandas_df.expanding(
+        min_periods=min_periods,
+        center=True,
+        axis=0,
+    )
+    modin_expanded = modin_df.expanding(
+        min_periods=min_periods,
+        center=True,
+        axis=0,
+    )
+    # aggregates are only supported on axis 0
+    df_equals(modin_expanded.aggregate(np.sum), pandas_expanded.aggregate(np.sum))
+    df_equals(
+        pandas_expanded.aggregate([np.sum, np.mean]),
+        modin_expanded.aggregate([np.sum, np.mean]),
+    )
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize("min_periods", [None, 5])
+def test_series(data, min_periods):
+    modin_series, pandas_series = create_test_series(data)
+    pandas_expanded = pandas_series.expanding(
+        min_periods=min_periods,
+        center=True,
+    )
+    modin_expanded = modin_series.expanding(
+        min_periods=min_periods,
+        center=True,
+    )
+
+    df_equals(modin_expanded.count(), pandas_expanded.count())
+    df_equals(modin_expanded.sum(), pandas_expanded.sum())
+    df_equals(modin_expanded.mean(), pandas_expanded.mean())
+    df_equals(modin_expanded.var(ddof=0), pandas_expanded.var(ddof=0))
+    df_equals(modin_expanded.std(ddof=0), pandas_expanded.std(ddof=0))
+    df_equals(modin_expanded.min(), pandas_expanded.min())
+    df_equals(modin_expanded.max(), pandas_expanded.max())
+
+
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize("min_periods", [None, 5])
+def test_series_agg(data, min_periods):
+    modin_series, pandas_series = create_test_series(data)
+    pandas_expanded = pandas_series.expanding(
+        min_periods=min_periods,
+        center=True,
+    )
+    modin_expanded = modin_series.expanding(
+        min_periods=min_periods,
+        center=True,
+    )
+
+    df_equals(modin_expanded.aggregate(np.sum), pandas_expanded.aggregate(np.sum))
+    df_equals(
+        pandas_expanded.aggregate([np.sum, np.mean]),
+        modin_expanded.aggregate([np.sum, np.mean]),
+    )

--- a/modin/pandas/test/test_expanding.py
+++ b/modin/pandas/test/test_expanding.py
@@ -20,8 +20,6 @@ from .utils import (
     df_equals,
     test_data_values,
     test_data_keys,
-    create_test_dfs,
-    default_to_pandas_ignore_string,
 )
 from modin.config import NPartitions
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1894,9 +1894,8 @@ def test_ewm(data):
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_expanding(data):
-    modin_series, _ = create_test_series(data)  # noqa: F841
-    with warns_that_defaulting_to_pandas():
-        modin_series.expanding()
+    modin_series, pandas_series = create_test_series(data)  # noqa: F841
+    df_equals(modin_series.expanding().sum(), pandas_series.expanding().sum())
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2303,6 +2303,7 @@ def test_loc(data):
     data = np.arange(100)
     modin_series = pd.Series(data, index=index).sort_index()
     pandas_series = pandas.Series(data, index=index).sort_index()
+    # Using 'fmt: skip' below as 'black' and 'flake8' can't agree on how this should be formatted
     modin_result = modin_series.loc[
         (slice(None), 1),
     ]  # fmt: skip

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2303,7 +2303,6 @@ def test_loc(data):
     data = np.arange(100)
     modin_series = pd.Series(data, index=index).sort_index()
     pandas_series = pandas.Series(data, index=index).sort_index()
-    # Using 'fmt: skip' below as 'black' and 'flake8' can't agree on how this should be formatted
     modin_result = modin_series.loc[
         (slice(None), 1),
     ]  # fmt: skip

--- a/modin/pandas/window.py
+++ b/modin/pandas/window.py
@@ -290,6 +290,11 @@ class Expanding(ClassLogger):
         ]
         self.axis = axis
 
+    def aggregate(self, *args, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_aggregate(
+                self.axis, self.expanding_args, *args, **kwargs)
+        )
     def sum(self, *args, **kwargs):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.expanding_sum(

--- a/modin/pandas/window.py
+++ b/modin/pandas/window.py
@@ -273,6 +273,26 @@ class Rolling(ClassLogger):
             )
         )
 
+    def rank(
+        self,
+        method="average",
+        ascending=True,
+        pct=False,
+        numeric_only=False,
+        **kwargs
+    ):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.rolling_rank(
+                self.axis,
+                self.rolling_args,
+                method,
+                ascending,
+                pct,
+                numeric_only,
+                **kwargs
+            )
+        )
+
 
 @_inherit_docstrings(
     pandas.core.window.expanding.Expanding,
@@ -351,3 +371,44 @@ class Expanding(ClassLogger):
             )
         )
 
+    def skew(self, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_skew(
+                self.axis, self.expanding_args, **kwargs
+            )
+        )
+
+    def kurt(self, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_kurt(
+                self.axis, self.expanding_args, **kwargs
+            )
+        )
+
+    def quantile(self, quantile, interpolation="linear", **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_quantile(
+                self.axis, self.expanding_args, quantile, interpolation, **kwargs
+            )
+        )
+
+    def rank(
+        self,
+        method="average",
+        ascending=True,
+        pct=False,
+        numeric_only=False,
+        **kwargs
+    ):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_rank(
+                self.axis,
+                self.expanding_args,
+                method,
+                ascending,
+                pct,
+                numeric_only,
+                **kwargs
+            )
+        )
+>>>>>>> 3c10b00d (FEAT: Add support for rolling/expanding.quantile/rank, rename_axis, droplevel (#31))

--- a/modin/pandas/window.py
+++ b/modin/pandas/window.py
@@ -274,12 +274,7 @@ class Rolling(ClassLogger):
         )
 
     def rank(
-        self,
-        method="average",
-        ascending=True,
-        pct=False,
-        numeric_only=False,
-        **kwargs
+        self, method="average", ascending=True, pct=False, numeric_only=False, **kwargs
     ):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.rolling_rank(
@@ -289,7 +284,7 @@ class Rolling(ClassLogger):
                 ascending,
                 pct,
                 numeric_only,
-                **kwargs
+                **kwargs,
             )
         )
 
@@ -310,11 +305,22 @@ class Expanding(ClassLogger):
         ]
         self.axis = axis
 
-    def aggregate(self, *args, **kwargs):
-        return self._dataframe.__constructor__(
+    def aggregate(self, func, *args, **kwargs):
+        from .dataframe import DataFrame
+
+        dataframe = DataFrame(
             query_compiler=self._query_compiler.expanding_aggregate(
-                self.axis, self.expanding_args, *args, **kwargs)
+                self.axis, self.expanding_args, func, *args, **kwargs
+            )
         )
+        if isinstance(self._dataframe, DataFrame):
+            return dataframe
+        elif is_list_like(func):
+            dataframe.columns = dataframe.columns.droplevel()
+            return dataframe
+        else:
+            return dataframe.squeeze()
+
     def sum(self, *args, **kwargs):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.expanding_sum(
@@ -393,12 +399,7 @@ class Expanding(ClassLogger):
         )
 
     def rank(
-        self,
-        method="average",
-        ascending=True,
-        pct=False,
-        numeric_only=False,
-        **kwargs
+        self, method="average", ascending=True, pct=False, numeric_only=False, **kwargs
     ):
         return self._dataframe.__constructor__(
             query_compiler=self._query_compiler.expanding_rank(
@@ -408,6 +409,6 @@ class Expanding(ClassLogger):
                 ascending,
                 pct,
                 numeric_only,
-                **kwargs
+                **kwargs,
             )
         )

--- a/modin/pandas/window.py
+++ b/modin/pandas/window.py
@@ -272,3 +272,27 @@ class Rolling(ClassLogger):
                 self.axis, self.rolling_args, quantile, interpolation, **kwargs
             )
         )
+
+
+@_inherit_docstrings(
+    pandas.core.window.expanding.Expanding,
+    excluded=[pandas.core.window.expanding.Expanding.__init__],
+)
+class Expanding(ClassLogger):
+    def __init__(self, dataframe, min_periods=1, center=None, axis=0, method="single"):
+        self._dataframe = dataframe
+        self._query_compiler = dataframe._query_compiler
+        self.expanding_args = [
+            min_periods,
+            center,
+            axis,
+            method,
+        ]
+        self.axis = axis
+
+    def sum(self, *args, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_sum(
+                self.axis, self.expanding_args, *args, **kwargs
+            )
+        )

--- a/modin/pandas/window.py
+++ b/modin/pandas/window.py
@@ -301,3 +301,53 @@ class Expanding(ClassLogger):
                 self.axis, self.expanding_args, *args, **kwargs
             )
         )
+
+    def min(self, *args, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_min(
+                self.axis, self.expanding_args, *args, **kwargs
+            )
+        )
+
+    def max(self, *args, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_max(
+                self.axis, self.expanding_args, *args, **kwargs
+            )
+        )
+
+    def mean(self, *args, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_mean(
+                self.axis, self.expanding_args, *args, **kwargs
+            )
+        )
+
+    def var(self, *args, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_var(
+                self.axis, self.expanding_args, *args, **kwargs
+            )
+        )
+
+    def std(self, *args, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_std(
+                self.axis, self.expanding_args, *args, **kwargs
+            )
+        )
+
+    def count(self, *args, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_count(
+                self.axis, self.expanding_args, *args, **kwargs
+            )
+        )
+
+    def sem(self, *args, **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.expanding_sem(
+                self.axis, self.expanding_args, *args, **kwargs
+            )
+        )
+

--- a/modin/pandas/window.py
+++ b/modin/pandas/window.py
@@ -411,4 +411,3 @@ class Expanding(ClassLogger):
                 **kwargs
             )
         )
->>>>>>> 3c10b00d (FEAT: Add support for rolling/expanding.quantile/rank, rename_axis, droplevel (#31))

--- a/modin/pandas/window.py
+++ b/modin/pandas/window.py
@@ -266,28 +266,6 @@ class Rolling(ClassLogger):
 
     agg = aggregate
 
-    def quantile(self, quantile, interpolation="linear", **kwargs):
-        return self._dataframe.__constructor__(
-            query_compiler=self._query_compiler.rolling_quantile(
-                self.axis, self.rolling_args, quantile, interpolation, **kwargs
-            )
-        )
-
-    def rank(
-        self, method="average", ascending=True, pct=False, numeric_only=False, **kwargs
-    ):
-        return self._dataframe.__constructor__(
-            query_compiler=self._query_compiler.rolling_rank(
-                self.axis,
-                self.rolling_args,
-                method,
-                ascending,
-                pct,
-                numeric_only,
-                **kwargs,
-            )
-        )
-
 
 @_inherit_docstrings(
     pandas.core.window.expanding.Expanding,

--- a/modin/pandas/window.py
+++ b/modin/pandas/window.py
@@ -266,6 +266,13 @@ class Rolling(ClassLogger):
 
     agg = aggregate
 
+    def quantile(self, quantile, interpolation="linear", **kwargs):
+        return self._dataframe.__constructor__(
+            query_compiler=self._query_compiler.rolling_quantile(
+                self.axis, self.rolling_args, quantile, interpolation, **kwargs
+            )
+        )
+
 
 @_inherit_docstrings(
     pandas.core.window.expanding.Expanding,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Ports pandas expanding window methods implemented in https://github.com/ponder-org/modin-public, and adds simple tests.

The implementation for `Expanding.aggregate` has been changed to match that of `Rolling.aggregate` in order to support lists of multiple aggregation functions; it seems like this method was not tested in the other repository's version.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6062
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
