### PR TITLE
FIX-#6336: pin 'pydantic<2' to fix CI

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -14,6 +14,8 @@ sphinx<6.0.0
 sphinx-click
 # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
 ray[default]>=1.13.0,!=2.5.0
+# https://github.com/modin-project/modin/issues/6336
+pydantic<2
 # Override to latest version of modin-spreadsheet
 git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
 sphinxcontrib_plantuml

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -6,6 +6,8 @@ dependencies:
   - numpy>=1.18.5
   # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
   - ray-default>=1.13.0,!=2.5.0
+  # https://github.com/modin-project/modin/issues/6336
+  - pydantic<2
   - pyarrow
   # workaround for https://github.com/conda/conda/issues/11744
   - grpcio!=1.45.*

--- a/examples/tutorial/jupyter/execution/pandas_on_ray/requirements.txt
+++ b/examples/tutorial/jupyter/execution/pandas_on_ray/requirements.txt
@@ -3,4 +3,6 @@ jupyterlab
 ipywidgets
 tqdm
 modin[ray]
+# https://github.com/modin-project/modin/issues/6336
+pydantic<2
 modin[spreadsheet]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,8 @@ dask[complete]>=2.22.0
 distributed>=2.22.0
 # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
 ray[default]>=1.13.0,!=2.5.0
+# https://github.com/modin-project/modin/issues/6336
+pydantic<2
 pyarrow
 psutil
 fsspec

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,8 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 dask_deps = ["dask>=2.22.0", "distributed>=2.22.0"]
 # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
-ray_deps = ["ray[default]>=1.13.0,!=2.5.0", "pyarrow"]
+# pydantic<2: https://github.com/modin-project/modin/issues/6336
+ray_deps = ["ray[default]>=1.13.0,!=2.5.0", "pyarrow", "pydantic<2"]
 unidist_deps = ["unidist[mpi]>=0.2.1"]
 remote_deps = ["rpyc==4.1.5", "cloudpickle", "boto3"]
 spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6336 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
