### PR TITLE
FIX-#6204: Use reset_index instead of insert in to_sql

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3362,7 +3362,11 @@ class BasePandasDataset(ClassLogger):
         if index:
             if not index_label:
                 index_label = "index"
-            new_query_compiler = new_query_compiler.insert(0, index_label, self.index)
+            new_query_compiler = new_query_compiler.reset_index()
+            if new_query_compiler.columns[0] != index_label:
+                new_query_compiler.columns = [index_label] + list(
+                    new_query_compiler.columns[1:]
+                )
             # so pandas._to_sql will not write the index to the database as well
             index = False
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3365,7 +3365,7 @@ class BasePandasDataset(ClassLogger):
                 if not is_list_like(index_label):
                     index_label = [index_label]
                 new_query_compiler.columns = list(index_label) + list(
-                    new_query_compiler.columns[len(index_label):]
+                    new_query_compiler.columns[len(index_label) :]
                 )
             # so pandas._to_sql will not write the index to the database as well
             index = False

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3360,12 +3360,12 @@ class BasePandasDataset(ClassLogger):
         new_query_compiler = self._query_compiler
         # writing the index to the database by inserting it to the DF
         if index:
-            if not index_label:
-                index_label = "index"
             new_query_compiler = new_query_compiler.reset_index()
-            if new_query_compiler.columns[0] != index_label:
-                new_query_compiler.columns = [index_label] + list(
-                    new_query_compiler.columns[1:]
+            if index_label is not None:
+                if not is_list_like(index_label):
+                    index_label = [index_label]
+                new_query_compiler.columns = list(index_label) + list(
+                    new_query_compiler.columns[len(index_label):]
                 )
             # so pandas._to_sql will not write the index to the database as well
             index = False


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6204
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
