### PR TITLE
FIX-#5077: fix `Series.rename_axis` signature

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1412,6 +1412,22 @@ class Series(BasePandasDataset):
             fill_value=fill_value,
         )
 
+    def rename_axis(
+        self,
+        mapper=no_default,
+        *,
+        index=no_default,
+        axis=0,
+        copy=True,
+        inplace=False,
+    ):  # noqa: PR01, RT01, D200
+        """
+        Set the name of the axis for the index or columns.
+        """
+        return super().rename_axis(
+            mapper=mapper, index=index, axis=axis, copy=copy, inplace=inplace
+        )
+
     def rename(
         self,
         index=None,

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -272,8 +272,6 @@ def test_series_api_equality():
 
     # These have to be checked manually
     allowed_different = ["to_hdf", "hist"]
-    # skip verifying .rename_axis() due to https://github.com/modin-project/modin/issues/5077
-    allowed_different.append("rename_axis")
 
     assert_parameters_eq((pandas.Series, pd.Series), modin_dir, allowed_different)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5077 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
