### PR TITLE
FIX-#6479: HDK CalciteBuilder: Do not call is_bool_dtype() for categorical

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
@@ -45,7 +45,7 @@ from .df_algebra import (
 )
 
 from collections import abc
-from pandas.core.dtypes.common import get_dtype, is_bool_dtype
+from pandas.core.dtypes.common import get_dtype, is_categorical_dtype, is_bool_dtype
 
 
 class CalciteBuilder:
@@ -906,7 +906,10 @@ class CalciteBuilder:
             bool_cols := {
                 c: cast_agg[agg_exprs[c].agg]
                 for c, t in frame.dtypes.items()
-                if is_bool_dtype(t) and agg_exprs[c].agg in cast_agg
+                # Do not call is_bool_dtype() for categorical since it checks all the categories
+                if not is_categorical_dtype(t)
+                and is_bool_dtype(t)
+                and agg_exprs[c].agg in cast_agg
             }
         ):
             trans = self._input_ctx()._maybe_copy_and_translate_expr


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6479 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
