### PR TITLE
FEAT-#0000: enable interchange protocol for Series

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -210,6 +210,38 @@ class Series(BasePandasDataset):
         """
         return super(Series, self).__array__(dtype).flatten()
 
+    def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
+        """
+        Get a Modin DataFrame that implements the dataframe exchange protocol.
+
+        See more about the protocol in https://data-apis.org/dataframe-protocol/latest/index.html.
+
+        Parameters
+        ----------
+        nan_as_null : bool, default: False
+            A keyword intended for the consumer to tell the producer
+            to overwrite null values in the data with ``NaN`` (or ``NaT``).
+            This currently has no effect; once support for nullable extension
+            dtypes is added, this value should be propagated to columns.
+        allow_copy : bool, default: True
+            A keyword that defines whether or not the library is allowed
+            to make a copy of the data. For example, copying data would be necessary
+            if a library supports strided buffers, given that this protocol
+            specifies contiguous buffers. Currently, if the flag is set to ``False``
+            and a copy is needed, a ``RuntimeError`` will be raised.
+
+        Returns
+        -------
+        ProtocolDataframe
+            A dataframe object following the dataframe protocol specification.
+        """
+        from modin.pandas import DataFrame
+
+        df = DataFrame(self)
+        return df._query_compiler.to_dataframe(
+            nan_as_null=nan_as_null, allow_copy=allow_copy
+        )
+
     def __contains__(self, key):
         """
         Check if `key` in the `Series.index`.

--- a/modin/test/interchange/dataframe_protocol/base/test_sanity.py
+++ b/modin/test/interchange/dataframe_protocol/base/test_sanity.py
@@ -48,3 +48,6 @@ def test_basic_io(get_unique_base_execution):
 
     with pytest.raises(TestPassed):
         pd.DataFrame([[1]]).__dataframe__()
+
+    with pytest.raises(TestPassed):
+        pd.Series([[1]]).__dataframe__()

--- a/modin/test/interchange/dataframe_protocol/test_general.py
+++ b/modin/test/interchange/dataframe_protocol/test_general.py
@@ -82,6 +82,13 @@ def test_na_float(df_from_dict):
     assert colX.null_count == 1
 
 
+def test_na_float_series():
+    ser = pd.Series([1.0, math.nan, 2.0], name="a")
+    dfX = ser.__dataframe__()
+    colX = dfX.get_column_by_name("a")
+    assert colX.null_count == 1
+
+
 def test_noncategorical(df_from_dict):
     df = df_from_dict({"a": [1, 2, 3]})
     dfX = df.__dataframe__()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This pull request makes it possible to use the dataframe interchange protocol on a Series object. If on the side of the third-party library one need to get a pandas series from the Modin series, then this can be done in the following way:
`pandas_series = pandas.api.interchange.from_dataframe(modin_series).squeeze()`.

The need for such a conversion can be seen from https://github.com/modin-project/modin/issues/3211. 

@vnlitvinov @YarShev please provide your opinion.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
