### PR TITLE
FIX-#6368: Apply deferred indices before map-reduce groupby

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3556,7 +3556,7 @@ class PandasDataframe(ClassLogger):
 
         return result
 
-    @lazy_metadata_decorator(apply_axis="opposite", axis_arg=0)
+    @lazy_metadata_decorator(apply_axis="both")
     def groupby_reduce(
         self,
         axis,

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -2757,3 +2757,29 @@ def test_rolling_timedelta_window(center, closed, as_index, on):
         datetime.timedelta(days=3), center=center, closed=closed, on=on
     )
     eval_rolling(md_window, pd_window)
+
+
+@pytest.mark.parametrize(
+    "func",
+    [
+        pytest.param("sum", id="map_reduce_func"),
+        pytest.param("median", id="full_axis_func"),
+    ],
+)
+def test_groupby_deferred_index(func):
+    # the test is copied from the issue:
+    # https://github.com/modin-project/modin/issues/6368
+
+    def perform(lib):
+        df1 = lib.DataFrame({"a": [1, 1, 2, 2]})
+        df2 = lib.DataFrame({"b": [3, 4, 5, 6], "c": [7, 5, 4, 3]})
+
+        df = lib.concat([df1, df2], axis=1)
+        df.index = [10, 11, 12, 13]
+
+        grp = df.groupby("a")
+        grp.indices
+
+        return getattr(grp, func)()
+
+    eval_general(pd, pandas, perform)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Check the [linked issue](https://github.com/modin-project/modin/issues/6368) for the motivation of this changes

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6368 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
