### PR TITLE
FIX-#6297: fix experimental numpy.argmax/argmin with Nans in data

### DIFF
--- a/modin/numpy/arr.py
+++ b/modin/numpy/arr.py
@@ -2239,7 +2239,7 @@ class array(object):
         na_mask = self._query_compiler.isna().any(axis=apply_axis)
         if na_mask.any(axis=apply_axis ^ 1).to_numpy()[0, 0]:
             na_idxs = self._query_compiler.isna().idxmax(axis=apply_axis)
-            result = na_mask.where(na_idxs, result)
+            result = na_idxs.where(na_mask, result)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             result = result.to_numpy()[0, 0]
@@ -2304,7 +2304,7 @@ class array(object):
         na_mask = self._query_compiler.isna().any(axis=apply_axis)
         if na_mask.any(axis=apply_axis ^ 1).to_numpy()[0, 0]:
             na_idxs = self._query_compiler.isna().idxmax(axis=apply_axis)
-            result = na_mask.where(na_idxs, result)
+            result = na_idxs.where(na_mask, result)
         new_ndim = self._ndim - 1 if not keepdims else self._ndim
         if new_ndim == 0:
             result = result.to_numpy()[0, 0]

--- a/modin/numpy/test/test_array.py
+++ b/modin/numpy/test/test_array.py
@@ -271,6 +271,16 @@ def test_array_where():
     assert_scalar_or_array_equal(modin_result, numpy_result)
 
 
+@pytest.mark.parametrize("method", ["argmax", "argmin"])
+def test_argmax_argmin(method):
+    numpy_arr = numpy.array([[1, 2, 3], [4, 5, np.NaN]])
+    modin_arr = np.array(numpy_arr)
+    assert_scalar_or_array_equal(
+        getattr(np, method)(modin_arr, axis=1),
+        getattr(numpy, method)(numpy_arr, axis=1),
+    )
+
+
 def test_flatten():
     numpy_flat_arr = numpy.random.randint(-100, 100, size=100)
     modin_flat_arr = np.array(numpy_flat_arr)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6297 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
