### PR TITLE
FEAT-#5759: Implement lazy Arrow execution for the HDK engine

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/base_worker.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/base_worker.py
@@ -251,4 +251,4 @@ class BaseDbWorker(abc.ABC):
         str
             Imported table name.
         """
-        return cls.import_arrow_table(pa.Table.from_pandas(df))
+        return cls.import_arrow_table(pa.Table.from_pandas(df), name=name)

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_serializer.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_serializer.py
@@ -189,7 +189,10 @@ class CalciteSerializer:
         res = {}
         for k, v in obj.__dict__.items():
             if k[0] != "_":
-                res[k] = self.serialize_item(v)
+                if k == "op" and isinstance(obj, OpExpr) and v == "//":
+                    res[k] = "/"
+                else:
+                    res[k] = self.serialize_item(v)
         return res
 
     def serialize_typed_obj(self, obj):

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -17,7 +17,6 @@ import re
 import numpy as np
 from collections import OrderedDict
 
-import typing
 from typing import List, Hashable, Optional, Tuple, Union
 
 import pyarrow
@@ -30,7 +29,6 @@ from pandas.core.dtypes.common import (
     get_dtype,
     is_list_like,
     is_bool_dtype,
-    is_string_dtype,
     is_categorical_dtype,
 )
 
@@ -48,13 +46,11 @@ from .utils import (
     check_join_supported,
     check_cols_to_join,
     get_data_for_join_by_index,
-    get_common_arrow_type,
     build_categorical_from_at,
 )
 from ..partitioning.partition_manager import HdkOnNativeDataframePartitionManager
 from modin.core.dataframe.pandas.metadata import LazyProxyCategoricalDtype
 from modin.error_message import ErrorMessage
-from modin.pandas.indexing import is_range_like
 from modin.utils import MODIN_UNNAMED_SERIES_LABEL, _inherit_docstrings
 from modin.core.dataframe.pandas.utils import concatenate
 from modin.core.dataframe.base.dataframe.utils import join_columns
@@ -82,12 +78,11 @@ from ..expr import (
 )
 from modin.pandas.utils import check_both_not_none
 
-
 IDX_COL_NAME = ColNameCodec.IDX_COL_NAME
 ROWID_COL_NAME = ColNameCodec.ROWID_COL_NAME
+UNNAMED_IDX_COL_NAME = ColNameCodec.UNNAMED_IDX_COL_NAME
 encode_col_name = ColNameCodec.encode
 decode_col_name = ColNameCodec.decode
-concat_index_names = ColNameCodec.concat_index_names
 mangle_index_names = ColNameCodec.mangle_index_names
 demangle_index_names = ColNameCodec.demangle_index_names
 
@@ -238,7 +233,7 @@ class HdkOnNativeDataframe(PandasDataframe):
         else:
             self.set_dtypes_cache(dtypes)
 
-        if partitions is not None:
+        if partitions is not None and partitions.size > 1:
             self._filter_empties()
 
         self._uses_rowid = uses_rowid
@@ -578,7 +573,7 @@ class HdkOnNativeDataframe(PandasDataframe):
         base = self.__constructor__(
             columns=base_cols,
             dtypes=self._dtypes_for_exprs(exprs),
-            op=TransformNode(base, exprs, fold=True),
+            op=TransformNode(base, exprs),
             index_cols=None,
             force_execution_mode=self._force_execution_mode,
         )
@@ -785,6 +780,44 @@ class HdkOnNativeDataframe(PandasDataframe):
             force_execution_mode=base._force_execution_mode,
         )
         return result
+
+    def isna(self, invert):
+        """
+        Detect missing values.
+
+        Parameters
+        ----------
+        invert : bool
+
+        Returns
+        -------
+        HdkOnNativeDataframe
+        """
+        expr = "is_not_null" if invert else "is_null"
+        exprs = self._index_exprs()
+        for col in self.columns:
+            exprs[col] = getattr(self.ref(col), expr)()
+        return self.__constructor__(
+            columns=self.columns,
+            dtypes=self._dtypes_for_exprs(exprs),
+            op=TransformNode(self, exprs),
+            index=self._index_cache,
+            index_cols=self._index_cols,
+            force_execution_mode=self._force_execution_mode,
+        )
+
+    def invert(self):
+        """
+        Apply bitwise inverse to each column.
+
+        Returns
+        -------
+        HdkOnNativeDataframe
+        """
+        exprs = self._index_exprs()
+        for col in self.columns:
+            exprs[col] = self.ref(col).invert()
+        return self.copy(op=TransformNode(self, exprs))
 
     def dt_extract(self, obj):
         """
