### PR TITLE
FIX-#6338: fix TypeError: WorksheetReader.__init__() got an unexpected keyword argument 'rich_text'

### DIFF
--- a/modin/core/io/text/excel_dispatcher.py
+++ b/modin/core/io/text/excel_dispatcher.py
@@ -147,7 +147,7 @@ class ExcelDispatcher(TextFileDispatcher):
                 ex.shared_strings,
                 False,
             )
-            if cls.need_rich_text_param:
+            if cls.need_rich_text_param():
                 reader = WorksheetReader(*common_args, rich_text=False)
             else:
                 reader = WorksheetReader(*common_args)

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -557,8 +557,8 @@ class PandasExcelParser(PandasParser):
 
         return cell.value
 
-    @property
-    def need_rich_text_param(self):
+    @staticmethod
+    def need_rich_text_param():
         """
         Determine whether a required `rich_text` parameter should be specified for the ``WorksheetReader`` constructor.
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

It is correct to call property only from a class instance.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6338 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
