### PR TITLE
FIX-#6146: Fix `pivot` when `values=None`

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1482,6 +1482,10 @@ class DataFrame(BasePandasDataset):
         """
         Return reshaped ``DataFrame`` organized by given index / column values.
         """
+        # if values is not specified, it should be the remaining columns not in
+        # index or columns
+        if values is None:
+            values = [c for c in self.columns if c not in index and c not in columns]
         return self.__constructor__(
             query_compiler=self._query_compiler.pivot(
                 index=index, columns=columns, values=values

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1485,7 +1485,12 @@ class DataFrame(BasePandasDataset):
         # if values is not specified, it should be the remaining columns not in
         # index or columns
         if values is None:
-            values = [c for c in self.columns if c not in index and c not in columns]
+            values = list(self.columns)
+            if index:
+                values = [v for v in values if v not in index]
+            if columns:
+                values = [v for v in values if v not in columns]
+
         return self.__constructor__(
             query_compiler=self._query_compiler.pivot(
                 index=index, columns=columns, values=values

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -553,10 +553,8 @@ def test_pivot_values_is_none():
             "zoo": ["x", "y", "z", "q", "w", "t"],
         }
     )
-    pandas_test_df = test_df._to_pandas()
-    modin_df = pd.pivot(test_df, index="foo", columns="bar")
-    pandas_df = pandas.pivot(pandas_test_df, index="foo", columns="bar")
-    df_equals(modin_df, pandas_df)
+    df = pd.pivot(test_df, index="foo", columns="bar")
+    assert isinstance(df, pd.DataFrame)
 
 
 def test_pivot_table():

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -544,6 +544,21 @@ def test_pivot():
         pd.pivot(test_df["bar"], index="foo", columns="bar", values="baz")
 
 
+def test_pivot_values_is_none():
+    test_df = pd.DataFrame(
+        {
+            "foo": ["one", "one", "one", "two", "two", "two"],
+            "bar": ["A", "B", "C", "A", "B", "C"],
+            "baz": [1, 2, 3, 4, 5, 6],
+            "zoo": ["x", "y", "z", "q", "w", "t"],
+        }
+    )
+    pandas_test_df = test_df._to_pandas()
+    modin_df = pd.pivot(test_df, index="foo", columns="bar")
+    pandas_df = pandas.pivot(pandas_test_df, index="foo", columns="bar")
+    df_equals(modin_df, pandas_df)
+
+
 def test_pivot_table():
     test_df = pd.DataFrame(
         {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6146 ? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
