### PR TITLE
FIX-#6219: don't default to pandas for 'copy' on empty DataFrame/Series objects

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3725,6 +3725,7 @@ class PandasDataframe(ClassLogger):
         df = self._partition_mgr_cls.to_pandas(self._partitions)
         if df.empty:
             df = pandas.DataFrame(columns=self.columns, index=self.index)
+            df = df.astype(self.dtypes)
         else:
             for axis, has_external_index in enumerate(
                 ["has_materialized_index", "has_materialized_columns"]

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3725,7 +3725,7 @@ class PandasDataframe(ClassLogger):
         df = self._partition_mgr_cls.to_pandas(self._partitions)
         if df.empty:
             df = pandas.DataFrame(columns=self.columns, index=self.index)
-            if self.has_materialized_dtypes:
+            if len(df.columns) and self.has_materialized_dtypes:
                 df = df.astype(self.dtypes)
         else:
             for axis, has_external_index in enumerate(

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3725,7 +3725,8 @@ class PandasDataframe(ClassLogger):
         df = self._partition_mgr_cls.to_pandas(self._partitions)
         if df.empty:
             df = pandas.DataFrame(columns=self.columns, index=self.index)
-            df = df.astype(self.dtypes)
+            if self.has_materialized_dtypes:
+                df = df.astype(self.dtypes)
         else:
             for axis, has_external_index in enumerate(
                 ["has_materialized_index", "has_materialized_columns"]

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -86,6 +86,7 @@ _DEFAULT_BEHAVIOUR = {
     "dtypes",
     "dtype",
     "groupby",
+    "copy",
     "_get_name",
     "_set_name",
     "_default_to_pandas",

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -86,7 +86,6 @@ _DEFAULT_BEHAVIOUR = {
     "dtypes",
     "dtype",
     "groupby",
-    "copy",
     "_get_name",
     "_set_name",
     "_default_to_pandas",

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -320,6 +320,12 @@ def test_copy(data):
     df_equals(modin_df, modin_df_cp)
 
 
+def test_copy_empty_dataframe():
+    df = pd.DataFrame(range(3))
+    res = df[:0].copy()
+    assert res.dtypes.equals(df.dtypes)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_dtypes(data):
     modin_df = pd.DataFrame(data)

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1409,6 +1409,12 @@ def test_copy(data):
     df_equals(modin_series.copy(), pandas_series.copy())
 
 
+def test_copy_empty_series():
+    ser = pd.Series(range(3))
+    res = ser[:0].copy()
+    assert res.dtype == ser.dtype
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_corr(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6219 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
