### PR TITLE
REFACTOR-#4278: remove unused arguments from `BasePandasDataset.apply`

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -854,11 +854,8 @@ class BasePandasDataset(ClassLogger):
         self,
         func,
         axis,
-        broadcast,
         raw,
-        reduce,
         result_type,
-        convert_dtype,
         args,
         **kwds,
     ):  # noqa: PR01, RT01, D200

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -394,11 +394,8 @@ class DataFrame(BasePandasDataset):
         query_compiler = super(DataFrame, self).apply(
             func,
             axis=axis,
-            broadcast=None,
             raw=raw,
-            reduce=None,
             result_type=result_type,
-            convert_dtype=None,
             args=args,
             **kwargs,
         )

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -604,11 +604,8 @@ class Series(BasePandasDataset):
             result = super(Series, self).apply(
                 func,
                 axis=0,
-                broadcast=None,
                 raw=False,
-                reduce=None,
                 result_type=None,
-                convert_dtype=convert_dtype,
                 args=args,
                 **kwargs,
             )


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4278 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