@@ -1038,350 +1071,107 @@ class HdkOnNativeDataframe(PandasDataframe):
         HdkOnNativeDataframe
             The new frame.
         """
-        frames = [self] + other_modin_frames
+        index_cols = None
+        columns = OrderedDict()
+        for col in self.columns:
+            columns[col] = self._dtypes[col]
 
-        # This is a special case, where we need to preserve the index of empty frames.
-        if any(len(f.columns) == 0 for f in frames):
-            return self._union_all_arrow(frames, join, sort, ignore_index)
-
-        # determine output columns
-        def join_cols():
-            new_cols_map = OrderedDict()
-            for col in self.columns:
-                new_cols_map[col] = self._dtypes[col]
+        if join == "inner":
             for frame in other_modin_frames:
-                if join == "inner":
-                    for col in list(new_cols_map):
-                        if col not in frame.columns:
-                            del new_cols_map[col]
-                elif join == "outer":
-                    for col in frame.columns:
-                        if col not in new_cols_map:
-                            new_cols_map[col] = frame._dtypes[col]
-                else:
-                    raise NotImplementedError(f"Unsupported join type {join=}")
+                for col in list(columns):
+                    if col not in frame.columns:
+                        del columns[col]
+        elif join == "outer":
+            for frame in other_modin_frames:
+                for col in frame.columns:
+                    if col not in columns:
+                        columns[col] = frame._dtypes[col]
+        else:
+            raise NotImplementedError(f"Unsupported join type {join=}")
 
+        frames = []
+        for frame in [self] + other_modin_frames:
+            # Empty frames are filtered out only in case of the outer join.
+            if (
+                join == "inner"
+                or len(frame.columns) != 0
+                or (frame.has_index_cache and len(frame.index) != 0)
+                or (not frame.has_index_cache and frame.index_cols)
+            ):
+                if isinstance(frame._op, UnionNode):
+                    frames.extend(frame._op.input)
+                else:
+                    frames.append(frame)
+
+        if len(columns) == 0:
+            if len(frames) == 0:
+                dtypes = pd.Series()
+            elif ignore_index:
+                index_cols = [UNNAMED_IDX_COL_NAME]
+                dtypes = pd.Series([get_dtype(int)], index=index_cols)
+            else:
+                index_names = ColNameCodec.concat_index_names(frames)
+                index_cols = list(index_names)
+                dtypes = pd.Series(index_names.values(), index=index_cols)
+        else:
+            # Find common dtypes
             for frame in other_modin_frames:
                 frame_dtypes = frame._dtypes
-                for col, dtype in new_cols_map.items():
+                for col in columns:
                     if col in frame_dtypes:
-                        new_cols_map[col] = pd.core.dtypes.cast.find_common_type(
-                            [dtype, frame_dtypes[col]]
+                        columns[col] = pd.core.dtypes.cast.find_common_type(
+                            [columns[col], frame_dtypes[col]]
                         )
 
             if sort:
-                new_columns = sorted(new_cols_map.keys())
-                new_dtypes = [new_cols_map[col] for col in new_columns]
+                columns = OrderedDict((col, columns[col]) for col in sorted(columns))
+
+            if ignore_index:
+                table_columns = columns
             else:
-                new_columns = new_cols_map.keys()
-                new_dtypes = list(new_cols_map.values())
+                table_columns = ColNameCodec.concat_index_names(frames)
+                index_cols = list(table_columns)
+                table_columns.update(columns)
 
-            return new_columns, new_dtypes
-
-        # If all frames are either FrameNode(materialized frame) or UnionNode,
-        # containing only FrameNodes and having the same concatenation options,
-        # put all frames into a single UnionNode. It allows to concatenate
-        # multiple frames with arrow in a single batch operation.
-        materialized = []
-        for f in frames:
-            if isinstance(f._op, FrameNode):
-                materialized.append(f)
-            elif (
-                isinstance(f._op, UnionNode)
-                and f._op.join == join
-                and f._op.sort == sort
-                and f._op.ignore_index == ignore_index
-            ):
-                materialized.extend(f._op.input)
-            else:
-                materialized.clear()
-                break
-        if materialized:
-            new_columns, new_dtypes = join_cols()
-            if not ignore_index:
-                index_cols = concat_index_names(frames)
-                new_dtypes = list(index_cols.values()) + new_dtypes
-            return self.copy(
-                partitions=None,
-                index=None,
-                columns=new_columns,
-                dtypes=new_dtypes,
-                op=UnionNode(materialized, join, sort, ignore_index),
-                index_cols=None if ignore_index else list(index_cols.keys()),
-            )
-
-        # In case of different number of columns, HDK performs
-        # slowly and supports only numeric column types.
-        # See https://github.com/intel-ai/hdk/issues/182
-        # To work around this issue, perform concatenation
-        # with arrow.
-        if (
-            len(other_modin_frames) == 0
-            or len(self.columns) == 0
-            or any(len(f.columns) != len(self.columns) for f in other_modin_frames)
-        ):
-            return self._union_all_arrow(frames, join, sort, ignore_index)
-
-        dtypes = self._dtypes.to_dict()
-        if any(is_string_dtype(t) for t in dtypes.values()) or any(
-            f._dtypes.to_dict() != dtypes for f in other_modin_frames
-        ):
-            return self._union_all_arrow(frames, join, sort, ignore_index)
-
-        new_columns, new_dtypes = join_cols()
-
-        # determine how many index components are going into
-        # the resulting table
-        if not ignore_index:
-            index_width = self._index_width()
-            for frame in other_modin_frames:
-                index_width = min(index_width, frame._index_width())
-
-        # build projections to align all frames
-        aligned_frames = []
-        for frame in frames:
-            aligned_index = None
-            exprs = OrderedDict()
-            uses_rowid = False
-
-            if not ignore_index:
-                if frame._index_cols:
-                    aligned_index = frame._index_cols[0 : index_width + 1]
-                    aligned_index_dtypes = frame._dtypes[aligned_index].tolist()
-                    for i in range(0, index_width):
-                        col = frame._index_cols[i]
-                        exprs[col] = frame.ref(col)
-                else:
-                    assert index_width == 1, "unexpected index width"
-                    aligned_index = mangle_index_names([None])
-                    exprs[aligned_index[0]] = frame.ref(ROWID_COL_NAME)
-                    aligned_index_dtypes = [get_dtype(int)]
-                    uses_rowid = True
-                aligned_dtypes = aligned_index_dtypes + new_dtypes
-            else:
-                aligned_dtypes = new_dtypes
-
-            for col in new_columns:
-                if col in frame._table_cols:
-                    exprs[col] = frame.ref(col)
-                else:
-                    exprs[col] = LiteralExpr(None)
-
-            aligned_frame_op = TransformNode(frame, exprs)
-            aligned_frames.append(
-                self.__constructor__(
-                    columns=new_columns,
-                    dtypes=aligned_dtypes,
-                    op=aligned_frame_op,
-                    index_cols=aligned_index,
-                    uses_rowid=uses_rowid,
-                    force_execution_mode=self._force_execution_mode,
-                )
-            )
-
-        new_frame = aligned_frames[0]
-        for frame in aligned_frames[1:]:
-            new_frame = self.__constructor__(
-                columns=new_columns,
-                dtypes=new_frame.copy_dtypes_cache(),
-                op=UnionNode([new_frame, frame], join, sort, ignore_index),
-                index_cols=new_frame._index_cols,
-                force_execution_mode=self._force_execution_mode,
-            )
-
-        return new_frame
-
-    @staticmethod
-    def _union_all_arrow(frames, join, sort, ignore_index, frame_to_table=None):
-        """
-        Concatenate frames' rows, using the PyArrow API.
-
-        Parameters
-        ----------
-        frames : list of HdkOnNativeDataframe
-            Frames to concat.
-        join : {"outer", "inner"}
-            How to handle columns with mismatched names.
-            "inner" - drop such columns. "outer" - fill
-            with NULLs.
-        sort : bool
-            Sort unaligned columns for 'outer' join.
-        ignore_index : bool
-            Ignore index columns.
-        frame_to_table : dict, default: None
-            Dictionary, containing arrow tables for each frame.
-            If not None, this method returns an arrow table. This
-            parameter is used by the `_execute_arrow()` function,
-            which provides arrow tables for each frame and requires
-            an arrow table to be returned.
-
-        Returns
-        -------
-        HdkOnNativeDataframe or pyarrow.Table
-            The new frame or table.
-        """
-
-        class FrameData:
-            def __init__(self, frame):
-                if frame_to_table is None:
-                    if not frame._has_arrow_table():
-                        frame._execute()
-                    if not frame._has_arrow_table():
-                        raise NotImplementedError(
-                            "PyArrow tables concatenation without any PyArrow table"
-                        )
-                    self.table = frame._partitions[0][0].arrow_table
-                else:
-                    self.table = frame_to_table[frame]
-                self.frame = frame
-                self.index = frame.index
-                self.columns = frame.columns
-                self.index_cols = frame._index_cols
-
-        frames: List[FrameData] = [FrameData(f) for f in frames]
-        col_fields: typing.OrderedDict[Tuple[str, str], pyarrow.Field] = OrderedDict()
-
-        # Add field to the col_fields dictionary. If the field is already exists, chose
-        # the most appropriate field, according to the fields type and bit_width.
-        def add_col_field(table, col_name, table_col_name):
-            key = (col_name, table_col_name)
-            field = table.field(table_col_name)
-            cur_field = col_fields.get(key, None)
-            if cur_field is None or (
-                cur_field.type != get_common_arrow_type(cur_field.type, field.type)
-            ):
-                col_fields[key] = field
-
-        if join == "outer":
-            frames = [f for f in frames if len(f.columns) != 0 or len(f.index) != 0]
-            for frame in frames:
-                table = frame.table
-                idx_width = 0 if frame.index_cols is None else len(frame.index_cols)
-                table_cols = table.column_names[idx_width:]
-                for col_name, table_col_name in zip(frame.columns, table_cols):
-                    add_col_field(table, col_name, table_col_name)
-        else:
-            col_names = {c for c in frames[0].columns} if len(frames) > 1 else []
-            if len(col_names) != 0:
-                for frame in frames[1:]:
-                    for name in list(col_names):
-                        if name not in frame.columns:
-                            col_names.remove(name)
-                if len(col_names) != 0:
-                    for frame in frames:
-                        table = frame.table
-                        idx_width = (
-                            0 if frame.index_cols is None else len(frame.index_cols)
-                        )
-                        table_cols = table.column_names[idx_width:]
-                        for col_name, table_col_name in zip(frame.columns, table_cols):
-                            if col_name in col_names:
-                                add_col_field(table, col_name, table_col_name)
-
-        if len(col_fields) == 0:
-            if ignore_index or len(frames) == 0:
-                idx = RangeIndex(0, sum(len(f.table) for f in frames))
-            else:
-                idx = frames[0].index.append([f.index for f in frames[1:]])
-            idx_cols = mangle_index_names(idx.names)
-            idx_df = pd.DataFrame(index=idx).reset_index()
-            union = pyarrow.Table.from_pandas(idx_df).rename_columns(idx_cols)
-        else:
-            # Process empty frames with non-empty index
-            for frame in frames:
-                if len(frame.table) == 0 and len(frame.index) != 0:
-                    if ignore_index:
-                        frame.index = pd.RangeIndex(0, len(frame.index))
-                    idx = frame.index
-                    frame.index_cols = mangle_index_names(idx.names)
-                    idx_df = pd.DataFrame(index=idx).reset_index()
-                    frame.table = pyarrow.Table.from_pandas(idx_df)
-                    frame.table = frame.table.rename_columns(frame.index_cols)
-
-            idx_cols = None
-            idx_table = None
-            idx_fields: typing.OrderedDict[str, pyarrow.Field] = OrderedDict()
-
-            if not ignore_index:
-                idx_cols = frames[0].index_cols
-                idx_equal = idx_cols is not None
-
-                if idx_equal:
-                    idx_width = len(idx_cols)
-                    idx_types = [frames[0].table.field(c).type for c in idx_cols]
-                    for frame in frames[1:]:
-                        table = frame.table
-                        frame_idx_cols = frame.index_cols
-                        if (
-                            (frame_idx_cols is None)
-                            or (len(frame_idx_cols) != idx_width)
-                            or any(
-                                idx_types[i] != table.field(frame_idx_cols[i]).type
-                                for i in range(idx_width)
-                            )
-                        ):
-                            idx_equal = False
-                            break
-
-                if idx_equal:
-                    idx_cols = list(
-                        concat_index_names([f.frame for f in frames]).keys()
+            dtypes = pd.Series(table_columns.values(), index=table_columns.keys())
+            for i, frame in enumerate(frames):
+                frame_dtypes = frame._dtypes.get()
+                if (
+                    len(frame_dtypes) != len(dtypes)
+                    or any(frame_dtypes.index != dtypes.index)
+                    or any(frame_dtypes.values != dtypes.values)
+                ):
+                    exprs = OrderedDict()
+                    uses_rowid = False
+                    for col in table_columns:
+                        if col in frame_dtypes:
+                            expr = frame.ref(col)
+                        elif col == UNNAMED_IDX_COL_NAME:
+                            if frame._index_cols is not None:
+                                assert len(frame._index_cols) == 1
+                                expr = frame.ref(frame._index_cols[0])
+                            else:
+                                uses_rowid = True
+                                expr = frame.ref(ROWID_COL_NAME)
+                        else:
+                            expr = LiteralExpr(None, table_columns[col])
+                        if expr._dtype != table_columns[col]:
+                            expr = expr.cast(table_columns[col])
+                        exprs[col] = expr
+                    frames[i] = frame.__constructor__(
+                        columns=dtypes.index,
+                        dtypes=dtypes,
+                        uses_rowid=uses_rowid,
+                        op=TransformNode(frame, exprs),
+                        force_execution_mode=frame._force_execution_mode,
                     )
 
-                    # Rename index columns
-                    for frame in frames:
-                        table = frame.table
-                        new_names = idx_cols + table.column_names[len(idx_cols) :]
-                        frame.table = table.rename_columns(new_names)
-
-                    for name in idx_cols:
-                        idx_fields[name] = frames[0].table.field(name)
-                else:
-                    # Align index columns
-                    idx = frames[0].index.append([f.index for f in frames[1:]])
-                    idx_cols = mangle_index_names(idx.names)
-                    idx_df = pd.DataFrame(index=idx).reset_index()
-                    obj_cols = idx_df.select_dtypes(include=["object"]).columns.tolist()
-                    if len(obj_cols) != 0:
-                        # PyArrow fails to convert object fields. Converting to str.
-                        idx_df[obj_cols] = idx_df[obj_cols].astype(str)
-                    idx_table = pyarrow.Table.from_pandas(idx_df, preserve_index=False)
-                    idx_table = idx_table.rename_columns(idx_cols)
-
-            if sort:
-                col_fields = OrderedDict(sorted(col_fields.items(), key=lambda i: i[0]))
-
-            schema = pyarrow.schema(
-                list(idx_fields.values()) + list(col_fields.values())
-            )
-
-            tables = []
-            for frame in frames:
-                data = []
-                table = frame.table
-                col_names = table.column_names
-                for field in schema:
-                    if field.name in col_names:
-                        data.append(table.column(field.name))
-                    else:
-                        data.append(pyarrow.nulls(len(table), field.type))
-                tables.append(pyarrow.table(data, schema=schema))
-
-            union = pyarrow.concat_tables(tables)
-
-            if idx_table is not None:
-                for i, name in enumerate(idx_table.column_names):
-                    union = union.add_column(i, idx_table.field(i), idx_table.column(i))
-
-        return (
-            HdkOnNativeDataframe.from_arrow(
-                union,
-                index_cols=idx_cols,
-                columns=[k[0] for k in col_fields.keys()],
-                encode_col_names=False,
-            )
-            if frame_to_table is None
-            else union
+        return self.__constructor__(
+            index_cols=index_cols,
+            columns=columns.keys(),
+            dtypes=dtypes,
+            op=UnionNode(frames, columns, ignore_index),
+            force_execution_mode=self._force_execution_mode,
         )
 
     def _join_by_index(self, other_modin_frames, how, sort, ignore_index):
@@ -1501,10 +1291,8 @@ class HdkOnNativeDataframe(PandasDataframe):
         frames = [self] + other_modin_frames
         if all(
             f._index_cols is None
-            # Make sure all the frames have an arrow table in partitions. The
-            # method _execute() is no-op if the frame is already materialized
-            # and always returns None.
-            and (f._execute() or f._has_arrow_table())
+            # Make sure all the frames have an arrow table in partitions.
+            and isinstance(f._execute(), pyarrow.Table)
             for f in frames
         ):
             tables = [f._partitions[0][0].get() for f in frames]
@@ -2051,62 +1839,64 @@ class HdkOnNativeDataframe(PandasDataframe):
         Materialize lazy frame.
 
         After this call frame always has ``FrameNode`` operation.
+
+        Returns
+        -------
+        pyarrow.Table or pandas.Dataframe
         """
         if isinstance(self._op, FrameNode):
