### PR TITLE
FEAT-#6322: Give a warning only if the major or minor part of pandas version are different

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -26,6 +26,9 @@ if (
         + f" Modin ({__pandas_version__}.X). This may cause undesired side effects!"
     )
 
+# to not pollute namespace
+del version
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     from pandas import (

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -13,13 +13,17 @@
 
 import pandas
 import warnings
+from packaging import version
 
-__pandas_version__ = "2.0.3"
+__pandas_version__ = "2.0"
 
-if pandas.__version__ != __pandas_version__:
+if (
+    version.parse(pandas.__version__).release[:2]
+    != version.parse(__pandas_version__).release[:2]
+):
     warnings.warn(
         f"The pandas version installed ({pandas.__version__}) does not match the supported pandas version in"
-        + f" Modin ({__pandas_version__}). This may cause undesired side effects!"
+        + f" Modin ({__pandas_version__}.X). This may cause undesired side effects!"
     )
 
 with warnings.catch_warnings():

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -14,7 +14,7 @@
 import pandas
 import warnings
 
-__pandas_version__ = "2.0.2"
+__pandas_version__ = "2.0.3"
 
 if pandas.__version__ != __pandas_version__:
     warnings.warn(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

CI using pandas version 2.0.3 for a couple of days now and it works.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6322 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
