### PR TITLE
FIX-#6107: Allow pass through of `tz_convert` and `tz_localize` to QC if possible

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3455,15 +3455,20 @@ class BasePandasDataset(ClassLogger):
         """
         Convert tz-aware axis to target time zone.
         """
-        axis = self._get_axis_number(axis)
-        if level is not None:
-            new_labels = (
-                pandas.Series(index=self.axes[axis]).tz_convert(tz, level=level).index
+        if hasattr(self._query_compiler, "tz_convert"):
+            return self.__constructor__(
+                query_compiler=self._query_compiler.tz_convert(tz, axis, level, copy)
             )
         else:
-            new_labels = self.axes[axis].tz_convert(tz)
-        obj = self.copy() if copy else self
-        return obj.set_axis(new_labels, axis, copy=copy)
+            axis = self._get_axis_number(axis)
+            if level is not None:
+                new_labels = (
+                    pandas.Series(index=self.axes[axis]).tz_convert(tz, level=level).index
+                )
+            else:
+                new_labels = self.axes[axis].tz_convert(tz)
+            obj = self.copy() if copy else self
+            return obj.set_axis(new_labels, axis, copy=copy)
 
     def tz_localize(
         self, tz, axis=0, level=None, copy=True, ambiguous="raise", nonexistent="raise"
@@ -3471,20 +3476,27 @@ class BasePandasDataset(ClassLogger):
         """
         Localize tz-naive index of a `BasePandasDataset` to target time zone.
         """
-        axis = self._get_axis_number(axis)
-        new_labels = (
-            pandas.Series(index=self.axes[axis])
-            .tz_localize(
-                tz,
-                axis=axis,
-                level=level,
-                copy=False,
-                ambiguous=ambiguous,
-                nonexistent=nonexistent,
+        if hasattr(self._query_compiler, "tz_localize"):
+            return self.__constructor__(
+                query_compiler=self._query_compiler.tz_localize(
+                    tz, axis, level, copy, ambiguous, nonexistent
+                )
             )
-            .index
-        )
-        return self.set_axis(new_labels, axis, copy=copy)
+        else:
+            axis = self._get_axis_number(axis)
+            new_labels = (
+                pandas.Series(index=self.axes[axis])
+                .tz_localize(
+                    tz,
+                    axis=axis,
+                    level=level,
+                    copy=False,
+                    ambiguous=ambiguous,
+                    nonexistent=nonexistent,
+                )
+                .index
+            )
+            return self.set_axis(new_labels, axis, copy=copy)
 
     # TODO: uncomment the following lines when #3331 issue will be closed
     # @prepend_to_notes(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3463,7 +3463,9 @@ class BasePandasDataset(ClassLogger):
             axis = self._get_axis_number(axis)
             if level is not None:
                 new_labels = (
-                    pandas.Series(index=self.axes[axis]).tz_convert(tz, level=level).index
+                    pandas.Series(index=self.axes[axis])
+                    .tz_convert(tz, level=level)
+                    .index
                 )
             else:
                 new_labels = self.axes[axis].tz_convert(tz)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3461,22 +3461,12 @@ class BasePandasDataset(ClassLogger):
         """
         Convert tz-aware axis to target time zone.
         """
-        if hasattr(self._query_compiler, "tz_convert"):
-            return self.__constructor__(
-                query_compiler=self._query_compiler.tz_convert(tz, axis, level, copy)
-            )
-        else:
-            axis = self._get_axis_number(axis)
-            if level is not None:
-                new_labels = (
-                    pandas.Series(index=self.axes[axis])
-                    .tz_convert(tz, level=level)
-                    .index
-                )
-            else:
-                new_labels = self.axes[axis].tz_convert(tz)
-            obj = self.copy() if copy else self
-            return obj.set_axis(new_labels, axis, copy=copy)
+        return self._create_or_update_from_compiler(
+            self._query_compiler.tz_convert(
+                tz, axis=self._get_axis_number(axis), level=level, copy=True
+            ),
+            inplace=(not copy),
+        )
 
     def tz_localize(
         self, tz, axis=0, level=None, copy=True, ambiguous="raise", nonexistent="raise"
@@ -3484,27 +3474,17 @@ class BasePandasDataset(ClassLogger):
         """
         Localize tz-naive index of a `BasePandasDataset` to target time zone.
         """
-        if hasattr(self._query_compiler, "tz_localize"):
-            return self.__constructor__(
-                query_compiler=self._query_compiler.tz_localize(
-                    tz, axis, level, copy, ambiguous, nonexistent
-                )
-            )
-        else:
-            axis = self._get_axis_number(axis)
-            new_labels = (
-                pandas.Series(index=self.axes[axis])
-                .tz_localize(
-                    tz,
-                    axis=axis,
-                    level=level,
-                    copy=False,
-                    ambiguous=ambiguous,
-                    nonexistent=nonexistent,
-                )
-                .index
-            )
-            return self.set_axis(new_labels, axis, copy=copy)
+        return self._create_or_update_from_compiler(
+            self._query_compiler.tz_localize(
+                tz,
+                axis=self._get_axis_number(axis),
+                level=level,
+                copy=True,
+                ambiguous=ambiguous,
+                nonexistent=nonexistent,
+            ),
+            inplace=(not copy),
+        )
 
     def interpolate(
         self,


### PR DESCRIPTION


<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6107 ? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
