### PR TITLE
FIX-#4347: read_excel: defaults to pandas for unsupported types of 'io'

### DIFF
--- a/modin/core/io/io.py
+++ b/modin/core/io/io.py
@@ -279,6 +279,10 @@ class BaseIO:
     def read_excel(cls, **kwargs):  # noqa: PR01
         ErrorMessage.default_to_pandas("`read_excel`")
         if isinstance(kwargs["io"], ExcelFile):
+            # otherwise, Modin objects may be passed to the pandas context, resulting
+            # in undefined behavior
+            # for example in the case: pd.read_excel(pd.ExcelFile), since reading from
+            # pd.ExcelFile in `read_excel` isn't supported
             kwargs["io"]._set_pandas_mode()
         intermediate = pandas.read_excel(**kwargs)
         if isinstance(intermediate, (OrderedDict, dict)):

--- a/modin/core/io/io.py
+++ b/modin/core/io/io.py
@@ -28,6 +28,7 @@ from modin.db_conn import ModinDatabaseConnection
 from modin.error_message import ErrorMessage
 from modin.core.storage_formats.base.query_compiler import BaseQueryCompiler
 from modin.utils import _inherit_docstrings
+from modin.pandas.io import ExcelFile
 
 _doc_default_io_method = """
 {summary} using pandas.
@@ -277,6 +278,8 @@ class BaseIO:
     )
     def read_excel(cls, **kwargs):  # noqa: PR01
         ErrorMessage.default_to_pandas("`read_excel`")
+        if isinstance(kwargs["io"], ExcelFile):
+            kwargs["io"]._set_pandas_mode()
         intermediate = pandas.read_excel(**kwargs)
         if isinstance(intermediate, (OrderedDict, dict)):
             parsed = type(intermediate)()

--- a/modin/core/io/text/excel_dispatcher.py
+++ b/modin/core/io/text/excel_dispatcher.py
@@ -70,7 +70,8 @@ class ExcelDispatcher(TextFileDispatcher):
                 io._set_pandas_mode()
             return cls.single_worker_read(
                 io,
-                reason="Modin only implements parallel `read_excel` the following types of `io`: str.",
+                reason="Modin only implements parallel `read_excel` the following types of `io`: "
+                + "str, os.PathLike, io.BytesIO, io.StringIO.",
                 **kwargs
             )
 
@@ -98,7 +99,7 @@ class ExcelDispatcher(TextFileDispatcher):
 
         # NOTE: ExcelReader() in read-only mode does not close file handle by itself
         # work around that by passing file object if we received some path
-        io_file = open(io, "rb") if isinstance(io, str) else io
+        io_file = open(io, "rb") if isinstance(io, (str, os.PathLike)) else io
         try:
             ex = ExcelReader(io_file, read_only=True)
             ex.read()
@@ -109,7 +110,7 @@ class ExcelDispatcher(TextFileDispatcher):
             ex.read_strings()
             ws = Worksheet(wb)
         finally:
-            if isinstance(io, str):
+            if isinstance(io, (str, os.PathLike)):
                 # close only if it were us who opened the object
                 io_file.close()
 

--- a/modin/core/io/text/excel_dispatcher.py
+++ b/modin/core/io/text/excel_dispatcher.py
@@ -14,7 +14,7 @@
 """Module houses `ExcelDispatcher` class, that is used for reading excel files."""
 
 import os
-from io import BytesIO, StringIO
+from io import BytesIO
 
 import pandas
 import re
@@ -63,7 +63,7 @@ class ExcelDispatcher(TextFileDispatcher):
             io = BytesIO(io)
 
         # isinstance(ExcelFile, os.PathLike) == True
-        if not isinstance(io, (str, os.PathLike, BytesIO, StringIO)) or isinstance(
+        if not isinstance(io, (str, os.PathLike, BytesIO)) or isinstance(
             io, (ExcelFile, pandas.ExcelFile)
         ):
             if isinstance(io, ExcelFile):
@@ -71,7 +71,7 @@ class ExcelDispatcher(TextFileDispatcher):
             return cls.single_worker_read(
                 io,
                 reason="Modin only implements parallel `read_excel` the following types of `io`: "
-                + "str, os.PathLike, io.BytesIO, io.StringIO.",
+                + "str, os.PathLike, io.BytesIO.",
                 **kwargs
             )
 

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -839,6 +839,8 @@ class ExcelFile(ClassLogger, pandas.ExcelFile):  # noqa: PR01, D200
 
     def _set_pandas_mode(self):  # noqa
         # disable Modin behavior to be able to pass object to `pandas.read_excel`
+        # otherwise, Modin objects may be passed to the pandas context, resulting
+        # in undefined behavior
         self._behave_like_pandas = True
 
     def __getattribute__(self, item):

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -837,7 +837,8 @@ class ExcelFile(ClassLogger, pandas.ExcelFile):  # noqa: PR01, D200
 
     _behave_like_pandas = False
 
-    def _set_pandas_mode(self):
+    def _set_pandas_mode(self):  # noqa
+        # disable Modin behavior to be able to pass object to `pandas.read_excel`
         self._behave_like_pandas = True
 
     def __getattribute__(self, item):

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -835,10 +835,18 @@ class ExcelFile(ClassLogger, pandas.ExcelFile):  # noqa: PR01, D200
     Class for parsing tabular excel sheets into DataFrame objects.
     """
 
+    _behave_like_pandas = False
+
+    def _set_pandas_mode(self):
+        self._behave_like_pandas = True
+
     def __getattribute__(self, item):
