### PR TITLE
REFACTOR-#6065: Use between_time in at_time

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -4237,6 +4237,17 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         self.get_axis(axis).names = names
 
     # DateTime methods
+    def between_time(self, **kwargs):  # noqa: PR01
+        """
+        Select values between particular times of the day (e.g., 9:00-9:30 AM).
+
+        By setting start_time to be later than end_time, you can get the times that are not between the two times.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        return DataFrameDefault.register(pandas.DataFrame.between_time)(self, **kwargs)
 
     def tz_convert(
         self,

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -35,9 +35,9 @@ from pandas.util._validators import (
     validate_percentile,
     validate_bool_kwarg,
     validate_ascending,
+    validate_inclusive,
 )
-from pandas._libs.lib import NoDefault
-from pandas._libs.lib import no_default
+from pandas._libs.lib import no_default, NoDefault
 from pandas._libs.tslibs import to_offset
 from pandas._typing import (
     IndexKeyFunc,
@@ -1034,10 +1034,12 @@ class BasePandasDataset(ClassLogger):
         """
         Select values at particular time of day (e.g., 9:30AM).
         """
-        axis = self._get_axis_number(axis)
-        idx = self.index if axis == 0 else self.columns
-        indexer = pandas.Series(index=idx).at_time(time, asof=asof).index
-        return self.loc[indexer] if axis == 0 else self.loc[:, indexer]
+        if asof:
+            # pandas raises NotImplementedError for asof=True, so we do, too.
+            raise NotImplementedError("'asof' argument is not supported")
+        return self.between_time(
+            start_time=time, end_time=time, inclusive="both", axis=axis
+        )
 
     @_inherit_docstrings(
         pandas.DataFrame.between_time, apilink="pandas.DataFrame.between_time"
@@ -1051,20 +1053,45 @@ class BasePandasDataset(ClassLogger):
         inclusive: "str | None" = None,
         axis=None,
     ):  # noqa: PR01, RT01, D200
-        axis = self._get_axis_number(axis)
-        idx = self.index if axis == 0 else self.columns
-        indexer = (
-            pandas.Series(index=idx)
-            .between_time(
-                start_time,
-                end_time,
-                include_start=include_start,
-                include_end=include_end,
-                inclusive=inclusive,
-            )
-            .index
+        old_include_arg_used = (include_start is not no_default) or (
+            include_end is not no_default
         )
-        return self.loc[indexer] if axis == 0 else self.loc[:, indexer]
+
+        if old_include_arg_used and inclusive is not None:
+            raise ValueError(
+                "Deprecated arguments `include_start` and `include_end` "
+                "cannot be passed if `inclusive` has been given."
+            )
+        elif old_include_arg_used:
+            warnings.warn(
+                "`include_start` and `include_end` are deprecated in "
+                "favour of `inclusive`.",
+                FutureWarning,
+                stacklevel=2,
+            )
+            left = True if include_start is no_default else include_start
+            right = True if include_end is no_default else include_end
+
+            inc_dict = {
+                (True, True): "both",
+                (True, False): "left",
+                (False, True): "right",
+                (False, False): "neither",
+            }
+            inclusive = inc_dict[(left, right)]
+        elif inclusive is None:
+            # On arg removal inclusive can default to "both"
+            inclusive = "both"
+        left_inclusive, right_inclusive = validate_inclusive(inclusive)
+        return self._create_or_update_from_compiler(
+            self._query_compiler.between_time(
+                start_time=pandas.core.tools.times.to_time(start_time),
+                end_time=pandas.core.tools.times.to_time(end_time),
+                include_start=left_inclusive,
+                include_end=right_inclusive,
+                axis=self._get_axis_number(axis),
+            )
+        )
 
     def bfill(
         self, axis=None, inplace=False, limit=None, downcast=None

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1060,12 +1060,12 @@ class BasePandasDataset(ClassLogger):
         if old_include_arg_used and inclusive is not None:
             raise ValueError(
                 "Deprecated arguments `include_start` and `include_end` "
-                "cannot be passed if `inclusive` has been given."
+                + "cannot be passed if `inclusive` has been given."
             )
         elif old_include_arg_used:
             warnings.warn(
                 "`include_start` and `include_end` are deprecated in "
-                "favour of `inclusive`.",
+                + "favour of `inclusive`.",
                 FutureWarning,
                 stacklevel=2,
             )


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6065
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
