### PR TITLE
FIX-#6456: create fake xgboost module for building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ def noop_decorator(*args, **kwargs):
 ray.remote = noop_decorator
 
 # fake modules if they're missing
-for mod_name in ("cudf", "cupy", "pyarrow.gandiva", "pyhdk", "pyhdk.hdk"):
+for mod_name in ("cudf", "cupy", "pyarrow.gandiva", "pyhdk", "pyhdk.hdk", "xgboost"):
     try:
         __import__(mod_name)
     except ImportError:
@@ -49,6 +49,8 @@ if not hasattr(sys.modules["pyhdk.hdk"], "RelAlgExecutor"):
 if not hasattr(sys.modules["pyhdk"], "__version__"):
     # Show all known pyhdk config options in documentation
     sys.modules["pyhdk"].__version__ = "999"
+if not hasattr(sys.modules["xgboost"], "Booster"):
+    sys.modules["xgboost"].Booster = type("Booster", (object,), {})
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 import modin

--- a/docs/getting_started/using_modin/using_modin_cluster.rst
+++ b/docs/getting_started/using_modin/using_modin_cluster.rst
@@ -55,8 +55,6 @@ Modin:
    ray.shutdown()
 
 Congratualions! You have successfully connected to the Ray cluster.
-See more on the :doc:`Modin in the Cloud </usage_guide/advanced_usage/modin_in_the_cloud>`
-documentation page.
 
 Using Modin on a Ray Cluster
 ----------------------------


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

It is strange that this problem did not appear before. Perhaps there was some kind of caching that I did not take into account.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6456 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
