### PR TITLE
PERF-#6224: Use 'Map' operator to retrieve categorical codes

### DIFF
--- a/modin/core/dataframe/base/dataframe/dataframe.py
+++ b/modin/core/dataframe/base/dataframe/dataframe.py
@@ -93,6 +93,7 @@ class ModinDataframe(ABC):
         function: Callable,
         axis: Optional[Union[int, Axis]] = None,
         dtypes: Optional[str] = None,
+        new_columns: Optional[List[Hashable]] = None,
     ) -> "ModinDataframe":
         """
         Apply a user-defined function row-wise if `axis`=0, column-wise if `axis`=1, and cell-wise if `axis` is None.
@@ -107,6 +108,9 @@ class ModinDataframe(ABC):
             The data types for the result. This is an optimization
             because there are functions that always result in a particular data
             type, and this allows us to avoid (re)computing it.
+        new_columns : List[Hashable], optional
+            New column labels of the result, its length has to be identical
+            to the older columns. If not specified, old column labels are preserved.
 
         Returns
         -------

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1939,8 +1939,7 @@ class PandasDataframe(ClassLogger):
             type, and this allows us to avoid (re)computing it.
         new_columns : pandas.Index, optional
             New column labels of the result, its length has to be identical
-            to the older columns. If not specified, new columns will be computed
-            on demand.
+            to the older columns. If not specified, old column labels are preserved.
 
         Returns
         -------

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -4028,21 +4028,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # Cat operations
     def cat_codes(self):
-        def func(df) -> np.ndarray:
-            # `df` is supposed to be consisted of multiple partitions,
-            # which should be concatenated before applying a function.
-            # `pd.concat` doesn't preserve categorical dtype
-            # if the dfs have categorical columns
-            # so we intentionaly restore the right dtype.
-            # TODO: revert the change when https://github.com/pandas-dev/pandas/issues/51362 is fixed.
+        def func(df: pandas.DataFrame) -> pandas.DataFrame:
             ser = df.iloc[:, 0]
-            if ser.dtype != "category":
-                ser = ser.astype("category", copy=False)
+            assert ser.dtype == "category"
             return ser.cat.codes.to_frame(name=MODIN_UNNAMED_SERIES_LABEL)
 
-        res = self._modin_frame.fold(
-            axis=0, func=func, new_columns=[MODIN_UNNAMED_SERIES_LABEL]
-        )
+        res = self._modin_frame.map(func=func, new_columns=[MODIN_UNNAMED_SERIES_LABEL])
         return self.__constructor__(res, shape_hint="column")
 
     # END Cat operations


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

After #6222 we guarantee that each partition has knowledge about the whole categorical table, meaning that we don't need to build the whole axis no more in order to retrieve valid categorical codes. So this PR basically replaces `.fold(axis=0, ...)` to the `.map(...)` in the `.cat_codes` implementation.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6224  <!-- issue must be created for each patch -->
- [x] tests are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
