### PR TITLE
FIX-#6372: precompute dtypes for 'sum' operation

### DIFF
--- a/modin/core/dataframe/algebra/tree_reduce.py
+++ b/modin/core/dataframe/algebra/tree_reduce.py
@@ -20,7 +20,7 @@ class TreeReduce(Operator):
     """Builder class for TreeReduce operator."""
 
     @classmethod
-    def register(cls, map_function, reduce_function=None, axis=None):
+    def register(cls, map_function, reduce_function=None, axis=None, dtypes=None):
         """
         Build TreeReduce operator.
 
@@ -32,6 +32,8 @@ class TreeReduce(Operator):
             Source reduce function.
         axis : int, optional
             Specifies axis to apply function along.
+        dtypes : callable(pandas.Series, *func_args, **func_kwargs) -> np.dtype, optional
+            Callable for computing dtypes.
 
         Returns
         -------
@@ -45,11 +47,17 @@ class TreeReduce(Operator):
         def caller(query_compiler, *args, **kwargs):
             """Execute TreeReduce function against passed query compiler."""
             _axis = kwargs.get("axis") if axis is None else axis
+
+            new_dtypes = None
+            if dtypes and query_compiler._modin_frame.has_materialized_dtypes:
+                new_dtypes = str(dtypes(query_compiler.dtypes, *args, **kwargs))
+
             return query_compiler.__constructor__(
                 query_compiler._modin_frame.tree_reduce(
                     cls.validate_axis(_axis),
                     lambda x: map_function(x, *args, **kwargs),
                     lambda y: reduce_function(y, *args, **kwargs),
+                    dtypes=new_dtypes,
                 )
             )
 

--- a/modin/core/dataframe/algebra/tree_reduce.py
+++ b/modin/core/dataframe/algebra/tree_reduce.py
@@ -20,7 +20,9 @@ class TreeReduce(Operator):
     """Builder class for TreeReduce operator."""
 
     @classmethod
-    def register(cls, map_function, reduce_function=None, axis=None, dtypes=None):
+    def register(
+        cls, map_function, reduce_function=None, axis=None, compute_dtypes=None
+    ):
         """
         Build TreeReduce operator.
 
@@ -32,7 +34,7 @@ class TreeReduce(Operator):
             Source reduce function.
         axis : int, optional
             Specifies axis to apply function along.
-        dtypes : callable(pandas.Series, *func_args, **func_kwargs) -> np.dtype, optional
+        compute_dtypes : callable(pandas.Series, *func_args, **func_kwargs) -> np.dtype, optional
             Callable for computing dtypes.
 
         Returns
@@ -49,8 +51,8 @@ class TreeReduce(Operator):
             _axis = kwargs.get("axis") if axis is None else axis
 
             new_dtypes = None
-            if dtypes and query_compiler._modin_frame.has_materialized_dtypes:
-                new_dtypes = str(dtypes(query_compiler.dtypes, *args, **kwargs))
+            if compute_dtypes and query_compiler._modin_frame.has_materialized_dtypes:
+                new_dtypes = str(compute_dtypes(query_compiler.dtypes, *args, **kwargs))
 
             return query_compiler.__constructor__(
                 query_compiler._modin_frame.tree_reduce(

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1936,7 +1936,9 @@ class PandasDataframe(ClassLogger):
         reduce_parts = self._partition_mgr_cls.map_axis_partitions(
             axis.value, map_parts, reduce_func
         )
-        return self._compute_tree_reduce_metadata(axis.value, reduce_parts)
+        return self._compute_tree_reduce_metadata(
+            axis.value, reduce_parts, dtypes=dtypes
+        )
 
     @lazy_metadata_decorator(apply_axis=None)
     def map(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -852,7 +852,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # TreeReduce operations
     count = TreeReduce.register(pandas.DataFrame.count, pandas.DataFrame.sum)
-    sum = TreeReduce.register(pandas.DataFrame.sum)
+
+    def _dtypes_sum(dtypes: pandas.Series, *func_args, **func_kwargs):  # noqa: GL08
+        # The common type evaluation for `TreeReduce` operator may differ depending
+        # on the pandas function, so it's better to pass a evaluation function that
+        # should be defined for each Modin's function.
+        return find_common_type(dtypes.tolist())
+
+    sum = TreeReduce.register(pandas.DataFrame.sum, dtypes=_dtypes_sum)
     prod = TreeReduce.register(pandas.DataFrame.prod)
     any = TreeReduce.register(pandas.DataFrame.any, pandas.DataFrame.any)
     all = TreeReduce.register(pandas.DataFrame.all, pandas.DataFrame.all)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -859,7 +859,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         # should be defined for each Modin's function.
         return find_common_type(dtypes.tolist())
 
-    sum = TreeReduce.register(pandas.DataFrame.sum, dtypes=_dtypes_sum)
+    sum = TreeReduce.register(pandas.DataFrame.sum, compute_dtypes=_dtypes_sum)
     prod = TreeReduce.register(pandas.DataFrame.prod)
     any = TreeReduce.register(pandas.DataFrame.any, pandas.DataFrame.any)
     all = TreeReduce.register(pandas.DataFrame.all, pandas.DataFrame.all)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6372 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
