### PR TITLE
FIX-#6113: Add QC Layer implementation for idxmin/max

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -2791,6 +2791,42 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.doc_groupby_method(
+        action="get the index of the minimum value",
+        result="index of minimum value",
+        refer_to="idxmin",
+    )
+    def groupby_idxmin(
+        self, by, axis, groupby_kwargs, agg_args, agg_kwargs, drop=False
+    ):
+        return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.idxmin)(
+            self,
+            by=by,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
+        action="get the index of the maximum value",
+        result="index of maximum value",
+        refer_to="idxmax",
+    )
+    def groupby_idxmax(
+        self, by, axis, groupby_kwargs, agg_args, agg_kwargs, drop=False
+    ):
+        return GroupByDefault.register(pandas.core.groupby.DataFrameGroupBy.idxmax)(
+            self,
+            by=by,
+            axis=axis,
+            groupby_kwargs=groupby_kwargs,
+            agg_args=agg_args,
+            agg_kwargs=agg_kwargs,
+            drop=drop,
+        )
+
+    @doc_utils.doc_groupby_method(
         action="get the minimum value", result="minimum value", refer_to="min"
     )
     def groupby_min(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -339,8 +339,15 @@ class DataFrameGroupBy(ClassLogger):
             agg_kwargs=dict(min_count=min_count),
         )
 
-    def idxmax(self):
-        return self._default_to_pandas(lambda df: df.idxmax())
+    def idxmax(self, axis=0, skipna=True, numeric_only=True):
+        if any(d == np.dtype("O") for d in self._df._get_dtypes()):
+            raise TypeError("reduce operation 'argmin' not allowed for this dtype")
+
+        return self._wrap_aggregation(
+            type(self._query_compiler).groupby_idxmax,
+            agg_kwargs=dict(axis=axis, skipna=skipna),
+            numeric_only=numeric_only,
+        )
 
     @property
     def ndim(self):
@@ -679,8 +686,15 @@ class DataFrameGroupBy(ClassLogger):
         )
         return self.fillna(limit=limit, method="bfill")
 
-    def idxmin(self):
-        return self._default_to_pandas(lambda df: df.idxmin())
+    def idxmin(self, axis=0, skipna=True, numeric_only=True):
+        if any(d == np.dtype("O") for d in self._df._get_dtypes()):
+            raise TypeError("reduce operation 'argmin' not allowed for this dtype")
+
+        return self._wrap_aggregation(
+            type(self._query_compiler).groupby_idxmin,
+            agg_kwargs=dict(axis=axis, skipna=skipna),
+            numeric_only=numeric_only,
+        )
 
     def prod(self, numeric_only=None, min_count=0):
         return self._wrap_aggregation(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -340,9 +340,6 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def idxmax(self, axis=0, skipna=True, numeric_only=True):
-        if any(d == np.dtype("O") for d in self._df._get_dtypes()):
-            raise TypeError("reduce operation 'argmin' not allowed for this dtype")
-
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_idxmax,
             agg_kwargs=dict(axis=axis, skipna=skipna),
@@ -687,9 +684,6 @@ class DataFrameGroupBy(ClassLogger):
         return self.fillna(limit=limit, method="bfill")
 
     def idxmin(self, axis=0, skipna=True, numeric_only=True):
-        if any(d == np.dtype("O") for d in self._df._get_dtypes()):
-            raise TypeError("reduce operation 'argmin' not allowed for this dtype")
-
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_idxmin,
             agg_kwargs=dict(axis=axis, skipna=skipna),


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6113 ? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