-            return
+            return self._op.execute_arrow()
 
+        result = None
         stack = [self._materialize, self]
         while stack:
             frame = stack.pop()
             if callable(frame):
-                frame()
-            elif isinstance(frame._op, FrameNode):
+                result = frame()
                 continue
-            elif frame._require_executed_base():
+            if isinstance(frame._op, FrameNode):
+                result = frame._op.execute_arrow()
+                continue
+            if not frame._op.can_execute_hdk():
+                stack.append(frame._materialize)
+            if frame._uses_rowid or frame._op.require_executed_base():
                 for i in reversed(frame._op.input):
                     if not isinstance(i._op, FrameNode):
                         stack.append(i._materialize)
                         stack.append(i)
             else:
                 stack.extend(reversed(frame._op.input))
+        return result
 
     def _materialize(self):
-        """Materialize this frame."""
-        if self._force_execution_mode == "lazy":
-            raise RuntimeError("unexpected execution triggered on lazy frame")
-
-        if self._can_execute_arrow():
-            new_table = self._execute_arrow()
-            new_partitions = np.empty((1, 1), dtype=np.dtype(object))
-            new_partitions[0][0] = self._partition_mgr_cls._partition_class.put_arrow(
-                new_table
-            )
-        else:
-            if self._force_execution_mode == "arrow":
-                raise RuntimeError("forced arrow execution failed")
-
-            new_partitions = self._partition_mgr_cls.run_exec_plan(
-                self._op, self._table_cols
-            )
-
-        self._partitions = new_partitions
-        self._op = FrameNode(self)
-
-    def _require_executed_base(self):
         """
-        Check if materialization of input frames is required.
+        Materialize this frame.
 
         Returns
         -------
-        bool
+        pyarrow.Table
         """
-        if isinstance(self._op, MaskNode) or (
-            # HDK does not support union of more than 2 frames.
-            isinstance(self._op, UnionNode)
-            and (len(self._op.input) > 2)
-        ):
-            return True
-        return self._uses_rowid
+        assert (
+            self._force_execution_mode != "lazy"
+        ), "Unexpected execution triggered on lazy frame!"
+
+        if self._force_execution_mode != "hdk" and self._can_execute_arrow():
+            new_table = self._execute_arrow()
+            partitions = np.empty((1, 1), dtype=np.dtype(object))
+            partitions[0][0] = self._partition_mgr_cls._partition_class.put_arrow(
+                new_table
+            )
+        else:
+            assert (
+                self._force_execution_mode != "arrow"
+            ), "Forced arrow execution failed!"
+            partitions = self._partition_mgr_cls.run_exec_plan(
+                self._op, self._table_cols
+            )
+
+        self._partitions = partitions
+        self._op = FrameNode(self)
+        return partitions[0][0].get()
 
     def _can_execute_arrow(self):
         """
@@ -2119,27 +1909,13 @@ class HdkOnNativeDataframe(PandasDataframe):
         -------
         bool
         """
-        if isinstance(self._op, FrameNode):
-            return self._has_arrow_table()
-
         stack = [self]
         while stack:
-            frame = stack.pop()
-            if isinstance(frame._op, FrameNode):
-                if not frame._has_arrow_table():
-                    return False
-            elif isinstance(frame._op, MaskNode):
-                if frame._op.row_labels is not None:
-                    return False
-                stack.append(frame._op.input[0])
-            elif isinstance(frame._op, TransformNode):
-                if not frame._op.is_simple_select():
-                    return False
-                stack.append(frame._op.input[0])
-            elif isinstance(frame._op, UnionNode):
-                stack.extend(frame._op.input)
-            else:
+            op = stack.pop()._op
+            if not op.can_execute_arrow():
                 return False
+            if input := getattr(op, "input", None):
+                stack.extend(input)
         return True
 
     def _execute_arrow(self):
@@ -2158,144 +1934,41 @@ class HdkOnNativeDataframe(PandasDataframe):
             frame = stack.pop()
 
             if callable(frame):
-                result = frame()
-            elif isinstance(frame._op, FrameNode):
-                if frame._partitions.size == 0:
-                    result = pyarrow.Table.from_pandas(
-                        pd.DataFrame(
-                            index=frame._index_cache, columns=frame._columns_cache
-                        )
-                    )
+                result = frame(result)
+            elif input := getattr(frame._op, "input", None):
+                if len(input) == 1:
+                    stack.append(frame._op.execute_arrow)
+                    stack.append(input[0])
                 else:
-                    assert frame._partitions.size == 1
-                    result = frame._partitions[0][0].get()
-            elif isinstance(frame._op, MaskNode):
 
-                def slice(positions=frame._op.row_positions):
-                    return self._arrow_row_slice(result, positions)
+                    def to_arrow(result, op=frame._op, tables=[], frames=iter(input)):
+                        """
+                        Convert the input list to a list of arrow tables.
 
-                stack.append(slice)
-                stack.append(frame._op.input[0])
-            elif isinstance(frame._op, TransformNode):
+                        This function is created for each input list. When the function
+                        is created, the frames iterator is saved in the `frames` argument.
+                        Then, the function is added to the stack followed by the first
+                        frame from the `frames` iterator. When the frame is processed, the
+                        arrow table is added to the `tables` list. This procedure is
+                        repeated until the iterator is not empty. When all the frames are
+                        processed, the arrow tables are passed to `execute_arrow` and the
+                        result is returned.
+                        """
+                        if (f := next(frames, None)) is None:
+                            return op.execute_arrow(tables)
+                        else:
+                            # When this function is called, the `frame` attribute contains
+                            # a reference to this function.
+                            stack.append(frame if callable(frame) else to_arrow)
+                            stack.append(tables.append)
+                            stack.append(f)
+                            return result
 
-                def select(exprs=frame._op.exprs):
-                    return self._arrow_select(result, exprs)
-
-                stack.append(select)
-                stack.append(frame._op.input[0])
-            elif isinstance(frame._op, UnionNode):
-
-                def union(op=frame._op, tables={}, input=iter(frame._op.input)):
-                    """
-                    Concatenate the frames.
-
-                    This function is created for each UnionNode. When the function
-                    is created, the frames iterator is saved in the `input` argument.
-                    Then, the function is added to the stack followed by the first
-                    frame from the `input` iterator. When the frame is processed, the
-                    arrow table is added to the `tables` dictionary. This procedure is
-                    repeated until the iterator is not empty. When all the frames are
-                    processed, the arrow tables are concatenated and the result is returned.
-                    """
-                    if (i := next(input, None)) is None:
-                        return self._union_all_arrow(
-                            op.input, op.join, op.sort, op.ignore_index, tables
-                        )
-                    else:
-
-                        def add_result(f=i):
-                            tables[f] = result
-
-                        # When this function is called, the `frame` attribute contains
-                        # a reference to this function.
-                        stack.append(frame if callable(frame) else union)
-                        stack.append(add_result)
-                        stack.append(i)
-                        return result
-
-                union()
+                    to_arrow(result)
             else:
-                raise RuntimeError(
-                    f"Unexpected op ({type(frame._op)}) in _execute_arrow"
-                )
+                result = frame._op.execute_arrow(result)
 
         return result
