### PR TITLE
FIX-#6299: __array__ method always returns array of vanilla numpy

### DIFF
--- a/modin/numpy/test/test_array.py
+++ b/modin/numpy/test/test_array.py
@@ -331,3 +331,12 @@ def test_set_shape():
     assert_scalar_or_array_equal(modin_arr, numpy_arr)
     with pytest.raises(ValueError, match="cannot reshape"):
         modin_arr.shape = (4,)
+
+
+def test__array__():
+    numpy_arr = numpy.array([[1, 2, 3], [4, 5, 6]])
+    modin_arr = np.array(numpy_arr)
+    # this implicitly calls `__array__`
+    converted_array = numpy.array(modin_arr)
+    assert type(converted_array) == type(numpy_arr)
+    assert_scalar_or_array_equal(converted_array, numpy_arr)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3104,11 +3104,23 @@ class BasePandasDataset(ClassLogger):
             storage_options=storage_options,
         )
 
-    def to_numpy(
+    def _to_bare_numpy(
         self, dtype=None, copy=False, na_value=no_default
     ):  # noqa: PR01, RT01, D200
         """
         Convert the `BasePandasDataset` to a NumPy array.
+        """
+        return self._query_compiler.to_numpy(
+            dtype=dtype,
+            copy=copy,
+            na_value=na_value,
+        )
+
+    def to_numpy(
+        self, dtype=None, copy=False, na_value=no_default
+    ):  # noqa: PR01, RT01, D200
+        """
+        Convert the `BasePandasDataset` to a NumPy array or a Modin wrapper for NumPy array.
         """
         from modin.config import ExperimentalNumPyAPI
 
@@ -3117,7 +3129,7 @@ class BasePandasDataset(ClassLogger):
 
             return array(self, copy=copy)
 
-        return self._query_compiler.to_numpy(
+        return self._to_bare_numpy(
             dtype=dtype,
             copy=copy,
             na_value=na_value,
@@ -3438,17 +3450,7 @@ class BasePandasDataset(ClassLogger):
         arr : np.ndarray
             NumPy representation of Modin object.
         """
-        from modin.config import ExperimentalNumPyAPI
-
-        exp_numpy_api = ExperimentalNumPyAPI.get()
-        try:
-            if exp_numpy_api:
-                ExperimentalNumPyAPI.put(False)
-            arr = self.to_numpy(dtype)
-        finally:
-            if exp_numpy_api:
-                ExperimentalNumPyAPI.put(True)
-        return arr
+        return self._to_bare_numpy(dtype)
 
     def __copy__(self, deep=True):
         """

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3438,7 +3438,16 @@ class BasePandasDataset(ClassLogger):
         arr : np.ndarray
             NumPy representation of Modin object.
         """
-        arr = self.to_numpy(dtype)
+        from modin.config import ExperimentalNumPyAPI
+
+        exp_numpy_api = ExperimentalNumPyAPI.get()
+        try:
+            if exp_numpy_api:
+                ExperimentalNumPyAPI.put(False)
+            arr = self.to_numpy(dtype)
+        finally:
+            if exp_numpy_api:
+                ExperimentalNumPyAPI.put(True)
         return arr
 
     def __copy__(self, deep=True):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6299 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
