### PR TITLE
FEAT-#6253: add `dtype_backend` parameter support for read_parquet/read_feather

### DIFF
--- a/modin/core/io/column_stores/feather_dispatcher.py
+++ b/modin/core/io/column_stores/feather_dispatcher.py
@@ -13,8 +13,6 @@
 
 """Module houses `FeatherDispatcher` class, that is used for reading `.feather` files."""
 
-import pandas._libs.lib as lib
-
 from modin.core.io.column_stores.column_store_dispatcher import ColumnStoreDispatcher
 from modin.utils import import_optional_dependency
 from modin.core.io.file_dispatcher import OpenFile
@@ -49,14 +47,6 @@ class FeatherDispatcher(ColumnStoreDispatcher):
         PyArrow feather is used. Please refer to the documentation here
         https://arrow.apache.org/docs/python/api.html#feather-format
         """
-        if kwargs["dtype_backend"] != lib.no_default:
-            return cls.single_worker_read(
-                path,
-                columns=columns,
-                reason="'dtype_backend' not supported",
-                **kwargs,
-            )
-
         path = cls.get_path(path)
         if columns is None:
             import_optional_dependency(
@@ -81,4 +71,6 @@ class FeatherDispatcher(ColumnStoreDispatcher):
             )
             # Filtering out the columns that describe the frame's index
             columns = [col for col in reader.schema.names if col not in index_cols]
-        return cls.build_query_compiler(path, columns, use_threads=False)
+        return cls.build_query_compiler(
+            path, columns, use_threads=False, dtype_backend=kwargs["dtype_backend"]
+        )

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -620,7 +620,6 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         if (
             any(arg not in ("storage_options",) for arg in kwargs)
             or use_nullable_dtypes != lib.no_default
-            or dtype_backend != lib.no_default
         ):
             return cls.single_worker_read(
                 path,
@@ -692,7 +691,9 @@ class ParquetDispatcher(ColumnStoreDispatcher):
             if c not in index_columns and not cls.index_regex.match(c)
         ]
 
-        return cls.build_query_compiler(dataset, columns, index_columns, **kwargs)
+        return cls.build_query_compiler(
+            dataset, columns, index_columns, dtype_backend=dtype_backend, **kwargs
+        )
 
     @staticmethod
     def _to_parquet_check_support(kwargs):

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -282,6 +282,11 @@ def read_parquet(
 ) -> DataFrame:
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
+    if engine == "fastparquet" and dtype_backend is not no_default:
+        raise ValueError(
+            "The 'dtype_backend' argument is not supported for the fastparquet engine"
+        )
+
     return DataFrame(
         query_compiler=FactoryDispatcher.read_parquet(
             path=path,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6253 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
