### PR TITLE
FIX-#6334: improve error message if hdk isn't installed in the environment

### DIFF
--- a/modin/core/execution/dispatching/factories/dispatcher.py
+++ b/modin/core/execution/dispatching/factories/dispatcher.py
@@ -155,7 +155,16 @@ class FactoryDispatcher(object):
                 raise FactoryNotFoundError(msg.format(factory_name))
             cls.__factory = StubFactory.set_failing_name(factory_name)
         else:
-            cls.__factory.prepare()
+            try:
+                cls.__factory.prepare()
+            except ModuleNotFoundError as err:
+                # incorrectly initialized, should be reset to None again
+                # so that an unobvious error does not appear in the following code:
+                # "AttributeError: 'NoneType' object has no attribute 'from_non_pandas'"
+                cls.__factory = None
+                raise ModuleNotFoundError(
+                    f"Make sure all required packages are installed: {str(err)}"
+                ) from err
 
     @classmethod
     @_inherit_docstrings(factories.BaseFactory._from_pandas)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6334 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
