### PR TITLE
FIX-#6072: unpin pyarrow and xfail `test_read_parquet_pandas_index` test

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,7 @@ dependencies:
   - pandas==1.5.3
   - numpy>=1.18.5
   - ray-default>=1.13.0
-  - pyarrow<12 # workaround for https://github.com/modin-project/modin/issues/6072
+  - pyarrow
   # workaround for https://github.com/conda/conda/issues/11744
   - grpcio!=1.45.*
   - grpcio!=1.46.*

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1541,6 +1541,12 @@ class TestParquet:
         reason="The reason of tests fail in `cloud` mode is unknown for now - issue #3264",
     )
     def test_read_parquet_pandas_index(self, engine):
+        if (
+            version.parse(pa.__version__) >= version.parse("12.0.0")
+            and version.parse(pd.__version__) < version.parse("2.0.0")
+            and engine == "pyarrow"
+        ):
+            pytest.xfail("incompatible versions; see #6072")
         # Ensure modin can read parquet files written by pandas with a non-RangeIndex object
         pandas_df = pandas.DataFrame(
             {

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -3,7 +3,7 @@ channels:
   - conda-forge
 dependencies:
   - pandas==1.5.3
-  - pyarrow<12 # workaround for https://github.com/modin-project/modin/issues/6072
+  - pyarrow
   - numpy>=1.18.5
   - fsspec
   - pip

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -5,7 +5,7 @@ dependencies:
   - unidist-mpi>=0.2.1
   - pandas==1.5.3
   - numpy>=1.18.5
-  - pyarrow<12 # workaround for https://github.com/modin-project/modin/issues/6072
+  - pyarrow
   - fsspec
   - xarray
   - Jinja2

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -3,7 +3,7 @@ channels:
 dependencies:
   - pandas==1.5.3
   - numpy>=1.18.5
-  - pyarrow<12 # workaround for https://github.com/modin-project/modin/issues/6072
+  - pyarrow
   - fsspec
   - xarray
   - Jinja2


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6072 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
