### PR TITLE
FEAT-#6147: HDK: Arrow-based columns concatenation of frames with trivial index.

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -1293,35 +1293,10 @@ class HdkOnNativeDataframe(PandasDataframe):
         try:
             check_join_supported(how)
         except NotImplementedError as err:
-            frames = [self] + other_modin_frames
             # The outer join is not supported by HDK, however, if all the frames
             # have a trivial index, we can simply concatenate the columns with arrow.
-            if all(
-                f._index_cols is None
-                # Make sure all the frames have an arrow table in partitions. The
-                # method _execute() is no-op if the frame is already materialized
-                # and always returns None.
-                and (f._execute() or f._has_arrow_table())
-                for f in frames
-            ):
-                tables = [f._partitions[0][0].get() for f in frames]
-                column_names = [c for t in tables for c in t.column_names]
-                # Duplicate column names are not supported
-                if len(column_names) == len(set(column_names)):
-                    max_len = max(len(t) for t in tables)
-                    columns = [c for t in tables for c in t.columns]
-                    # Make all columns of the same length, if required.
-                    for i, col in enumerate(columns):
-                        if len(col) < max_len:
-                            columns[i] = pyarrow.chunked_array(
-                                col.chunks
-                                + [pyarrow.nulls(max_len - len(col), col.type)]
-                            )
-                    return self.from_arrow(
-                        at=pyarrow.table(columns, column_names),
-                        columns=[c for f in frames for c in f.columns],
-                        encode_col_names=False,
-                    )
+            if (frame := self._join_arrow_columns(other_modin_frames)) is not None:
+                return frame
             raise err
 
         lhs = self._maybe_materialize_rowid()
@@ -1392,6 +1367,50 @@ class HdkOnNativeDataframe(PandasDataframe):
             lhs = lhs._set_columns(new_columns)
 
         return lhs
+
+    def _join_arrow_columns(self, other_modin_frames):
+        """
+        Join arrow table columns.
+
+        If all the frames have a trivial index and an arrow
+        table in partitions, concatenate the table columns.
+
+        Parameters
+        ----------
+        other_modin_frames : list of HdkOnNativeDataframe
+            Frames to join with.
+
+        Returns
+        -------
+        HdkOnNativeDataframe or None
+        """
+        frames = [self] + other_modin_frames
+        if all(
+            f._index_cols is None
+            # Make sure all the frames have an arrow table in partitions. The
+            # method _execute() is no-op if the frame is already materialized
+            # and always returns None.
+            and (f._execute() or f._has_arrow_table())
+            for f in frames
+        ):
+            tables = [f._partitions[0][0].get() for f in frames]
+            column_names = [c for t in tables for c in t.column_names]
+            if len(column_names) != len(set(column_names)):
+                raise NotImplementedError("Duplicate column names")
+            max_len = max(len(t) for t in tables)
+            columns = [c for t in tables for c in t.columns]
+            # Make all columns of the same length, if required.
+            for i, col in enumerate(columns):
+                if len(col) < max_len:
+                    columns[i] = pyarrow.chunked_array(
+                        col.chunks + [pyarrow.nulls(max_len - len(col), col.type)]
+                    )
+            return self.from_arrow(
+                at=pyarrow.table(columns, column_names),
+                columns=[c for f in frames for c in f.columns],
+                encode_col_names=False,
+            )
+        return None
 
     def concat(
         self,

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -1290,7 +1290,40 @@ class HdkOnNativeDataframe(PandasDataframe):
         HdkOnNativeDataframe
             The new frame.
         """
-        check_join_supported(how)
+        try:
+            check_join_supported(how)
+        except NotImplementedError as err:
+            frames = [self] + other_modin_frames
+            # The outer join is not supported by HDK, however, if all the frames
+            # have a trivial index, we can simply concatenate the columns with arrow.
+            if all(
+                f._index_cols is None
+                # Make sure all the frames have an arrow table in partitions. The
+                # method _execute() is no-op if the frame is already materialized
+                # and always returns None.
+                and (f._execute() or f._has_arrow_table())
+                for f in frames
+            ):
+                tables = [f._partitions[0][0].get() for f in frames]
+                column_names = [c for t in tables for c in t.column_names]
+                # Duplicate column names are not supported
+                if len(column_names) == len(set(column_names)):
+                    max_len = max(len(t) for t in tables)
+                    columns = [c for t in tables for c in t.columns]
+                    # Make all columns of the same length, if required.
+                    for i, col in enumerate(columns):
+                        if len(col) < max_len:
+                            columns[i] = pyarrow.chunked_array(
+                                col.chunks
+                                + [pyarrow.nulls(max_len - len(col), col.type)]
+                            )
+                    return self.from_arrow(
+                        at=pyarrow.table(columns, column_names),
+                        columns=[c for f in frames for c in f.columns],
+                        encode_col_names=False,
+                    )
+            raise err
+
         lhs = self._maybe_materialize_rowid()
         reset_index_names = False
         new_columns_dtype = self.columns.dtype
@@ -2269,6 +2302,12 @@ class HdkOnNativeDataframe(PandasDataframe):
         HdkOnNativeDataframe
             The new frame.
         """
+        if (
+            self.columns.identical(new_columns)
+            if isinstance(new_columns, Index)
+            else all(self.columns == new_columns)
+        ):
+            return self
         exprs = self._index_exprs()
         for old, new in zip(self.columns, new_columns):
             expr = self.ref(old)

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
@@ -224,9 +224,7 @@ def check_join_supported(join_type: str):
     None
     """
     if join_type not in ("inner", "left"):
-        raise NotImplementedError(
-            f"{join_type} join is not supported by the HDK engine"
-        )
+        raise NotImplementedError(f"{join_type} join")
 
 
 def check_cols_to_join(what, df, col_names):

--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -84,8 +84,15 @@ def test_concat_on_index():
     )
 
 
-def test_concat_on_column():
+@pytest.mark.parametrize("no_dup_cols", [True, False])
+@pytest.mark.parametrize("different_len", [True, False])
+def test_concat_on_column(no_dup_cols, different_len):
     df, df2 = generate_dfs()
+    if no_dup_cols:
+        df = df.drop(set(df.columns) & set(df2.columns), axis="columns")
+    if different_len:
+        df = pandas.concat([df, df], ignore_index=True)
+
     modin_df, modin_df2 = from_pandas(df), from_pandas(df2)
 
     df_equals(


### PR DESCRIPTION
The outer join is not supported by HDK, however, if all the frames have a trivial index, we can simply concatenate the columns with arrow.

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6147 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