-
-    @staticmethod
-    def _arrow_select(table, exprs):
-        """
-        Perform column selection on the table using Arrow API.
-
-        Parameters
-        ----------
-        table : pyarrow.Table
-            The table to select from.
-        exprs : dict
-            Select expressions.
-
-        Returns
-        -------
-        pyarrow.Table
-            The resulting table.
-        """
-        new_fields = []
-        new_columns = []
-
-        for col, expr in exprs.items():
-            col_name = expr.column
-            if col_name == ROWID_COL_NAME:
-                if ROWID_COL_NAME not in table.schema.names:
-                    arr = pyarrow.array(np.arange(0, table.num_rows))
-                    table = table.append_column(ROWID_COL_NAME, arr)
-            else:
-                col_name = encode_col_name(col_name)
-
-            field = table.schema.field(col_name)
-            if col != expr.column:
-                field = field.with_name(encode_col_name(col))
-            new_fields.append(field)
-            new_columns.append(table.column(col_name))
-
-        new_schema = pyarrow.schema(new_fields)
-
-        return pyarrow.Table.from_arrays(new_columns, schema=new_schema)
-
-    @staticmethod
-    def _arrow_row_slice(table, row_positions):
-        """
-        Perform row selection on the table using Arrow API.
-
-        Parameters
-        ----------
-        table : pyarrow.Table
-            The table to select from.
-        row_positions : list of int
-            Row positions to select.
-
-        Returns
-        -------
-        pyarrow.Table
-            The resulting table.
-        """
-        if not isinstance(row_positions, slice) and not is_range_like(row_positions):
-            if not isinstance(row_positions, (pyarrow.Array, np.ndarray, list)):
-                row_positions = pyarrow.array(row_positions)
-            return table.take(row_positions)
-
-        if isinstance(row_positions, slice):
-            row_positions = range(*row_positions.indices(table.num_rows))
-
-        start, stop, step = (
-            row_positions.start,
-            row_positions.stop,
-            row_positions.step,
-        )
-
-        if step == 1:
-            return table.slice(start, len(row_positions))
-        else:
-            indices = np.arange(start, stop, step)
-            return table.take(indices)
 
     def _build_index_cache(self):
         """
@@ -2367,10 +2040,8 @@ class HdkOnNativeDataframe(PandasDataframe):
                 "HdkOnNativeDataframe._set_index is not yet suported"
             )
 
-        self._execute()
-
+        obj = self._execute()
         assert self._partitions.size == 1
-        obj = self._partitions[0][0].get()
         if isinstance(obj, pd.DataFrame):
             raise NotImplementedError(
                 "HdkOnNativeDataframe._set_index is not yet suported"

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
@@ -20,22 +20,25 @@ from typing import Tuple, Union, List, Any
 from functools import lru_cache
 from collections import OrderedDict
 
-import numpy as np
-
 import pandas
 from pandas import Timestamp
-from pandas.core.dtypes.common import get_dtype
+from pandas.core.dtypes.common import get_dtype, is_string_dtype
 from pandas.core.arrays.arrow.extension_types import ArrowIntervalType
 
 import pyarrow as pa
 from pyarrow.types import is_dictionary
 
+import numpy as np
+
 from modin.utils import MODIN_UNNAMED_SERIES_LABEL
+
+_EMPTY_ARROW_TABLE = None
 
 
 class ColNameCodec:
     IDX_COL_NAME = "__index__"
     ROWID_COL_NAME = "__rowid__"
+    UNNAMED_IDX_COL_NAME = "__index__0__N"
 
     _IDX_NAME_PATTERN = re.compile(f"{IDX_COL_NAME}\\d+_(.*)")
     _RESERVED_NAMES = (MODIN_UNNAMED_SERIES_LABEL, ROWID_COL_NAME)
@@ -259,21 +262,20 @@ class ColNameCodec:
                 elif f.has_index_cache:
                     idx_names.update(mangle(f.index.names))
                 else:
-                    idx_names.update(mangle([None]))
+                    idx_names.add(ColNameCodec.UNNAMED_IDX_COL_NAME)
                 if len(idx_names) > 1:
-                    names[mangle([None])[0]] = get_dtype(int)
-                    return names
+                    idx_names = [ColNameCodec.UNNAMED_IDX_COL_NAME]
+                    break
 
-            # Inherit Index's name and dtype from the first frame.
+            name = next(iter(idx_names))
+            # Inherit the Index's dtype from the first frame.
             if first._index_cols is not None:
-                name = first._index_cols[0]
-                names[name] = first._dtypes[name]
+                names[name] = first._dtypes.iloc[0]
             elif first.has_index_cache:
-                idx = first.index
-                names[mangle(idx.names)[0]] = idx.dtype
+                names[name] = first.index.dtype
             else:
                 # A trivial index with no name
-                names[mangle([None])[0]] = get_dtype(int)
+                names[name] = get_dtype(int)
         return names
 
 
@@ -462,6 +464,37 @@ def get_data_for_join_by_index(
         new_dtypes.append(df._dtypes[orig_name])
 
     return index_cols, exprs, new_dtypes, merged.columns
+
+
+def empty_arrow_table() -> pa.Table:
+    """
+    Return an empty arrow table.
+
+    Returns
+    -------
+    pyarrow.Table
+    """
+    global _EMPTY_ARROW_TABLE
+    if _EMPTY_ARROW_TABLE is None:
+        _EMPTY_ARROW_TABLE = pa.Table.from_pandas(pandas.DataFrame({}))
+    return _EMPTY_ARROW_TABLE
+
+
+def to_arrow_type(dtype) -> pa.lib.DataType:
+    """
+    Convert the specified dtype to arrow.
+
+    Parameters
+    ----------
+    dtype : dtype
+
+    Returns
+    -------
+    pa.lib.DataType
+    """
+    if is_string_dtype(dtype):
+        return pa.from_numpy_dtype(str)
+    return pa.from_numpy_dtype(dtype)
 
 
 def get_common_arrow_type(t1: pa.lib.DataType, t2: pa.lib.DataType) -> pa.lib.DataType:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
@@ -20,6 +20,7 @@ from typing import Tuple, Union, List, Any
 from functools import lru_cache
 from collections import OrderedDict
 
+import numpy as np
 import pandas
 from pandas import Timestamp
 from pandas.core.dtypes.common import get_dtype, is_string_dtype
@@ -28,11 +29,9 @@ from pandas.core.arrays.arrow.extension_types import ArrowIntervalType
 import pyarrow as pa
 from pyarrow.types import is_dictionary
 
-import numpy as np
-
 from modin.utils import MODIN_UNNAMED_SERIES_LABEL
 
-_EMPTY_ARROW_TABLE = None
+EMPTY_ARROW_TABLE = pa.Table.from_pandas(pandas.DataFrame({}))
 
 
 class ColNameCodec:
@@ -464,20 +463,6 @@ def get_data_for_join_by_index(
         new_dtypes.append(df._dtypes[orig_name])
 
     return index_cols, exprs, new_dtypes, merged.columns
-
-
-def empty_arrow_table() -> pa.Table:
-    """
-    Return an empty arrow table.
-
-    Returns
-    -------
-    pyarrow.Table
-    """
-    global _EMPTY_ARROW_TABLE
-    if _EMPTY_ARROW_TABLE is None:
-        _EMPTY_ARROW_TABLE = pa.Table.from_pandas(pandas.DataFrame({}))
-    return _EMPTY_ARROW_TABLE
 
 
 def to_arrow_type(dtype) -> pa.lib.DataType:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/df_algebra.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/df_algebra.py
@@ -29,7 +29,7 @@ from modin.utils import _inherit_docstrings
 from modin.pandas.indexing import is_range_like
 
 from .expr import InputRefExpr, LiteralExpr, OpExpr
-from .dataframe.utils import ColNameCodec, empty_arrow_table, get_common_arrow_type
+from .dataframe.utils import ColNameCodec, EMPTY_ARROW_TABLE, get_common_arrow_type
 
 if TYPE_CHECKING:
     from .dataframe.dataframe import HdkOnNativeDataframe
@@ -445,7 +445,7 @@ class FrameNode(DFAlgNode):
             return pa.Table.from_pandas(
                 pandas.DataFrame(index=frame._index_cache, columns=frame._columns_cache)
             )
-        return empty_arrow_table()
+        return EMPTY_ARROW_TABLE
 
     def copy(self):
         """
@@ -950,7 +950,7 @@ class UnionNode(DFAlgNode):
         if len(self.columns) == 0:
             frames = self.input
             if len(frames) == 0:
-                return empty_arrow_table()
+                return EMPTY_ARROW_TABLE
             elif self.ignore_index:
                 idx = pandas.RangeIndex(0, sum(len(frame.index) for frame in frames))
             else:
@@ -996,7 +996,7 @@ class UnionNode(DFAlgNode):
         -------
         UnionNode
         """
-        return UnionNode(self.input)
+        return UnionNode(self.input, self.columns, self.ignore_index)
 
     def _prints(self, prefix):
         """

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/df_algebra.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/df_algebra.py
@@ -15,9 +15,24 @@
 
 import abc
 
-from .dataframe.utils import ColNameCodec
-from .expr import InputRefExpr
+import typing
+from typing import TYPE_CHECKING, List, Dict, Union
 from collections import OrderedDict
+
+import pandas
+from pandas.core.dtypes.common import is_string_dtype
+
+import numpy as np
+import pyarrow as pa
+
+from modin.utils import _inherit_docstrings
+from modin.pandas.indexing import is_range_like
+
+from .expr import InputRefExpr, LiteralExpr, OpExpr
+from .dataframe.utils import ColNameCodec, empty_arrow_table, get_common_arrow_type
+
+if TYPE_CHECKING:
+    from .dataframe.dataframe import HdkOnNativeDataframe
 
 
 class TransformMapper:
@@ -221,6 +236,59 @@ class DFAlgNode(abc.ABC):
         self.walk_dfs(lambda a, b: a._append_frames(b), frames)
         return frames
 
+    def require_executed_base(self) -> bool:
+        """
+        Check if materialization of input frames is required.
+
+        Returns
+        -------
+        bool
+        """
+        return False
+
+    def can_execute_hdk(self) -> bool:
+        """
+        Check for possibility of HDK execution.
+
+        Check if the computation can be executed using an HDK query.
+
+        Returns
+        -------
+        bool
+        """
+        return True
+
+    def can_execute_arrow(self) -> bool:
+        """
+        Check for possibility of Arrow execution.
+
+        Check if the computation can be executed using
+        the Arrow API instead of HDK query.
+
+        Returns
+        -------
+        bool
+        """
+        return False
+
+    def execute_arrow(
+        self, arrow_input: Union[None, pa.Table, List[pa.Table]]
+    ) -> pa.Table:
+        """
+        Compute the frame data using the Arrow API.
+
+        Parameters
+        ----------
+        arrow_input : None, pa.Table or list of pa.Table
+            The input, converted to arrow.
+
+        Returns
+        -------
+        pyarrow.Table
+            The resulting table.
+        """
+        raise RuntimeError(f"Arrow execution is not supported by {type(self)}")
+
     def _append_partitions(self, partitions):
         """
         Append all used by the node partitions to `partitions` list.
@@ -341,8 +409,43 @@ class FrameNode(DFAlgNode):
         Referenced frame.
     """
 
-    def __init__(self, modin_frame):
+    def __init__(self, modin_frame: "HdkOnNativeDataframe"):
         self.modin_frame = modin_frame
+
+    @_inherit_docstrings(DFAlgNode.can_execute_arrow)
+    def can_execute_arrow(self) -> bool:
+        frame = self.modin_frame
+        return not frame._has_unsupported_data and all(
+            p.arrow_table is not None for p in frame._partitions.flatten()
+        )
+
+    def execute_arrow(self, ignore=None) -> Union[pa.Table, pandas.DataFrame]:
+        """
+        Materialized frame.
+
+        If `can_execute_arrow` returns True, this method returns an arrow table,
+        otherwise - a pandas Dataframe.
+
+        Parameters
+        ----------
+        ignore : None, pa.Table or list of pa.Table, default: None
+
+        Returns
+        -------
+        pa.Table or pandas.Dataframe
+        """
+        frame = self.modin_frame
+        if frame._partitions is not None and frame._partitions.size != 0:
+            return frame._partitions[0][0].get()
+        if frame._has_unsupported_data:
+            return pandas.DataFrame(
+                index=frame._index_cache, columns=frame._columns_cache
+            )
+        if frame._index_cache or frame._columns_cache:
+            return pa.Table.from_pandas(
+                pandas.DataFrame(index=frame._index_cache, columns=frame._columns_cache)
+            )
+        return empty_arrow_table()
 
     def copy(self):
         """
@@ -398,7 +501,7 @@ class MaskNode(DFAlgNode):
 
     Parameters
     ----------
-    base : DFAlgNode
+    base : HdkOnNativeDataframe
         A filtered frame.
     row_labels : list, optional
         List of row labels to select.
@@ -407,7 +510,7 @@ class MaskNode(DFAlgNode):
 
     Attributes
     ----------
-    input : list of DFAlgNode
+    input : list of HdkOnNativeDataframe
         Holds a single filtered frame.
     row_labels : list or None
         List of row labels to select.
@@ -415,10 +518,58 @@ class MaskNode(DFAlgNode):
         List of rows ids to select.
     """
 
