### PR TITLE
FIX-#6446: Stop requiring modin-xgboost approval

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -6,7 +6,3 @@
 # of Modin.
 /modin/experimental/core/storage_formats/hdk/**    @modin-project/modin-hdk
 /modin/experimental/core/execution/native/implementations/hdk_on_native/**    @modin-project/modin-hdk
-
-# These owners will review everything related to the xgboost implementation
-# in Modin
-/modin/experimental/xgboost/**  @modin-project/modin-xgboost


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Stop requiring modin-xgboost approval for xgboost code. Current @modin-project/modin-xgboost members don't know much more than other members of modin-core about the xgboost code.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6446 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
