### PR TITLE
FEAT-#6382: Execute bitwise NOT (~) operations on HDK

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
@@ -485,7 +485,7 @@ class BaseExpr(abc.ABC):
         OpExpr
             The resulting bitwise inverse expression.
         """
-        return OpExpr("~", [self], self._dtype)
+        return OpExpr("BIT_NOT", [self], self._dtype)
 
     def _cmp_op(self, other, op_name):
         """
@@ -983,7 +983,7 @@ class OpExpr(BaseExpr):
         "POWER": lambda self: self._fold_arithm("__pow__"),
         "/": lambda self: self._fold_arithm("__truediv__"),
         "//": lambda self: self._fold_arithm("__floordiv__"),
-        "~": lambda self: self._fold_invert(),
+        "BIT_NOT": lambda self: self._fold_invert(),
         "CAST": lambda self: self._fold_literal("cast", self._dtype),
         "IS NULL": lambda self: self._fold_literal("is_null"),
         "IS NOT NULL": lambda self: self._fold_literal("is_not_null"),
@@ -996,7 +996,7 @@ class OpExpr(BaseExpr):
         "POWER": lambda self, table: self._pc("power", table),
         "/": lambda self, table: self._pc("divide", table),
         "//": lambda self, table: self._pc("divide", table),
-        "~": lambda self, table: self._invert(table),
+        "BIT_NOT": lambda self, table: self._invert(table),
         "CAST": lambda self, table: self._col(table).cast(to_arrow_type(self._dtype)),
         "IS NULL": lambda self, table: self._col(table).is_null(nan_is_null=True),
         "IS NOT NULL": lambda self, table: pc.invert(
@@ -1004,7 +1004,7 @@ class OpExpr(BaseExpr):
         ),
     }
 
-    _UNSUPPORTED_HDK_OPS = {"~"}
+    _UNSUPPORTED_HDK_OPS = {}
 
     def __init__(self, op, operands, dtype):
         self.op = op


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6382 <!-- issue must be created for each patch -->
- [] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
