### PR TITLE
REFACTOR-#6091: Push more of memory_usage down to query compiler.

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -42,7 +42,6 @@ import sys
 from typing import IO, Optional, Union, Iterator, Hashable, Sequence
 import warnings
 
-import modin
 from modin.pandas import Categorical
 from modin.error_message import ErrorMessage
 from modin.utils import (
@@ -1459,18 +1458,6 @@ class DataFrame(BasePandasDataset):
                 ignore_index=ignore_index,
             )
         )
-
-    def memory_usage(self, index=True, deep=False):  # noqa: PR01, RT01, D200
-        """
-        Return the memory usage of each column in bytes.
-        """
-        if index:
-            result = self._reduce_dimension(
-                self._query_compiler.memory_usage(index=False, deep=deep)
-            )
-            index_value = self.index.memory_usage(deep=deep)
-            return modin.pandas.concat([Series(index_value, index=["Index"]), result])
-        return super(DataFrame, self).memory_usage(index=index, deep=deep)
 
     def merge(
         self,

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1327,13 +1327,7 @@ class Series(BasePandasDataset):
         """
         Return the memory usage of the Series.
         """
-        if index:
-            result = self._reduce_dimension(
-                self._query_compiler.memory_usage(index=False, deep=deep)
-            )
-            index_value = self.index.memory_usage(deep=deep)
-            return result + index_value
-        return super(Series, self).memory_usage(index=index, deep=deep)
+        return super(Series, self).memory_usage(index=index, deep=deep).sum()
 
     def mod(self, other, level=None, fill_value=None, axis=0):  # noqa: PR01, RT01, D200
         """


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6091 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
