### PR TITLE
FIX-#6175: Fix groupby agg columns for empty column partition

### DIFF
--- a/modin/core/storage_formats/pandas/groupby.py
+++ b/modin/core/storage_formats/pandas/groupby.py
@@ -141,7 +141,7 @@ class GroupbyReduceImpl:
         def skew_reduce(dfgb, *args, **kwargs):
             df = dfgb.sum(*args, **kwargs)
             if df.empty:
-                return df
+                return df.droplevel(GroupByReduce.ID_LEVEL_NAME, axis=1)
 
             count = df["count"]
             s = df["sum"]
@@ -211,7 +211,7 @@ class GroupbyReduceImpl:
             """
             sums_counts_df = dfgb.sum(**kwargs)
             if sums_counts_df.empty:
-                return sums_counts_df
+                return sums_counts_df.droplevel(GroupByReduce.ID_LEVEL_NAME, axis=1)
 
             sum_df = sums_counts_df["sum"]
             count_df = sums_counts_df["count"]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

FIX-#6175: Fix groupby agg columns for empty column partition

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6175 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
