### PR TITLE
FIX-#6402: Allow datetime and timedelta types in `diff`

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1237,7 +1237,7 @@ class BasePandasDataset(ClassLogger):
 
         # Attempting to match pandas error behavior here
         for dtype in self._get_dtypes():
-            if not is_numeric_dtype(dtype):
+            if not (is_numeric_dtype(dtype) or is_datetime_or_timedelta_dtype(dtype)):
                 raise TypeError(f"unsupported operand type for -: got {dtype}")
 
         axis = self._get_axis_number(axis)

--- a/modin/pandas/test/dataframe/test_window.py
+++ b/modin/pandas/test/dataframe/test_window.py
@@ -91,6 +91,25 @@ def test_diff(axis, periods):
     )
 
 
+def test_diff_with_datetime_types():
+    pandas_df = pandas.DataFrame(
+        [[1, 2.0, 3], [4, 5.0, 6], [7, np.nan, 9], [10, 11.3, 12], [13, 14.5, 15]]
+    )
+    data = pandas.date_range("2018-01-01", periods=5, freq="H").values
+    pandas_df = pandas.concat([pandas_df, pandas.Series(data)], axis=1)
+    modin_df = pd.DataFrame(pandas_df)
+
+    # Test `diff` with datetime type.
+    pandas_result = pandas_df.diff()
+    modin_result = modin_df.diff()
+    df_equals(modin_result, pandas_result)
+
+    # Test `diff` with timedelta type.
+    td_pandas_result = pandas_result.diff()
+    td_modin_result = modin_result.diff()
+    df_equals(td_modin_result, td_pandas_result)
+
+
 def test_diff_error_handling():
     df = pd.DataFrame([["a", "b", "c"]], columns=["col 0", "col 1", "col 2"])
     with pytest.raises(

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1585,6 +1585,22 @@ def test_diff(data, periods):
         df_equals(modin_result, pandas_result)
 
 
+def test_diff_with_dates():
+    data = pandas.date_range("2018-01-01", periods=15, freq="H").values
+    pandas_series = pandas.Series(data)
+    modin_series = pd.Series(pandas_series)
+
+    # Check that `diff` with datetime types works correctly.
+    pandas_result = pandas_series.diff()
+    modin_result = modin_series.diff()
+    df_equals(modin_result, pandas_result)
+
+    # Check that `diff` with timedelta types works correctly.
+    td_pandas_result = pandas_result.diff()
+    td_modin_result = modin_result.diff()
+    df_equals(td_modin_result, td_pandas_result)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_div(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6402 ? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
