### PR TITLE
FIX-#6229: fix `Series.equals`/`DataFrame.equals` with NA entries

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -382,7 +382,7 @@ class Binary(Operator):
                             lambda x, y: func(x, y, *args, **kwargs),
                             [other._modin_frame],
                             join_type=join_type,
-                            labels=None,
+                            labels=labels,
                             dtypes=dtypes,
                         ),
                         shape_hint=shape_hint,

--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -382,6 +382,7 @@ class Binary(Operator):
                             lambda x, y: func(x, y, *args, **kwargs),
                             [other._modin_frame],
                             join_type=join_type,
+                            labels=None,
                             dtypes=dtypes,
                         ),
                         shape_hint=shape_hint,

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3280,7 +3280,7 @@ class PandasDataframe(ClassLogger):
         right_frames: list,
         join_type="outer",
         copartition_along_columns=True,
-        labels="keep",
+        labels="replace",
         dtypes=None,
     ):
         """
@@ -3297,6 +3297,9 @@ class PandasDataframe(ClassLogger):
         copartition_along_columns : bool, default: True
             Whether to perform copartitioning along columns or not.
             For some ops this isn't needed (e.g., `fillna`).
+        labels : {"replace", "drop"}, default: "replace"
+            Whether use labels from joined DataFrame or drop altogether to make
+            them be computed lazily later.
         dtypes : series, default: None
             Dtypes of the resultant dataframe, this argument will be
             received if the resultant dtypes of n-opary operation is precomputed.
@@ -3350,9 +3353,9 @@ class PandasDataframe(ClassLogger):
 
         return self.__constructor__(
             new_frame,
-            joined_index if labels == "keep" else None,
+            joined_index if labels == "replace" else None,
             joined_columns,
-            row_lengths if labels == "keep" else None,
+            row_lengths if labels == "replace" else None,
             column_widths,
             dtypes,
         )

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3350,13 +3350,15 @@ class PandasDataframe(ClassLogger):
                 left_parts, op, list_of_right_parts
             )
         )
+        if labels == "drop":
+            joined_index = joined_columns = row_lengths = column_widths = None
 
         return self.__constructor__(
             new_frame,
-            joined_index if labels == "replace" else None,
-            joined_columns if labels == "replace" else None,
-            row_lengths if labels == "replace" else None,
-            column_widths if labels == "replace" else None,
+            joined_index,
+            joined_columns,
+            row_lengths,
+            column_widths,
             dtypes,
         )
 

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3354,9 +3354,9 @@ class PandasDataframe(ClassLogger):
         return self.__constructor__(
             new_frame,
             joined_index if labels == "replace" else None,
-            joined_columns,
+            joined_columns if labels == "replace" else None,
             row_lengths if labels == "replace" else None,
-            column_widths,
+            column_widths if labels == "replace" else None,
             dtypes,
         )
 

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3280,6 +3280,7 @@ class PandasDataframe(ClassLogger):
         right_frames: list,
         join_type="outer",
         copartition_along_columns=True,
+        labels="keep",
         dtypes=None,
     ):
         """
@@ -3349,9 +3350,9 @@ class PandasDataframe(ClassLogger):
 
         return self.__constructor__(
             new_frame,
-            joined_index,
+            joined_index if labels == "keep" else None,
             joined_columns,
-            row_lengths,
+            row_lengths if labels == "keep" else None,
             column_widths,
             dtypes,
         )

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -580,7 +580,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         return BinaryDefault.register(pandas.DataFrame.eq)(self, other=other, **kwargs)
 
     @doc_utils.add_refer_to("DataFrame.equals")
-    def equals(self, other):  # noqa: PR02
+    def equals(self, other):  # noqa: PR01, RT01
         return BinaryDefault.register(pandas.DataFrame.equals)(self, other=other)
 
     @doc_utils.doc_binary_method(operation="integer division", sign="//")

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -579,6 +579,10 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     def eq(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.eq)(self, other=other, **kwargs)
 
