### PR TITLE
REFACTOR-#6362: `__setitem__` on multiple columns should be evaluated lazily

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -4366,10 +4366,27 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         BaseQueryCompiler
             New QueryCompiler with updated values.
         """
+        from modin.pandas.utils import _broadcast_to_numpy
+
         if not isinstance(row_numeric_index, slice):
             row_numeric_index = list(row_numeric_index)
         if not isinstance(col_numeric_index, slice):
             col_numeric_index = list(col_numeric_index)
+
+        if isinstance(broadcasted_items, BaseQueryCompiler):
+            new_row_len = (
+                len(self.index[row_numeric_index])
+                if isinstance(row_numeric_index, slice)
+                else len(row_numeric_index)
+            )
+            new_col_len = (
+                len(self.columns[col_numeric_index])
+                if isinstance(col_numeric_index, slice)
+                else len(col_numeric_index)
+            )
+            broadcasted_items = _broadcast_to_numpy(
+                broadcasted_items.to_pandas(), (new_row_len, new_col_len)
+            )
 
         def write_items(df, broadcasted_items):
             if isinstance(df.iloc[row_numeric_index, col_numeric_index], pandas.Series):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -56,7 +56,6 @@ from .utils import (
     from_pandas,
     from_non_pandas,
     broadcast_item,
-    _maybe_reindex_item,
     cast_function_modin2pandas,
     SET_DATAFRAME_ATTRIBUTE_WARNING,
 )
@@ -2452,22 +2451,13 @@ class DataFrame(BasePandasDataset):
                         value = np.array(value)
                     if len(key) != value.shape[-1]:
                         raise ValueError("Columns must be same length as key")
-
-                # If we have a modin Series or DataFrame, let's not convert it to
-                # a numpy array if we can help it.
-                if isinstance(value, (DataFrame, Series)):
-                    item = _maybe_reindex_item(
-                        self, slice(None), key, value, need_columns_reindex=False
-                    )
-                else:
-                    item = broadcast_item(
-                        self,
-                        slice(None),
-                        key,
-                        value,
-                        need_columns_reindex=False,
-                    )
-
+                item = broadcast_item(
+                    self,
+                    slice(None),
+                    key,
+                    value,
+                    need_columns_reindex=False,
+                )
                 new_qc = self._query_compiler.write_items(
                     slice(None), self.columns.get_indexer_for(key), item
                 )

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -316,7 +316,7 @@ def broadcast_item(
 
     Returns
     -------
-    np.ndarray
+    np.ndarray or BaseQueryCompiler
         `item` after it was broadcasted to `to_shape`.
 
     Raises


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6362 
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
