### PR TITLE
REFACTOR-#6159: Stop defaulting at API layer for a few more methods

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -472,6 +472,28 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         """
         return SeriesDefault.register(pandas.Series.to_list)(self)
 
+    @doc_utils.add_refer_to("DataFrame.to_dict")
+    def dataframe_to_dict(self, orient="dict", into=dict):  # noqa: PR01
+        """
+        Convert the DataFrame to a dictionary.
+
+        Returns
+        -------
+        dict or `into` instance
+        """
+        return self.to_pandas().to_dict(orient, into)
+
+    @doc_utils.add_refer_to("Series.to_dict")
+    def series_to_dict(self, into=dict):  # noqa: PR01
+        """
+        Convert the Series to a dictionary.
+
+        Returns
+        -------
+        dict or `into` instance
+        """
+        return self.to_pandas().to_dict(into)
+
     # Abstract inter-data operations (e.g. add, sub)
     # These operations require two DataFrames and will change the shape of the
     # data if the index objects don't match. An outer join + op is performed,
@@ -653,6 +675,17 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             Correlation matrix.
         """
         return DataFrameDefault.register(pandas.DataFrame.corr)(self, **kwargs)
+
+    @doc_utils.add_refer_to("DataFrame.corrwith")
+    def corrwith(self, **kwargs):  # noqa: PR01
+        """
+        Compute pairwise correlation.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        return DataFrameDefault.register(pandas.DataFrame.corrwith)(self, **kwargs)
 
     @doc_utils.add_refer_to("DataFrame.cov")
     def cov(self, **kwargs):  # noqa: PR02
@@ -986,6 +1019,17 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         return DataFrameDefault.register(pandas.DataFrame.merge)(
             self, right=right, **kwargs
         )
+
+    @doc_utils.add_refer_to("merge_ordered")
+    def merge_ordered(self, right, **kwargs):  # noqa: PR01
+        """
+        Perform a merge for ordered data with optional filling/interpolation.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        return DataFrameDefault.register(pandas.merge_ordered)(self, right, **kwargs)
 
     def _get_column_as_pandas_series(self, key):
         """
@@ -2545,6 +2589,12 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
         return DataFrameDefault.register(get_row)(self, key=key)
 
+    def lookup(self, row_labels, col_labels):  # noqa: PR01, RT01, D200
+        """
+        Label-based "fancy indexing" function for ``DataFrame``.
+        """
+        return self.default_to_pandas(pandas.DataFrame.lookup, row_labels, col_labels)
+
     # END Abstract __getitem__ methods
 
     # Abstract insert
@@ -3683,6 +3733,17 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         return DataFrameDefault.register(pandas.DataFrame.unstack)(
             self, level=level, fill_value=fill_value
         )
+
+    @doc_utils.add_refer_to("wide_to_long")
+    def wide_to_long(self, **kwargs):  # noqa: PR01
+        """
+        Unpivot a DataFrame from wide to long format.
+
+        Returns
+        -------
+        BaseQueryCompiler
+        """
+        return DataFrameDefault.register(pandas.wide_to_long)(self, **kwargs)
 
     @doc_utils.add_refer_to("DataFrame.pivot")
     def pivot(self, index, columns, values):

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -460,6 +460,18 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
 
     # END Dataframe exchange protocol
 
+    def to_list(self):
+        """
+        Return a list of the values.
+
+        These are each a scalar type, which is a Python scalar (for str, int, float) or a pandas scalar (for Timestamp/Timedelta/Interval/Period).
+
+        Returns
+        -------
+        list
+        """
+        return SeriesDefault.register(pandas.Series.to_list)(self)
+
     # Abstract inter-data operations (e.g. add, sub)
     # These operations require two DataFrames and will change the shape of the
     # data if the index objects don't match. An outer join + op is performed,
@@ -5214,6 +5226,10 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     def str_get(self, i):
         return StrDefault.register(pandas.Series.str.get)(self, i)
 
+    @doc_utils.doc_str_method(refer_to="get_dummies", params="sep : str")
+    def str_get_dummies(self, sep):
+        return StrDefault.register(pandas.Series.str.get_dummies)(self, sep)
+
     @doc_utils.doc_str_method(
         refer_to="index",
         params="""
