### PR TITLE
FIX-#6201: align groupby objects signatures with pandas

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -279,23 +279,11 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def mean(self, numeric_only=no_default, engine="cython", engine_kwargs=None):
-        def _resolve_numeric_only(how: str, numeric_only, axis):
-            # partially copied from pandas
-            if numeric_only is no_default:
-                # i.e. not explicitly passed by user
-                if self._df.ndim == 2:
-                    # i.e. DataFrameGroupBy
-                    numeric_only = axis != 1
-                else:
-                    numeric_only = False
-            return numeric_only
-
-        numeric_only = _resolve_numeric_only("mean", numeric_only, axis=0)
         return self._check_index(
             self._wrap_aggregation(
                 type(self._query_compiler).groupby_mean,
                 agg_kwargs=dict(
-                    numeric_only=numeric_only,
+                    numeric_only=None if numeric_only is no_default else numeric_only,
                     engine=engine,
                     engine_kwargs=engine_kwargs,
                 ),

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -1023,9 +1023,9 @@ class DataFrameGroupBy(ClassLogger):
                 ax=ax,
                 figsize=figsize,
                 layout=layout,
-                sharex=False,
-                sharey=True,
-                backend=None,
+                sharex=sharex,
+                sharey=sharey,
+                backend=backend,
                 **kwargs,
             )
         )

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -279,13 +279,19 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def mean(self, numeric_only=no_default, engine="cython", engine_kwargs=None):
+        if engine not in ("cython", None) and engine_kwargs is not None:
+            return self._default_to_pandas(
+                lambda df: df.mean(
+                    numeric_only=numeric_only,
+                    engine=engine,
+                    engine_kwargs=engine_kwargs,
+                )
+            )
         return self._check_index(
             self._wrap_aggregation(
                 type(self._query_compiler).groupby_mean,
                 agg_kwargs=dict(
                     numeric_only=None if numeric_only is no_default else numeric_only,
-                    engine=engine,
-                    engine_kwargs=engine_kwargs,
                 ),
                 numeric_only=numeric_only,
             )
@@ -348,20 +354,34 @@ class DataFrameGroupBy(ClassLogger):
         return self._groups_cache
 
     def min(self, numeric_only=False, min_count=-1, engine=None, engine_kwargs=None):
+        if engine not in ("cython", None) and engine_kwargs is not None:
+            return self._default_to_pandas(
+                lambda df: df.min(
+                    numeric_only=numeric_only,
+                    min_count=min_count,
+                    engine=engine,
+                    engine_kwargs=engine_kwargs,
+                )
+            )
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_min,
-            agg_kwargs=dict(
-                min_count=min_count, engine=engine, engine_kwargs=engine_kwargs
-            ),
+            agg_kwargs=dict(min_count=min_count),
             numeric_only=numeric_only,
         )
 
     def max(self, numeric_only=False, min_count=-1, engine=None, engine_kwargs=None):
+        if engine not in ("cython", None) and engine_kwargs is not None:
+            return self._default_to_pandas(
+                lambda df: df.max(
+                    numeric_only=numeric_only,
+                    min_count=min_count,
+                    engine=engine,
+                    engine_kwargs=engine_kwargs,
+                )
+            )
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_max,
-            agg_kwargs=dict(
-                min_count=min_count, engine=engine, engine_kwargs=engine_kwargs
-            ),
+            agg_kwargs=dict(min_count=min_count),
             numeric_only=numeric_only,
         )
 
@@ -744,21 +764,26 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def std(self, ddof=1, engine=None, engine_kwargs=None, numeric_only=no_default):
+        if engine not in ("cython", None) and engine_kwargs is not None:
+            return self._default_to_pandas(
+                lambda df: df.std(
+                    ddof=ddof,
+                    engine=engine,
+                    engine_kwargs=engine_kwargs,
+                    numeric_only=numeric_only,
+                )
+            )
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_std,
-            agg_kwargs=dict(ddof=ddof, engine=engine, engine_kwargs=engine_kwargs),
+            agg_kwargs=dict(ddof=ddof),
             numeric_only=numeric_only,
         )
 
     def aggregate(self, func=None, *args, engine=None, engine_kwargs=None, **kwargs):
-        if engine is not None and engine_kwargs is not None:
+        if engine not in ("cython", None) and engine_kwargs is not None:
             return self._default_to_pandas(
                 lambda df: df.aggregate(
-                    func=func,
-                    *args,
-                    engine=engine,
-                    engine_kwargs=engine_kwargs,
-                    **kwargs,
+                    func, *args, engine=engine, engine_kwargs=engine_kwargs, **kwargs
                 )
             )
         if self._axis != 0:
@@ -915,9 +940,18 @@ class DataFrameGroupBy(ClassLogger):
         return self.fillna(limit=limit, method="pad")
 
     def var(self, ddof=1, engine=None, engine_kwargs=None, numeric_only=no_default):
