### PR TITLE
FEAT-#6440: Use different HDK parameters for different queries

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
@@ -583,6 +583,8 @@ class CalciteBuilder:
 
     def __init__(self):
         self._input_ctx_stack = []
+        self.has_join = False
+        self.has_groupby = False
 
     def build(self, op):
         """
@@ -880,6 +882,7 @@ class CalciteBuilder:
         op : GroupbyAggNode
             An operation to translate.
         """
+        self.has_groupby = True
         frame = op.input[0]
 
         # Aggregation's input should always be a projection and
@@ -957,6 +960,7 @@ class CalciteBuilder:
         op : JoinNode
             An operation to translate.
         """
+        self.has_join = True
         node = CalciteJoinNode(
             left_id=self._input_node(0).id,
             right_id=self._input_node(1).id,

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/partitioning/partition_manager.py
@@ -256,11 +256,10 @@ class HdkOnNativeDataframePartitionManager(PandasDataframePartitionManager):
             calcite_json = "execute calcite " + calcite_json
         else:
             exec_calcite = False
-        if builder.has_groupby == builder.has_join:
-            exec_args = {}
-        elif builder.has_groupby:
+        exec_args = {}
+        if builder.has_groupby and not builder.has_join:
             exec_args = {"enable_lazy_fetch": 0, "enable_columnar_output": 0}
-        elif builder.has_join:
+        elif not builder.has_groupby and builder.has_join:
             exec_args = {"enable_lazy_fetch": 1, "enable_columnar_output": 1}
         table = worker.executeRA(calcite_json, exec_calcite, **exec_args)
 


### PR DESCRIPTION
## What do these changes do?

Disable lazy_fetch and columnar_output for groupby and enable for join queries.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6440 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