-    def __init__(self, base, row_labels=None, row_positions=None):
+    def __init__(
+        self,
+        base: "HdkOnNativeDataframe",
+        row_labels: List[str] = None,
+        row_positions: List[int] = None,
+    ):
         self.input = [base]
         self.row_labels = row_labels
         self.row_positions = row_positions
+
+    @_inherit_docstrings(DFAlgNode.require_executed_base)
+    def require_executed_base(self) -> bool:
+        return True
+
+    @_inherit_docstrings(DFAlgNode.can_execute_arrow)
+    def can_execute_arrow(self) -> bool:
+        return self.row_labels is None
+
+    def execute_arrow(self, table: pa.Table) -> pa.Table:
+        """
+        Perform row selection on the frame using Arrow API.
+
+        Parameters
+        ----------
+        table : pa.Table
+
+        Returns
+        -------
+        pyarrow.Table
+            The resulting table.
+        """
+        row_positions = self.row_positions
+
+        if not isinstance(row_positions, slice) and not is_range_like(row_positions):
+            if not isinstance(row_positions, (pa.Array, np.ndarray, list)):
+                row_positions = pa.array(row_positions)
+            return table.take(row_positions)
+
+        if isinstance(row_positions, slice):
+            row_positions = range(*row_positions.indices(table.num_rows))
+
+        start, stop, step = (
+            row_positions.start,
+            row_positions.stop,
+            row_positions.step,
+        )
+
+        if step == 1:
+            return table.slice(start, len(row_positions))
+        else:
+            indices = np.arange(start, stop, step)
+            return table.take(indices)
 
     def copy(self):
         """
@@ -524,64 +675,59 @@ class TransformNode(DFAlgNode):
 
     Parameters
     ----------
-    base : DFAlgNode
+    base : HdkOnNativeDataframe
         A transformed frame.
     exprs : dict
         Expressions for frame's columns computation.
-    fold : bool, default: True
-        If True and `base` is another `TransformNode`, then translate all
-        expressions in `expr` to its base.
 
     Attributes
     ----------
-    input : list of DFAlgNode
+    input : list of HdkOnNativeDataframe
         Holds a single projected frame.
     exprs : dict
         Expressions used to compute frame's columns.
-    _original_refs : set
-        Set of columns expressed with `InputRefExpr` prior folding.
     """
 
-    def __init__(self, base, exprs, fold=True):
-        self.exprs = exprs
-        self.input = [base]
-        self._original_refs = None
-        if fold:
-            self.fold()
+    def __init__(
+        self,
+        base: "HdkOnNativeDataframe",
+        exprs: Dict[str, Union[InputRefExpr, LiteralExpr, OpExpr]],
+    ):
+        # If base of this node is another `TransformNode`, then translate all
+        # expressions in `expr` to its base.
+        if isinstance(base._op, TransformNode):
+            self.input = [base._op.input[0]]
+            self.exprs = exprs = translate_exprs_to_base(exprs, self.input[0])
+            for col, expr in exprs.items():
+                exprs[col] = expr.fold()
+        else:
+            self.input = [base]
+            self.exprs = exprs
 
-    def fold(self):
+    @_inherit_docstrings(DFAlgNode.can_execute_hdk)
+    def can_execute_hdk(self) -> bool:
+        return self._check_exprs("can_execute_hdk")
+
+    @_inherit_docstrings(DFAlgNode.can_execute_arrow)
+    def can_execute_arrow(self) -> bool:
+        return self._check_exprs("can_execute_arrow")
+
+    def execute_arrow(self, table: pa.Table) -> pa.Table:
         """
-        Fold two ``TransformNode``-s.
-
-        If base of this node is another `TransformNode`, then translate all
-        expressions in `expr` to its base.
-        """
-        if isinstance(self.input[0]._op, TransformNode):
-            self._original_refs = {
-                col for col in self.exprs if isinstance(self.exprs[col], InputRefExpr)
-            }
-            self.input[0] = self.input[0]._op.input[0]
-            self.exprs = translate_exprs_to_base(self.exprs, self.input[0])
-
-    def is_original_ref(self, col):
-        """
-        Check original column expression type.
-
-        Return True if `col` is an ``InputRefExpr`` expression or originally was
-        an ``InputRefExpr`` expression before folding.
+        Perform column selection on the frame using Arrow API.
 
         Parameters
         ----------
-        col : str
-            Column name.
+        table : pa.Table
 
         Returns
         -------
-        bool
+        pyarrow.Table
+            The resulting table.
         """
-        if self._original_refs is not None:
-            return col in self._original_refs
-        return isinstance(self.exprs[col], InputRefExpr)
+        cols = [expr.execute_arrow(table) for expr in self.exprs.values()]
+        names = [ColNameCodec.encode(c) for c in self.exprs]
+        return pa.table(cols, names)
 
     def copy(self):
         """
@@ -591,7 +737,7 @@ class TransformNode(DFAlgNode):
         -------
         TransformNode
         """
-        return TransformNode(self.input[0], self.exprs, self.keep_index)
+        return TransformNode(self.input[0], self.exprs)
 
     def is_simple_select(self):
         """
@@ -620,12 +766,31 @@ class TransformNode(DFAlgNode):
         str
         """
         res = f"{prefix}TransformNode:\n"
-        if self._original_refs is not None:
-            res += f"{prefix}  Original refs: {self._original_refs}\n"
         for k, v in self.exprs.items():
             res += f"{prefix}  {k}: {v}\n"
         res += self._prints_input(prefix + "  ")
         return res
+
+    def _check_exprs(self, attr) -> bool:
+        """
+        Check if the specified attribute is True for all expressions.
+
+        Parameters
+        ----------
+        attr : str
+
+        Returns
+        -------
+        bool
+        """
+        stack = list(self.exprs.values())
+        while stack:
+            expr = stack.pop()
+            if not getattr(expr, attr)():
+                return False
+            if isinstance(expr, OpExpr):
+                stack.extend(expr.operands)
+        return True
 
 
 class JoinNode(DFAlgNode):
@@ -719,26 +884,109 @@ class UnionNode(DFAlgNode):
 
     Parameters
     ----------
-    frames : list of DFAlgNode
+    frames : list of HdkOnNativeDataframe
         Input frames.
-    join : str
-        Either outer or inner.
-    sort : bool
-        Sort columns.
+    columns : dict
+        Column names and dtypes.
     ignore_index : bool
-        Ignore index columns.
 
     Attributes
     ----------
-    input : list of DFAlgNode
+    input : list of HdkOnNativeDataframe
         Input frames.
     """
 
-    def __init__(self, frames, join, sort, ignore_index):
+    def __init__(
+        self,
+        frames: List["HdkOnNativeDataframe"],
+        columns: Dict[str, np.dtype],
+        ignore_index: bool,
+    ):
         self.input = frames
-        self.join = join
-        self.sort = sort
+        self.columns = columns
         self.ignore_index = ignore_index
+
+    @_inherit_docstrings(DFAlgNode.require_executed_base)
+    def require_executed_base(self) -> bool:
+        return not self.can_execute_hdk()
+
+    @_inherit_docstrings(DFAlgNode.can_execute_hdk)
+    def can_execute_hdk(self) -> bool:
+        # Hdk does not support union of more than 2 frames.
+        if len(self.input) > 2:
+            return False
+
+        # Arrow execution is required for empty frames to preserve the index.
+        if len(self.input) == 0 or len(self.columns) == 0:
+            return False
+
+        # Only numeric columns of the same type are supported by HDK.
+        # See https://github.com/intel-ai/hdk/issues/182
+        dtypes = self.input[0]._dtypes.to_dict()
+        if any(is_string_dtype(t) for t in dtypes.values()) or any(
+            f._dtypes.to_dict() != dtypes for f in self.input[1:]
+        ):
+            return False
+
+        return True
+
+    @_inherit_docstrings(DFAlgNode.can_execute_arrow)
+    def can_execute_arrow(self) -> bool:
+        return True
+
+    def execute_arrow(self, tables: Union[pa.Table, List[pa.Table]]) -> pa.Table:
+        """
+        Concat frames' rows using Arrow API.
+
+        Parameters
+        ----------
+        tables : pa.Table or list of pa.Table
+
+        Returns
+        -------
+        pyarrow.Table
+            The resulting table.
+        """
+        if len(self.columns) == 0:
+            frames = self.input
+            if len(frames) == 0:
+                return empty_arrow_table()
+            elif self.ignore_index:
+                idx = pandas.RangeIndex(0, sum(len(frame.index) for frame in frames))
+            else:
+                idx = frames[0].index.append([f.index for f in frames[1:]])
+            idx_cols = ColNameCodec.mangle_index_names(idx.names)
+            idx_df = pandas.DataFrame(index=idx).reset_index()
+            obj_cols = idx_df.select_dtypes(include=["object"]).columns.tolist()
+            if len(obj_cols) != 0:
+                # PyArrow fails to convert object fields. Converting to str.
+                idx_df[obj_cols] = idx_df[obj_cols].astype(str)
+            idx_table = pa.Table.from_pandas(idx_df, preserve_index=False)
+            return idx_table.rename_columns(idx_cols)
+
+        if isinstance(tables, pa.Table):
+            assert len(self.input) == 1
+            return tables
+
+        try:
+            return pa.concat_tables(tables)
+        except pa.lib.ArrowInvalid:
+            # Probably, some tables have different column types.
+            # Trying to find a common type and cast the columns.
+            fields: typing.OrderedDict[str, pa.Field] = OrderedDict()
+            for table in tables:
+                for col_name in table.column_names:
+                    field = table.field(col_name)
+                    cur_field = fields.get(col_name, None)
+                    if cur_field is None or (
+                        cur_field.type
+                        != get_common_arrow_type(cur_field.type, field.type)
+                    ):
+                        fields[col_name] = field
+            schema = pa.schema(list(fields.values()))
+            for i, table in enumerate(tables):
+                tables[i] = pa.table(table.columns, schema=schema)
+            return pa.concat_tables(tables)
 
     def copy(self):
         """
