### PR TITLE
FIX-#6294: implement `__iter__` for `array` class that defaults to numpy

### DIFF
--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -734,6 +734,16 @@ class array(object):
 
     absolute = __abs__
 
+    def __iter__(self):
+        """
+        Return an iterator of the values.
+
+        Returns
+        -------
+        iterable
+        """
+        return self._to_numpy().__iter__()
+
     def __invert__(self):
         """
         Apply bitwise inverse to each element of the `BasePandasDataset`.


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6294 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
