### PR TITLE
FIX-#6443: Cast boolean columns before sum|mean|median groupby aggregations

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
@@ -45,7 +45,7 @@ from .df_algebra import (
 )
 
 from collections import abc
-from pandas.core.dtypes.common import get_dtype
+from pandas.core.dtypes.common import get_dtype, is_bool_dtype
 
 
 class CalciteBuilder:
@@ -581,6 +581,13 @@ class CalciteBuilder:
         bool: "BOOLEAN",
     }
 
+    # The following aggregates require boolean columns to be cast.
+    _bool_cast_aggregates = {
+        "sum": get_dtype(int),
+        "mean": get_dtype(float),
+        "median": get_dtype(float),
+    }
+
     def __init__(self):
         self._input_ctx_stack = []
 
@@ -888,10 +895,29 @@ class CalciteBuilder:
         for col in frame._table_cols:
             if col not in op.by:
                 proj_cols.append(col)
-        proj_exprs = [self._ref(frame, col) for col in proj_cols]
+
+        # Cast boolean columns, if required
+        agg_exprs = op.agg_exprs
+        cast_agg = self._bool_cast_aggregates
+        if any(v.agg in cast_agg for v in agg_exprs.values()) and (
+            bool_cols := {
+                c: cast_agg[agg_exprs[c].agg]
+                for c, t in frame.dtypes.items()
+                if is_bool_dtype(t) and agg_exprs[c].agg in cast_agg
+            }
+        ):
+            trans = self._input_ctx()._maybe_copy_and_translate_expr
+            proj_exprs = [
+                trans(frame.ref(c).cast(bool_cols[c]))
+                if c in bool_cols
+                else self._ref(frame, c)
+                for c in proj_cols
+            ]
+        else:
+            proj_exprs = [self._ref(frame, col) for col in proj_cols]
         # Add expressions required for compound aggregates
         compound_aggs = {}
-        for agg, expr in op.agg_exprs.items():
+        for agg, expr in agg_exprs.items():
             if expr.agg in self._compound_aggregates:
                 compound_aggs[agg] = self._compound_aggregates[expr.agg](
                     self, expr.operands[0]
@@ -907,7 +933,7 @@ class CalciteBuilder:
         group = [self._ref_idx(frame, col) for col in op.by]
         fields = op.by.copy()
         aggs = []
-        for agg, expr in op.agg_exprs.items():
+        for agg, expr in agg_exprs.items():
             if agg in compound_aggs:
                 extra_aggs = compound_aggs[agg].gen_agg_exprs()
                 fields.extend(extra_aggs.keys())
@@ -922,8 +948,8 @@ class CalciteBuilder:
             self._input_ctx().replace_input_node(frame, node, fields)
             proj_cols = op.by.copy()
             proj_exprs = [self._ref(frame, col) for col in proj_cols]
-            proj_cols.extend(op.agg_exprs.keys())
-            for agg in op.agg_exprs:
+            proj_cols.extend(agg_exprs.keys())
+            for agg in agg_exprs:
                 if agg in compound_aggs:
                     proj_exprs.append(compound_aggs[agg].gen_reduce_expr())
                 else:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -841,6 +841,7 @@ class TestGroupby:
         "a": [1, 1, 2, 2, 2, 1],
         "b": [11, 21, 12, 22, 32, 11],
         "c": [101, 201, 202, 202, 302, 302],
+        "d": [True, True, False, True, False, True],
     }
     cols_value = ["a", ["a", "b"]]
 
@@ -908,7 +909,7 @@ class TestGroupby:
         index = generate_multiindex(len(self.data["a"]))
 
         def groupby(df, *args, **kwargs):
-            df = df + 1
+            df = df[["a", "b", "c"]] + 1
             return df.groupby("a").agg({"b": "size"})
 
         run_and_compare(groupby, data=self.data, constructor_kwargs={"index": index})
@@ -1285,6 +1286,7 @@ class TestAgg:
         "b": [10, 20, None, 20, 10, None],
         "c": [None, 200, None, 400, 500, 600],
         "d": [11, 22, 33, 22, 33, 22],
+        "e": [True, True, False, True, False, True],
     }
     int_data = pandas.DataFrame(data).fillna(0).astype("int").to_dict()
 

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -857,9 +857,9 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         return self._modin_frame.dtypes
 
 
-_SUPPORTED_NUM_TYPE_CODES = set(np.typecodes["AllInteger"] + np.typecodes["Float"]) - {
-    np.dtype(np.float16).char
-}
+_SUPPORTED_NUM_TYPE_CODES = set(
+    np.typecodes["AllInteger"] + np.typecodes["Float"] + "?"
+) - {np.dtype(np.float16).char}
 
 
 def _check_int_or_float(op, dtypes):  # noqa: GL08

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -857,6 +857,7 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         return self._modin_frame.dtypes
 
 
+# "?" is the boolean type code.
 _SUPPORTED_NUM_TYPE_CODES = set(
     np.typecodes["AllInteger"] + np.typecodes["Float"] + "?"
 ) - {np.dtype(np.float16).char}


### PR DESCRIPTION

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6443 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
