### PR TITLE
PERF-#0000: use apply_select_indices instead of apply_full_axis_select_indices for insert

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2776,12 +2776,19 @@ class PandasDataframe(ClassLogger):
                 self._row_lengths_cache,
                 self._column_widths_cache,
             )
+            columns_cache = self._column_widths_cache
+            if (
+                new_columns is not None
+                and columns_cache is not None
+                and len(new_columns) != sum(columns_cache)
+            ):
+                columns_cache[-1] = columns_cache[-1] + 1
             return self.__constructor__(
                 new_partitions,
                 new_index,
                 new_columns,
                 self._row_lengths_cache,
-                self._column_widths_cache,
+                columns_cache,
             )
 
     @lazy_metadata_decorator(apply_axis="both")

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1313,6 +1313,10 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
                 if item_to_distribute is not no_default:
                     if isinstance(item_to_distribute, np.ndarray):
+                        if len(item_to_distribute.shape) == 1:
+                            item_to_distribute = item_to_distribute.reshape(
+                                (item_to_distribute[0], 1)
+                            )
                         item = item_to_distribute[
                             row_position_counter : row_position_counter + row_offset,
                             col_position_counter : col_position_counter + col_offset,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2427,7 +2427,16 @@ class DataFrame(BasePandasDataset):
                 self.columns = prev_index.insert(0, key)
                 return
             # Do new column assignment after error checks and possible value modifications
-            self.insert(loc=len(self.columns), column=key, value=value)
+            item = value
+            if not hasattr(value, "_query_compiler"):
+                item = broadcast_item(
+                    self,
+                    slice(None),
+                    key,
+                    value,
+                    need_columns_reindex=False,
+                )
+            self.insert(loc=len(self.columns), column=key, value=item)
             return
 
         if not hashable(key):

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -338,6 +338,8 @@ def broadcast_item(
     new_row_len = (
         len(obj.index[row_lookup]) if isinstance(row_lookup, slice) else len(row_lookup)
     )
+    if isinstance(col_lookup, str):
+        col_lookup = [col_lookup]
     new_col_len = (
         len(obj.columns[col_lookup])
         if isinstance(col_lookup, slice)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
