### PR TITLE
FIX-#6429: exclude pymssql==2.2.8 from environments

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -34,7 +34,8 @@ dependencies:
   - sqlalchemy>=1.4.0,<1.4.46
   - pandas-gbq>=0.15.0
   - pytables>=3.6.1
-  - pymssql>=2.1.5
+  # pymssql==2.2.8 broken: https://github.com/modin-project/modin/issues/6429
+  - pymssql>=2.1.5,!=2.2.8
   - psycopg2>=2.8.6
   - fastparquet>=0.6.3,<2023.1.0
   - tqdm>=4.60.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -24,7 +24,8 @@ matplotlib>=3.6.1
 sqlalchemy>=1.4.0,<1.4.46
 pandas-gbq>=0.15.0
 tables>=3.6.1
-pymssql>=2.1.5
+# pymssql==2.2.8 broken: https://github.com/modin-project/modin/issues/6429
+pymssql>=2.1.5,!=2.2.8
 psycopg2>=2.8.6
 connectorx>=0.2.6a4
 fastparquet>=0.6.3,<2023.1.0

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -26,7 +26,8 @@ dependencies:
   - sqlalchemy>=1.4.0,<1.4.46
   - pandas-gbq>=0.15.0
   - pytables>=3.6.1
-  - pymssql>=2.1.5
+  # pymssql==2.2.8 broken: https://github.com/modin-project/modin/issues/6429
+  - pymssql>=2.1.5,!=2.2.8
   - psycopg2>=2.8.6
   - fastparquet>=0.6.3,<2023.1.0
   - tqdm>=4.60.0


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6429 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
