### PR TITLE
FIX-#4485: fix 'clip' with list-like bounds and axis=None

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1083,8 +1083,6 @@ class BasePandasDataset(ClassLogger):
         if upper is not None and np.any(np.isnan(upper)):
             upper = None
         if is_list_like(lower) or is_list_like(upper):
-            if axis is None:
-                raise ValueError("Must specify axis = 0 or 1")
             lower = self._validate_other(lower, axis)
             upper = self._validate_other(upper, axis)
         # FIXME: Judging by pandas docs `*args` and `**kwargs` serves only compatibility

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -893,6 +893,12 @@ def test_clip(request, data, axis, bound_type):
             modin_df.clip(lower=[1, 2, 3], axis=None)
 
 
+def test_clip_4485():
+    modin_result = pd.DataFrame([1]).clip([3])
+    pandas_result = pandas.DataFrame([1]).clip([3])
+    df_equals(modin_result, pandas_result)
+
+
 def test_drop():
     frame_data = {"A": [1, 2, 3, 4], "B": [0, 1, 2, 3]}
     simple = pandas.DataFrame(frame_data)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2898,6 +2898,12 @@ def test_repeat_lists(data, repeats):
     )
 
 
+def test_clip_4485():
+    modin_result = pd.Series([1]).clip([3])
+    pandas_result = pandas.Series([1]).clip([3])
+    df_equals(modin_result, pandas_result)
+
+
 def test_replace():
     modin_series = pd.Series([0, 1, 2, 3, 4])
     pandas_series = pandas.Series([0, 1, 2, 3, 4])


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4485 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