+        if engine not in ("cython", None) and engine_kwargs is not None:
+            return self._default_to_pandas(
+                lambda df: df.var(
+                    ddof=ddof,
+                    engine=engine,
+                    engine_kwargs=engine_kwargs,
+                    numeric_only=numeric_only,
+                )
+            )
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_var,
-            agg_kwargs=dict(ddof=ddof, engine=engine, engine_kwargs=engine_kwargs),
+            agg_kwargs=dict(ddof=ddof),
             numeric_only=numeric_only,
         )
 
@@ -985,11 +1019,19 @@ class DataFrameGroupBy(ClassLogger):
     def sum(
         self, numeric_only=no_default, min_count=0, engine=None, engine_kwargs=None
     ):
+        if engine not in ("cython", None) and engine_kwargs is not None:
+            return self._default_to_pandas(
+                lambda df: df.sum(
+                    numeric_only=numeric_only,
+                    min_count=min_count,
+                    engine=engine,
+                    engine_kwargs=engine_kwargs,
+                )
+            )
+
         return self._wrap_aggregation(
             type(self._query_compiler).groupby_sum,
-            agg_kwargs=dict(
-                min_count=min_count, engine=engine, engine_kwargs=engine_kwargs
-            ),
+            agg_kwargs=dict(min_count=min_count),
             numeric_only=numeric_only,
         )
 
@@ -1096,8 +1138,13 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def transform(self, func, *args, engine=None, engine_kwargs=None, **kwargs):
-        kwargs["engine"] = engine
-        kwargs["engine_kwargs"] = engine_kwargs
+        if engine not in ("cython", None) and engine_kwargs is not None:
+            return self._default_to_pandas(
+                lambda df: df.transform(
+                    func, *args, engine=engine, engine_kwargs=engine_kwargs, **kwargs
+                )
+            )
+
         return self._check_index_name(
             self._wrap_aggregation(
                 qc_method=type(self._query_compiler).groupby_agg,
@@ -1747,7 +1794,9 @@ class SeriesGroupBy(DataFrameGroupBy):
             maybe_squeezed = result.squeeze() if self._squeeze else result
             return maybe_squeezed.set_axis(labels=self._try_get_str_func(func), axis=1)
         else:
-            return super().aggregate(func, *args, **kwargs)
+            return super().aggregate(
+                func, *args, engine=engine, engine_kwargs=engine_kwargs, **kwargs
+            )
 
     agg = aggregate
 

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -288,6 +288,7 @@ class DataFrameGroupBy(ClassLogger):
                     numeric_only = axis != 1
                 else:
                     numeric_only = False
+            return numeric_only
 
         numeric_only = _resolve_numeric_only("mean", numeric_only, axis=0)
         return self._check_index(

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -279,10 +279,25 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def mean(self, numeric_only=no_default, engine="cython", engine_kwargs=None):
+        def _resolve_numeric_only(how: str, numeric_only, axis):
+            # partially copied from pandas
+            if numeric_only is no_default:
+                # i.e. not explicitly passed by user
+                if self._df.ndim == 2:
+                    # i.e. DataFrameGroupBy
+                    numeric_only = axis != 1
+                else:
+                    numeric_only = False
+
+        numeric_only = _resolve_numeric_only("mean", numeric_only, axis=0)
         return self._check_index(
             self._wrap_aggregation(
                 type(self._query_compiler).groupby_mean,
-                agg_kwargs=dict(engine=engine, engine_kwargs=engine_kwargs),
+                agg_kwargs=dict(
+                    numeric_only=numeric_only,
+                    engine=engine,
+                    engine_kwargs=engine_kwargs,
+                ),
                 numeric_only=numeric_only,
             )
         )

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -229,7 +229,7 @@ def test_sparse_accessor_api_equality(obj):
 
 
 @pytest.mark.parametrize("obj", ["SeriesGroupBy", "DataFrameGroupBy"])
-def test_series_groupby_api_equality(obj):
+def test_groupby_api_equality(obj):
     modin_dir = [x for x in dir(getattr(pd.groupby, obj)) if x[0] != "_"]
     pandas_dir = [x for x in dir(getattr(pandas.core.groupby, obj)) if x[0] != "_"]
     # This attribute is hidden from the DataFrameGroupBy object
@@ -239,10 +239,15 @@ def test_series_groupby_api_equality(obj):
         len(missing_from_modin)
     )
     # FIXME: wrong inheritance
-    ignore = ["boxplot", "corrwith", "dtypes"]
+    ignore = (
+        ["boxplot", "corrwith", "dtypes"] if obj == "SeriesGroupBy" else ["boxplot"]
+    )
     extra_in_modin = set(modin_dir) - set(pandas_dir) - set(ignore)
     assert not len(extra_in_modin), "Differences found in API: {}".format(
         extra_in_modin
+    )
+    assert_parameters_eq(
+        (getattr(pandas.core.groupby, obj), getattr(pd.groupby, obj)), modin_dir, ignore
     )
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6201 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
