### PR TITLE
REFACTOR-#6108: Move implementation of `pd.cut` to QC layer

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -3588,6 +3588,16 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         """
         return SeriesDefault.register(pandas.Series.repeat)(self, repeats=repeats)
 
+    @doc_utils.add_refer_to("cut")
+    def cut(
+        self,
+        **kwargs,
+    ):
+        return SeriesDefault.register(pandas.cut)(
+            self,
+            **kwargs,
+        )
+
     # Indexing
 
     index = property(_get_axis(0), _set_axis(0))

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -26,7 +26,6 @@ with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     from pandas import (
         eval,
-        cut,
         factorize,
         test,
         date_range,
@@ -247,6 +246,7 @@ from .general import (
     wide_to_long,
     to_timedelta,
     pivot_table,
+    cut,
 )
 
 from .plotting import Plotting as plotting

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -290,6 +290,42 @@ def qcut(
     return x._qcut(q, **kwargs)
 
 
+@_inherit_docstrings(pandas.cut, apilink="pandas.cut")
+@enable_logging
+def cut(
+    x,
+    bins,
+    right: bool = True,
+    labels=None,
+    retbins: bool = False,
+    precision: int = 3,
+    include_lowest: bool = False,
+    duplicates: str = "raise",
+    ordered: bool = True,
+):
+    if isinstance(x, DataFrame):
+        raise ValueError("Input array must be 1 dimensional")
+    if not isinstance(x, Series):
+        import pandas
+
+        return pandas.cut(
+            x,
+            bins,
+            right=right,
+            labels=labels,
+            retbins=retbins,
+            precision=precision,
+            include_lowest=include_lowest,
+            duplicates=duplicates,
+            ordered=ordered,
+        )
+    return Series(
+        query_compiler=x._query_compiler.cut(
+            bins, right, labels, retbins, precision, include_lowest, duplicates, ordered
+        )
+    )
+
+
 @_inherit_docstrings(pandas.unique, apilink="pandas.unique")
 @enable_logging
 def unique(values):  # noqa: PR01, RT01, D200

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -759,6 +759,56 @@ def test_qcut(retbins):
 
 
 @pytest.mark.parametrize(
+    "bins, labels",
+    [
+        pytest.param(
+            [-int(1e18), -1000, 0, 1000, 2000, int(1e18)],
+            [
+                "-inf_to_-1000",
+                "-1000_to_0",
+                "0_to_1000",
+                "1000_to_2000",
+                "2000_to_inf",
+            ],
+            id="bin_list_spanning_entire_range_with_custom_labels",
+        ),
+        pytest.param(
+            [-int(1e18), -1000, 0, 1000, 2000, int(1e18)],
+            None,
+            id="bin_list_spanning_entire_range_with_default_labels",
+        ),
+        pytest.param(
+            [-1000, 0, 1000, 2000], None, id="bin_list_not_spanning_entire_range"
+        ),
+        pytest.param(
+            10,
+            [f"custom_label{i}" for i in range(9)],
+            id="int_bin_10_with_custom_labels",
+        ),
+        pytest.param(1, None, id="int_bin_1_with_default_labels"),
+        pytest.param(-1, None, id="int_bin_-1_with_default_labels"),
+        pytest.param(111, None, id="int_bin_111_with_default_labels"),
+    ],
+)
+@pytest.mark.parametrize("retbins", bool_arg_values, ids=bool_arg_keys)
+def test_cut(retbins, bins, labels):
+    eval_general(
+        pd,
+        pandas,
+        lambda lib, series: lib.cut(series, retbins=retbins, bins=bins, labels=labels),
+        series=pandas.Series(range(1000)),
+        md_extra_kwargs={"series": pd.Series(range(1000))},
+    )
+
+
+def test_cut_fallback():
+    # Test case for falling back to pandas for cut.
+    pandas_result = pandas.cut(range(5), 4)
+    modin_result = pd.cut(range(5), 4)
+    df_equals(modin_result, pandas_result)
+
+
+@pytest.mark.parametrize(
     "data", [test_data_values[0], []], ids=["test_data_values[0]", "[]"]
 )
 def test_to_pandas_indices(data):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6108 ? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
