### PR TITLE
FEAT-#5645: add support for modin's numpy array in `dataframe.insert` function

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -991,9 +991,11 @@ class DataFrame(BasePandasDataset):
         """
         Insert column into ``DataFrame`` at specified location.
         """
+        from modin.numpy import array
+
         if (
             isinstance(value, (DataFrame, pandas.DataFrame))
-            or isinstance(value, np.ndarray)
+            or isinstance(value, (array, np.ndarray))
             and len(value.shape) > 1
         ):
             if value.shape[1] != 1:
@@ -1042,7 +1044,7 @@ class DataFrame(BasePandasDataset):
                 )
             elif loc < 0:
                 raise ValueError("unbounded slice")
-            if isinstance(value, Series):
+            if isinstance(value, (Series, array)):
                 value = value._query_compiler
             new_query_compiler = self._query_compiler.insert(loc, column, value)
 

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -1385,6 +1385,19 @@ def test_insert_4407():
         )
 
 
+def test_insert_modin_array():
+    from modin.numpy import array
+
+    data = {"col1": [1, 2, 3], "col2": [2, 3, 4]}
+    modin_df1, modin_df2 = pd.DataFrame(data), pd.DataFrame(data)
+    np_value = np.array([7, 7, 7])
+    md_np_value = array(np_value)
+
+    modin_df1.insert(1, "new_col", np_value)
+    modin_df2.insert(1, "new_col", md_np_value)
+    df_equals(modin_df1, modin_df2)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_ndim(data):
     modin_df = pd.DataFrame(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5645 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
