### PR TITLE
REFACTOR-#6116: Move `groupby_ohlc` implementation to QC layer

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3461,7 +3461,17 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         agg_kwargs,
         is_df,
     ):
-        return DataFrameDefault.register(lambda df: df.ohlc())(self)
+        if not is_df:
+            return self.groupby_agg(
+                by=by,
+                agg_func="ohlc",
+                axis=axis,
+                groupby_kwargs=groupby_kwargs,
+                agg_args=agg_args,
+                agg_kwargs=agg_kwargs,
+                series_groupby=True,
+            )
+        return self.default_to_pandas(lambda df: df.ohlc())
 
     # END Manual Partitioning methods
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3459,6 +3459,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         groupby_kwargs,
         agg_args,
         agg_kwargs,
+        is_df,
     ):
         return DataFrameDefault.register(lambda df: df.ohlc())(self)
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3471,7 +3471,15 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
                 agg_kwargs=agg_kwargs,
                 series_groupby=True,
             )
-        return self.default_to_pandas(lambda df: df.ohlc())
+        return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.ohlc)(
+            self,
+            by=by,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=True,
+        )
 
     # END Manual Partitioning methods
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3452,6 +3452,16 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             series_groupby=True,
         )
 
+    def groupby_ohlc(
+        self,
+        by,
+        axis,
+        groupby_kwargs,
+        agg_args,
+        agg_kwargs,
+    ):
+        return DataFrameDefault.register(lambda df: df.ohlc())(self)
+
     # END Manual Partitioning methods
 
     @doc_utils.add_refer_to("DataFrame.unstack")

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -300,6 +300,7 @@ class DataFrameGroupBy(ClassLogger):
 
     def ohlc(self):
         from .dataframe import DataFrame
+
         return DataFrame(
             query_compiler=self._query_compiler.groupby_ohlc(
                 by=self._by,

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -307,6 +307,7 @@ class DataFrameGroupBy(ClassLogger):
                 groupby_kwargs=self._kwargs,
                 agg_args=[],
                 agg_kwargs={},
+                is_df=isinstance(self._df, DataFrame),
             ),
         )
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -299,7 +299,16 @@ class DataFrameGroupBy(ClassLogger):
         return self._default_to_pandas(lambda df: df.plot)
 
     def ohlc(self):
-        return self._default_to_pandas(lambda df: df.ohlc())
+        from .dataframe import DataFrame
+        return DataFrame(
+            query_compiler=self._query_compiler.groupby_ohlc(
+                by=self._by,
+                axis=self._axis,
+                groupby_kwargs=self._kwargs,
+                agg_args=[],
+                agg_kwargs={},
+            ),
+        )
 
     def __bytes__(self):
         """

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -46,6 +46,7 @@ from .utils import (
     default_to_pandas_ignore_string,
 )
 from modin.config import NPartitions
+from modin.test.test_utils import warns_that_defaulting_to_pandas
 
 
 NPartitions.put(4)
@@ -2347,6 +2348,29 @@ def test_mean_with_datetime(by_func):
 
     modin_df, pandas_df = create_test_dfs(data)
     eval_general(modin_df, pandas_df, lambda df: df.groupby(by=by_func(df)).mean())
+
+
+def test_groupby_ohlc():
+    pandas_df = pandas.DataFrame(
+        np.random.randint(0, 100, (50, 2)), columns=["stock A", "stock B"]
+    )
+    pandas_df["Date"] = pandas.concat(
+        [pandas.date_range("1/1/2000", periods=10, freq="min").to_series()] * 5
+    ).reset_index(drop=True)
+    modin_df = pd.DataFrame(pandas_df)
+    eval_general(modin_df, pandas_df, lambda df: df.groupby("Date")["stock A"].ohlc())
+    pandas_multiindex_result = pandas_df.groupby("Date")[["stock A"]].ohlc()
+
+    with warns_that_defaulting_to_pandas():
+        modin_multiindex_result = modin_df.groupby("Date")[["stock A"]].ohlc()
+    df_equals(modin_multiindex_result, pandas_multiindex_result)
+
+    pandas_multiindex_result = pandas_df.groupby("Date")[["stock A", "stock B"]].ohlc()
+    with warns_that_defaulting_to_pandas():
+        modin_multiindex_result = modin_df.groupby("Date")[
+            ["stock A", "stock B"]
+        ].ohlc()
+    df_equals(modin_multiindex_result, pandas_multiindex_result)
 
 
 def test_groupby_mad_warn():


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6116 ? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
