### PR TITLE
FIX-#6184: Make Series.to_list return proper list

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -470,7 +470,14 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         -------
         list
         """
-        return SeriesDefault.register(pandas.Series.to_list)(self)
+
+        def to_list_series(ser):
+            # we need a wrapper as defaulter internals would transform anything
+            # but Series or DataFrame into them following some implicit rules,
+            # and might do so wrong
+            return pandas.Series(ser.to_list())
+
+        return SeriesDefault.register(to_list_series)(self)
 
     @doc_utils.add_refer_to("DataFrame.to_dict")
     def dataframe_to_dict(self, orient="dict", into=dict):  # noqa: PR01

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1942,7 +1942,9 @@ class Series(BasePandasDataset):
         """
         Return a list of the values.
         """
-        return self._query_compiler.to_list()
+        return list(
+            self.__constructor__(query_compiler=self._query_compiler.to_list()).values
+        )
 
     def to_numpy(
         self, dtype=None, copy=False, na_value=no_default, **kwargs

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -228,6 +228,14 @@ def test_to_frame(data):
     df_equals(modin_series.to_frame(name="miao"), pandas_series.to_frame(name="miao"))
 
 
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+def test_to_list(data):
+    modin_series, pandas_series = create_test_series(data)
+    pd_res = pandas_series.to_list()
+    md_res = modin_series.to_list()
+    assert type(pd_res) == type(md_res) and pd_res == md_res
+
+
 def test_accessing_index_element_as_property():
     s = pd.Series([10, 20, 30], index=["a", "b", "c"])
     assert s.b == 20


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6184
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
