### PR TITLE
FIX-#5627: Stop checking temp_df.dtype == 'category'

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -23,7 +23,11 @@ import pandas
 import datetime
 from pandas.api.types import is_object_dtype
 from pandas.core.indexes.api import Index, RangeIndex
-from pandas.core.dtypes.common import is_numeric_dtype, is_list_like
+from pandas.core.dtypes.common import (
+    is_numeric_dtype,
+    is_list_like,
+    is_categorical_dtype,
+)
 from pandas._libs.lib import no_default
 from typing import List, Hashable, Optional, Callable, Union, Dict, TYPE_CHECKING
 
@@ -3536,7 +3540,7 @@ class PandasDataframe(ClassLogger):
             by = [by]
 
         def apply_func(df):  # pragma: no cover
-            if any(dtype == "category" for dtype in df.dtypes[by].values):
+            if any(is_categorical_dtype(dtype) for dtype in df.dtypes[by].values):
                 raise NotImplementedError(
                     "Reshuffling groupby is not yet supported when grouping on a categorical column. "
                     + "https://github.com/modin-project/modin/issues/5925"

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -31,6 +31,7 @@ from pandas.core.dtypes.common import (
     is_datetime_or_timedelta_dtype,
     is_datetime64_any_dtype,
     is_bool_dtype,
+    is_categorical_dtype,
 )
 from pandas.core.dtypes.cast import find_common_type
 from pandas.errors import DataError, MergeError
@@ -3419,7 +3420,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         # So this check works only if we have dtypes cache materialized, otherwise the exception will be thrown
         # inside the kernel and so it will be uncatchable. TODO: figure out a better way to handle this.
         if self._modin_frame._dtypes is not None and any(
-            dtype == "category" for dtype in self.dtypes[by].values
+            is_categorical_dtype(dtype) for dtype in self.dtypes[by].values
         ):
             raise NotImplementedError(
                 "Reshuffling groupby is not yet supported when grouping on a categorical column. "
@@ -4137,7 +4138,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     def cat_codes(self):
         def func(df: pandas.DataFrame) -> pandas.DataFrame:
             ser = df.iloc[:, 0]
-            assert ser.dtype == "category"
+            assert is_categorical_dtype(ser.dtype)
             return ser.cat.codes.to_frame(name=MODIN_UNNAMED_SERIES_LABEL)
 
         res = self._modin_frame.map(func=func, new_columns=[MODIN_UNNAMED_SERIES_LABEL])

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/dataframe.py
@@ -1670,7 +1670,7 @@ class HdkOnNativeDataframe(PandasDataframe):
             The new frame.
         """
         assert len(self.columns) == 1
-        assert self._dtypes[-1] == "category"
+        assert is_categorical_dtype(self._dtypes[-1])
 
         exprs = self._index_exprs()
         col_expr = self.ref(self.columns[-1])

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -23,6 +23,7 @@ from pandas.util._validators import validate_bool_kwarg
 from pandas.core.dtypes.common import (
     is_dict_like,
     is_list_like,
+    is_categorical_dtype,
 )
 from pandas.core.series import _coerce_method
 from pandas._libs.lib import no_default, NoDefault
@@ -421,7 +422,7 @@ class Series(BasePandasDataset):
         if (
             isinstance(temp_df, pandas.Series)
             and temp_df.name is not None
-            and temp_df.dtype == "category"
+            and is_categorical_dtype(temp_df.dtype)
         ):
             maxsplit = 2
         return temp_str.rsplit("\n", maxsplit)[0] + "\n{}{}{}{}".format(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5627 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
