### PR TITLE
FEAT-#6296: Add pyhdk feature flags

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,6 +13,7 @@ import types
 
 import ray
 
+
 # stub ray.remote to be a no-op so it doesn't shadow docstrings
 def noop_decorator(*args, **kwargs):
     if len(args) == 1 and len(kwargs) == 0 and callable(args[0]):
@@ -43,6 +44,9 @@ if not hasattr(sys.modules["pyhdk.hdk"], "ExecutionResult"):
     sys.modules["pyhdk.hdk"].ExecutionResult = type("ExecutionResult", (object,), {})
 if not hasattr(sys.modules["pyhdk.hdk"], "RelAlgExecutor"):
     sys.modules["pyhdk.hdk"].RelAlgExecutor = type("RelAlgExecutor", (object,), {})
+if not hasattr(sys.modules["pyhdk"], "__version__"):
+    # Show all known pyhdk config options in documentation
+    sys.modules["pyhdk"].__version__ = "999"
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import modin

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -517,15 +517,6 @@ class HdkLaunchParameters(EnvironmentVariable, type=dict):
     """
 
     varname = "MODIN_HDK_LAUNCH_PARAMETERS"
-    default = {
-        "enable_union": 1,
-        "enable_columnar_output": 1,
-        "enable_lazy_fetch": 0,
-        "null_div_by_zero": 1,
-        "enable_watchdog": 0,
-        "enable_thrift_logs": 0,
-        "cpu_only": 1,
-    }
 
     @classmethod
     def get(cls) -> dict:
@@ -558,11 +549,43 @@ class HdkLaunchParameters(EnvironmentVariable, type=dict):
             Decoded and verified config value.
         """
         custom_parameters = super().get()
-        result = cls.default.copy()
+        result = cls._get_default().copy()
         result.update(
             {key.replace("-", "_"): value for key, value in custom_parameters.items()}
         )
         return result
+
+    @classmethod
+    def _get_default(cls) -> Any:
+        """
+        Get default value of the config. Checks the pyhdk version and omits variables unsupported in prior versions.
+
+        Returns
+        -------
+        dict
+            Config keys and corresponding values.
+        """
+        if (default := getattr(cls, "default", None)) is None:
+            cls.default = default = {
+                "enable_union": 1,
+                "enable_columnar_output": 1,
+                "enable_lazy_fetch": 0,
+                "null_div_by_zero": 1,
+                "enable_watchdog": 0,
+                "enable_thrift_logs": 0,
+                "cpu_only": 1,
+            }
+
+            try:
+                import pyhdk
+
+                if version.parse(pyhdk.__version__) >= version.parse("0.6.1"):
+                    default["enable_lazy_dict_materialization"] = 0
+                    default["log_dir"] = "pyhdk_log"
+            except ImportError:
+                # if pyhdk is not available, do not show any additional options
+                pass
+        return default
 
 
 class OmnisciLaunchParameters(HdkLaunchParameters, type=dict):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

* Adds feature flag controlling lazy dictionary materialization. Lazy dict materialization delays building dictionaries for text types until query time. For datasets with large numbers of text columns that are not directly processed, this can speed up import and querying. 
* Adds feature flag to set the log file directory. Can be set to the tmp directory to suppress log artifacts. This was a request from a benchmarking team. 

These features are available in HDK main branch now and will be released this week. The version check prevents passing the flags to earlier versions of HDK which do not support them.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6296 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
