### PR TITLE
PERF-#6378: use numpy.array operations in internals of iloc/loc operation

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1075,10 +1075,10 @@ class PandasDataframe(ClassLogger):
         -------
         PandasDataframe
         """
-        # ensure that `row_positions` and `col_positions` are  either None or np.array for efficiency
-        if row_positions is not None:
+        # if positions are plain lists or tuples, convert them to numpy for faster operations
+        if isinstance(row_positions, (list, tuple)):
             row_positions = np.asarray(row_positions, dtype=np.intp)
-        if col_positions is not None:
+        if isinstance(col_positions, (list, tuple)):
             col_positions = np.asarray(col_positions, dtype=np.intp)
         # Check if monotonically increasing, return if it is. Fast track code path for
         # common case to keep it fast.

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1075,11 +1075,6 @@ class PandasDataframe(ClassLogger):
         -------
         PandasDataframe
         """
-        # if positions are plain lists or tuples, convert them to numpy for faster operations
-        if isinstance(row_positions, (list, tuple)):
-            row_positions = np.asarray(row_positions, dtype=np.intp)
-        if isinstance(col_positions, (list, tuple)):
-            col_positions = np.asarray(col_positions, dtype=np.intp)
         # Check if monotonically increasing, return if it is. Fast track code path for
         # common case to keep it fast.
         if (
@@ -1113,12 +1108,16 @@ class PandasDataframe(ClassLogger):
                 # do not need to re-order positive-step-ranges
                 new_row_order = pandas.RangeIndex(len(row_positions) - 1, -1, -1)
         elif row_positions is not None:
-            new_row_order = np.argsort(np.argsort(row_positions))
+            new_row_order = np.argsort(
+                np.argsort(np.asarray(row_positions, dtype=np.intp))
+            )
         if is_range_like(col_positions):
             if col_positions.step < 0:
                 new_col_order = pandas.RangeIndex(len(col_positions) - 1, -1, -1)
         elif col_positions is not None:
-            new_col_order = np.argsort(np.argsort(col_positions))
+            new_col_order = np.argsort(
+                np.argsort(np.asarray(col_positions, dtype=np.intp))
+            )
         return intermediate._reorder_labels(
             row_positions=new_row_order, col_positions=new_col_order
         )

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1108,9 +1108,16 @@ class PandasDataframe(ClassLogger):
         # First argsort brings us to the proper "index space" (according to smaller labels count),
         # and the second re-orders them to match the original data.
         new_row_order, new_col_order = None, None
-        if row_positions is not None:
+        if is_range_like(row_positions):
+            if row_positions.step < 0:
+                # do not need to re-order positive-step-ranges
+                new_row_order = pandas.RangeIndex(len(row_positions) - 1, -1, -1)
+        elif row_positions is not None:
             new_row_order = np.argsort(np.argsort(row_positions))
-        if col_positions is not None:
+        if is_range_like(col_positions):
+            if col_positions.step < 0:
+                new_col_order = pandas.RangeIndex(len(col_positions) - 1, -1, -1)
+        elif col_positions is not None:
             new_col_order = np.argsort(np.argsort(col_positions))
         return intermediate._reorder_labels(
             row_positions=new_row_order, col_positions=new_col_order

--- a/modin/core/execution/ray/implementations/cudf_on_ray/dataframe/dataframe.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/dataframe/dataframe.py
@@ -272,16 +272,8 @@ class cuDFOnRayDataframe(PandasOnRayDataframe):
             new_dtypes,
         )
 
-        sorted_row_positions = sorted_col_positions = None
-        if row_positions is not None:
-            sorted_row_positions = sorted(row_positions)
-        if col_positions is not None:
-            sorted_col_positions = sorted(col_positions)
-
         return self._maybe_reorder_labels(
             intermediate,
             row_positions,
-            sorted_row_positions,
             col_positions,
-            sorted_col_positions,
         )


### PR DESCRIPTION
Based on https://github.com/modin-project/modin/pull/6379

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Command: `MODIN_CPUS=44 MODIN_TEST_DATASET_SIZE="Big" asv continuous master vnlitvin/use-numpy-iloc -b "^benchmarks.TimeIndexing" --launch-method=spawn --no-only-changed -a repeat=5 -a warmup_time=2`
Perf results (44 CPUs, Ray):
<details>

```bash
All benchmarks:

       before           after         ratio
     [ea0a6acb]       [691fffd3]
     <master>
       7.240.1ms      7.980.07ms    ~1.10  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'continuous_slice')
         54410ms         59610ms     1.10  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'slice')
      5.190.06ms       5.670.2ms     1.09  benchmarks.TimeIndexingNumericSeries.time_loc_scalar([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
       7.280.1ms      7.880.09ms     1.08  benchmarks.TimeIndexing.time_loc([1000000, 10], 'continuous_slice')
       3.220.1ms      3.470.07ms     1.08  benchmarks.TimeIndexingNumericSeries.time_loc_slice([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
       4.330.2ms       4.670.1ms     1.08  benchmarks.TimeIndexingNumericSeries.time_iloc_scalar([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
       5.360.2ms       5.760.2ms     1.07  benchmarks.TimeIndexingNumericSeries.time_getitem_scalar([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
      3.720.08ms       3.990.1ms     1.07  benchmarks.TimeIndexingNumericSeries.time_loc_list_like([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
      3.900.09ms       4.170.2ms     1.07  benchmarks.TimeIndexingNumericSeries.time_loc_slice([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
       3.810.1ms       4.060.2ms     1.07  benchmarks.TimeIndexingNumericSeries.time_getitem_list_like([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
      3.410.05ms       3.620.1ms     1.06  benchmarks.TimeIndexingNumericSeries.time_getitem_slice([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
          5737ms         60830ms     1.06  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'bool_array')
       4.190.2ms      4.420.06ms     1.05  benchmarks.TimeIndexingNumericSeries.time_loc_slice([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
      3.540.07ms      3.730.07ms     1.05  benchmarks.TimeIndexingNumericSeries.time_getitem_slice([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
      3.850.07ms       4.050.2ms     1.05  benchmarks.TimeIndexingNumericSeries.time_loc_list_like([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
       3.540.1ms       3.730.2ms     1.05  benchmarks.TimeIndexingNumericSeries.time_iloc_slice([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
      3.150.05ms       3.320.3ms     1.05  benchmarks.TimeIndexingNumericSeries.time_iloc_list_like([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
       4.110.1ms      4.320.05ms     1.05  benchmarks.TimeIndexingNumericSeries.time_loc_slice([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
       23.60.2ms       24.80.2ms     1.05  benchmarks.TimeIndexing.time_loc([5000, 5000], 'numpy_array_take_all_values')
       4.020.1ms      4.220.09ms     1.05  benchmarks.TimeIndexingNumericSeries.time_getitem_list_like([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
       3.490.2ms       3.650.1ms     1.04  benchmarks.TimeIndexingNumericSeries.time_iloc_slice([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
       28.50.6ms       29.70.8ms     1.04  benchmarks.TimeIndexing.time_loc([5000, 5000], 'continuous_slice')
       8.960.1ms      9.320.07ms     1.04  benchmarks.TimeIndexingNumericSeries.time_loc_array([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
          5339ms         55410ms     1.04  benchmarks.TimeIndexing.time_loc([5000, 5000], 'slice')
       3.540.1ms      3.670.04ms     1.04  benchmarks.TimeIndexingNumericSeries.time_iloc_slice([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
      4.100.07ms       4.250.1ms     1.04  benchmarks.TimeIndexingNumericSeries.time_getitem_slice([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
       4.070.2ms       4.210.1ms     1.03  benchmarks.TimeIndexingNumericSeries.time_loc_slice([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
      4.130.07ms      4.270.07ms     1.03  benchmarks.TimeIndexingNumericSeries.time_getitem_slice([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
      3.860.09ms      3.980.08ms     1.03  benchmarks.TimeIndexingNumericSeries.time_loc_list_like([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
      4.750.09ms       4.880.1ms     1.03  benchmarks.TimeIndexingNumericSeries.time_loc_scalar([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
       6.900.4ms       7.090.3ms     1.03  benchmarks.TimeIndexingNumericSeries.time_iloc_array([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
         52520ms         53930ms     1.03  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'bool_series')
       5.300.3ms       5.440.3ms     1.03  benchmarks.TimeIndexingNumericSeries.time_loc_scalar([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
       3.470.1ms       3.560.1ms     1.03  benchmarks.TimeIndexingNumericSeries.time_iloc_slice([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
       3.990.2ms       4.090.1ms     1.03  benchmarks.TimeIndexingNumericSeries.time_getitem_list_like([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
      4.200.08ms       4.300.2ms     1.03  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'scalar')
       5.310.5ms      5.450.07ms     1.03  benchmarks.TimeIndexingNumericSeries.time_getitem_scalar([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
      4.450.09ms       4.560.1ms     1.02  benchmarks.TimeIndexingNumericSeries.time_iloc_scalar([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
       3.520.1ms       3.600.1ms     1.02  benchmarks.TimeIndexingNumericSeries.time_iloc_slice([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
      3.360.07ms      3.440.03ms     1.02  benchmarks.TimeIndexingNumericSeries.time_getitem_slice([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
      3.420.09ms       3.510.1ms     1.02  benchmarks.TimeIndexingNumericSeries.time_iloc_slice([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
       3.080.1ms       3.160.2ms     1.02  benchmarks.TimeIndexingNumericSeries.time_iloc_list_like([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
       4.560.4ms       4.660.1ms     1.02  benchmarks.TimeIndexingNumericSeries.time_iloc_scalar([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
       6.810.2ms       6.970.2ms     1.02  benchmarks.TimeIndexingNumericSeries.time_iloc_array([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
         82630ms         84440ms     1.02  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'function')
      3.540.08ms      3.610.06ms     1.02  benchmarks.TimeIndexingNumericSeries.time_getitem_slice([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
       6.590.1ms       6.730.1ms     1.02  benchmarks.TimeIndexingNumericSeries.time_iloc_array([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
       21.60.5ms       22.00.4ms     1.02  benchmarks.TimeIndexingColumns.time___getitem__([1000000, 10])
       46.10.4ms         46.91ms     1.02  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'slice')
       6.960.1ms       7.080.5ms     1.02  benchmarks.TimeIndexingNumericSeries.time_iloc_array([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
      3.750.06ms      3.820.07ms     1.02  benchmarks.TimeIndexingNumericSeries.time_getitem_list_like([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
          3311ms          3365ms     1.02  benchmarks.TimeIndexingNumericSeries.time_getitem_array([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
      3.050.03ms      3.090.03ms     1.02  benchmarks.TimeIndexingNumericSeries.time_iloc_list_like([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
       6.850.2ms       6.950.3ms     1.02  benchmarks.TimeIndexingNumericSeries.time_iloc_array([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
       24.20.7ms       24.50.4ms     1.01  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'numpy_array_take_all_values')
      3.010.04ms      3.040.09ms     1.01  benchmarks.TimeIndexingNumericSeries.time_iloc_list_like([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
       5.670.1ms       5.740.2ms     1.01  benchmarks.TimeIndexingNumericSeries.time_getitem_scalar([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
          4794ms          4854ms     1.01  benchmarks.TimeIndexingNumericSeries.time_getitem_array([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
       57.70.7ms         58.33ms     1.01  benchmarks.TimeIndexing.time_loc([1000000, 10], 'bool_array')
          4744ms          4793ms     1.01  benchmarks.TimeIndexingNumericSeries.time_getitem_array([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
         33.91ms       34.20.6ms     1.01  benchmarks.TimeIndexingNumericSeries.time_loc_array([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
       5.810.3ms       5.860.2ms     1.01  benchmarks.TimeIndexingNumericSeries.time_getitem_scalar([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
      4.120.05ms       4.150.1ms     1.01  benchmarks.TimeIndexingNumericSeries.time_loc_slice([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
      3.010.07ms      3.030.09ms     1.01  benchmarks.TimeIndexingNumericSeries.time_iloc_list_like([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
      3.070.08ms       3.090.1ms     1.01  benchmarks.TimeIndexingNumericSeries.time_iloc_list_like([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
          3405ms          3423ms     1.01  benchmarks.TimeIndexingNumericSeries.time_getitem_lists([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
       7.730.1ms       7.780.1ms     1.01  benchmarks.TimeIndexingNumericSeries.time_loc_array([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
          3333ms          3355ms     1.01  benchmarks.TimeIndexingNumericSeries.time_getitem_lists([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
       3.840.1ms      3.860.05ms     1.00  benchmarks.TimeIndexingNumericSeries.time_getitem_list_like([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
         22.71ms       22.80.6ms     1.00  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'bool_series')
          3367ms          3372ms     1.00  benchmarks.TimeIndexingNumericSeries.time_getitem_array([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
       34.30.5ms       34.30.9ms     1.00  benchmarks.TimeIndexingNumericSeries.time_loc_array([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
      5.350.09ms       5.350.3ms     1.00  benchmarks.TimeIndexingNumericSeries.time_loc_scalar([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
      4.530.09ms       4.530.1ms     1.00  benchmarks.TimeIndexing.time_loc([1000000, 10], 'scalar')
       17.10.3ms       17.10.5ms     1.00  benchmarks.TimeIndexingColumns.time_loc([5000, 5000])
          4857ms          4836ms     1.00  benchmarks.TimeIndexingNumericSeries.time_getitem_lists([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
          4785ms          4759ms     0.99  benchmarks.TimeIndexingNumericSeries.time_getitem_lists([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
       60.10.6ms       59.70.3ms     0.99  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'numpy_array_take_all_values')
          3454ms          3429ms     0.99  benchmarks.TimeIndexingNumericSeries.time_getitem_array([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
          3442ms          3419ms     0.99  benchmarks.TimeIndexingNumericSeries.time_getitem_lists([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
       21.10.8ms         20.91ms     0.99  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'scalar')
      5.620.08ms      5.570.09ms     0.99  benchmarks.TimeIndexingNumericSeries.time_loc_scalar([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
       17.50.2ms       17.30.4ms     0.99  benchmarks.TimeIndexing.time_loc([5000, 5000], 'python_list_take_10_values')
       23.40.4ms         23.11ms     0.99  benchmarks.TimeIndexingColumns.time_loc([1000000, 10])
       6.860.1ms       6.790.1ms     0.99  benchmarks.TimeIndexingNumericSeries.time_iloc_array([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
         57120ms         56420ms     0.99  benchmarks.TimeIndexing.time_loc([5000, 5000], 'bool_series')
       17.30.4ms       17.10.5ms     0.99  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'python_list_take_10_values')
       22.30.6ms       22.00.4ms     0.98  benchmarks.TimeIndexingColumns.time_iloc([1000000, 10])
       46.50.5ms       45.70.8ms     0.98  benchmarks.TimeIndexing.time_loc([1000000, 10], 'slice')
       17.10.3ms       16.80.3ms     0.98  benchmarks.TimeIndexingColumns.time___getitem__([5000, 5000])
       3.640.1ms       3.580.3ms     0.98  benchmarks.TimeIndexingNumericSeries.time_loc_list_like([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
       4.810.2ms       4.730.1ms     0.98  benchmarks.TimeIndexingNumericSeries.time_getitem_scalar([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
        7.360.2s        7.220.3s     0.98  benchmarks.TimeIndexingNumericSeries.time_getitem_array([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
       3.860.1ms       3.780.1ms     0.98  benchmarks.TimeIndexing.time_loc([1000000, 10], 'python_list_take_10_values')
      3.800.03ms       3.730.1ms     0.98  benchmarks.TimeIndexingNumericSeries.time_loc_list_like([100000, 1], <class 'numpy.int64'>, 'nonunique_monotonic_inc')
        7.420.2s        7.260.2s     0.98  benchmarks.TimeIndexingNumericSeries.time_getitem_lists([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
       56.20.8ms       54.70.8ms     0.97  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'bool_array')
       8.530.3ms       8.310.1ms     0.97  benchmarks.TimeIndexingNumericSeries.time_loc_array([100000, 1], <class 'numpy.uint64'>, 'unique_monotonic_inc')
      4.690.08ms       4.570.1ms     0.97  benchmarks.TimeIndexingNumericSeries.time_iloc_scalar([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
       4.680.2ms       4.550.1ms     0.97  benchmarks.TimeIndexingNumericSeries.time_iloc_scalar([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
       3.670.1ms      3.560.04ms     0.97  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'python_list_take_10_values')
       4.660.3ms      4.490.07ms     0.97  benchmarks.TimeIndexingNumericSeries.time_iloc_scalar([100000, 1], <class 'numpy.uint64'>, 'nonunique_monotonic_inc')
         68.02ms       65.50.8ms     0.96  benchmarks.TimeIndexing.time_loc([1000000, 10], 'numpy_array_take_all_values')
       3.470.2ms       3.340.2ms     0.96  benchmarks.TimeIndexingNumericSeries.time_getitem_list_like([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
       3.610.2ms       3.460.1ms     0.96  benchmarks.TimeIndexingNumericSeries.time_loc_list_like([100000, 1], <class 'numpy.int64'>, 'unique_monotonic_inc')
       38.30.8ms         36.62ms     0.96  benchmarks.TimeIndexing.time_loc([1000000, 10], 'bool_series')
       21.60.2ms         20.61ms     0.96  benchmarks.TimeIndexing.time_loc([5000, 5000], 'scalar')
         36.71ms       35.00.8ms     0.95  benchmarks.TimeIndexingNumericSeries.time_loc_array([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
       5.800.2ms       5.490.1ms     0.95  benchmarks.TimeIndexingNumericSeries.time_getitem_scalar([100000, 1], <class 'numpy.float64'>, 'unique_monotonic_inc')
       5.910.1ms       5.560.1ms     0.94  benchmarks.TimeIndexingNumericSeries.time_loc_scalar([100000, 1], <class 'numpy.float64'>, 'nonunique_monotonic_inc')
       30.90.8ms       29.00.4ms     0.94  benchmarks.TimeIndexing.time_iloc([5000, 5000], 'continuous_slice')
         85220ms         78860ms     0.92  benchmarks.TimeIndexing.time_loc([5000, 5000], 'function')
         61730ms          5708ms     0.92  benchmarks.TimeIndexing.time_loc([5000, 5000], 'bool_array')
         18.62ms       17.20.5ms     0.92  benchmarks.TimeIndexingColumns.time_iloc([5000, 5000])
-         3521ms        1970.7ms     0.56  benchmarks.TimeIndexing.time_iloc([1000000, 10], 'function')
-         3684ms          1933ms     0.53  benchmarks.TimeIndexing.time_loc([1000000, 10], 'function')
```

</details>

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6378 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
