### PR TITLE
PERF-#6332: don't materialize axes in concat operation

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3434,8 +3434,11 @@ class PandasDataframe(ClassLogger):
         if new_lengths is None:
             new_lengths = new_lengths2
         new_dtypes = None
+        new_index = None
+        new_columns = None
         if axis == Axis.ROW_WISE:
-            new_index = self.index.append([other.index for other in others])
+            if all((obj.has_materialized_index for obj in (self, *others))):
+                new_index = self.index.append([other.index for other in others])
             new_columns = joined_index
             frames = [self] + others
             if all(frame.has_materialized_dtypes for frame in frames):
@@ -3462,7 +3465,8 @@ class PandasDataframe(ClassLogger):
                             new_lengths = None
                             break
         else:
-            new_columns = self.columns.append([other.columns for other in others])
+            if all((obj.has_materialized_columns for obj in (self, *others))):
+                new_columns = self.columns.append([other.columns for other in others])
             new_index = joined_index
             if self.has_materialized_dtypes and all(
                 o.has_materialized_dtypes for o in others

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -131,7 +131,11 @@ class PandasDataframe(ClassLogger):
 
     def _validate_axes_lengths(self):
         """Validate that labels are split correctly if split is known."""
-        if self._row_lengths_cache is not None and len(self.index) > 0:
+        if (
+            self._row_lengths_cache is not None
+            and self.has_materialized_index
+            and len(self.index) > 0
+        ):
             # An empty frame can have 0 rows but a nonempty index. If the frame
             # does have rows, the number of rows must equal the size of the
             # index.
@@ -145,7 +149,11 @@ class PandasDataframe(ClassLogger):
                 any(val < 0 for val in self._row_lengths_cache),
                 f"Row lengths cannot be negative: {self._row_lengths_cache}",
             )
-        if self._column_widths_cache is not None and len(self.columns) > 0:
+        if (
+            self._column_widths_cache is not None
+            and self.has_materialized_columns
+            and len(self.columns) > 0
+        ):
             # An empty frame can have 0 column but a nonempty column index. If
             # the frame does have columns, the number of columns must equal the
             # size of the columns.

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3437,7 +3437,7 @@ class PandasDataframe(ClassLogger):
         new_index = None
         new_columns = None
         if axis == Axis.ROW_WISE:
-            if all((obj.has_materialized_index for obj in (self, *others))):
+            if all(obj.has_materialized_index for obj in (self, *others)):
                 new_index = self.index.append([other.index for other in others])
             new_columns = joined_index
             frames = [self] + others
@@ -3465,7 +3465,7 @@ class PandasDataframe(ClassLogger):
                             new_lengths = None
                             break
         else:
-            if all((obj.has_materialized_columns for obj in (self, *others))):
+            if all(obj.has_materialized_columns for obj in (self, *others)):
                 new_columns = self.columns.append([other.columns for other in others])
             new_index = joined_index
             if self.has_materialized_dtypes and all(

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -1045,6 +1045,31 @@ def test_binary_op_preserve_dtypes():
     assert_cache(setup_cache(df) + setup_cache(other, has_cache=False), has_cache=False)
 
 
+@pytest.mark.parametrize("axis", [0, 1])
+def test_concat_dont_materialize_opposite_axis(axis):
+    data = {"a": [1, 2, 3], "b": [4.0, 5.0, 6.0]}
+    df1, df2 = pd.DataFrame(data), pd.DataFrame(data)
+
+    def assert_no_cache(df, axis):
+        if axis:
+            assert not df._query_compiler._modin_frame.has_materialized_columns
+        else:
+            assert not df._query_compiler._modin_frame.has_materialized_index
+
+    def remove_cache(df, axis):
+        if axis:
+            df._query_compiler._modin_frame.set_columns_cache(None)
+        else:
+            df._query_compiler._modin_frame.set_index_cache(None)
+        assert_no_cache(df, axis)
+        return df
+
+    df1, df2 = remove_cache(df1, axis), remove_cache(df2, axis)
+
+    df_concated = pd.concat((df1, df2), axis=axis)
+    assert_no_cache(df_concated, axis)
+
+
 def test_setitem_bool_preserve_dtypes():
     df = pd.DataFrame({"a": [1, 1, 2, 2], "b": [3, 4, 5, 6]})
     indexer = pd.Series([True, False, True, False])

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -1067,6 +1067,8 @@ def test_concat_dont_materialize_opposite_axis(axis):
     df1, df2 = remove_cache(df1, axis), remove_cache(df2, axis)
 
     df_concated = pd.concat((df1, df2), axis=axis)
+    assert_no_cache(df1, axis)
+    assert_no_cache(df2, axis)
     assert_no_cache(df_concated, axis)
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6332 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
