### PR TITLE
TEST-#6315: increase 'install_timeout' for ASV benchmarks: 600 -> 6000 sec

### DIFF
--- a/asv_bench/asv.conf.dask.json
+++ b/asv_bench/asv.conf.dask.json
@@ -48,7 +48,7 @@
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min
-    //"install_timeout": 600,
+    "install_timeout": 6000,
 
     // the base URL to show a commit for the project.
     "show_commit_url": "https://github.com/modin-project/modin/commit/",

--- a/asv_bench/asv.conf.hdk.json
+++ b/asv_bench/asv.conf.hdk.json
@@ -25,6 +25,10 @@
     // variable.
     "environment_type": "conda",
 
+    // timeout in seconds for installing any dependencies in environment
+    // defaults to 10 min
+    "install_timeout": 6000,
+
     // the base URL to show a commit for the project.
     "show_commit_url": "https://github.com/modin-project/modin/commit/",
 

--- a/asv_bench/asv.conf.json
+++ b/asv_bench/asv.conf.json
@@ -48,7 +48,7 @@
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min
-    //"install_timeout": 600,
+    "install_timeout": 6000,
 
     // the base URL to show a commit for the project.
     "show_commit_url": "https://github.com/modin-project/modin/commit/",

--- a/asv_bench/asv.conf.unidist.json
+++ b/asv_bench/asv.conf.unidist.json
@@ -48,7 +48,7 @@
 
     // timeout in seconds for installing any dependencies in environment
     // defaults to 10 min
-    //"install_timeout": 600,
+    "install_timeout": 6000,
 
     // the base URL to show a commit for the project.
     "show_commit_url": "https://github.com/modin-project/modin/commit/",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Avoid errors like in https://github.com/modin-project/modin/actions/runs/5406761992/jobs/9825588358?pr=6286

```bash
  File "/usr/share/miniconda/lib/python3.10/site-packages/asv/plugins/conda.py", line 227, in _run_conda
    return util.check_output([conda] + args, env=env)
  File "/usr/share/miniconda/lib/python3.10/site-packages/asv/util.py", line 754, in check_output
    raise ProcessError(args, retcode, stdout, stderr)
asv.util.ProcessError: Command '/usr/share/miniconda/bin/conda env create -f ../requirements/env_hdk.yml -p /home/runner/work/modin/modin/asv_bench/.asv/env/6df994238d3562d4e97431b9f4cec556 --force' timed out
```

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6315 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
