### PR TITLE
PERF-#6437: preserve dtypes for 'reindex'

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -653,8 +653,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 # "-1" means that the required labels are missing in the dataframe and the
                 # corresponding rows will be filled with "fill_value" that may change the column type.
                 if indexer is not None and -1 in indexer:
-                    for col in new_dtypes.keys():
-                        new_dtypes[col] = find_common_type((new_dtypes[col], dtype))
+                    for col, col_dtype in new_dtypes.items():
+                        new_dtypes[col] = find_common_type((col_dtype, dtype))
             else:
                 new_dtypes = self.dtypes.reindex(labels, fill_value=dtype)
         new_modin_frame = self._modin_frame.apply_full_axis(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -647,6 +647,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
             self._modin_frame.has_materialized_dtypes
             and kwargs.get("method", None) is None
         ):
+            # For columns, defining types is easier because we don't have to calculate the common
+            # type, since the entire column is filled. A simple `reindex` covers our needs.
+            # For rows, we can avoid calculating common types if we know that no new strings of
+            # arbitrary type have been added (this information is in `indexer`).
             dtype = pandas.Index([kwargs.get("fill_value", np.nan)]).dtype
             if axis == 0:
                 new_dtypes = self.dtypes.copy()

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -1089,3 +1089,14 @@ def test_setitem_bool_preserve_dtypes():
     # scalar as a col_loc
     df.loc[indexer, "a"] = 2.0
     assert df._query_compiler._modin_frame.has_materialized_dtypes
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [dict(axis=0, labels=[]), dict(axis=1, labels=["a"]), dict(axis=1, labels=[])],
+)
+def test_reindex_preserve_dtypes(kwargs):
+    df = pd.DataFrame({"a": [1, 1, 2, 2], "b": [3, 4, 5, 6]})
+
+    reindexed_df = df.reindex(**kwargs)
+    assert reindexed_df._query_compiler._modin_frame.has_materialized_dtypes


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6437 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
