### PR TITLE
FEAT-#6351: Add a simple heuristic for fragment size when running on a GPU

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/base_worker.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/base_worker.py
@@ -15,13 +15,11 @@
 
 import abc
 import uuid
-import os
 from typing import Tuple, List
 
 import pyarrow as pa
 import numpy as np
 
-from modin.config import OmnisciFragmentSize, HdkFragmentSize
 from modin.error_message import ErrorMessage
 
 
@@ -240,36 +238,6 @@ class BaseDbWorker(abc.ABC):
                 ) from err
 
         return table
-
-    @classmethod
-    def compute_fragment_size(cls, table):
-        """
-        Compute fragment size to be used for table import.
-
-        Parameters
-        ----------
-        table : pyarrow.Table
-            A table to import.
-
-        Returns
-        -------
-        int
-            Fragment size to use for import.
-        """
-        fragment_size = HdkFragmentSize.get()
-        if fragment_size is None:
-            fragment_size = OmnisciFragmentSize.get()
-        if fragment_size is None:
-            cpu_count = os.cpu_count()
-            if cpu_count is not None:
-                fragment_size = table.num_rows // cpu_count
-                fragment_size = min(fragment_size, 2**25)
-                fragment_size = max(fragment_size, 2**18)
-            else:
-                fragment_size = 0
-        else:
-            fragment_size = int(fragment_size)
-        return fragment_size
 
     @classmethod
     @abc.abstractmethod


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Set fragment size to a constant for GPU execution via HDK.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6351 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
