### PR TITLE
REFACTOR-#6470: remove 'Patcher' internal class

### DIFF
--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -99,34 +99,6 @@ def pytest_addoption(parser):
     )
 
 
-class Patcher:
-    def __init__(self, conn, *pairs):
-        self.pairs = pairs
-        self.originals = None
-        self.conn = conn
-
-    def __wrap(self, func):
-        def wrapper(*a, **kw):
-            return func(
-                *(tuple(self.conn.obtain(x) for x in a)),
-                **({k: self.conn.obtain(v) for k, v in kw.items()}),
-            )
-
-        return func, wrapper
-
-    def __enter__(self):
-        self.originals = []
-        for module, attrname in self.pairs:
-            orig, wrapped = self.__wrap(getattr(module, attrname))
-            self.originals.append((module, attrname, orig))
-            setattr(module, attrname, wrapped)
-        return self
-
-    def __exit__(self, *a, **kw):
-        for module, attrname, orig in self.originals:
-            setattr(module, attrname, orig)
-
-
 def set_experimental_env(mode):
     IsExperimental.put(mode == "experimental")
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6470 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
