### PR TITLE
REFACTOR-#6279: HDK DataFrame should not have more than one partition

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_algebra.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_algebra.py
@@ -180,7 +180,7 @@ class CalciteScanNode(CalciteBaseNode):
     """
 
     def __init__(self, modin_frame):
-        assert modin_frame._partitions.size == 1
+        assert modin_frame._partitions is not None
         assert modin_frame._partitions[0][0].frame_id is not None
         super(CalciteScanNode, self).__init__("EnumerableTableScan")
         self.table = ["hdk", modin_frame._partitions[0][0].frame_id]

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -1964,7 +1964,7 @@ class HdkOnNativeDataframe(PandasDataframe):
         if self._force_execution_mode != "hdk" and self._can_execute_arrow():
             new_table = self._execute_arrow()
             partitions = self._partition_mgr_cls.from_arrow(
-                new_table, unsupported_cols=False, encode_col_names=False
+                new_table, unsupported_cols=[], encode_col_names=False
             )[0]
         else:
             assert (

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/df_algebra.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/df_algebra.py
@@ -414,10 +414,7 @@ class FrameNode(DFAlgNode):
 
     @_inherit_docstrings(DFAlgNode.can_execute_arrow)
     def can_execute_arrow(self) -> bool:
-        frame = self.modin_frame
-        return not frame._has_unsupported_data and all(
-            p.arrow_table is not None for p in frame._partitions.flatten()
-        )
+        return self.modin_frame._has_arrow_table()
 
     def execute_arrow(self, ignore=None) -> Union[pa.Table, pandas.DataFrame]:
         """
@@ -435,7 +432,7 @@ class FrameNode(DFAlgNode):
         pa.Table or pandas.Dataframe
         """
         frame = self.modin_frame
-        if frame._partitions is not None and frame._partitions.size != 0:
+        if frame._partitions is not None:
             return frame._partitions[0][0].get()
         if frame._has_unsupported_data:
             return pandas.DataFrame(

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition.py
@@ -38,7 +38,7 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
 
     Attributes
     ----------
-    data :  pandas.DataFrame or pyarrow.Table
+    _data :  pandas.DataFrame or pyarrow.Table
         Partition data in either pandas or PyArrow format.
     frame_id : str
         A corresponding HDK table name if partition was imported
@@ -54,7 +54,7 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
         data: Union[pa.Table, pandas.DataFrame],
         frame_id: Optional[str] = None,
     ):
-        self.data = data
+        self._data = data
         self.frame_id = frame_id
         if isinstance(data, pa.Table):
             self._length_cache = data.num_rows
@@ -106,7 +106,7 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
         -------
         pandas.DataFrame or pyarrow.Table
         """
-        return self.data
+        return self._data
 
     @classmethod
     def put(cls, obj):

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition.py
@@ -12,13 +12,15 @@
 # governing permissions and limitations under the License.
 
 """Module provides a partition class for ``HdkOnNativeDataframe`` frame."""
+from typing import Optional, Union
 
 import pandas
+
+import pyarrow as pa
 
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from ..dataframe.utils import arrow_to_pandas
 from ..db_worker import DbWorker
-import pyarrow
 
 
 class HdkOnNativeDataframePartition(PandasDataframePartition):
@@ -29,27 +31,18 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
 
     Parameters
     ----------
+    data :  pandas.DataFrame or pyarrow.Table
+        Partition data in either pandas or PyArrow format.
     frame_id : str, optional
         A corresponding HDK table name or None.
-    pandas_df : pandas.DataFrame, optional
-        Partition data in pandas format.
-    arrow_table : pyarrow.Table, optional
-        Partition data in Arrow format.
-    length : int, optional
-        Length of the partition.
-    width : int, optional
-        Width of the partition.
 
     Attributes
     ----------
+    data :  pandas.DataFrame or pyarrow.Table
+        Partition data in either pandas or PyArrow format.
     frame_id : str
         A corresponding HDK table name if partition was imported
         into HDK. Otherwise None.
