### PR TITLE
FIX-#6237: Log errors only from deepest modin layer

### DIFF
--- a/modin/logging/logger_decorator.py
+++ b/modin/logging/logger_decorator.py
@@ -132,8 +132,17 @@ def enable_logging(
             logger_level(start_line)
             try:
                 result = obj(*args, **kwargs)
-            except BaseException:
-                get_logger("modin.logger.errors").exception(stop_line)
+            except BaseException as e:
+                # Only log the exception if a deeper layer of the modin stack has not
+                # already logged it.
+                if not hasattr(e, "_modin_logged"):
+                    # use stack_info=True so that even if we are a few layers deep in
+                    # modin, we log a stack trace that includes calls to higher layers
+                    # of modin
+                    get_logger("modin.logger.errors").exception(
+                        stop_line, stack_info=True
+                    )
+                    e._modin_logged = True
                 raise
             finally:
                 logger_level(stop_line)

--- a/modin/logging/logger_decorator.py
+++ b/modin/logging/logger_decorator.py
@@ -142,7 +142,7 @@ def enable_logging(
                     get_logger("modin.logger.errors").exception(
                         stop_line, stack_info=True
                     )
-                    e._modin_logged = True
+                    e._modin_logged = True  # type: ignore[attr-defined]
                 raise
             finally:
                 logger_level(stop_line)

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -32,7 +32,7 @@ from packaging import version
 import pandas
 import numpy as np
 
-from pandas.util._decorators import Appender
+from pandas.util._decorators import Appender  # type: ignore
 from pandas.util._print_versions import _get_sys_info, _get_dependency_info  # type: ignore[attr-defined]
 from pandas._typing import JSONSerializable
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6237 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
