### PR TITLE
REFACTOR-#6071: Push first and last down to query compiler. (#64)

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -4392,6 +4392,44 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     # End of DateTime methods
 
+    def first(self, offset: pandas.DateOffset):
+        """
+        Select initial periods of time series data based on a date offset.
+
+        When having a query compiler with dates as index, this function can
+        select the first few rows based on a date offset.
+
+        Parameters
+        ----------
+        offset : pandas.DateOffset
+            The offset length of the data to select.
+
+        Returns
+        -------
+        BaseQueryCompiler
+            New compiler containing the selected data.
+        """
+        return DataFrameDefault.register(pandas.DataFrame.first)(self, offset)
+
+    def last(self, offset: pandas.DateOffset):
+        """
+        Select final periods of time series data based on a date offset.
+
+        For a query compiler with a sorted DatetimeIndex, this function
+        selects the last few rows based on a date offset.
+
+        Parameters
+        ----------
+        offset : pandas.DateOffset
+            The offset length of the data to select.
+
+        Returns
+        -------
+        BaseQueryCompiler
+            New compiler containing the selected data.
+        """
+        return DataFrameDefault.register(pandas.DataFrame.last)(self, offset)
+
     # Resample methods
 
     # FIXME:

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1629,7 +1629,7 @@ class BasePandasDataset(ClassLogger):
         Select initial periods of time series data based on a date offset.
         """
         return self._create_or_update_from_compiler(
-            self._query_compiler.first(to_offset(offset))
+            self._query_compiler.first(offset=to_offset(offset))
         )
 
     def first_valid_index(self):  # noqa: RT01, D200
@@ -1812,7 +1812,7 @@ class BasePandasDataset(ClassLogger):
         Select final periods of time series data based on a date offset.
         """
         return self._create_or_update_from_compiler(
-            self._query_compiler.last(to_offset(offset))
+            self._query_compiler.last(offset=to_offset(offset))
         )
 
     def last_valid_index(self):  # noqa: RT01, D200

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -10,7 +10,6 @@
 # the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
-
 """Implement DataFrame/Series public API as pandas does."""
 from __future__ import annotations
 import numpy as np
@@ -39,6 +38,7 @@ from pandas.util._validators import (
 )
 from pandas._libs.lib import NoDefault
 from pandas._libs.lib import no_default
+from pandas._libs.tslibs import to_offset
 from pandas._typing import (
     IndexKeyFunc,
     StorageOptions,
@@ -1628,7 +1628,9 @@ class BasePandasDataset(ClassLogger):
         """
         Select initial periods of time series data based on a date offset.
         """
-        return self.loc[pandas.Series(index=self.index).first(offset).index]
+        return self._create_or_update_from_compiler(
+            self._query_compiler.first(to_offset(offset))
+        )
 
     def first_valid_index(self):  # noqa: RT01, D200
         """
@@ -1809,7 +1811,9 @@ class BasePandasDataset(ClassLogger):
         """
         Select final periods of time series data based on a date offset.
         """
-        return self.loc[pandas.Series(index=self.index).last(offset).index]
+        return self._create_or_update_from_compiler(
+            self._query_compiler.last(to_offset(offset))
+        )
 
     def last_valid_index(self):  # noqa: RT01, D200
         """


### PR DESCRIPTION

Signed-off-by: mvashishtha <mahesh@ponder.io><!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

REFACTOR-#6071: Push first and last down to query compiler. (#64) [core]

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6071 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