-    pandas_df : pandas.DataFrame, optional
-        Partition data in pandas format.
-    arrow_table : pyarrow.Table
-        Partition data in Arrow format. None for partitions holding
-        `pandas.DataFrame`.
     _length_cache : int
         Length of the partition.
     _width_cache : int
@@ -57,19 +50,24 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
     """
 
     def __init__(
-        self, frame_id=None, pandas_df=None, arrow_table=None, length=None, width=None
+        self,
+        data: Union[pa.Table, pandas.DataFrame],
+        frame_id: Optional[str] = None,
     ):
-        self.pandas_df = pandas_df
+        self.data = data
         self.frame_id = frame_id
-        self.arrow_table = arrow_table
-        self._length_cache = length
-        self._width_cache = width
-        self._server = DbWorker
+        if isinstance(data, pa.Table):
+            self._length_cache = data.num_rows
+            self._width_cache = data.num_columns
+        else:
+            assert isinstance(data, pandas.DataFrame)
+            self._length_cache = len(data)
+            self._width_cache = len(data.columns)
 
     def __del__(self):
         """Deallocate HDK resources related to the partition."""
         if self.frame_id is not None:
-            self._server.dropTable(self.frame_id)
+            DbWorker.dropTable(self.frame_id)
 
     def to_pandas(self):
         """
@@ -80,9 +78,9 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
         pandas.DataFrame
         """
         obj = self.get()
-        if isinstance(obj, (pandas.DataFrame, pandas.Series)):
+        if isinstance(obj, pandas.DataFrame):
             return obj
-        assert isinstance(obj, pyarrow.Table)
+        assert isinstance(obj, pa.Table)
         return arrow_to_pandas(obj)
 
     def to_numpy(self, **kwargs):
@@ -108,18 +106,16 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
         -------
         pandas.DataFrame or pyarrow.Table
         """
-        if self.arrow_table is not None:
-            return self.arrow_table
-        return self.pandas_df
+        return self.data
 
     @classmethod
     def put(cls, obj):
         """
-        Create partition from ``pandas.DataFrame`` or ``pandas.Series``.
+        Create partition from ``pandas.DataFrame`` or ``pyarrow.Table``.
 
         Parameters
         ----------
-        obj : pandas.Series or pandas.DataFrame
+        obj : pandas.DataFrame or pyarrow.Table
             Source frame.
 
         Returns
@@ -127,38 +123,4 @@ class HdkOnNativeDataframePartition(PandasDataframePartition):
         HdkOnNativeDataframePartition
             The new partition.
         """
-        return cls(pandas_df=obj.copy(), length=len(obj.index), width=len(obj.columns))
-
-    def wait(self):
-        """
-        Wait until the partition data is ready for use.
-
-        Returns
-        -------
-        pandas.DataFrame
-            The partition that is ready to be used.
-        """
-        if self.arrow_table is not None:
-            return self.arrow_table
-        return self.pandas_df
-
-    @classmethod
-    def put_arrow(cls, obj):
-        """
-        Create partition from ``pyarrow.Table``.
-
-        Parameters
-        ----------
-        obj : pyarrow.Table
-            Source table.
-
-        Returns
-        -------
-        HdkOnNativeDataframePartition
-            The new partition.
-        """
-        return cls(
-            arrow_table=obj,
-            length=len(obj),
-            width=len(obj.columns),
-        )
+        return cls(obj)

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -75,8 +75,8 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
             if not return_dims:
                 return np.array(parts), unsupported_cols
             else:
-                row_lengths = len(df)
-                col_widths = len(df.columns)
+                row_lengths = [len(df)]
+                col_widths = [len(df.columns)]
                 return np.array(parts), row_lengths, col_widths, unsupported_cols
         else:
             # Since we already have arrow table, putting it into partitions instead

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -96,7 +96,7 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
             Input table.
         return_dims : bool, default: False
             True to include dimensions into returned tuple.
-        unsupported_cols : list of str or False, optional
+        unsupported_cols : list of str, optional
             List of columns holding unsupported data. If None then
             check all columns to compute the list.
         encode_col_names : bool, default: True