@@ -5305,6 +5321,15 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     )
     def str_extract(self, pat, flags=0, expand=True):
         return StrDefault.register(pandas.Series.str.extract)(self, pat, flags, expand)
+
+    @doc_utils.doc_str_method(
+        refer_to="extractall",
+        params="""
+        pat : str
+        flags : int, default: 0""",
+    )
+    def str_extractall(self, pat, flags=0):
+        return StrDefault.register(pandas.Series.str.extractall)(self, pat, flags)
 
     @doc_utils.doc_str_method(
         refer_to="normalize", params="form : {'NFC', 'NFKC', 'NFD', 'NFKD'}"
@@ -5521,6 +5546,13 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         return StrDefault.register(pandas.Series.str.cat)(
             self, others, sep, na_rep, join
         )
+
+    @doc_utils.doc_str_method(
+        refer_to="casefold",
+        params="",
+    )
+    def str_casefold(self):
+        return StrDefault.register(pandas.Series.str.casefold)(self)
 
     # End of Str methods
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3126,7 +3126,7 @@ class BasePandasDataset(ClassLogger):
         )
 
     def to_dict(self, orient="dict", into=dict):  # pragma: no cover
-        return self._default_to_pandas("to_dict", orient=orient, into=into)
+        return self._query_compiler.dataframe_to_dict(orient, into)
 
     def to_hdf(
         self, path_or_buf, key, format="table", **kwargs

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1018,23 +1018,22 @@ class DataFrame(BasePandasDataset):
         """
         Make a histogram of the ``DataFrame``.
         """
-        return self.__constructor__(
-            query_compiler=self._query_compiler.dataframe_hist(
-                column,
-                by,
-                grid,
-                xlabelsize,
-                xrot,
-                ylabelsize,
-                yrot,
-                ax,
-                sharex,
-                sharey,
-                figsize,
-                layout,
-                bins,
-                **kwds,
-            )
+        return self._default_to_pandas(
+            pandas.DataFrame.hist,
+            column=column,
+            by=by,
+            grid=grid,
+            xlabelsize=xlabelsize,
+            xrot=xrot,
+            ylabelsize=ylabelsize,
+            yrot=yrot,
+            ax=ax,
+            sharex=sharex,
+            sharey=sharey,
+            figsize=figsize,
+            layout=layout,
+            bins=bins,
+            **kwds,
         )
 
     def info(

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -734,9 +734,11 @@ class DataFrame(BasePandasDataset):
         """
         Compute pairwise correlation.
         """
+        if not isinstance(other, (Series, DataFrame)):
+            raise TypeError(f"unsupported type: {type(other)}")
         return self.__constructor__(
             query_compiler=self._query_compiler.corrwith(
-                other=other,
+                other=other._query_compiler,
                 axis=axis,
                 drop=drop,
                 method=method,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -734,15 +734,10 @@ class DataFrame(BasePandasDataset):
         """
         Compute pairwise correlation.
         """
-        if isinstance(other, DataFrame):
-            other = other._query_compiler.to_pandas()
-        return self._default_to_pandas(
-            pandas.DataFrame.corrwith,
-            other,
-            axis=axis,
-            drop=drop,
-            method=method,
-            numeric_only=numeric_only,
+        return self.__constructor__(
+            query_compiler=self._query_compiler.corrwith(
+                other, axis, drop, method, numeric_only
+            )
         )
 
     def cov(
@@ -1023,22 +1018,23 @@ class DataFrame(BasePandasDataset):
         """
         Make a histogram of the ``DataFrame``.
         """
-        return self._default_to_pandas(
-            pandas.DataFrame.hist,
-            column=column,
-            by=by,
-            grid=grid,
-            xlabelsize=xlabelsize,
-            xrot=xrot,
-            ylabelsize=ylabelsize,
-            yrot=yrot,
-            ax=ax,
-            sharex=sharex,
-            sharey=sharey,
-            figsize=figsize,
-            layout=layout,
-            bins=bins,
-            **kwds,
+        return self.__constructor__(
+            query_compiler=self._query_compiler.dataframe_hist(
+                column,
+                by,
+                grid,
+                xlabelsize,
+                xrot,
+                ylabelsize,
+                yrot,
+                ax,
+                sharex,
+                sharey,
+                figsize,
+                layout,
+                bins,
+                **kwds,
+            )
         )
 
     def info(
@@ -1283,7 +1279,7 @@ class DataFrame(BasePandasDataset):
         """
         Label-based "fancy indexing" function for ``DataFrame``.
         """
-        return self._default_to_pandas(pandas.DataFrame.lookup, row_labels, col_labels)
+        return self.__constructor__(self._query_compiler.lookup(row_labels, col_labels))
 
     def lt(self, other, axis="columns", level=None):  # noqa: PR01, RT01, D200
         """
@@ -2684,7 +2680,7 @@ class DataFrame(BasePandasDataset):
         -------
         DataFrame
         """
-        return self._default_to_pandas(pandas.DataFrame.__round__, decimals=decimals)
+        return self.round(decimals)
 
     def __delitem__(self, key):
         """

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -736,7 +736,11 @@ class DataFrame(BasePandasDataset):
         """
         return self.__constructor__(
             query_compiler=self._query_compiler.corrwith(
-                other, axis, drop, method, numeric_only
+                other=other,
+                axis=axis,
+                drop=drop,
+                method=method,
+                numeric_only=numeric_only,
             )
         )
 

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -737,11 +737,11 @@ def wide_to_long(
         )
     return DataFrame(
         query_compiler=df._query_compiler.wide_to_long(
-            stubnames,
-            i,
-            j,
-            sep,
-            suffix,
+            stubnames=stubnames,
+            i=i,
+            j=j,
+            sep=sep,
+            suffix=suffix,
         )
     )
 

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -127,12 +127,8 @@ def merge_ordered(
         raise ValueError(
             "can not merge DataFrame with instance of type {}".format(type(right))
         )
-    ErrorMessage.default_to_pandas("`merge_ordered`")
-    if isinstance(right, DataFrame):
-        right = to_pandas(right)
     return DataFrame(
-        pandas.merge_ordered(
-            to_pandas(left),
+        query_compiler=left._query_compiler.merge_ordered(
             right,
             on=on,
             left_on=left_on,
@@ -739,9 +735,14 @@ def wide_to_long(
         raise ValueError(
             "can not wide_to_long with instance of type {}".format(type(df))
         )
-    ErrorMessage.default_to_pandas("`wide_to_long`")
     return DataFrame(
-        pandas.wide_to_long(to_pandas(df), stubnames, i, j, sep=sep, suffix=suffix)
+        query_compiler=df._query_compiler.wide_to_long(
+            stubnames,
+            i,
+            j,
+            sep,
+            suffix,
+        )
     )
 
 

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -123,13 +123,15 @@ def merge_ordered(
     """
     Perform a merge for ordered data with optional filling/interpolation.
     """
-    if not isinstance(left, DataFrame):
-        raise ValueError(
-            "can not merge DataFrame with instance of type {}".format(type(right))
-        )
+    for operand in (left, right):
+        if not isinstance(operand, (Series, DataFrame)):
+            raise TypeError(
+                f"Can only merge Series or DataFrame objects, a {type(operand)} was passed"
+            )
+
     return DataFrame(
         query_compiler=left._query_compiler.merge_ordered(
-            right,
+            right._query_compiler,
             on=on,
             left_on=left_on,
             right_on=right_on,

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1916,7 +1916,7 @@ class Series(BasePandasDataset):
         """
         Convert Series to {label -> value} dict or dict-like object.
         """
-        return self.__query_compiler__.series_to_dict(into)
+        return self._query_compiler.series_to_dict(into)
 
     def to_frame(
         self, name: Hashable = no_default
@@ -1939,7 +1939,7 @@ class Series(BasePandasDataset):
         """
         Return a list of the values.
         """
-        return self.__query_compiler__.to_list()
+        return self._query_compiler.to_list()
 
     def to_numpy(
         self, dtype=None, copy=False, na_value=no_default, **kwargs

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1916,7 +1916,7 @@ class Series(BasePandasDataset):
         """
         Convert Series to {label -> value} dict or dict-like object.
         """
-        return self._default_to_pandas("to_dict", into=into)
+        return self.__query_compiler__.series_to_dict(into)
 
     def to_frame(
         self, name: Hashable = no_default
@@ -1939,7 +1939,7 @@ class Series(BasePandasDataset):
         """
         Return a list of the values.
         """
-        return self._default_to_pandas(pandas.Series.to_list)
+        return self.__query_compiler__.to_list()
 
     def to_numpy(
         self, dtype=None, copy=False, na_value=no_default, **kwargs
@@ -2032,16 +2032,6 @@ class Series(BasePandasDataset):
 
     div = divide = truediv
 
-    def truncate(
-        self, before=None, after=None, axis=None, copy=True
-    ):  # noqa: PR01, RT01, D200
-        """
-        Truncate a Series before and after some index value.
-        """
-        return self._default_to_pandas(
-            pandas.Series.truncate, before=before, after=after, axis=axis, copy=copy
-        )
-
     def unique(self):  # noqa: RT01, D200
         """
         Return unique values of Series object.
@@ -2109,8 +2099,11 @@ class Series(BasePandasDataset):
         """
         Replace values where the condition is False.
         """
+        # TODO: probably need to remove this conversion to pandas
         if isinstance(other, Series):
             other = to_pandas(other)
+        # TODO: add error checking like for dataframe where, then forward to
+        # same query compiler method
         return self._default_to_pandas(
             pandas.Series.where,
             cond,

--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -142,7 +142,7 @@ class StringMethods(ClassLogger):
         return Series
 
     def casefold(self):
-        return self._default_to_pandas(pandas.Series.str.casefold)
+        return self._Series(query_compiler=self._query_compiler.str_casefold())
 
     def cat(self, others=None, sep=None, na_rep=None, join="left"):
         if isinstance(others, self._Series):
@@ -206,7 +206,7 @@ class StringMethods(ClassLogger):
         return self._Series(query_compiler=self._query_compiler.str_join(sep))
 
     def get_dummies(self, sep="|"):
-        return self._default_to_pandas(pandas.Series.str.get_dummies, sep=sep)
+        return self._Series(query_compiler=self._query_compiler.str_get_dummies(sep))
 
     def contains(self, pat, case=True, flags=0, na=None, regex=True):
         if pat is None and not case:
@@ -342,7 +342,9 @@ class StringMethods(ClassLogger):
         )
 
     def extractall(self, pat, flags=0):
-        return self._default_to_pandas(pandas.Series.str.extractall, pat, flags=flags)
+        return self._Series(
+            query_compiler=self._query_compiler.str_extractall(pat, flags)
+        )
 
     def len(self):
         return self._Series(query_compiler=self._query_compiler.str_len())

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -1519,8 +1519,7 @@ def test___abs__(request, data):
 
 def test___round__():
     data = test_data_values[0]
-    with warns_that_defaulting_to_pandas():
-        pd.DataFrame(data).__round__()
+    eval_general(pd.DataFrame(data), pandas.DataFrame(data), lambda df: df.__round__())
 
 
 @pytest.mark.parametrize(

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -213,7 +213,7 @@ def test_merge_ordered():
         )
         assert isinstance(df, pd.DataFrame)
 
-    with pytest.raises(ValueError):
+    with pytest.raises(TypeError):
         pd.merge_ordered(data_a, data_b, fill_method="ffill", left_by="group")
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6159
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
