### PR TITLE
FIX-#6120: HDK read_csv(): Fixed parsing dates with nanosecond precision

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -156,14 +156,18 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
                 column_types = {}
 
             if parse_dates := kwargs["parse_dates"]:
-                if isinstance(parse_dates, list) and isinstance(
-                    parse_dates[0], (str, int)
+                # Either list of column names or list of column indices is supported.
+                if isinstance(parse_dates, list) and (
+                    all(isinstance(col, str) for col in parse_dates)
+                    or all(isinstance(col, int) for col in parse_dates)
                 ):
                     # Pandas uses datetime64[ns] dtype for dates.
                     timestamp_dt = pa.timestamp("ns")
                     if names and isinstance(parse_dates[0], str):
-                        # If both `names` and column names in `parse_dates` are
-                        # specified, replace the column names with indices.
+                        # The `names` parameter could be used to override the
+                        # column names. If new names are specified in `parse_dates`
+                        # they should be replaced with the real names. Replacing
+                        # with the column indices first.
                         parse_dates = [names.index(name) for name in parse_dates]
                     if isinstance(parse_dates[0], int):
                         # If column indices are specified, load the column names

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -159,10 +159,15 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
                 if isinstance(parse_dates, list) and isinstance(
                     parse_dates[0], (str, int)
                 ):
+                    # Pandas uses datetime64[ns] dtype for dates.
                     timestamp_dt = pa.timestamp("ns")
                     if names and isinstance(parse_dates[0], str):
+                        # If both `names` and column names in `parse_dates` are
+                        # specified, replace the column names with indices.
                         parse_dates = [names.index(name) for name in parse_dates]
                     if isinstance(parse_dates[0], int):
+                        # If column indices are specified, load the column names
+                        # with pandas and replace the indices with column names.
                         column_names = get_col_names()
                         parse_dates = [column_names[i] for i in parse_dates]
                     for c in parse_dates:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -136,7 +136,7 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
             if names and kwargs["header"] == 0:
                 skiprows = skiprows + 1 if skiprows is not None else 1
 
-            @functools.cache
+            @functools.lru_cache(maxsize=None)
             def get_col_names():
                 # Using pandas to read the column names
                 return pandas.read_csv(

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -19,6 +19,7 @@ Module houses ``HdkOnNativeIO`` class.
 
 from csv import Dialect
 from typing import Union, Sequence, Callable, Dict, Tuple
+import functools
 import inspect
 import os
 
@@ -135,16 +136,12 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
             if names and kwargs["header"] == 0:
                 skiprows = skiprows + 1 if skiprows is not None else 1
 
-            column_names = None
-
+            @functools.cache
             def get_col_names():
-                nonlocal column_names
-                if column_names is None:
-                    # Using pandas to read the column names
-                    column_names = pandas.read_csv(
-                        kwargs["filepath_or_buffer"], nrows=0, engine="c"
-                    ).columns.tolist()
-                return column_names
+                # Using pandas to read the column names
+                return pandas.read_csv(
+                    kwargs["filepath_or_buffer"], nrows=0, engine="c"
+                ).columns.tolist()
 
             if dtype := kwargs["dtype"]:
                 if isinstance(dtype, dict):

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -546,15 +546,6 @@ class TestCsv:
         dayfirst,
         cache_dates,
     ):
-        if (
-            StorageFormat.get() == "Hdk"
-            and isinstance(parse_dates, list)
-            and ("col4" in parse_dates or 3 in parse_dates)
-        ):
-            pytest.xfail(
-                "In some cases read_csv with `parse_dates` with HDK storage format outputs incorrect result - issue #3081"
-            )
-
         raising_exceptions = io_ops_bad_exc  # default value
         if isinstance(parse_dates, dict) and callable(date_parser):
             # In this case raised TypeError: <lambda>() takes 1 positional argument but 2 were given
@@ -574,6 +565,21 @@ class TestCsv:
             dayfirst=dayfirst,
             cache_dates=cache_dates,
         )
+
+    @pytest.mark.parametrize("date", ["2023-01-01 00:00:01.000000000", "2023"])
+    @pytest.mark.parametrize("dtype", [None, "str", {"id": "int64"}])
+    @pytest.mark.parametrize("parse_dates", [None, [], ["date"], [1]])
+    def test_read_csv_dtype_parse_dates(self, date, dtype, parse_dates):
+        with ensure_clean(".csv") as filename:
+            with open(filename, "w") as file:
+                file.write(f"id,date\n1,{date}")
+            eval_io(
+                fn_name="read_csv",
+                # read_csv kwargs
+                filepath_or_buffer=filename,
+                dtype=dtype,
+                parse_dates=parse_dates,
+            )
 
     # Iteration tests
     @pytest.mark.parametrize("iterator", [True, False])


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6120 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
