### PR TITLE
FIX-#6104: Ensure `repr` does not duplicate columns

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -237,6 +237,18 @@ class BasePandasDataset(ClassLogger):
                     if len(self.columns) - num_cols_for_front >= 0
                     else None
                 )
+                # Scenario: num_cols = 20, len(self.columns) = 21
+                # num_cols_for_front works out to 11, num_cols_for_back works out to 11
+                # this leads to over lap in the columns between the set from the first
+                # part of the dataframe and the set from the last part of the dataframe.
+                # The last column from the front is the same as the first column
+                # from the back. This leads to specifying the same column twice
+                # which we should avoid doing.
+                if num_cols_for_back is not None:
+                    if num_cols_for_front + num_cols_for_back > len(self.columns):
+                        num_cols_for_back -= (
+                            num_cols_for_front + num_cols_for_back - len(self.columns)
+                        )
                 col_indexer = list(range(len(self.columns))[:num_cols_for_front]) + (
                     list(range(len(self.columns))[-num_cols_for_back:])
                     if num_cols_for_back is not None


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6104 ? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
