### PR TITLE
FEAT-#6141: ray.data.from_modin should work with non-partitioned storage format

### DIFF
--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -86,7 +86,7 @@ def _ray_from_modin_non_partition(api_layer_object: DataFrame | Series):
         """
         start_idx = part_idx * part_size
         end_idx = (part_idx + 1) * part_size
-        return pd.DataFrame(api_layer_object.iloc[start_idx:end_idx])
+        return pandas.DataFrame(api_layer_object.iloc[start_idx:end_idx])
 
     # Store things into ray.
     return [store_range.remote(api_layer_object, i) for i in range(num_parts)]

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -24,11 +24,11 @@ from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.pandas.dataframe import DataFrame, Series
 
 if TYPE_CHECKING:
-    from modin.core.execution.dask.implementations.pandas_on_dask.partitioning import (
-        PandasOnDaskDataframePartition,
-    )
     from modin.core.execution.ray.implementations.pandas_on_ray.partitioning import (
         PandasOnRayDataframePartition,
+    )
+    from modin.core.execution.dask.implementations.pandas_on_dask.partitioning import (
+        PandasOnDaskDataframePartition,
     )
     from modin.core.execution.unidist.implementations.pandas_on_unidist.partitioning.partition import (
         PandasOnUnidistDataframePartition,
@@ -80,6 +80,10 @@ def _ray_from_modin_non_partition(api_layer_object: DataFrame | Series):
 
     @remote
     def store_range(api_layer_object: DataFrame | Series, part_idx: int):
+        """
+        This function stores chunks of the `api_layer_object` into Ray's distributed object store.
+        Since ray automatically puts objects into shared memory, the "upload" is done implicitly.
+        """
         start_idx = part_idx * part_size
         end_idx = (part_idx + 1) * part_size
         return pd.DataFrame(api_layer_object.iloc[start_idx:end_idx])

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -45,10 +45,12 @@ else:
     PartitionUnionType = Any
 
 
-def _ray_from_modin_hack(api_layer_object: DataFrame | Series):
+def _ray_from_modin_non_partition(api_layer_object: DataFrame | Series):
     """
     HACK:
-    This is a hack that enables support of soda within the ray.data.from_modin function here: https://docs.ray.io/en/latest/data/api/doc/ray.data.from_modin.html#ray-data-from-modin.
+    This is a hack that makes ray.data.from_modin work with modin dataframe not backed by partitions.
+
+    See also: https://docs.ray.io/en/latest/data/api/doc/ray.data.from_modin.html#ray-data-from-modin for ray.data.from_modin's documentation.
 
     Parameters
     ----------
@@ -127,7 +129,7 @@ def unwrap_partitions(
 
     if not is_modin_distributed and axis == 0:
         # Directly uses the iloc API to extract data.
-        return _ray_from_modin_hack(api_layer_object=api_layer_object)
+        return _ray_from_modin_non_partition(api_layer_object=api_layer_object)
 
     modin_frame._propagate_index_objs(None)
     if axis is None:

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -64,7 +64,7 @@ def _ray_from_modin_non_partition(api_layer_object: DataFrame | Series):
     A list of Ray.ObjectRef that can be combined into the original ``api_layer_object``
     """
 
-    import pandas as pd
+    import pandas
     import ray
     from ray import remote
 


### PR DESCRIPTION
I added a hack that would make `from_modin` work. I think a long term solution would be to change the unwrap_partition function completely / provide abstractions instead of relying on implementation details. Fixes #6141.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
