### PR TITLE
PERF-#6378: use numpy.array instead of list in internals of iloc/loc operation

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1110,14 +1110,22 @@ class PandasDataframe(ClassLogger):
             row_order_mapping = dict(
                 zip(sorted_row_positions, range(len(row_positions)))
             )
-            new_row_order = [row_order_mapping[idx] for idx in row_positions]
+            new_row_order = np.fromiter(
+                (row_order_mapping[idx] for idx in row_positions),
+                dtype="int64",
+                count=len(row_positions),
+            )
         else:
             new_row_order = None
         if col_positions is not None:
             col_order_mapping = dict(
                 zip(sorted_col_positions, range(len(col_positions)))
             )
-            new_col_order = [col_order_mapping[idx] for idx in col_positions]
+            new_col_order = np.fromiter(
+                (col_order_mapping[idx] for idx in col_positions),
+                dtype="int64",
+                count=len(col_positions),
+            )
         else:
             new_col_order = None
         return intermediate._reorder_labels(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

numpy arrays are much faster to serialize than lists , what will need to be done next when performing `map_axis_partitions` operation.

<details>

<summary>
Script to measure
</summary>

```python
import numpy as np
import ray
from time import time

# initialize it
ray.put([1,2,3,4])

np.random.seed(42)

len_rows = 10**7
sorted_rows_position = np.arange(len_rows)
row_positions = sorted_rows_position.copy()
np.random.shuffle(row_positions)


row_order_mapping = dict(
    zip(sorted_rows_position, range(len(row_positions)))
)

print("old way")
for _ in range(3):
    start = time()
    new_row_order = [row_order_mapping[idx] for idx in row_positions]
    print(f"time: {time()-start}")


start = time()
ref = ray.put(new_row_order)
print(f"ray put {time()-start}")
del ref


print("from_iter way")
for _ in range(3):
    start = time()
    new_row_order = np.fromiter((row_order_mapping[idx] for idx in row_positions), dtype="int64", count=len(row_positions))
    print(f"time: {time()-start}")

start = time()
ref = ray.put(new_row_order)
print(f"ray put {time()-start}")
```

</details>

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6378 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