+        if item in ["_set_pandas_mode", "_behave_like_pandas"]:
+            return object.__getattribute__(self, item)
+
         default_behaviors = ["__init__", "__class__"]
         method = super(ExcelFile, self).__getattribute__(item)
-        if item not in default_behaviors:
+        if not self._behave_like_pandas and item not in default_behaviors:
             if callable(method):
 
                 def return_handler(*args, **kwargs):

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -44,6 +44,7 @@ from modin.test.test_utils import warns_that_defaulting_to_pandas
 import pyarrow as pa
 import fastparquet
 import os
+from io import BytesIO, StringIO
 from scipy import sparse
 import sys
 import sqlalchemy as sa
@@ -1006,8 +1007,6 @@ class TestCsv:
             warning_suffix = ""
         with warns_that_defaulting_to_pandas(suffix=warning_suffix):
             # This tests that we default to pandas on a buffer
-            from io import StringIO
-
             with open(pytest.csvs_names["test_read_csv_regular"], "r") as _f:
                 pd.read_csv(StringIO(_f.read()))
 
@@ -1944,11 +1943,13 @@ class TestJson:
 @pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestExcel:
     @check_file_leaks
-    def test_read_excel(self, make_excel_file):
+    @pytest.mark.parametrize("pathlike", [False, True])
+    def test_read_excel(self, pathlike, make_excel_file):
+        unique_filename = make_excel_file()
         eval_io(
             fn_name="read_excel",
             # read_excel kwargs
-            io=make_excel_file(),
+            io=Path(unique_filename) if pathlike else unique_filename,
         )
 
     @check_file_leaks
@@ -2089,6 +2090,51 @@ class TestExcel:
         finally:
             modin_excel_file.close()
             pandas_excel_file.close()
+
+    def test_ExcelFile_bytes(self, make_excel_file):
+        unique_filename = make_excel_file()
+        with open(unique_filename, mode="rb") as f:
+            content = f.read()
+
+        modin_excel_file = pd.ExcelFile(content)
+        pandas_excel_file = pandas.ExcelFile(content)
+
+        df_equals(modin_excel_file.parse(), pandas_excel_file.parse())
+        assert isinstance(modin_excel_file, pd.ExcelFile)
+
+    def test_read_excel_from_ExcelFile(self, make_excel_file):
+        unique_filename = make_excel_file()
+        with open(unique_filename, mode="rb") as f:
+            content = f.read()
+
+        modin_excel_file = pd.ExcelFile(content)
+        pandas_excel_file = pandas.ExcelFile(content)
+
+        df_equals(pd.read_excel(modin_excel_file), pandas.read_excel(pandas_excel_file))
+
+    @pytest.mark.parametrize("use_bytes_io", [False, True])
+    def test_read_excel_from_bytes(self, use_bytes_io, make_excel_file):
+        unique_filename = make_excel_file()
+        with open(unique_filename, mode="rb") as f:
+            io_bytes = f.read()
+
+        if use_bytes_io:
+            io_bytes = BytesIO(io_bytes)
+
+        eval_io(
+            fn_name="read_excel",
+            # read_excel kwargs
+            io=io_bytes,
+        )
+
+    def test_read_excel_from_file_handle(self, make_excel_file):
+        unique_filename = make_excel_file()
+        with open(unique_filename, mode="rb") as f:
+            eval_io(
+                fn_name="read_excel",
+                # read_excel kwargs
+                io=f,
+            )
 
     @pytest.mark.xfail(strict=False, reason="Flaky test, defaults to pandas")
     def test_to_excel(self, tmp_path):

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -2102,7 +2102,7 @@ class TestExcel:
         df_equals(modin_excel_file.parse(), pandas_excel_file.parse())
         assert isinstance(modin_excel_file, pd.ExcelFile)
 
-    def test_read_excel_from_ExcelFile(self, make_excel_file):
+    def test_read_excel_ExcelFile(self, make_excel_file):
         unique_filename = make_excel_file()
         with open(unique_filename, mode="rb") as f:
             content = f.read()
@@ -2113,7 +2113,7 @@ class TestExcel:
         df_equals(pd.read_excel(modin_excel_file), pandas.read_excel(pandas_excel_file))
 
     @pytest.mark.parametrize("use_bytes_io", [False, True])
-    def test_read_excel_from_bytes(self, use_bytes_io, make_excel_file):
+    def test_read_excel_bytes(self, use_bytes_io, make_excel_file):
         unique_filename = make_excel_file()
         with open(unique_filename, mode="rb") as f:
             io_bytes = f.read()
@@ -2127,7 +2127,7 @@ class TestExcel:
             io=io_bytes,
         )
 
-    def test_read_excel_from_file_handle(self, make_excel_file):
+    def test_read_excel_file_handle(self, make_excel_file):
         unique_filename = make_excel_file()
         with open(unique_filename, mode="rb") as f:
             eval_io(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -2086,7 +2086,6 @@ class TestExcel:
         try:
             df_equals(modin_excel_file.parse(), pandas_excel_file.parse())
             assert modin_excel_file.io == unique_filename
-            assert isinstance(modin_excel_file, pd.ExcelFile)
         finally:
             modin_excel_file.close()
             pandas_excel_file.close()
@@ -2100,7 +2099,6 @@ class TestExcel:
         pandas_excel_file = pandas.ExcelFile(content)
 
         df_equals(modin_excel_file.parse(), pandas_excel_file.parse())
-        assert isinstance(modin_excel_file, pd.ExcelFile)
 
     def test_read_excel_ExcelFile(self, make_excel_file):
         unique_filename = make_excel_file()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4347 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