@@ -910,8 +1158,8 @@ def translate_exprs_to_base(exprs, base):
     new_exprs = dict(exprs)
 
     frames = set()
-    for k, v in new_exprs.items():
-        v.collect_frames(frames)
+    for expr in new_exprs.values():
+        expr.collect_frames(frames)
     frames.discard(base)
 
     while len(frames) > 0:
@@ -925,7 +1173,7 @@ def translate_exprs_to_base(exprs, base):
             mapper.add_mapper(frame, TransformMapper(frame._op))
 
         for k, v in new_exprs.items():
-            new_expr = new_exprs[k].translate_input(mapper)
+            new_expr = v.translate_input(mapper)
             new_expr.collect_frames(new_frames)
             new_exprs[k] = new_expr
 

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
@@ -14,8 +14,13 @@
 """Module provides classes for scalar expression trees."""
 
 import abc
+from typing import Union
 
-import pandas as pd
+import numpy as np
+import pyarrow as pa
+import pyarrow.compute as pc
+
+import pandas
 from pandas.core.dtypes.common import (
     is_list_like,
     get_dtype,
@@ -27,7 +32,9 @@ from pandas.core.dtypes.common import (
     is_datetime64_any_dtype,
     is_bool_dtype,
 )
-import numpy as np
+
+from modin.utils import _inherit_docstrings
+from .dataframe.utils import ColNameCodec, to_arrow_type
 
 
 def _get_common_dtype(lhs_dtype, rhs_dtype):
@@ -155,7 +162,7 @@ class BaseExpr(abc.ABC):
         "sub": "-",
         "mul": "*",
         "mod": "MOD",
-        "floordiv": "/",
+        "floordiv": "//",
         "truediv": "/",
         "pow": "POWER",
         "eq": "=",
@@ -445,6 +452,17 @@ class BaseExpr(abc.ABC):
         """
         return OpExpr("FLOOR", [self], get_dtype(int))
 
+    def invert(self) -> "OpExpr":
+        """
+        Build a bitwise inverse expression.
+
+        Returns
+        -------
+        OpExpr
+            The resulting bitwise inverse expression.
+        """
+        return OpExpr("~", [self], self._dtype)
+
     def _cmp_op(self, other, op_name):
         """
         Build a comparison expression.
@@ -583,8 +601,8 @@ class BaseExpr(abc.ABC):
         """
         if hasattr(self, "operands"):
             res = self.copy()
-            for i in range(0, len(self.operands)):
-                res.operands[i] = res.operands[i].translate_input(mapper)
+            for i, op in enumerate(self.operands):
+                res.operands[i] = op.translate_input(mapper)
             return res
         return self._translate_input(mapper)
 
@@ -606,6 +624,60 @@ class BaseExpr(abc.ABC):
             The expression copy with translated input columns.
         """
         return self
+
+    def fold(self):
+        """
+        Fold the operands.
+
+        This operation is used by `TransformNode` when translating to base.
+
+        Returns
+        -------
+        BaseExpr
+        """
+        if (operands := getattr(self, "operands", None)) is not None:
+            for i, o in enumerate(operands):
+                operands[i] = o.fold()
+        return self
+
+    def can_execute_hdk(self) -> bool:
+        """
+        Check for possibility of HDK execution.
+
+        Check if the computation can be executed using an HDK query.
+
+        Returns
+        -------
+        bool
+        """
+        return True
+
+    def can_execute_arrow(self) -> bool:
+        """
+        Check for possibility of Arrow execution.
+
+        Check if the computation can be executed using
+        the Arrow API instead of HDK query.
+
+        Returns
+        -------
+        bool
+        """
+        return False
+
+    def execute_arrow(self, table: pa.Table) -> pa.ChunkedArray:
+        """
+        Compute the column data using the Arrow API.
+
+        Parameters
+        ----------
+        table : pa.Table
+
+        Returns
+        -------
+        pa.ChunkedArray
+        """
+        raise RuntimeError(f"Arrow execution is not supported by {type(self)}")
 
 
 class InputRefExpr(BaseExpr):
@@ -673,6 +745,20 @@ class InputRefExpr(BaseExpr):
         """
         return mapper.translate(self)
 
+    @_inherit_docstrings(BaseExpr.fold)
+    def fold(self):
+        return self
+
+    @_inherit_docstrings(BaseExpr.can_execute_arrow)
+    def can_execute_arrow(self) -> bool:
+        return True
+
+    @_inherit_docstrings(BaseExpr.execute_arrow)
+    def execute_arrow(self, table: pa.Table) -> pa.ChunkedArray:
+        if self.column == ColNameCodec.ROWID_COL_NAME:
+            return pa.chunked_array([range(len(table))], pa.int64())
+        return table.column(ColNameCodec.encode(self.column))
+
     def __repr__(self):
         """
         Return a string representation of the expression.
@@ -692,6 +778,8 @@ class LiteralExpr(BaseExpr):
     ----------
     val : int, np.int, float, bool, str or None
         Literal value.
+    dtype : None or dtype, default: None
+        Value dtype.
 
     Attributes
     ----------
@@ -701,30 +789,32 @@ class LiteralExpr(BaseExpr):
         Literal data type.
     """
 
-    def __init__(self, val):
-        if val is not None and not isinstance(
-            val,
-            (
-                int,
-                float,
-                bool,
-                str,
-                np.int8,
-                np.int16,
-                np.int32,
-                np.int64,
-                np.uint8,
-                np.uint16,
-                np.uint32,
-                np.uint64,
-            ),
-        ):
-            raise NotImplementedError(f"Literal value {val} of type {type(val)}")
+    def __init__(self, val, dtype=None):
+        if dtype is None:
+            if val is not None and not isinstance(
+                val,
+                (
+                    int,
+                    float,
+                    bool,
+                    str,
+                    np.int8,
+                    np.int16,
+                    np.int32,
+                    np.int64,
+                    np.uint8,
+                    np.uint16,
+                    np.uint32,
+                    np.uint64,
+                ),
+            ):
+                raise NotImplementedError(f"Literal value {val} of type {type(val)}")
+            if val is None:
+                dtype = get_dtype(float)
+            else:
+                dtype = get_dtype(type(val))
         self.val = val
-        if val is None:
-            self._dtype = get_dtype(float)
-        else:
-            self._dtype = get_dtype(type(val))
+        self._dtype = dtype
 
     def copy(self):
         """
@@ -736,6 +826,31 @@ class LiteralExpr(BaseExpr):
         """
         return LiteralExpr(self.val)
 
+    @_inherit_docstrings(BaseExpr.fold)
+    def fold(self):
+        return self
+
+    @_inherit_docstrings(BaseExpr.cast)
+    def cast(self, res_type):
+        dtype = np.dtype(res_type)
+        return LiteralExpr(dtype.type(self.val), dtype)
+
+    @_inherit_docstrings(BaseExpr.is_null)
+    def is_null(self):
+        return LiteralExpr(pandas.isnull(self.val), np.dtype(bool))
+
+    @_inherit_docstrings(BaseExpr.is_null)
+    def is_not_null(self):
+        return LiteralExpr(not pandas.isnull(self.val), np.dtype(bool))
+
+    @_inherit_docstrings(BaseExpr.can_execute_arrow)
+    def can_execute_arrow(self) -> bool:
+        return True
+
+    @_inherit_docstrings(BaseExpr.execute_arrow)
+    def execute_arrow(self, table: pa.Table) -> pa.ChunkedArray:
+        return pa.chunked_array([[self.val] * len(table)], to_arrow_type(self._dtype))
+
     def __repr__(self):
         """
         Return a string representation of the expression.
@@ -745,6 +860,20 @@ class LiteralExpr(BaseExpr):
         str
         """
         return f"{self.val}[{self._dtype}]"
+
+    def __eq__(self, obj):
+        """
+        Check if `obj` is a `LiteralExpr` with an equal value.
+
+        Parameters
+        ----------
+        obj : Any object
+
+        Returns
+        -------
+        bool
+        """
+        return isinstance(obj, LiteralExpr) and self.val == obj.val
 
 
 class OpExpr(BaseExpr):
@@ -772,6 +901,36 @@ class OpExpr(BaseExpr):
         Result data type.
     """
 
+    _FOLD_OPS = {
+        "+": lambda self: self._fold_arithm("__add__"),
+        "-": lambda self: self._fold_arithm("__sub__"),
+        "*": lambda self: self._fold_arithm("__mul__"),
+        "POWER": lambda self: self._fold_arithm("__pow__"),
+        "/": lambda self: self._fold_arithm("__truediv__"),
+        "//": lambda self: self._fold_arithm("__floordiv__"),
+        "~": lambda self: self._fold_invert(),
+        "CAST": lambda self: self._fold_literal("cast", self._dtype),
+        "IS NULL": lambda self: self._fold_literal("is_null"),
+        "IS NOT NULL": lambda self: self._fold_literal("is_not_null"),
+    }
+
+    _ARROW_EXEC = {
+        "+": lambda self, table: self._pc("add", table),
+        "-": lambda self, table: self._pc("subtract", table),
+        "*": lambda self, table: self._pc("multiply", table),
+        "POWER": lambda self, table: self._pc("power", table),
+        "/": lambda self, table: self._pc("divide", table),
+        "//": lambda self, table: self._pc("divide", table),
+        "~": lambda self, table: self._invert(table),
+        "CAST": lambda self, table: self._col(table).cast(to_arrow_type(self._dtype)),
+        "IS NULL": lambda self, table: self._col(table).is_null(nan_is_null=True),
+        "IS NOT NULL": lambda self, table: pc.invert(
+            self._col(table).is_null(nan_is_null=True)
+        ),
+    }
+
+    _UNSUPPORTED_HDK_OPS = {"~"}
+
     def __init__(self, op, operands, dtype):
         self.op = op
         self.operands = operands
@@ -787,6 +946,94 @@ class OpExpr(BaseExpr):
         """
         return OpExpr(self.op, self.operands.copy(), self._dtype)
 
+    @_inherit_docstrings(BaseExpr.fold)
+    def fold(self):
+        super().fold()
+        return self if (op := self._FOLD_OPS.get(self.op, None)) is None else op(self)
+
+    def _fold_arithm(self, op) -> Union["OpExpr", LiteralExpr]:
+        """
+        Fold arithmetic expressions.
+
+        Parameters
+        ----------
+        op : str
+
+        Returns
+        -------
+        OpExpr or LiteralExpr
+        """
+        operands = self.operands
+        i = 0
+        while i < len(operands):
+            if isinstance((o := operands[i]), OpExpr):
+                if self.op == o.op:
+                    # Fold operands in case of the same operation
+                    operands[i : i + 1] = o.operands
+                else:
+                    i += 1
+                    continue
+            if i == 0:
+                i += 1
+                continue
+            if isinstance(o, LiteralExpr) and isinstance(operands[i - 1], LiteralExpr):
+                # Fold two sequential literal expressions
+                val = getattr(operands[i - 1].val, op)(o.val)
+                operands[i - 1] = LiteralExpr(val).cast(o._dtype)
+                del operands[i]
+            else:
+                i += 1
+        return operands[0] if len(operands) == 1 else self
+
+    def _fold_invert(self) -> Union["OpExpr", LiteralExpr]:
+        """
+        Fold invert expression.
+
+        Returns
+        -------
+        OpExpr or LiteralExpr
+        """
+        assert len(self.operands) == 1
+        op = self.operands[0]
+        if isinstance(op, LiteralExpr):
+            return LiteralExpr(~op.val, op._dtype)
+        if isinstance(op, OpExpr):
+            if op.op == "IS NULL":
+                return OpExpr("IS NOT NULL", op.operands, op._dtype)
+            if op.op == "IS NOT NULL":
+                return OpExpr("IS NULL", op.operands, op._dtype)
+        return self
+
+    def _fold_literal(self, op, *args):
+        """
+        Fold literal expressions.
+
+        Parameters
+        ----------
+        op : str
+
+        *args : list
+
+        Returns
+        -------
+        OpExpr or LiteralExpr
+        """
+        assert len(self.operands) == 1
+        expr = self.operands[0]
+        return getattr(expr, op)(*args) if isinstance(expr, LiteralExpr) else self
+
+    @_inherit_docstrings(BaseExpr.can_execute_hdk)
+    def can_execute_hdk(self) -> bool:
+        return self.op not in self._UNSUPPORTED_HDK_OPS
+
+    @_inherit_docstrings(BaseExpr.can_execute_arrow)
+    def can_execute_arrow(self) -> bool:
+        return self.op in self._ARROW_EXEC
+
+    @_inherit_docstrings(BaseExpr.execute_arrow)
+    def execute_arrow(self, table: pa.Table) -> pa.ChunkedArray:
+        return self._ARROW_EXEC[self.op](self, table)
+
     def __repr__(self):
         """
         Return a string representation of the expression.
@@ -798,6 +1045,80 @@ class OpExpr(BaseExpr):
         if len(self.operands) == 1:
             return f"({self.op} {self.operands[0]} [{self._dtype}])"
         return f"({self.op} {self.operands} [{self._dtype}])"
+
+    def _col(self, table: pa.Table) -> pa.ChunkedArray:
+        """
+        Return the column referenced by the `InputRefExpr` operand.
+
+        Parameters
+        ----------
+        table : pa.Table
+
+        Returns
+        -------
+        pa.ChunkedArray
+        """
+        assert isinstance(self.operands[0], InputRefExpr)
+        return self.operands[0].execute_arrow(table)
+
+    def _pc(self, op: str, table: pa.Table) -> pa.ChunkedArray:
+        """
+        Perform the specified pyarrow.compute operation on the operands.
+
+        Parameters
+        ----------
+        op : str
+        table : pyarrow.Table
+
+        Returns
+        -------
+        pyarrow.ChunkedArray
+        """
+        op = getattr(pc, op)
+        val = self._op_value(0, table)
+        for i in range(1, len(self.operands)):
+            val = op(val, self._op_value(i, table))
+        if not isinstance(val, pa.ChunkedArray):
+            val = LiteralExpr(val).execute_arrow(table)
+        if val.type != (at := to_arrow_type(self._dtype)):
+            val = val.cast(at)
+        return val
+
+    def _op_value(self, op_idx: int, table: pa.Table):
+        """
+        Get the specified operand value.
+
+        Parameters
+        ----------
+        op_idx : int
+        table : pyarrow.Table
+
+        Returns
+        -------
+        pyarrow.ChunkedArray or expr.val
+        """
+        expr = self.operands[op_idx]
+        return expr.val if isinstance(expr, LiteralExpr) else expr.execute_arrow(table)
+
+    def _invert(self, table: pa.Table) -> pa.ChunkedArray:
+        """
+        Bitwise inverse the column values.
+
+        Parameters
+        ----------
+        table : pyarrow.Table
+
+        Returns
+        -------
+        pyarrow.ChunkedArray
+        """
+        if is_bool_dtype(self._dtype):
+            return pc.invert(self._col(table))
+
+        try:
+            return pc.bit_wise_not(self._col(table))
+        except pa.ArrowNotImplementedError as err:
+            raise TypeError(str(err))
 
 
 class AggregateExpr(BaseExpr):
@@ -882,7 +1203,7 @@ def build_row_idx_filter_expr(row_idx, row_col):
     if not is_list_like(row_idx):
         return row_col.eq(row_idx)
 
-    if isinstance(row_idx, (pd.RangeIndex, range)) and row_idx.step == 1:
+    if isinstance(row_idx, (pandas.RangeIndex, range)) and row_idx.step == 1:
         exprs = [row_col.ge(row_idx[0]), row_col.le(row_idx[-1])]
         return OpExpr("AND", exprs, get_dtype(bool))
 

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/hdk_worker.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/hdk_worker.py
@@ -84,6 +84,7 @@ class HdkWorker(BaseDbWorker):
     @classmethod
     def executeRA(cls, query):
         if query.startswith("execute relalg"):
+            # 14 == len("execute relalg")
             ra = query[14:]
         else:
             assert query.startswith("execute calcite")

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/hdk_worker.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/hdk_worker.py
@@ -84,10 +84,11 @@ class HdkWorker(BaseDbWorker):
     @classmethod
     def executeRA(cls, query):
         if query.startswith("execute relalg"):
-            ra = query.removeprefix("execute relalg")
+            ra = query[14:]
         else:
             assert query.startswith("execute calcite")
             ra = cls._calcite.process(query, db_name="hdk")
+
         return cls._executeRelAlgJson(ra)
 
     @classmethod

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/interchange/dataframe_protocol/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/interchange/dataframe_protocol/dataframe.py
@@ -185,13 +185,13 @@ class HdkProtocolDataframe(ProtocolDataframe):
         is_zero_copy_op = False
         if isinstance(op, (FrameNode, TransformNode, UnionNode)):
             # - FrameNode: already materialized PyArrow table
-            # - TransformNode: select certain columns of the table, implemented zero-copy (``df._arrow_select``)
-            # - UnionNode: concatenate PyArrow tables, implemented zero-copy (``df._arrow_concat``)
+            # - TransformNode: select certain columns of the table, implemented zero-copy
+            # - UnionNode: concatenate PyArrow tables, implemented zero-copy
             is_zero_copy_op = True
         elif isinstance(op, MaskNode) and (
             isinstance(op.row_positions, slice) or is_range_like(op.row_positions)
         ):
-            # Can select rows zero-copy if indexer is a slice-like (``df._arrow_row_slice``)
+            # Can select rows zero-copy if indexer is a slice-like
             is_zero_copy_op = True
         return is_zero_copy_op and all(
             # Walk the computation tree
@@ -209,10 +209,7 @@ class HdkProtocolDataframe(ProtocolDataframe):
         -------
         pyarrow.Table
         """
-        if not self._df._has_arrow_table():
-            self._df._execute()
-
-        at = self._df._partitions[0][0].arrow_table
+        at = self._df._execute()
         assert at is not None
         return at
 

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -581,8 +581,7 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
                 ErrorMessage.default_to_pandas(f"Argument {key}={value}")
                 return df.to_pandas().to_csv(**kwargs)
 
-        df._execute()
-        at = df._partitions[0][0].get()
+        at = df._execute()
         if not isinstance(at, pa.Table):
             return df.to_pandas().to_csv(**kwargs)
         idx_names = df._index_cols

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -279,7 +279,7 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
         for frame in frames:
             if frame._partitions.size != 1:
                 raise NotImplementedError(
-                    "HdkOnNative engine doesn't suport partitioned frames"
+                    "HdkOnNative engine doesn't support partitioned frames"
                 )
             for p in frame._partitions.flatten():
                 if p.frame_id is None:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/utils.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/utils.py
@@ -251,6 +251,7 @@ def run_and_compare(
     data,
     data2=None,
     force_lazy=True,
+    force_hdk_execute=False,
     force_arrow_execute=False,
     allow_subqueries=False,
     comparator=df_equals,
@@ -263,6 +264,7 @@ def run_and_compare(
         data,
         data2,
         force_lazy,
+        force_hdk_execute,
         force_arrow_execute,
         allow_subqueries,
         constructor_kwargs,
@@ -272,16 +274,21 @@ def run_and_compare(
         kwargs["df2"] = pd.DataFrame(data2, **constructor_kwargs)
         kwargs["df"] = kwargs["df1"]
 
-        if force_lazy:
-            set_execution_mode(kwargs["df1"], "lazy")
-            set_execution_mode(kwargs["df2"], "lazy")
+        if force_hdk_execute:
+            set_execution_mode(kwargs["df1"], "hdk")
+            set_execution_mode(kwargs["df2"], "hdk")
         elif force_arrow_execute:
             set_execution_mode(kwargs["df1"], "arrow")
             set_execution_mode(kwargs["df2"], "arrow")
+        elif force_lazy:
+            set_execution_mode(kwargs["df1"], "lazy")
+            set_execution_mode(kwargs["df2"], "lazy")
 
         exp_res = fn(lib=pd, **kwargs)
 
-        if force_arrow_execute:
+        if force_hdk_execute:
+            set_execution_mode(exp_res, "hdk", allow_subqueries)
+        elif force_arrow_execute:
             set_execution_mode(exp_res, "arrow", allow_subqueries)
         elif force_lazy:
             set_execution_mode(exp_res, None, allow_subqueries)
@@ -301,6 +308,7 @@ def run_and_compare(
                 data=data,
                 data2=data2,
                 force_lazy=force_lazy,
+                force_hdk_execute=force_hdk_execute,
                 force_arrow_execute=force_arrow_execute,
                 allow_subqueries=allow_subqueries,
                 constructor_kwargs=constructor_kwargs,
@@ -313,6 +321,7 @@ def run_and_compare(
             data=data,
             data2=data2,
             force_lazy=force_lazy,
+            force_hdk_execute=force_hdk_execute,
             force_arrow_execute=force_arrow_execute,
             allow_subqueries=allow_subqueries,
             constructor_kwargs=constructor_kwargs,

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -604,6 +604,15 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
             shape_hint=self._shape_hint,
         )
 
+    def isna(self):
+        return self.__constructor__(self._modin_frame.isna(invert=False))
+
+    def notna(self):
+        return self.__constructor__(self._modin_frame.isna(invert=True))
+
+    def invert(self):
+        return self.__constructor__(self._modin_frame.invert())
+
     def dt_year(self):
         return self.__constructor__(
             self._modin_frame.dt_extract("year"), self._shape_hint
@@ -665,6 +674,9 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
 
     def mul(self, other, **kwargs):
         return self._bin_op(other, "mul", **kwargs)
+
+    def pow(self, other, **kwargs):
+        return self._bin_op(other, "pow", **kwargs)
 
     def mod(self, other, **kwargs):
         def check_int(obj):

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -98,6 +98,10 @@ def test_count_specific(numeric_only):
     )
 
 
+@pytest.mark.skipif(
+    StorageFormat.get() == "Hdk",
+    reason="https://github.com/intel-ai/hdk/issues/513",
+)
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_count_dtypes(data):
     modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -48,7 +48,7 @@ def _nullcontext():
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("append_na", [True, False])
 @pytest.mark.parametrize("op", ["isna", "isnull", "notna", "notnull"])
-def test_isna(data, append_na, op):
+def test_isna_isnull_notna_notnull(data, append_na, op):
     pandas_df = pandas.DataFrame(data)
     modin_df = pd.DataFrame(pandas_df)
     if append_na:

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -46,64 +46,23 @@ def _nullcontext():
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_isna(data):
+@pytest.mark.parametrize("append_na", [True, False])
+@pytest.mark.parametrize("op", ["isna", "isnull", "notna", "notnull"])
+def test_isna(data, append_na, op):
     pandas_df = pandas.DataFrame(data)
-    modin_df = pd.DataFrame(data)
+    modin_df = pd.DataFrame(pandas_df)
+    if append_na:
+        pandas_df["NONE_COL"] = None
+        pandas_df["NAN_COL"] = np.nan
+        modin_df["NONE_COL"] = None
+        modin_df["NAN_COL"] = np.nan
 
-    pandas_result = pandas.isna(pandas_df)
-    modin_result = pd.isna(modin_df)
+    pandas_result = getattr(pandas, op)(pandas_df)
+    modin_result = getattr(pd, op)(modin_df)
     df_equals(modin_result, pandas_result)
 
-    modin_result = pd.isna(pd.Series([1, np.nan, 2]))
-    pandas_result = pandas.isna(pandas.Series([1, np.nan, 2]))
-    df_equals(modin_result, pandas_result)
-
-    assert pd.isna(np.nan) == pandas.isna(np.nan)
-
-
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_isnull(data):
-    pandas_df = pandas.DataFrame(data)
-    modin_df = pd.DataFrame(data)
-
-    pandas_result = pandas.isnull(pandas_df)
-    modin_result = pd.isnull(modin_df)
-    df_equals(modin_result, pandas_result)
-
-    modin_result = pd.isnull(pd.Series([1, np.nan, 2]))
-    pandas_result = pandas.isnull(pandas.Series([1, np.nan, 2]))
-    df_equals(modin_result, pandas_result)
-
-    assert pd.isna(np.nan) == pandas.isna(np.nan)
-
-
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_notna(data):
-    pandas_df = pandas.DataFrame(data)
-    modin_df = pd.DataFrame(data)
-
-    pandas_result = pandas.notna(pandas_df)
-    modin_result = pd.notna(modin_df)
-    df_equals(modin_result, pandas_result)
-
-    modin_result = pd.notna(pd.Series([1, np.nan, 2]))
-    pandas_result = pandas.notna(pandas.Series([1, np.nan, 2]))
-    df_equals(modin_result, pandas_result)
-
-    assert pd.isna(np.nan) == pandas.isna(np.nan)
-
-
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_notnull(data):
-    pandas_df = pandas.DataFrame(data)
-    modin_df = pd.DataFrame(data)
-
-    pandas_result = pandas.notnull(pandas_df)
-    modin_result = pd.notnull(modin_df)
-    df_equals(modin_result, pandas_result)
-
-    modin_result = pd.notnull(pd.Series([1, np.nan, 2]))
-    pandas_result = pandas.notnull(pandas.Series([1, np.nan, 2]))
+    modin_result = getattr(pd, op)(pd.Series([1, np.nan, 2]))
+    pandas_result = getattr(pandas, op)(pandas.Series([1, np.nan, 2]))
     df_equals(modin_result, pandas_result)
 
     assert pd.isna(np.nan) == pandas.isna(np.nan)


### PR DESCRIPTION
 - Reimplemented _union_all(), that used non-lazy arrow-based frames concatenation.
 - Added functionality to dataframe tree nodes and expressions for arrow execution. The arrow execution is performed if the frame has an arrow table in partitions and all the nodes support the arrow execution. It allows to save on the table import to HDK.
 - The arrow execution is also performed for the operations, not supported by HDK, for example, bitwise not '~'.
 
## What do these changes do?
#### [dataframe.py](https://github.com/modin-project/modin/pull/6251/files#diff-d1a0db76b871ca475d604ff109cc3ebf13d7ead8ce07cca7caa54ace5f736cc0):
[_execute()](https://github.com/modin-project/modin/pull/6251/files#diff-d1a0db76b871ca475d604ff109cc3ebf13d7ead8ce07cca7caa54ace5f736cc0R1842). The main changes here:
- Now the method returns either `pyarrow.Table` or `pandas.Dataframe`. Dataframe is returned if we have an unsupported data.
- Added new condition - `if not frame._op.can_execute_hdk()`. If it's true, then the operation can not be executed with HDK and should be executed with arrow. Currently, there is only one such operation - `~` `invert()`. The frame is added to the stack for the subsequent materialization.

[_materialize()](https://github.com/modin-project/modin/pull/6251/files#diff-d1a0db76b871ca475d604ff109cc3ebf13d7ead8ce07cca7caa54ace5f736cc0R1871):
- The method returns `pyarrow.Table`
- Added new execution mode - `hdk`. This is used by unit tests to force the HDK execution.

[_require_executed_base(), _can_execute_arrow(), execute_arrow()](https://github.com/modin-project/modin/pull/6251/files#diff-d1a0db76b871ca475d604ff109cc3ebf13d7ead8ce07cca7caa54ace5f736cc0L2095) moved to [DFAlgNode](https://github.com/modin-project/modin/pull/6251/files#diff-fc0f76c51d86e975ebb2af41cc109d92311368a9da5fc00a4b264f85d8bce737R239) and subclasses.

[_arrow_row_slice()](https://github.com/modin-project/modin/pull/6251/files#diff-d1a0db76b871ca475d604ff109cc3ebf13d7ead8ce07cca7caa54ace5f736cc0L2264) moved to [MaskNode.execute_arrow()](https://github.com/modin-project/modin/pull/6251/files#diff-fc0f76c51d86e975ebb2af41cc109d92311368a9da5fc00a4b264f85d8bce737R539)

[_arrow_select()](https://github.com/modin-project/modin/pull/6251/files#diff-d1a0db76b871ca475d604ff109cc3ebf13d7ead8ce07cca7caa54ace5f736cc0L2225) moved to [TransformNode.execute_arrow()](https://github.com/modin-project/modin/pull/6251/files#diff-fc0f76c51d86e975ebb2af41cc109d92311368a9da5fc00a4b264f85d8bce737R715) . The new implementation is much more simple, because the actual logic is now implemented in subclasses of [BaseExpr.execute_arrow()](https://github.com/modin-project/modin/pull/6251/files#diff-532f2950a0930fecba54c8ab7a130cd9baa85d9320e8b46d9035931be52bc987R668). Each implementation calculates an arrow column and this method just concatenates all the columns and creates a new arrow table.

[_union_all_arrow()](https://github.com/modin-project/modin/pull/6251/files#diff-d1a0db76b871ca475d604ff109cc3ebf13d7ead8ce07cca7caa54ace5f736cc0L1195) moved to [UnionNode.execute_arrow()](https://github.com/modin-project/modin/pull/6251/files#diff-fc0f76c51d86e975ebb2af41cc109d92311368a9da5fc00a4b264f85d8bce737R937). The new implementation is also much more simple, because it receives already computed tables. The actual tables computation is performed by the corresponding `execute_arrow()` implementation for each frame.

#### [df_algebra.py](https://github.com/modin-project/modin/pull/6251/files#diff-fc0f76c51d86e975ebb2af41cc109d92311368a9da5fc00a4b264f85d8bce737):
Added 4 new methods to `DFAlgNode` and subclasses. When processing the execution tree and all the nodes `can_execute_arrow()`, the execution is performed with `execute_arrow()`, but not HDK. Depending on the number of input nodes, this method receives either a single or multiple arrow tables, then performs the required computation and returns a single table.

#### [expr.py](https://github.com/modin-project/modin/pull/6251/files#diff-532f2950a0930fecba54c8ab7a130cd9baa85d9320e8b46d9035931be52bc987):
- Similarly to `DFAlgNode`, new arrow methods added to `BaseExpr`. Since `BaseExpr` represents a single column, the `execute_arow()` method returns a ChunkedArray.
- Added new method `fold()`. It allows, in some cases, to replace multiple expressions with a single one or with a precomputed value. For example, if we have multiple subsequent arithmetic expressions with literals, we can precompute the result and replace all the expressions with a single literal.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5759 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