+    @doc_utils.add_refer_to("DataFrame.equals")
+    def equals(self, other):  # noqa: PR02
+        return BinaryDefault.register(pandas.DataFrame.equals)(self, other=other)
+
     @doc_utils.doc_binary_method(operation="integer division", sign="//")
     def floordiv(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.floordiv)(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -391,7 +391,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     combine_first = Binary.register(pandas.DataFrame.combine_first, infer_dtypes="bool")
     eq = Binary.register(pandas.DataFrame.eq, infer_dtypes="bool")
     equals = Binary.register(
-        lambda df, other: pandas.DataFrame([df.equals(other)], columns=df.columns),
+        lambda df, other: pandas.DataFrame([df.equals(other)]),
         join_type=None,
         labels="drop",
         infer_dtypes="bool",

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -391,7 +391,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     combine_first = Binary.register(pandas.DataFrame.combine_first, infer_dtypes="bool")
     eq = Binary.register(pandas.DataFrame.eq, infer_dtypes="bool")
     equals = Binary.register(
-        lambda df, other: pandas.DataFrame([df.equals(other)]),
+        lambda df, other: pandas.DataFrame([[df.equals(other)]]),
         join_type=None,
         labels="drop",
         infer_dtypes="bool",

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -390,6 +390,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
     combine = Binary.register(pandas.DataFrame.combine, infer_dtypes="common_cast")
     combine_first = Binary.register(pandas.DataFrame.combine_first, infer_dtypes="bool")
     eq = Binary.register(pandas.DataFrame.eq, infer_dtypes="bool")
+    equals = Binary.register(
+        lambda df, other: pandas.DataFrame([df.equals(other)], columns=df.columns),
+        join_type=None,
+        infer_dtypes="bool",
+    )
     floordiv = Binary.register(pandas.DataFrame.floordiv, infer_dtypes="common_cast")
     ge = Binary.register(pandas.DataFrame.ge, infer_dtypes="bool")
     gt = Binary.register(pandas.DataFrame.gt, infer_dtypes="bool")

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -393,6 +393,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     equals = Binary.register(
         lambda df, other: pandas.DataFrame([df.equals(other)], columns=df.columns),
         join_type=None,
+        labels="drop",
         infer_dtypes="bool",
     )
     floordiv = Binary.register(pandas.DataFrame.floordiv, infer_dtypes="common_cast")

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -759,11 +759,19 @@ class DataFrame(BasePandasDataset):
         if isinstance(other, pandas.DataFrame):
             # Copy into a Modin DataFrame to simplify logic below
             other = self.__constructor__(other)
-        return (
-            self.index.equals(other.index)
-            and self.columns.equals(other.columns)
-            and self.eq(other).all().all()
+
+        if (
+            type(self) != type(other)
+            or not self.index.equals(other.index)
+            or not self.columns.equals(other.columns)
+        ):
+            return False
+
+        result = self.__constructor__(
+            query_compiler=self._query_compiler.equals(other._query_compiler)
         )
+        # this function should return only scalar
+        return result.at[0, 0]
 
     def _update_var_dicts_in_kwargs(self, expr, kwargs):
         """

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -770,8 +770,7 @@ class DataFrame(BasePandasDataset):
         result = self.__constructor__(
             query_compiler=self._query_compiler.equals(other._query_compiler)
         )
-        # this function should return only scalar
-        return result.at[0, 0]
+        return result.all(axis=None)
 
     def _update_var_dicts_in_kwargs(self, expr, kwargs):
         """

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -929,13 +929,11 @@ class Series(BasePandasDataset):
         if not self.name == other.name or not self.index.equals(other.index):
             return False
 
-        # self.eq(other).all()
-        # from pandas.core.dtypes.missing import array_equals
-
         res = self.__constructor__(
             query_compiler=self._query_compiler.equals(other._query_compiler)
         )
-        return res.all()
+        # this function should return only scalar
+        return res.iloc[0]
 
     def explode(self, ignore_index: bool = False):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -926,14 +926,21 @@ class Series(BasePandasDataset):
         """
         Test whether two objects contain the same elements.
         """
-        if not self.name == other.name or not self.index.equals(other.index):
+        if isinstance(other, pandas.Series):
+            # Copy into a Modin Series to simplify logic below
+            other = self.__constructor__(other)
+
+        if (
+            type(self) != type(other)
+            or not self.name == other.name
+            or not self.index.equals(other.index)
+        ):
             return False
 
-        res = self.__constructor__(
-            query_compiler=self._query_compiler.equals(other._query_compiler)
-        )
         # this function should return only scalar
-        return res.iloc[0]
+        return self.__constructor__(
+            query_compiler=self._query_compiler.equals(other._query_compiler)
+        ).iloc[0]
 
     def explode(self, ignore_index: bool = False):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -926,11 +926,16 @@ class Series(BasePandasDataset):
         """
         Test whether two objects contain the same elements.
         """
-        return (
-            self.name == other.name
-            and self.index.equals(other.index)
-            and self.eq(other).all()
+        if not self.name == other.name or not self.index.equals(other.index):
+            return False
+
+        # self.eq(other).all()
+        # from pandas.core.dtypes.missing import array_equals
+
+        res = self.__constructor__(
+            query_compiler=self._query_compiler.equals(other._query_compiler)
         )
+        return res.all()
 
     def explode(self, ignore_index: bool = False):  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -247,6 +247,12 @@ def test_equals():
     assert modin_df1.equals(modin_df2._query_compiler.to_pandas())
 
 
+def test_equals_with_nans():
+    df1 = pd.DataFrame([0, 1, None], dtype="uint8[pyarrow]")
+    df2 = pd.DataFrame([None, None, None], dtype="uint8[pyarrow]")
+    assert not df1.equals(df2)
+
+
 @pytest.mark.parametrize("is_more_other_partitions", [True, False])
 @pytest.mark.parametrize(
     "op_type", ["df_ser", "df_df", "ser_ser_same_name", "ser_ser_different_name"]

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -13,6 +13,7 @@
 
 import pytest
 import pandas
+import numpy as np
 import matplotlib
 import modin.pandas as pd
 
@@ -223,28 +224,75 @@ def test_multi_level_comparison(data, op):
         getattr(modin_df_multi_level, op)(modin_df_multi_level, axis=0, level=1)
 
 
-def test_equals():
-    frame_data = {"col1": [2.9, 3, 3, 3], "col2": [2, 3, 4, 1]}
-    modin_df1 = pd.DataFrame(frame_data)
-    modin_df2 = pd.DataFrame(frame_data)
+@pytest.mark.parametrize(
+    "frame1_data,frame2_data,expected_pandas_equals",
+    [
+        pytest.param({}, {}, True, id="two_empty_dataframes"),
+        pytest.param([[1]], [[0]], False, id="single_unequal_values"),
+        pytest.param([[None]], [[None]], True, id="single_none_values"),
+        pytest.param([[np.NaN]], [[np.NaN]], True, id="single_nan_values"),
+        pytest.param({1: [10]}, {1.0: [10]}, True, id="different_column_types"),
+        pytest.param({1: [10]}, {2: [10]}, False, id="different_columns"),
+        pytest.param(
+            pandas.DataFrame({1: [10]}, index=[1]),
+            pandas.DataFrame({1: [10]}, index=[1.0]),
+            True,
+            id="different_index_types",
+        ),
+        pytest.param(
+            pandas.DataFrame({1: [10]}, index=[1]),
+            pandas.DataFrame({1: [10]}, index=[2]),
+            False,
+            id="different_indexes",
+        ),
+        pytest.param({1: [10]}, {1: [10.0]}, False, id="different_value_types"),
+        pytest.param(
+            [[1, 2], [3, 4]],
+            [[1, 2], [3, 4]],
+            True,
+            id="equal_two_by_two_dataframes",
+        ),
+        pytest.param(
+            [[1, 2], [3, 4]],
+            [[5, 2], [3, 4]],
+            False,
+            id="unequal_two_by_two_dataframes",
+        ),
+        pytest.param(
+            [[1, 1]],
+            [[1]],
+            False,
+            id="different_row_lengths",
+        ),
+        pytest.param(
+            [[1], [1]],
+            [[1]],
+            False,
+            id="different_column_lengths",
+        ),
+    ],
+)
+def test_equals(frame1_data, frame2_data, expected_pandas_equals):
+    modin_df1 = pd.DataFrame(frame1_data)
+    pandas_df1 = pandas.DataFrame(frame1_data)
+    modin_df2 = pd.DataFrame(frame2_data)
+    pandas_df2 = pandas.DataFrame(frame2_data)
 
-    assert modin_df1.equals(modin_df2)
+    pandas_equals = pandas_df1.equals(pandas_df2)
+    assert pandas_equals == expected_pandas_equals, (
+        "Test expected pandas to say the dataframes were"
+        + f"{'' if expected_pandas_equals else ' not'} equal, but they were"
+        + f"{' not' if expected_pandas_equals else ''} equal."
+    )
 
-    df_equals(modin_df1, modin_df2)
-    df_equals(modin_df1, pd.DataFrame(modin_df1))
+    assert modin_df1.equals(modin_df2) == pandas_equals
+    assert modin_df1.equals(pandas_df2) == pandas_equals
 
-    frame_data = {"col1": [2.9, 3, 3, 3], "col2": [2, 3, 5, 1]}
-    modin_df3 = pd.DataFrame(frame_data, index=list("abcd"))
 
-    assert not modin_df1.equals(modin_df3)
-
-    with pytest.raises(AssertionError):
-        df_equals(modin_df3, modin_df1)
-
-    with pytest.raises(AssertionError):
-        df_equals(modin_df3, modin_df2)
-
-    assert modin_df1.equals(modin_df2._query_compiler.to_pandas())
+def test_equals_several_partitions():
+    modin_series1 = pd.concat([pd.DataFrame([0, 1]), pd.DataFrame([None, 1])])
+    modin_series2 = pd.concat([pd.DataFrame([0, 1]), pd.DataFrame([1, None])])
+    assert not modin_series1.equals(modin_series2)
 
 
 def test_equals_with_nans():

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1919,6 +1919,12 @@ def test_equals():
         df_equals(modin_df3, modin_df2)
 
 
+def test_equals_6229():
+    ser = pd.Series([0, 1, None], dtype="uint8[pyarrow]")
+    ser2 = pd.Series([None, None, None], dtype="uint8[pyarrow]")
+    assert not ser.equals(ser2)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_ewm(data):
     modin_series, _ = create_test_series(data)  # noqa: F841

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1919,10 +1919,10 @@ def test_equals():
         df_equals(modin_df3, modin_df2)
 
 
-def test_equals_6229():
-    ser = pd.Series([0, 1, None], dtype="uint8[pyarrow]")
+def test_equals_with_nans():
+    ser1 = pd.Series([0, 1, None], dtype="uint8[pyarrow]")
     ser2 = pd.Series([None, None, None], dtype="uint8[pyarrow]")
-    assert not ser.equals(ser2)
+    assert not ser1.equals(ser2)
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6229 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
