### PR TITLE
DOCS-#6078: correct default values for MODIN_CPUS and MODIN_NPARTITIONS

### DIFF
--- a/modin/config/__main__.py
+++ b/modin/config/__main__.py
@@ -45,6 +45,11 @@ def export_config_help(filename: str) -> None:
         Name of the file to export configs data.
     """
     configs_data = []
+    default_values = dict(
+        RayRedisPassword="random string",
+        CpuCount="multiprocessing.cpu_count()",
+        NPartitions="equals to MODIN_CPUS env",
+    )
     for objname in sorted(globals()):
         obj = globals()[objname]
         if isinstance(obj, type) and issubclass(obj, Parameter) and not obj.is_abstract:
@@ -54,8 +59,8 @@ def export_config_help(filename: str) -> None:
                     obj, "varname", "not backed by environment"
                 ),
                 "Default Value": obj._get_default()
-                if obj.__name__ != "RayRedisPassword"
-                else "random string",
+                if obj.__name__ not in default_values
+                else default_values[obj.__name__],
                 # `Notes` `-` underlining can't be correctly parsed inside csv table by sphinx
                 "Description": dedent(obj.__doc__ or "").replace(
                     "Notes\n-----", "Notes:\n"

--- a/modin/config/__main__.py
+++ b/modin/config/__main__.py
@@ -58,9 +58,7 @@ def export_config_help(filename: str) -> None:
                 "Env. Variable Name": getattr(
                     obj, "varname", "not backed by environment"
                 ),
-                "Default Value": obj._get_default()
-                if obj.__name__ not in default_values
-                else default_values[obj.__name__],
+                "Default Value": default_values.get(obj.__name__, obj._get_default()),
                 # `Notes` `-` underlining can't be correctly parsed inside csv table by sphinx
                 "Description": dedent(obj.__doc__ or "").replace(
                     "Notes\n-----", "Notes:\n"


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6078 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
