### PR TITLE
PERF-#6478: Do not propagate new columns if they're identical to the previous ones

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -579,6 +579,12 @@ class PandasDataframe(ClassLogger):
            The new column labels.
         """
         if self.has_materialized_columns:
+            # do not set new columns if they're identical to the previous ones
+            if (
+                isinstance(new_columns, pandas.Index)
+                and self.columns.equals(new_columns)
+            ) or np.array_equal(self.columns.values, new_columns):
+                return
             new_columns = self._validate_set_axis(new_columns, self._columns_cache)
             if self.has_materialized_dtypes:
                 self.dtypes.index = new_columns

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -639,6 +639,7 @@ class PandasDataframe(ClassLogger):
         List of int
             Size of partitions alongside specified `axis`.
         """
+
         if partitions is None:
             partitions = self._partitions
         new_index, internal_idx = self._partition_mgr_cls.get_indices(axis, partitions)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -581,9 +581,22 @@ class PandasDataframe(ClassLogger):
         if self.has_materialized_columns:
             # do not set new columns if they're identical to the previous ones
             if (
-                isinstance(new_columns, pandas.Index)
-                and self.columns.equals(new_columns)
-            ) or np.array_equal(self.columns.values, new_columns):
+                # `Index.equals()` doesn't compare metadata, thus we have to compare
+                # it manually. Here we process the simpliest and the most common case only
+                # (when index the index is a 'pandas.Index' dtype). Other cases are not that
+                # common and we can omit them
+                type(new_columns) in (pandas.Index, pandas.MultiIndex)
+                and (
+                    type(new_columns)
+                    is type(self.columns)  # noqa; here we need exact types comparison
+                )
+                and new_columns.name == self.columns.name
+                and new_columns.names == self.columns.names
+                and new_columns.equals(self.columns)
+            ) or (
+                not isinstance(new_columns, pandas.Index)
+                and np.array_equal(self.columns.values, new_columns)
+            ):
                 return
             new_columns = self._validate_set_axis(new_columns, self._columns_cache)
             if self.has_materialized_dtypes:
