### PR TITLE
FIX-#6232: support DataFrame.cov(numeric_only=False) without fallback to pandas

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2095,7 +2095,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
         This method is only used to compute covariance at the moment.
         """
         other = self.to_numpy()
-        other_mask = self._isfinite().to_numpy()
+        try:
+            other_mask = self._isfinite().to_numpy()
+        except TypeError as err:
+            # Pandas raises ValueError on unsupported types, so casting
+            # the exception to a proper type
+            raise ValueError("Unsupported types with 'numeric_only=False'") from err
         n_cols = other.shape[1]
 
         if min_periods is None:

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -687,19 +687,13 @@ class DataFrame(BasePandasDataset):
         """
         Compute pairwise covariance of columns, excluding NA/null values.
         """
-        # FIXME: https://github.com/modin-project/modin/issues/6232
-        if not numeric_only:
-            return self._default_to_pandas(
-                pandas.DataFrame.cov,
-                min_periods=min_periods,
-                ddof=ddof,
-                numeric_only=numeric_only,
+        cov_df = self
+        if numeric_only:
+            cov_df = self.drop(
+                columns=[
+                    i for i in self.dtypes.index if not is_numeric_dtype(self.dtypes[i])
+                ]
             )
-        cov_df = self.drop(
-            columns=[
-                i for i in self.dtypes.index if not is_numeric_dtype(self.dtypes[i])
-            ]
-        )
 
         if min_periods is not None and min_periods > len(cov_df):
             result = np.empty((cov_df.shape[1], cov_df.shape[1]))

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -358,6 +358,14 @@ def test_cov(min_periods, ddof):
     )
 
 
+@pytest.mark.parametrize("numeric_only", [True, False, None])
+def test_cov_numeric_only(numeric_only):
+    eval_general(
+        *create_test_dfs({"a": [1, 2, 3], "b": [3, 2, 5], "c": ["a", "b", "c"]}),
+        lambda df: df.cov(numeric_only=numeric_only),
+    )
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_dot(data):
     modin_df = pd.DataFrame(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6232 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
