### PR TITLE
FIX-#6436: Support ~ in paths in IO functions correctly

### DIFF
--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -177,6 +177,8 @@ def _make_parser_func(sep: str, funcname: str) -> Callable:
     ----------
     sep : str
         The separator default to use for the parser.
+    funcname : str
+        The name of the generated parser function.
 
     Returns
     -------

--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -26,10 +26,8 @@ from . import DataFrame
 from modin.config import IsExperimental
 from modin.core.storage_formats import BaseQueryCompiler
 from modin.utils import expanduser_path_arg
-from modin.logging import enable_logging
 
 
-@enable_logging
 def read_sql(
     sql,
     con,
@@ -123,7 +121,6 @@ def read_sql(
 
 
 @expanduser_path_arg("filepath_or_buffer")
-@enable_logging
 def read_custom_text(
     filepath_or_buffer,
     columns,
@@ -250,7 +247,7 @@ def _make_parser_func(sep: str, funcname: str) -> Callable:
 
     parser_func.__doc__ = _read.__doc__
     parser_func.__name__ = funcname
-    return expanduser_path_arg("filepath_or_buffer")(enable_logging(parser_func))
+    return expanduser_path_arg("filepath_or_buffer")(parser_func)
 
 
 def _read(**kwargs) -> DataFrame:
@@ -308,7 +305,6 @@ read_csv_glob = _make_parser_func(sep=",", funcname="read_csv_glob")
 
 
 @expanduser_path_arg("filepath_or_buffer")
-@enable_logging
 def read_pickle_distributed(
     filepath_or_buffer,
     compression: Optional[str] = "infer",
@@ -356,7 +352,6 @@ def read_pickle_distributed(
 
 
 @expanduser_path_arg("filepath_or_buffer")
-@enable_logging
 def to_pickle_distributed(
     self,
     filepath_or_buffer,

--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -248,7 +248,7 @@ def _make_parser_func(sep: str, funcname: str) -> Callable:
 
     parser_func.__doc__ = _read.__doc__
     parser_func.__name__ = funcname
-    return expanduser_path_arg()(enable_logging(parser_func))
+    return expanduser_path_arg("filepath_or_buffer")(enable_logging(parser_func))
 
 
 def _read(**kwargs) -> DataFrame:

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -57,7 +57,7 @@ import warnings
 
 
 from .utils import is_full_grab_slice, _doc_binary_op
-from modin.utils import try_cast_to_pandas, _inherit_docstrings
+from modin.utils import try_cast_to_pandas, _inherit_docstrings, expanduser_path_arg
 from modin.error_message import ErrorMessage
 from modin import pandas as pd
 from modin.pandas.utils import is_scalar
@@ -2866,6 +2866,7 @@ class BasePandasDataset(ClassLogger):
         """
         return self._default_to_pandas("to_clipboard", excel=excel, sep=sep, **kwargs)
 
+    @expanduser_path_arg("path_or_buf")
     def to_csv(
         self,
         path_or_buf=None,
@@ -2919,6 +2920,7 @@ class BasePandasDataset(ClassLogger):
             storage_options=storage_options,
         )
 
+    @expanduser_path_arg("excel_writer")
     def to_excel(
         self,
         excel_writer,
@@ -2962,6 +2964,7 @@ class BasePandasDataset(ClassLogger):
     def to_dict(self, orient="dict", into=dict, index=True):
         return self._query_compiler.dataframe_to_dict(orient, into, index)
 
+    @expanduser_path_arg("path_or_buf")
     def to_hdf(
         self, path_or_buf, key, format="table", **kwargs
     ):  # pragma: no cover  # noqa: PR01, RT01, D200
@@ -2972,6 +2975,7 @@ class BasePandasDataset(ClassLogger):
             "to_hdf", path_or_buf, key, format=format, **kwargs
         )
 
+    @expanduser_path_arg("path_or_buf")
     def to_json(
         self,
         path_or_buf=None,
@@ -3008,6 +3012,7 @@ class BasePandasDataset(ClassLogger):
             mode=mode,
         )
 
+    @expanduser_path_arg("buf")
     def to_latex(
         self,
         buf=None,
@@ -3060,6 +3065,7 @@ class BasePandasDataset(ClassLogger):
             position=position,
         )
 
+    @expanduser_path_arg("buf")
     def to_markdown(
         self,
         buf=None,
@@ -3080,6 +3086,7 @@ class BasePandasDataset(ClassLogger):
             **kwargs,
         )
 
+    @expanduser_path_arg("path")
     def to_pickle(
         self,
         path,
@@ -3140,6 +3147,7 @@ class BasePandasDataset(ClassLogger):
         """
         return self._default_to_pandas("to_period", freq=freq, axis=axis, copy=copy)
 
+    @expanduser_path_arg("buf")
     def to_string(
         self,
         buf=None,

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -51,6 +51,7 @@ from modin.utils import (
     hashable,
     MODIN_UNNAMED_SERIES_LABEL,
     try_cast_to_pandas,
+    expanduser_path_arg,
 )
 from modin.config import PersistentPickle
 from .utils import (
@@ -1965,6 +1966,7 @@ class DataFrame(BasePandasDataset):
             )
         )
 
+    @expanduser_path_arg("path")
     def to_feather(self, path, **kwargs):  # pragma: no cover # noqa: PR01, RT01, D200
         """
         Write a ``DataFrame`` to the binary Feather format.
@@ -2001,6 +2003,7 @@ class DataFrame(BasePandasDataset):
             credentials=credentials,
         )
 
+    @expanduser_path_arg("path")
     def to_orc(self, path=None, *, engine="pyarrow", index=None, engine_kwargs=None):
         return self._default_to_pandas(
             pandas.DataFrame.to_orc,
@@ -2010,6 +2013,7 @@ class DataFrame(BasePandasDataset):
             engine_kwargs=engine_kwargs,
         )
 
+    @expanduser_path_arg("buf")
     def to_html(
         self,
         buf=None,
@@ -2066,6 +2070,7 @@ class DataFrame(BasePandasDataset):
             encoding=None,
         )
 
+    @expanduser_path_arg("path")
     def to_parquet(
         self,
         path=None,
@@ -2112,6 +2117,7 @@ class DataFrame(BasePandasDataset):
             index_dtypes=index_dtypes,
         )
 
+    @expanduser_path_arg("path")
     def to_stata(
         self,
         path: FilePath | WriteBuffer[bytes],
@@ -2144,6 +2150,7 @@ class DataFrame(BasePandasDataset):
             value_labels=value_labels,
         )
 
+    @expanduser_path_arg("path_or_buffer")
     def to_xml(
         self,
         path_or_buffer=None,

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -66,7 +66,7 @@ from modin.error_message import ErrorMessage
 from modin.logging import ClassLogger, enable_logging
 from .dataframe import DataFrame
 from .series import Series
-from modin.utils import _inherit_docstrings
+from modin.utils import _inherit_docstrings, expanduser_path_arg
 
 
 def _read(**kwargs):
@@ -100,6 +100,7 @@ def _read(**kwargs):
 
 
 @_inherit_docstrings(pandas.read_xml, apilink="pandas.read_xml")
+@expanduser_path_arg("path_or_buffer")
 @enable_logging
 def read_xml(
     path_or_buffer: FilePath | ReadBuffer[bytes] | ReadBuffer[str],
@@ -126,6 +127,7 @@ def read_xml(
 
 
 @_inherit_docstrings(pandas.read_csv, apilink="pandas.read_csv")
+@expanduser_path_arg("filepath_or_buffer")
 @enable_logging
 def read_csv(
     filepath_or_buffer: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
@@ -197,6 +199,7 @@ def read_csv(
 
 
 @_inherit_docstrings(pandas.read_table, apilink="pandas.read_table")
+@expanduser_path_arg("filepath_or_buffer")
 @enable_logging
 def read_table(
     filepath_or_buffer: FilePath | ReadCsvBuffer[bytes] | ReadCsvBuffer[str],
@@ -270,6 +273,7 @@ def read_table(
 
 
 @_inherit_docstrings(pandas.read_parquet, apilink="pandas.read_parquet")
+@expanduser_path_arg("path")
 @enable_logging
 def read_parquet(
     path,
@@ -301,6 +305,7 @@ def read_parquet(
 
 
 @_inherit_docstrings(pandas.read_json, apilink="pandas.read_json")
+@expanduser_path_arg("path_or_buf")
 @enable_logging
 def read_json(
     path_or_buf,
@@ -356,6 +361,7 @@ def read_gbq(
 
 
 @_inherit_docstrings(pandas.read_html, apilink="pandas.read_html")
+@expanduser_path_arg("io")
 @enable_logging
 def read_html(
     io,
@@ -407,6 +413,7 @@ def read_clipboard(
 
 
 @_inherit_docstrings(pandas.read_excel, apilink="pandas.read_excel")
+@expanduser_path_arg("io")
 @enable_logging
 def read_excel(
     io,
@@ -457,6 +464,7 @@ def read_excel(
 
 
 @_inherit_docstrings(pandas.read_hdf, apilink="pandas.read_hdf")
+@expanduser_path_arg("path_or_buf")
 @enable_logging
 def read_hdf(
     path_or_buf,
@@ -483,6 +491,7 @@ def read_hdf(
 
 
 @_inherit_docstrings(pandas.read_feather, apilink="pandas.read_feather")
+@expanduser_path_arg("path")
 @enable_logging
 def read_feather(
     path,
@@ -499,6 +508,7 @@ def read_feather(
 
 
 @_inherit_docstrings(pandas.read_stata)
+@expanduser_path_arg("filepath_or_buffer")
 @enable_logging
 def read_stata(
     filepath_or_buffer,
@@ -523,6 +533,7 @@ def read_stata(
 
 
 @_inherit_docstrings(pandas.read_sas, apilink="pandas.read_sas")
+@expanduser_path_arg("filepath_or_buffer")
 @enable_logging
 def read_sas(
     filepath_or_buffer,
@@ -553,6 +564,7 @@ def read_sas(
 
 
 @_inherit_docstrings(pandas.read_pickle, apilink="pandas.read_pickle")
+@expanduser_path_arg("filepath_or_buffer")
 @enable_logging
 def read_pickle(
     filepath_or_buffer,
@@ -597,6 +609,7 @@ def read_sql(
 
 
 @_inherit_docstrings(pandas.read_fwf, apilink="pandas.read_fwf")
+@expanduser_path_arg("filepath_or_buffer")
 @enable_logging
 def read_fwf(
     filepath_or_buffer: Union[str, pathlib.Path, IO[AnyStr]],
@@ -672,6 +685,7 @@ def read_sql_query(
 
 
 @_inherit_docstrings(pandas.to_pickle)
+@expanduser_path_arg("filepath_or_buffer")
 @enable_logging
 def to_pickle(
     obj: Any,
@@ -694,6 +708,7 @@ def to_pickle(
 
 
 @_inherit_docstrings(pandas.read_spss, apilink="pandas.read_spss")
+@expanduser_path_arg("path")
 @enable_logging
 def read_spss(
     path: Union[str, pathlib.Path],
@@ -740,6 +755,7 @@ def json_normalize(
 
 
 @_inherit_docstrings(pandas.read_orc, apilink="pandas.read_orc")
+@expanduser_path_arg("path")
 @enable_logging
 def read_orc(
     path,

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -93,13 +93,6 @@ except ImportError:
 
 from modin.config import NPartitions
 
-# Our configuration in pytest.ini requires that we explicitly catch all
-# instances of defaulting to pandas, but some test modules, like this one,
-# have too many such instances.
-# TODO(https://github.com/modin-project/modin/issues/3655): catch all instances
-# of defaulting to pandas.
-pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
-
 NPartitions.put(4)
 
 DATASET_SIZE_DICT = {
@@ -269,6 +262,7 @@ def make_parquet_dir(tmp_path):
     IsExperimental.get() and StorageFormat.get() == "Pyarrow",
     reason="Segmentation fault; see PR #2347 ffor details",
 )
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestCsv:
     # delimiter tests
     @pytest.mark.parametrize("sep", [None, "_", ",", ".", "\n"])
@@ -1307,6 +1301,24 @@ class TestCsv:
         )
 
 
+# Leave this test apart from the test classes, which skip the default to pandas
+# warning check. We want to make sure we are NOT defaulting to pandas for a
+# path relative to user home.
+# TODO(https://github.com/modin-project/modin/issues/3655): Get rid of this
+# commment once we turn all default to pandas messages into errors.
+def test_read_csv_relative_to_user_home(make_csv_file):
+    with ensure_clean(".csv") as unique_filename:
+        make_csv_file(filename=unique_filename)
+
+        with mock.patch.dict(os.environ, {"HOME": os.path.dirname(unique_filename)}):
+            with warns_that_defaulting_to_pandas() if Engine.get() == "Python" else _nullcontext():
+                eval_io(
+                    fn_name="read_csv",
+                    filepath_or_buffer=f"~/{os.path.basename(unique_filename)}",
+                )
+
+
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestTable:
     def test_read_table(self, make_csv_file):
         with ensure_clean() as unique_filename:
@@ -1358,6 +1370,7 @@ class TestTable:
 
 
 @pytest.mark.parametrize("engine", ["pyarrow", "fastparquet"])
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestParquet:
     @pytest.mark.parametrize("columns", [None, ["col1"]])
     @pytest.mark.parametrize("row_group_size", [None, 100, 1000, 10_000])
@@ -1729,6 +1742,24 @@ class TestParquet:
         )
 
 
+# Leave this test apart from the test classes, which skip the default to pandas
+# warning check. We want to make sure we are NOT defaulting to pandas for a
+# path relative to user home.
+# TODO(https://github.com/modin-project/modin/issues/3655): Get rid of this
+# commment once we turn all default to pandas messages into errors.
+def test_read_parquet_relative_to_user_home(make_parquet_file):
+    with ensure_clean(".parquet") as unique_filename:
+        make_parquet_file(filename=unique_filename)
+
+        with mock.patch.dict(os.environ, {"HOME": os.path.dirname(unique_filename)}):
+            with warns_that_defaulting_to_pandas() if Engine.get() == "Python" else _nullcontext():
+                eval_io(
+                    fn_name="read_parquet",
+                    path=f"~/{os.path.basename(unique_filename)}",
+                )
+
+
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestJson:
     @pytest.mark.parametrize("lines", [False, True])
     def test_read_json(self, make_json_file, lines):
@@ -1838,6 +1869,7 @@ class TestJson:
         assert parts_width_cached == parts_width_actual
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestExcel:
     @check_file_leaks
     def test_read_excel(self, make_excel_file):
@@ -2018,6 +2050,7 @@ class TestExcel:
         )
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestHdf:
     @pytest.mark.parametrize("format", [None, "table"])
     def test_read_hdf(self, make_hdf_file, format):
@@ -2072,6 +2105,7 @@ class TestHdf:
         df_equals(modin_df, pandas_df)
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestSql:
     @pytest.mark.parametrize("read_sql_engine", ["Pandas", "Connectorx"])
     def test_read_sql(self, tmp_path, make_sql_connection, read_sql_engine):
@@ -2246,6 +2280,7 @@ class TestSql:
         assert df_modin_sql.sort_index().equals(df_pandas_sql.sort_index())
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestHtml:
     def test_read_html(self, make_html_file):
         eval_io(fn_name="read_html", io=make_html_file())
@@ -2262,6 +2297,7 @@ class TestHtml:
         )
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestFwf:
     def test_fwf_file(self, make_fwf_file):
         fwf_data = (
@@ -2489,6 +2525,7 @@ class TestFwf:
         )
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestGbq:
     @pytest.mark.skip(reason="Can not pass without GBQ access")
     def test_read_gbq(self):
@@ -2519,6 +2556,7 @@ class TestGbq:
         read_gbq.assert_called_once_with(*test_args, **test_kwargs)
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestStata:
     def test_read_stata(self, make_stata_file):
         eval_io(
@@ -2538,6 +2576,7 @@ class TestStata:
         )
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestSas:
     def test_read_sas(self):
         eval_io(
@@ -2547,6 +2586,7 @@ class TestSas:
         )
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestFeather:
     def test_read_feather(self, make_feather_file):
         eval_io(
@@ -2611,6 +2651,7 @@ class TestFeather:
         )
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestClipboard:
     @pytest.mark.skip(reason="No clipboard in CI")
     def test_read_clipboard(self):
@@ -2631,6 +2672,7 @@ class TestClipboard:
         assert modin_as_clip.equals(pandas_as_clip)
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestPickle:
     def test_read_pickle(self, make_pickle_file):
         eval_io(
@@ -2650,6 +2692,7 @@ class TestPickle:
         )
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestXml:
     def test_read_xml(self):
         # example from pandas
@@ -2669,6 +2712,7 @@ class TestXml:
         eval_io("read_xml", path_or_buffer=data)
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestOrc:
     # It's not easy to add infrastructure for `orc` format.
     # In case of defaulting to pandas, it's enough
@@ -2687,6 +2731,7 @@ class TestOrc:
         read_orc.assert_called_once_with(*test_args, **test_kwargs)
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestSpss:
     # It's not easy to add infrastructure for `spss` format.
     # In case of defaulting to pandas, it's enough
@@ -2703,6 +2748,7 @@ class TestSpss:
         read_spss.assert_called_once_with(*test_args, **test_kwargs)
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 def test_json_normalize():
     # example from pandas
     data = [
@@ -2713,12 +2759,14 @@ def test_json_normalize():
     eval_io("json_normalize", data=data)
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 def test_from_arrow():
     _, pandas_df = create_test_dfs(TEST_DATA)
     modin_df = from_arrow(pa.Table.from_pandas(pandas_df))
     df_equals(modin_df, pandas_df)
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 def test_from_spmatrix():
     data = sparse.eye(3)
     with pytest.warns(UserWarning, match="defaulting to pandas.*"):
@@ -2727,12 +2775,14 @@ def test_from_spmatrix():
     df_equals(modin_df, pandas_df)
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 def test_to_dense():
     data = {"col1": pandas.arrays.SparseArray([0, 1, 0])}
     modin_df, pandas_df = create_test_dfs(data)
     df_equals(modin_df.sparse.to_dense(), pandas_df.sparse.to_dense())
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 def test_to_dict_dataframe():
     modin_df, _ = create_test_dfs(TEST_DATA)
     assert modin_df.to_dict() == to_pandas(modin_df).to_dict()
@@ -2747,6 +2797,7 @@ def test_to_dict_dataframe():
         pytest.param({"into": defaultdict(list)}, id="into_defaultdict"),
     ],
 )
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 def test_to_dict_series(kwargs):
     eval_general(
         *[df.iloc[:, 0] for df in create_test_dfs(utils_test_data["int_data"])],
@@ -2757,11 +2808,13 @@ def test_to_dict_series(kwargs):
     )
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 def test_to_latex():
     modin_df, _ = create_test_dfs(TEST_DATA)
     assert modin_df.to_latex() == to_pandas(modin_df).to_latex()
 
 
+@pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 def test_to_period():
     index = pandas.DatetimeIndex(
         pandas.date_range("2000", freq="h", periods=len(TEST_DATA["col1"]))

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1301,11 +1301,11 @@ class TestCsv:
         )
 
 
-def _check_relative_io(fn_name, unique_filename, path_arg):
+def _check_relative_io(fn_name, unique_filename, path_arg, storage_default=()):
     # Windows can be funny at where it searches for ~; besides, Python >= 3.8 no longer honors %HOME%
     dirname, basename = os.path.split(unique_filename)
     pinned_home = {envvar: dirname for envvar in ("HOME", "USERPROFILE", "HOMEPATH")}
-    should_default = Engine.get() == "Python" or StorageFormat.get() == "Hdk"
+    should_default = Engine.get() == "Python" or StorageFormat.get() in storage_default
     with mock.patch.dict(os.environ, pinned_home):
         with warns_that_defaulting_to_pandas() if should_default else _nullcontext():
             eval_io(
@@ -1763,7 +1763,9 @@ class TestParquet:
 def test_read_parquet_relative_to_user_home(make_parquet_file):
     with ensure_clean(".parquet") as unique_filename:
         make_parquet_file(filename=unique_filename)
-        _check_relative_io("read_parquet", unique_filename, "path")
+        _check_relative_io(
+            "read_parquet", unique_filename, "path", storage_default=("Hdk",)
+        )
 
 
 @pytest.mark.filterwarnings(default_to_pandas_ignore_string)

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -928,6 +928,7 @@ def eval_general(
     )
     if values is not None:
         comparator(*values, **(comparator_kwargs or {}))
+        return values[0]
 
 
 def eval_io(
@@ -977,7 +978,7 @@ def eval_io(
         return result
 
     def call_eval_general():
-        eval_general(
+        return eval_general(
             pd,
             pandas,
             applyier,
@@ -993,9 +994,9 @@ def eval_io(
     warn_match = modin_warning_str_match if modin_warning is not None else None
     if modin_warning:
         with pytest.warns(modin_warning, match=warn_match):
-            call_eval_general()
+            return call_eval_general()
     else:
-        call_eval_general()
+        return call_eval_general()
 
 
 def eval_io_from_str(csv_str: str, unique_filename: str, **kwargs):

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -928,7 +928,6 @@ def eval_general(
     )
     if values is not None:
         comparator(*values, **(comparator_kwargs or {}))
-        return values[0]
 
 
 def eval_io(
@@ -978,7 +977,7 @@ def eval_io(
         return result
 
     def call_eval_general():
-        return eval_general(
+        eval_general(
             pd,
             pandas,
             applyier,
@@ -994,9 +993,9 @@ def eval_io(
     warn_match = modin_warning_str_match if modin_warning is not None else None
     if modin_warning:
         with pytest.warns(modin_warning, match=warn_match):
-            return call_eval_general()
+            call_eval_general()
     else:
-        return call_eval_general()
+        call_eval_general()
 
 
 def eval_io_from_str(csv_str: str, unique_filename: str, **kwargs):

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -460,9 +460,9 @@ def expanduser_path_arg(argname: str) -> Callable[[Fn], Fn]:
         Decorator which performs the replacement.
     """
 
-    def decorator(func):
+    def decorator(func: Callable) -> Callable:
         @functools.wraps(func)
-        def wrapped(*_args, **_kw):
+        def wrapped(*_args: Any, **_kw: Any) -> Any:
             kwargs = dict(locals())
             kwargs.pop("_args", None)
             kwargs.pop("_kw", None)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Implemented a decorator which would expand user paths (i.g. `~/foo.txt` or `~user/bar.txt`) passed as given argument in the decorated function. This should stop unnecessary defaulting to pandas for some implementations (where we checked that file existed, which it doesn't until one expands the path).

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6436, #3180
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

Note: supersedes #4724.