### PR TITLE
FIX-#1851: Squash multiple LogicalProject nodes

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
@@ -738,6 +738,18 @@ class CalciteBuilder:
         node : CalciteBaseNode
             A node to add.
         """
+        if (
+            len(self.res) != 0
+            and isinstance(node, CalciteProjectionNode)
+            and isinstance(self.res[-1], CalciteProjectionNode)
+            and all(isinstance(expr, CalciteInputRefExpr) for expr in node.exprs)
+        ):
+            # Replace the last CalciteProjectionNode with this one and
+            # translate the input refs.
+            exprs = self.res.pop().exprs
+            node = CalciteProjectionNode(
+                node.fields, [exprs[expr.input] for expr in node.exprs]
+            )
         self.res.append(node)
 
     def _last(self):

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -2041,9 +2041,7 @@ class HdkOnNativeDataframe(PandasDataframe):
                 new_table, unsupported_cols=[], encode_col_names=False
             )[0]
         else:
-            partitions = self._partition_mgr_cls.run_exec_plan(
-                self._op, self._table_cols
-            )
+            partitions = self._partition_mgr_cls.run_exec_plan(self._op)
 
         self._partitions = partitions
         self._op = FrameNode(self)

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
@@ -429,12 +429,12 @@ def get_data_for_join_by_index(
         index_cols = None
     else:
         index_cols = ColNameCodec.mangle_index_names(merged.index.names)
-        for orig_name, mangled_name in zip(merged.index.names, index_cols):
+        for name in index_cols:
             # Using _dtypes here since it contains all column names,
             # including the index.
-            df = left if mangled_name in left._dtypes else right
-            exprs[orig_name] = df.ref(mangled_name)
-            new_dtypes.append(df._dtypes[mangled_name])
+            df = left if name in left._dtypes else right
+            exprs[name] = df.ref(name)
+            new_dtypes.append(df._dtypes[name])
 
     left_col_names = set(left.columns)
     right_col_names = set(right.columns)

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -227,7 +227,7 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
         )
 
     @classmethod
-    def run_exec_plan(cls, plan, columns):
+    def run_exec_plan(cls, plan):
         """
         Run execution plan in HDK storage format to materialize frame.
 
@@ -235,8 +235,6 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
         ----------
         plan : DFAlgNode
             A root of an execution plan tree.
-        columns : list of str
-            A frame column names.
 
         Returns
         -------
@@ -255,10 +253,6 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
         if DoUseCalcite.get():
             calcite_json = "execute calcite " + calcite_json
         table = worker.executeRA(calcite_json)
-
-        # workaround for https://github.com/modin-project/modin/issues/1851
-        if DoUseCalcite.get():
-            table._column_names = [ColNameCodec.encode(c) for c in columns]
 
         res = np.empty((1, 1), dtype=np.dtype(object))
         res[0][0] = cls._partition_class(table)


### PR DESCRIPTION
## What do these changes do?

In case of multiple sequential LogicalProject nodes, Calcite squashes them, but gets the column names from the first one. To fix the issue, squash on the Modin side and keep the names from the last one.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #1851 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
