### PR TITLE
FIX-#6199: make sure `read_html` return a list of DataFrames

### DIFF
--- a/modin/core/io/io.py
+++ b/modin/core/io/io.py
@@ -256,8 +256,6 @@ class BaseIO:
             displayed_only=displayed_only,
             **kwargs,
         )
-        if isinstance(result, (pandas.DataFrame, pandas.Series)):
-            return (cls.from_pandas(result),)
         return (cls.from_pandas(df) for df in result)
 
     @classmethod

--- a/modin/core/io/io.py
+++ b/modin/core/io/io.py
@@ -238,26 +238,27 @@ class BaseIO:
         **kwargs,
     ):  # noqa: PR01
         ErrorMessage.default_to_pandas("`read_html`")
-        return cls.from_pandas(
-            pandas.read_html(
-                io=io,
-                match=match,
-                flavor=flavor,
-                header=header,
-                index_col=index_col,
-                skiprows=skiprows,
-                attrs=attrs,
-                parse_dates=parse_dates,
-                thousands=thousands,
-                encoding=encoding,
-                decimal=decimal,
-                converters=converters,
-                na_values=na_values,
-                keep_default_na=keep_default_na,
-                displayed_only=displayed_only,
-                **kwargs,
-            )[0]
+        result = pandas.read_html(
+            io=io,
+            match=match,
+            flavor=flavor,
+            header=header,
+            index_col=index_col,
+            skiprows=skiprows,
+            attrs=attrs,
+            parse_dates=parse_dates,
+            thousands=thousands,
+            encoding=encoding,
+            decimal=decimal,
+            converters=converters,
+            na_values=na_values,
+            keep_default_na=keep_default_na,
+            displayed_only=displayed_only,
+            **kwargs,
         )
+        if isinstance(result, (pandas.DataFrame, pandas.Series)):
+            return (cls.from_pandas(result),)
+        return (cls.from_pandas(df) for df in result)
 
     @classmethod
     @_inherit_docstrings(pandas.read_clipboard, apilink="pandas.read_clipboard")

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -393,28 +393,12 @@ def read_html(
     """
     Read HTML tables into a ``DataFrame`` object.
     """
+    _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
+
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(
-        query_compiler=FactoryDispatcher.read_html(
-            io,
-            match=match,
-            flavor=flavor,
-            header=header,
-            index_col=index_col,
-            skiprows=skiprows,
-            attrs=attrs,
-            parse_dates=parse_dates,
-            thousands=thousands,
-            encoding=encoding,
-            decimal=decimal,
-            converters=converters,
-            na_values=na_values,
-            keep_default_na=keep_default_na,
-            displayed_only=displayed_only,
-            extract_links=extract_links,
-        )
-    )
+    qcs = FactoryDispatcher.read_html(**kwargs)
+    return [DataFrame(query_compiler=qc) for qc in qcs]
 
 
 @_inherit_docstrings(pandas.read_clipboard, apilink="pandas.read_clipboard")

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -2300,7 +2300,6 @@ class TestSql:
 
 
 class TestHtml:
-    @pytest.mark.xfail(reason="read_html is not yet implemented properly - issue #1296")
     def test_read_html(self, make_html_file):
         eval_io(fn_name="read_html", io=make_html_file())
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6199 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
