### PR TITLE
FIX-#6405: Apply `disable_logging` to `__getattr__`

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -42,6 +42,7 @@ import sys
 from typing import IO, Optional, Union, Iterator, Hashable, Sequence
 import warnings
 
+from modin.logging import disable_logging
 from modin.pandas import Categorical
 from modin.error_message import ErrorMessage
 from modin.utils import (
@@ -2342,6 +2343,7 @@ class DataFrame(BasePandasDataset):
             s._parent_axis = 1
         return s
 
+    @disable_logging
     def __getattr__(self, key):
         """
         Return item identified by `key`.

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -25,7 +25,7 @@ from types import BuiltinFunctionType
 from collections.abc import Iterable
 
 from modin.error_message import ErrorMessage
-from modin.logging import ClassLogger
+from modin.logging import ClassLogger, disable_logging
 from modin.utils import (
     _inherit_docstrings,
     try_cast_to_pandas,
@@ -161,6 +161,7 @@ class DataFrameGroupBy(ClassLogger):
         new_kw.update(kwargs)
         return type(self)(**new_kw)
 
+    @disable_logging
     def __getattr__(self, key):
         """
         Alter regular attribute access, looks up the name in the columns.

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -31,6 +31,7 @@ from pandas._typing import IndexKeyFunc, Axis
 from typing import Union, Optional, Hashable, TYPE_CHECKING, IO
 import warnings
 
+from modin.logging import disable_logging
 from modin.utils import (
     _inherit_docstrings,
     to_pandas,
@@ -294,6 +295,7 @@ class Series(BasePandasDataset):
     def __rfloordiv__(self, right):
         return self.rfloordiv(right)
 
+    @disable_logging
     def __getattr__(self, key):
         """
         Return item identified by `key`.


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6405  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
