### PR TITLE
FIX-#0000: don't test experimental xgboost with Ray nightly build

### DIFF
--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -41,7 +41,6 @@ jobs:
       - run: sudo apt update && sudo apt install -y libhdf5-dev
       - name: Run Modin tests
         run: |
-          python -m pytest modin/experimental/xgboost/test/test_default.py
           python -m pytest modin/pandas/test/dataframe/test_binary.py
           python -m pytest modin/pandas/test/dataframe/test_default.py
           python -m pytest modin/pandas/test/dataframe/test_indexing.py


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Fix CI on master branch. We need to either install `xgboost` explicitly or not test `xgboost` at all. I see no reason to test `test_default.py` file, since the test in it does not run for Ray.

Failed CI run: https://github.com/modin-project/modin/actions/runs/5691288650/job/15426197945

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
