### PR TITLE
FIX-#6154: Ensure GroupBy.__getitem__ preserves key order

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -652,10 +652,13 @@ class DataFrameGroupBy(ClassLogger):
                     ),
                 )
             # We need to maintain order of the columns in key, using a set doesn't
-            # maintain order
-            cols_to_grab = list(self._internal_by)
-            cols_to_grab.extend(x for x in key if x not in cols_to_grab)
-            key = [col for col in cols_to_grab if col in self._df.columns]
+            # maintain order.
+            # We use dictionaries since they maintain insertion order as of 3.7,
+            # and its faster to call dict.update than it is to loop through `key`
+            # and select only the elements which aren't in `cols_to_grab`.
+            cols_to_grab = dict.fromkeys(self._internal_by)
+            cols_to_grab.update(dict.fromkeys(key))
+            key = [col for col in cols_to_grab.keys() if col in self._df.columns]
             return DataFrameGroupBy(
                 self._df[key],
                 drop=self._drop,

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -640,8 +640,11 @@ class DataFrameGroupBy(ClassLogger):
                         + "df.groupby(df['by_column'].copy())['by_column']"
                     ),
                 )
-            cols_to_grab = internal_by.union(key)
-            key = [col for col in self._df.columns if col in cols_to_grab]
+            # We need to maintain order of the columns in key, using a set doesn't
+            # maintain order
+            cols_to_grab = list(self._internal_by)
+            cols_to_grab.extend(x for x in key if x not in cols_to_grab)
+            key = [col for col in cols_to_grab if col in self._df.columns]
             return DataFrameGroupBy(
                 self._df[key],
                 drop=self._drop,

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -544,6 +544,21 @@ def test_pivot():
         pd.pivot(test_df["bar"], index="foo", columns="bar", values="baz")
 
 
+def test_pivot_values_is_none():
+    test_df = pd.DataFrame(
+        {
+            "foo": ["one", "one", "one", "two", "two", "two"],
+            "bar": ["A", "B", "C", "A", "B", "C"],
+            "baz": [1, 2, 3, 4, 5, 6],
+            "zoo": ["x", "y", "z", "q", "w", "t"],
+        }
+    )
+    pandas_test_df = test_df._to_pandas()
+    modin_df = pd.pivot(test_df, index="foo", columns="bar")
+    pandas_df = pandas.pivot(pandas_test_df, index="foo", columns="bar")
+    df_equals(modin_df, pandas_df)
+
+
 def test_pivot_table():
     test_df = pd.DataFrame(
         {

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -544,21 +544,6 @@ def test_pivot():
         pd.pivot(test_df["bar"], index="foo", columns="bar", values="baz")
 
 
-def test_pivot_values_is_none():
-    test_df = pd.DataFrame(
-        {
-            "foo": ["one", "one", "one", "two", "two", "two"],
-            "bar": ["A", "B", "C", "A", "B", "C"],
-            "baz": [1, 2, 3, 4, 5, 6],
-            "zoo": ["x", "y", "z", "q", "w", "t"],
-        }
-    )
-    pandas_test_df = test_df._to_pandas()
-    modin_df = pd.pivot(test_df, index="foo", columns="bar")
-    pandas_df = pandas.pivot(pandas_test_df, index="foo", columns="bar")
-    df_equals(modin_df, pandas_df)
-
-
 def test_pivot_table():
     test_df = pd.DataFrame(
         {

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1451,6 +1451,17 @@ def test_groupby_on_index_values_with_loop():
         df_equals(modin_dict[k], pandas_dict[k])
 
 
+def test_groupby_getitem_preserves_key_order():
+    a = np.tile(["a", "b", "c", "d", "e"], (1, 10))
+    np.random.shuffle(a[0])
+    df = pd.DataFrame(
+        np.hstack((a.T, np.random.randint(0, 100, (50, 2)))),
+        columns=["col 1", "col 2", "col 3"],
+    )
+    groupby_df_indexed = df.groupby("col 1")[["col 3", "col 2"]]._df
+    df_equals(df[["col 1", "col 3", "col 2"]], groupby_df_indexed)
+
+
 @pytest.mark.parametrize(
     "groupby_kwargs",
     [

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1453,15 +1453,12 @@ def test_groupby_on_index_values_with_loop():
         df_equals(modin_dict[k], pandas_dict[k])
 
 
-def test_groupby_getitem_preserves_key_order():
-    a = np.tile(["a", "b", "c", "d", "e"], (1, 10))
-    np.random.shuffle(a[0])
-    df = pd.DataFrame(
-        np.hstack((a.T, np.random.randint(0, 100, (50, 2)))),
-        columns=["col 1", "col 2", "col 3"],
+def test_groupby_getitem_preserves_key_order_issue_6154():
+    modin_df = pd.DataFrame(test_data["int_data"])
+    pandas_df = pandas.DataFrame(test_data["int_data"])
+    eval_general(
+        modin_df, pandas_df, lambda df: df.groupby("col 1")[["col 3", "col 2"]].count()
     )
-    groupby_df_indexed = df.groupby("col 1")[["col 3", "col 2"]]._df
-    df_equals(df[["col 1", "col 3", "col 2"]], groupby_df_indexed)
 
 
 @pytest.mark.parametrize(

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1454,10 +1454,14 @@ def test_groupby_on_index_values_with_loop():
 
 
 def test_groupby_getitem_preserves_key_order_issue_6154():
-    modin_df = pd.DataFrame(test_data["int_data"])
-    pandas_df = pandas.DataFrame(test_data["int_data"])
+    a = np.tile(["a", "b", "c", "d", "e"], (1, 10))
+    np.random.shuffle(a[0])
+    df = pd.DataFrame(
+        np.hstack((a.T, np.arange(100).reshape((50, 2)))),
+        columns=["col 1", "col 2", "col 3"],
+    )
     eval_general(
-        modin_df, pandas_df, lambda df: df.groupby("col 1")[["col 3", "col 2"]].count()
+        df, df._to_pandas(), lambda df: df.groupby("col 1")[["col 3", "col 2"]].count()
     )
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6154 ? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