@@ -119,8 +119,6 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
         parts = [[cls._partition_class(encoded_at)]]
         if unsupported_cols is None:
             _, unsupported_cols = cls._get_unsupported_cols(at)
-        elif unsupported_cols is False:
-            unsupported_cols = None
 
         if not return_dims:
             return np.array(parts), unsupported_cols

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -46,22 +46,9 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
     _partition_class = HdkOnNativeDataframePartition
 
     @classmethod
-    def _compute_num_partitions(cls):
-        """
-        Return a number of partitions a frame should be split to.
-
-        `HdkOnNativeDataframe` always has a single partition.
-
-        Returns
-        -------
-        int
-        """
-        return 1
-
-    @classmethod
     def from_pandas(cls, df, return_dims=False, encode_col_names=True):
         """
-        Create ``HdkOnNativeDataframe`` from ``pandas.DataFrame``.
+        Build partitions from a ``pandas.DataFrame``.
 
         Parameters
         ----------
@@ -84,28 +71,13 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
             # Putting pandas frame into partitions instead of arrow table, because we know
             # that all of operations with this frame will be default to pandas and don't want
             # unnecessaries conversion pandas->arrow->pandas
-
-            def tuple_wrapper(obj):
-                """
-                Wrap non-tuple object into a tuple.
-
-                Parameters
-                ----------
-                obj : Any.
-                    Wrapped object.
-
-                Returns
-                -------
-                tuple
-                """
-                if not isinstance(obj, tuple):
-                    obj = (obj,)
-                return obj
-
-            return (
-                *tuple_wrapper(super().from_pandas(df, return_dims)),
-                unsupported_cols,
-            )
+            parts = [[cls._partition_class(df)]]
+            if not return_dims:
+                return np.array(parts), unsupported_cols
+            else:
+                row_lengths = len(df)
+                col_widths = len(df.columns)
+                return np.array(parts), row_lengths, col_widths, unsupported_cols
         else:
             # Since we already have arrow table, putting it into partitions instead
             # of pandas frame, to skip that phase when we will be putting our frame to HDK
@@ -116,7 +88,7 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
         cls, at, return_dims=False, unsupported_cols=None, encode_col_names=True
     ):
         """
-        Build frame from Arrow table.
+        Build partitions from a ``pyarrow.Table``.
 
         Parameters
         ----------
@@ -124,7 +96,7 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
             Input table.
         return_dims : bool, default: False
             True to include dimensions into returned tuple.
-        unsupported_cols : list of str, optional
+        unsupported_cols : list of str or False, optional
             List of columns holding unsupported data. If None then
             check all columns to compute the list.
         encode_col_names : bool, default: True
@@ -144,10 +116,11 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
         else:
             encoded_at = at
 
-        put_func = cls._partition_class.put_arrow
-        parts = [[put_func(encoded_at)]]
+        parts = [[cls._partition_class(encoded_at)]]
         if unsupported_cols is None:
             _, unsupported_cols = cls._get_unsupported_cols(at)
+        elif unsupported_cols is False:
+            unsupported_cols = None
 
         if not return_dims:
             return np.array(parts), unsupported_cols
@@ -277,10 +250,6 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
         # First step is to make sure all partitions are in HDK.
         frames = plan.collect_frames()
         for frame in frames:
-            if frame._partitions.size != 1:
-                raise NotImplementedError(
-                    "HdkOnNative engine doesn't support partitioned frames"
-                )
             for p in frame._partitions.flatten():
                 if p.frame_id is None:
                     obj = p.get()
@@ -319,7 +288,7 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
         # workaround for https://github.com/modin-project/modin/issues/1851
         if DoUseCalcite.get():
             at = at.rename_columns([ColNameCodec.encode(c) for c in columns])
-        res[0][0] = cls._partition_class.put_arrow(at)
+        res[0][0] = cls._partition_class(at)
 
         return res
 


### PR DESCRIPTION
Now the partitions could be either None or contain a single non-empty partition.

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6279 <!-- issue must be created for each patch -->
- [] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
