### PR TITLE
FIX-#5091: Handle pd.Grouper objects correctly

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3116,7 +3116,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 by = [by] if by is not None else []
             internal_by = []
             for o in by:
-                if isinstance(o, pandas.Grouper):
+                if isinstance(o, pandas.Grouper) and o.key in self.columns:
                     internal_by.append(o.key)
                 elif hashable(o) and o in self.columns:
                     internal_by.append(o)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3114,7 +3114,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
         else:
             if not isinstance(by, list):
                 by = [by] if by is not None else []
-            internal_by = [o for o in by if hashable(o) and o in self.columns]
+            internal_by = []
+            for o in by:
+                if isinstance(o, pandas.Grouper):
+                    internal_by.append(o.key)
+                elif hashable(o) and o in self.columns:
+                    internal_by.append(o)
             internal_qc = (
                 [self.getitem_column_array(internal_by)] if len(internal_by) else []
             )

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -476,6 +476,8 @@ class DataFrame(BasePandasDataset):
             drop = by._parent is self
             idx_name = by.name
             by = by._query_compiler
+        elif isinstance(by, pandas.Grouper):
+            drop = by.key in self
         elif is_list_like(by):
             # fastpath for multi column groupby
             if axis == 0 and all(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -580,10 +580,12 @@ class DataFrameGroupBy(ClassLogger):
                     elif isinstance(by, pandas.Grouper):
                         internal_by_list.append(by.key)
                 internal_by = tuple(internal_by_list)
+            elif isinstance(self._by, pandas.Grouper):
+                internal_by = tuple([self._by.key])
             else:
                 ErrorMessage.catch_bugs_and_request_email(
                     failure_condition=not isinstance(self._by, BaseQueryCompiler),
-                    extra_log=f"When 'drop' is True, 'by' must be either list-like or a QueryCompiler, met: {type(self._by)}.",
+                    extra_log=f"When 'drop' is True, 'by' must be either list-like, Grouper, or a QueryCompiler, met: {type(self._by)}.",
                 )
                 internal_by = tuple(self._by.columns)
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -573,7 +573,13 @@ class DataFrameGroupBy(ClassLogger):
         internal_by = tuple()
         if self._drop:
             if is_list_like(self._by):
-                internal_by = tuple(by for by in self._by if isinstance(by, str))
+                internal_by_list = []
+                for by in self._by:
+                    if isinstance(by, str):
+                        internal_by_list.append(by)
+                    elif isinstance(by, pandas.Grouper):
+                        internal_by_list.append(by.key)
+                internal_by = tuple(internal_by_list)
             else:
                 ErrorMessage.catch_bugs_and_request_email(
                     failure_condition=not isinstance(self._by, BaseQueryCompiler),

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -2535,3 +2535,41 @@ def test_skew_corner_cases():
     # https://github.com/modin-project/modin/issues/5545
     modin_df, pandas_df = create_test_dfs({"col0": [1, 1], "col1": [171, 137]})
     eval_general(modin_df, pandas_df, lambda df: df.groupby("col0").skew())
+
+
+def test_groupby_with_grouper():
+    # See https://github.com/modin-project/modin/issues/5091 for more details
+    data = {
+        "id": [1, 2],
+        "time_stamp": ["2022-03-24 23:53:09", "2022-03-24 21:53:09"],
+        "count": [5, 5],
+    }
+    modin_df, pandas_df = create_test_dfs(data)
+
+    # modin Grouper is the same as the pandas Grouper objects
+    # test just for one key
+    eval_general(
+        modin_df,
+        pandas_df,
+        lambda df: df.groupby(pandas.Grouper(key="time_stamp", freq="D").mean()),
+    )
+
+    data = {
+        "Publish date": [
+            pd.Timestamp("2000-01-02"),
+            pd.Timestamp("2000-01-02"),
+            pd.Timestamp("2000-01-09"),
+            pd.Timestamp("2000-01-16"),
+        ],
+        "ID": [0, 1, 1, 3],
+        "Price": [10, 20, 30, 40],
+    }
+    modin_df, pandas_df = create_test_dfs(data)
+
+    eval_general(
+        modin_df,
+        pandas_df,
+        lambda df: df.groupby(
+            [pandas.Grouper(key="Publish date", freq="1M"), "ID"]
+        ).sum(),
+    )

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -2540,19 +2540,22 @@ def test_skew_corner_cases():
 @pytest.mark.parametrize(
     "by",
     [
-        pandas.Grouper(key="time_stamp", freq="D"),
+        pandas.Grouper(key="time_stamp", freq="3D"),
         [pandas.Grouper(key="time_stamp", freq="1M"), "count"],
     ],
 )
 def test_groupby_with_grouper(by):
     # See https://github.com/modin-project/modin/issues/5091 for more details
+    # Generate larger data so that it can handle partitioning cases
     data = {
         "id": [i for i in range(200)],
         "time_stamp": [
             pd.Timestamp("2000-01-02") + datetime.timedelta(days=x) for x in range(200)
         ],
-        "count": [5, 6] * 100,
     }
+    for i in range(200):
+        data[f"count_{i}"] = [i, i + 1] * 100
+
     modin_df, pandas_df = create_test_dfs(data)
     eval_general(
         modin_df,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR addresses two issues - it handles pd.Grouper objects correctly and also obeys the order of the groupby sorting keys as passed in. 

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5091
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
