### PR TITLE
FIX-#6341: call `_filter_empties` only if shapes are different on particular axis

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3606,7 +3606,8 @@ class PandasDataframe(ClassLogger):
 
         if by_parts is not None:
             # inplace operation
-            self._filter_empties(compute_metadata=False)
+            if by_parts.shape[axis] != self._partitions.shape[axis]:
+                self._filter_empties(compute_metadata=False)
         new_partitions = self._partition_mgr_cls.groupby_reduce(
             axis, self._partitions, by_parts, map_func, reduce_func, apply_indices
         )

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -737,6 +737,14 @@ def test_groupby_with_empty_partition():
     # check index error due to partitioning missmatching
     grp_obj.count()
 
+    md_df = construct_modin_df_by_scheme(
+        pandas_df=pandas.DataFrame({"a": [1, 1, 2, 2], "b": [3, 4, 5, 6]}),
+        partitioning_scheme={"row_lengths": [2, 2], "column_widths": [2]},
+    )
+    md_res = md_df.query("a > 1")
+    grp_obj = md_res.groupby(md_res["a"])
+    grp_obj.count()
+
 
 @pytest.mark.parametrize("set_num_partitions", [2], indirect=True)
 def test_repartitioning(set_num_partitions):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6341 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
