### PR TITLE
FEAT-#6325: Add GPU execution option for HDK backend

### DIFF
--- a/docs/development/using_hdk.rst
+++ b/docs/development/using_hdk.rst
@@ -37,8 +37,9 @@ If for some reasons ``Native`` engine is explicitly set using ``modin.config`` o
 
 Running on a GPU
 ----------------
+
 Prerequisites:
-* HDK’s GPU mode is currently supported on Linux and Intel GPU only.
+* HDK's GPU mode is currently supported on Linux and Intel GPU only.
 * HDK supports Gen9 architecture and higher (including Xe & Arc).
 * HDK's GPU mode requires proper driver installation. Follow this guide_ to set up your system. Make sure to install the compute runtime packages: ``intel-opencl-icd``, ``intel-level-zero-gpu``, ``level-zero``.
 * Make sure your GPU is visible and accessible.

--- a/docs/development/using_hdk.rst
+++ b/docs/development/using_hdk.rst
@@ -36,10 +36,9 @@ If for some reasons ``Native`` engine is explicitly set using ``modin.config`` o
 
 
 Running on a GPU
----
-
+----------------
 Prerequisites:
-* HDK’s GPU mode is currently supported on Linux only.
+* HDK’s GPU mode is currently supported on Linux and Intel GPU only.
 * HDK supports Gen9 architecture and higher (including Xe & Arc).
 * HDK's GPU mode requires proper driver installation. Follow this guide_ to set up your system. Make sure to install the compute runtime packages: ``intel-opencl-icd``, ``intel-level-zero-gpu``, ``level-zero``.
 * Make sure your GPU is visible and accessible.
@@ -47,9 +46,8 @@ Prerequisites:
 .. note::
    You can use ``hwinfo`` and ``clinfo`` utilities to verify the driver installation and device accessibility.
 
-HDK supports a heterogeneous execution mode (experimental) that is disabled by default in Modin. Starting with pyHDK version 0.8 Modin can run the workload on Intel GPU.
+HDK supports a heterogeneous execution mode (experimental) that is disabled by default in Modin. Starting with pyHDK version 0.7 Modin can run the workload on Intel GPU.
 Run on a GPU via ``MODIN_HDK_LAUNCH_PARAMETERS="cpu_only=0" python <your-script.py>``.
-
 
 .. _HDK: https://github.com/intel-ai/hdk
 .. _guide: https://dgpu-docs.intel.com/driver/installation.html

--- a/docs/development/using_hdk.rst
+++ b/docs/development/using_hdk.rst
@@ -34,4 +34,22 @@ If for some reasons ``Native`` engine is explicitly set using ``modin.config`` o
    If you encounter ``LLVM ERROR: inconsistency in registered CommandLine options`` error when using HDK,
    please refer to the respective section in :doc:`Troubleshooting </getting_started/troubleshooting>` page to avoid the issue.
 
+
+Running on a GPU
+---
+
+Prerequisites:
+* HDK’s GPU mode is currently supported on Linux only.
+* HDK supports Gen9 architecture and higher (including Xe & Arc).
+* HDK's GPU mode requires proper driver installation. Follow this guide_ to set up your system. Make sure to install the compute runtime packages: ``intel-opencl-icd``, ``intel-level-zero-gpu``, ``level-zero``.
+* Make sure your GPU is visible and accessible.
+
+.. note::
+   You can use ``hwinfo`` and ``clinfo`` utilities to verify the driver installation and device accessibility.
+
+HDK supports a heterogeneous execution mode (experimental) that is disabled by default in Modin. Starting with pyHDK version 0.8 Modin can run the workload on Intel GPU.
+Run on a GPU via ``MODIN_HDK_LAUNCH_PARAMETERS="cpu_only=0" python <your-script.py>``.
+
+
 .. _HDK: https://github.com/intel-ai/hdk
+.. _guide: https://dgpu-docs.intel.com/driver/installation.html

--- a/docs/development/using_hdk.rst
+++ b/docs/development/using_hdk.rst
@@ -39,6 +39,7 @@ Running on a GPU
 ----------------
 
 Prerequisites:
+
 * HDK's GPU mode is currently supported on Linux and Intel GPU only.
 * HDK supports Gen9 architecture and higher (including Xe & Arc).
 * HDK's GPU mode requires proper driver installation. Follow this guide_ to set up your system. Make sure to install the compute runtime packages: ``intel-opencl-icd``, ``intel-level-zero-gpu``, ``level-zero``.

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -524,6 +524,7 @@ class HdkLaunchParameters(EnvironmentVariable, type=dict):
         "null_div_by_zero": 1,
         "enable_watchdog": 0,
         "enable_thrift_logs": 0,
+        "cpu_only": 1,
     }
 
     @classmethod


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Add an option to run Modin on GPU via HDK. The behavior is controlled by an existing `cpu_only` config option as described in the updated doc.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6325 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