@@ -639,7 +652,6 @@ class PandasDataframe(ClassLogger):
         List of int
             Size of partitions alongside specified `axis`.
         """
-
         if partitions is None:
             partitions = self._partitions
         new_index, internal_idx = self._partition_mgr_cls.get_indices(axis, partitions)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -581,18 +581,8 @@ class PandasDataframe(ClassLogger):
         if self.has_materialized_columns:
             # do not set new columns if they're identical to the previous ones
             if (
-                # `Index.equals()` doesn't compare metadata, thus we have to compare
-                # it manually. Here we process the simpliest and the most common case only
-                # (when index the index is a 'pandas.Index' dtype). Other cases are not that
-                # common and we can omit them
-                type(new_columns) in (pandas.Index, pandas.MultiIndex)
-                and (
-                    type(new_columns)
-                    is type(self.columns)  # noqa; here we need exact types comparison
-                )
-                and new_columns.name == self.columns.name
-                and new_columns.names == self.columns.names
-                and new_columns.equals(self.columns)
+                isinstance(new_columns, pandas.Index)
+                and self.columns.identical(new_columns)
             ) or (
                 not isinstance(new_columns, pandas.Index)
                 and np.array_equal(self.columns.values, new_columns)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2401,7 +2401,8 @@ class DataFrame(BasePandasDataset):
         #   before it appears in __dict__.
         if key in ("_query_compiler", "_siblings", "_cache") or key in self.__dict__:
             pass
-        elif key in self and key not in dir(self):
+        # we have to check for the key in `dir(self)` first in order not to trigger columns computation
+        elif key not in dir(self) and key in self:
             self.__setitem__(key, value)
             # Note: return immediately so we don't keep this `key` as dataframe state.
             # `__getattr__` will return the columns not present in `dir(self)`, so we do not need

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -1167,6 +1167,27 @@ def test_skip_set_columns():
     assert not df._query_compiler._modin_frame._deferred_column
 
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [3, 4, 5]})
+    df.columns = pandas.Index(["col1", "col2"], name="new name")
+    # Verifies that the new columns weren't set if they're equal to the previous ones
+    assert df.columns.name == "new name"
+
+    df = pd.DataFrame(
+        {("a", "col1"): [1, 2, 3], ("a", "col2"): [3, 4, 5], ("b", "col1"): [6, 7, 8]}
+    )
+    df.columns = df.columns.copy()
+    # Verifies that the new columns weren't set if they're equal to the previous ones
+    assert not df._query_compiler._modin_frame._deferred_column
+
+    df = pd.DataFrame(
+        {("a", "col1"): [1, 2, 3], ("a", "col2"): [3, 4, 5], ("b", "col1"): [6, 7, 8]}
+    )
+    new_cols = df.columns[::-1]
+    df.columns = new_cols
+    # Verifies that the new columns were successfully set in case they're actually new
+    assert df._query_compiler._modin_frame._deferred_column
+    assert df.columns.equals(new_cols)
+
+    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [3, 4, 5]})
     remove_axis_cache(df, axis=1)
     df.columns = ["col1", "col2"]
     # Verifies that the computation of the old columns wasn't triggered for the sake

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -1168,7 +1168,7 @@ def test_skip_set_columns():
 
     df = pd.DataFrame({"col1": [1, 2, 3], "col2": [3, 4, 5]})
     df.columns = pandas.Index(["col1", "col2"], name="new name")
-    # Verifies that the new columns weren't set if they're equal to the previous ones
+    # Verifies that the new columns were successfully set in case they's new metadata
     assert df.columns.name == "new name"
 
     df = pd.DataFrame(

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -148,6 +148,29 @@ def validate_partitions_cache(df):
             assert df._partitions[i, j].width() == column_widths[j]
 
 
+def remove_axis_cache(df, axis, remove_lengths=True):
+    """
+    Remove index/columns cache for the passed dataframe.
+
+    Parameters
+    ----------
+    df : modin.pandas.DataFrame
+    axis : int
+        0 - remove index cache, 1 - remove columns cache.
+    remove_lengths : bool, default: True
+        Whether to remove row lengths/column widths cache.
+    """
+    mf = df._query_compiler._modin_frame
+    if axis == 0:
+        mf.set_index_cache(None)
+        if remove_lengths:
+            mf._row_lengths_cache = None
+    else:
+        mf.set_columns_cache(None)
+        if remove_lengths:
+            mf._column_widths_cache = None
+
+
 def test_aligning_blocks():
     # Test problem when modin frames have the same number of rows, but different
     # blocks (partition.list_of_blocks). See #2322 for details
@@ -1121,3 +1144,32 @@ def test_reindex_preserve_dtypes(kwargs):
 
     reindexed_df = df.reindex(**kwargs)
     assert reindexed_df._query_compiler._modin_frame.has_materialized_dtypes
+
+
+def test_skip_set_columns():
+    """
+    Verifies that the mechanism of skipping the actual ``._set_columns()`` call in case
+    the new columns are identical to the previous ones works properly.
+
+    In this test, we rely on the ``modin_frame._deferred_column`` attribute.
+    The new indices propagation is done lazily, and the ``deferred_column`` attribute
+    indicates whether there's a new indices propagation pending.
+    """
+    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [3, 4, 5]})
+    df.columns = ["col1", "col10"]
+    # Verifies that the new columns were successfully set in case they're actually new
+    assert df._query_compiler._modin_frame._deferred_column
+    assert np.all(df.columns.values == ["col1", "col10"])
+
+    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [3, 4, 5]})
+    df.columns = ["col1", "col2"]
+    # Verifies that the new columns weren't set if they're equal to the previous ones
+    assert not df._query_compiler._modin_frame._deferred_column
+
+    df = pd.DataFrame({"col1": [1, 2, 3], "col2": [3, 4, 5]})
+    remove_axis_cache(df, axis=1)
+    df.columns = ["col1", "col2"]
+    # Verifies that the computation of the old columns wasn't triggered for the sake
+    # of equality comparison, in this case the new columns should be set unconditionally,
+    # meaning that the '_deferred_column' has to be True
+    assert df._query_compiler._modin_frame._deferred_column

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ tag_prefix =
 parentdir_prefix = modin-
 
 [tool:pytest]
-addopts = --disable-pytest-warnings --cov-config=setup.cfg --cov=modin --cov-append --cov-report=
+addopts = --disable-pytest-warnings
 xfail_strict=true
 markers =
     xfail_executions

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ tag_prefix =
 parentdir_prefix = modin-
 
 [tool:pytest]
-addopts = --disable-pytest-warnings
+addopts = --disable-pytest-warnings --cov-config=setup.cfg --cov=modin --cov-append --cov-report=
 xfail_strict=true
 markers =
     xfail_executions


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The PR adds this new behavior for `._set_columns()` only, this is for the reason that the row indices are usually much longer and more complex than columns, thus their equality comparison may be much more expensive and would require additional heuristics valuing whether it's worth performing expensive comparison or not.

**Motivation for this PR:**

There are quite a few places where modin's implementations unconditionally overwrite the frame's columns with some specified key even if the original columns are identical to this key. For example, when setting new values for a column, the implementation sets the key as a new column value:
https://github.com/modin-project/modin/blob/3b3bba9a83b6bec35e86826800004987afe24d47/modin/core/storage_formats/pandas/query_compiler.py#L2817-L2818

New columns assignment happens despite the fact, that the old column value could be the same as the new one, for example as here:
`df["col_key"] = df["col_key"] * 2`

The same also applies to the `.insert()` operation: 
`df.insert(df2["value"], col="value")`
https://github.com/modin-project/modin/blob/3b3bba9a83b6bec35e86826800004987afe24d47/modin/core/storage_formats/pandas/query_compiler.py#L2925-L2926

There are probably more cases where this happens, those are the ones that I've seen in our workloads.

**Is skipping `._set_columns()` helps a lot?**

The `._propagate_index_objs()` call triggers empty partitions filtering that requires knowledge about row AND column partitions shapes (if they're not available, the computation will be triggered):
https://github.com/modin-project/modin/blob/3b3bba9a83b6bec35e86826800004987afe24d47/modin/core/dataframe/pandas/dataframe/dataframe.py#L709

Thus, here are two cases measured of setting new columns: if the index cache is available and when it's not available (its computation will be triggered during `._propagate_index_objs()`): 

| |master branch|this PR branch|
|-|-|-|
|with index cache (max; mean)| 0.069; 0.05 | 0.001; 0.001|
|without index cache (max; mean)| 0.12; 0.1 | 0.001; 0.001|

<details><summary>script to measure</summary>

```python
import modin.pandas as pd
import modin.config as cfg
import numpy as np
from timeit import default_timer as timer
import pandas

from asv_bench.benchmarks.utils.common import execute

# start all the workers
pd.DataFrame([np.arange(cfg.MinPartitionSize.get()) for _ in range(cfg.NPartitions.get() ** 2)]).to_numpy()
NROWS = 1_000_000
NCOLS = 1
NRUNS = 10

df = pd.DataFrame(pandas.DataFrame({f"col{i}": np.arange(NROWS) for i in range(NCOLS)}))

reses = []

for _ in range(NRUNS):
    t1 = timer()
    df.columns = df.columns.copy()
    if df._query_compiler._modin_frame._deferred_column:
        df._query_compiler._modin_frame._propagate_index_objs(axis=1)
    execute(df)
    reses.append(timer() - t1)

print(f"Results WITH index cache available: max={np.max(reses)}; mean={np.mean(reses)}")

reses = []

def reset_cache(df):
    mf = df._query_compiler._modin_frame
    mf.set_index_cache(None)
    mf._row_lengths_cache = None
    for part in mf._partitions.flatten():
        part._lengths_cache = None

for _ in range(NRUNS):
    reset_cache(df)
    t1 = timer()
    df.columns = df.columns.copy()
    if df._query_compiler._modin_frame._deferred_column:
        df._query_compiler._modin_frame._propagate_index_objs(axis=1)
    execute(df)
    reses.append(timer() - t1)

print(f"Results WITHOUT index cache available: max={np.max(reses)}; mean={np.mean(reses)}")
```

</details>

In this case, there were not delayed computations pending for the frame, in case there are delayed computations the performance improvement is expected to be even higher.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6478 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
