### PR TITLE
TEST-#5008: Set benchmark mode within unit test instead of with environment variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -389,7 +389,7 @@ jobs:
         run: |
           sudo docker pull postgres
           sudo docker run --name some-postgres -e POSTGRES_USER=sa -e POSTGRES_PASSWORD=Strong.Pwd-123 -e POSTGRES_DB=postgres -d -p 2345:5432 postgres
-      - run: MODIN_BENCHMARK_MODE=True mpiexec -n 1 python -m pytest modin/pandas/test/internals/test_benchmark_mode.py
+      - run: mpiexec -n 1 python -m pytest modin/pandas/test/internals/test_benchmark_mode.py
       - run: mpiexec -n 1 python -m pytest modin/pandas/test/internals/test_repartition.py
       - run: mpiexec -n 1 python -m pytest modin/test/test_partition_api.py
       - uses: ./.github/actions/run-core-tests
@@ -486,7 +486,7 @@ jobs:
           sudo docker run --name some-postgres -e POSTGRES_USER=sa -e POSTGRES_PASSWORD=Strong.Pwd-123 -e POSTGRES_DB=postgres -d -p 2345:5432 postgres
         if: matrix.os == 'ubuntu'
 
-      - run: MODIN_BENCHMARK_MODE=True python -m pytest modin/pandas/test/internals/test_benchmark_mode.py
+      - run: python -m pytest modin/pandas/test/internals/test_benchmark_mode.py
         if: matrix.engine == 'python' || matrix.test_task == 'group_1'
       - run: python -m pytest modin/pandas/test/internals/test_repartition.py
         if: matrix.engine == 'python' || matrix.test_task == 'group_1'

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -62,6 +62,7 @@ from modin.config import (  # noqa: E402
     CIAWSAccessKeyID,
     CIAWSSecretAccessKey,
     AsyncReadMode,
+    BenchmarkMode,
 )
 import uuid  # noqa: E402
 
@@ -556,6 +557,14 @@ def set_num_partitions(request):
     NPartitions.put(request.param)
     yield
     NPartitions.put(old_num_partitions)
+
+
+@pytest.fixture()
+def set_benchmark_mode(request):
+    old_benchmark_mode = BenchmarkMode.get()
+    BenchmarkMode.put(request.param)
+    yield
+    BenchmarkMode.put(old_benchmark_mode)
 
 
 @pytest.fixture

--- a/modin/pandas/test/internals/test_benchmark_mode.py
+++ b/modin/pandas/test/internals/test_benchmark_mode.py
@@ -13,9 +13,10 @@
 
 import unittest.mock as mock
 
+import pytest
+
 import modin.pandas as pd
-from modin.pandas.test.utils import test_data_values
-from modin.config import BenchmarkMode, Engine
+from modin.config import Engine
 
 
 engine = Engine.get()
@@ -46,26 +47,17 @@ else:
     )
 
 
-def test_from_environment_variable():
-    assert BenchmarkMode.get()
-    with mock.patch(wait_method) as wait:
-        pd.DataFrame(test_data_values[0]).mean()
-
-    wait.assert_called()
-
-
-def test_turn_off():
+@pytest.mark.parametrize("set_benchmark_mode", [False], indirect=True)
+def test_turn_off(set_benchmark_mode):
     df = pd.DataFrame([0])
-    BenchmarkMode.put(False)
     with mock.patch(wait_method) as wait:
         df.dropna()
     wait.assert_not_called()
 
 
-def test_turn_on():
-    BenchmarkMode.put(False)
+@pytest.mark.parametrize("set_benchmark_mode", [True], indirect=True)
+def test_turn_on(set_benchmark_mode):
     df = pd.DataFrame([0])
-    BenchmarkMode.put(True)
     with mock.patch(wait_method) as wait:
         df.dropna()
     wait.assert_called()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5008 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
