### PR TITLE
PERF-#0000: Do not trigger computation of another axis on '_set_index'

### DIFF
--- a/modin/core/dataframe/pandas/metadata/index.py
+++ b/modin/core/dataframe/pandas/metadata/index.py
@@ -44,6 +44,10 @@ class ModinIndex:
         """
         return isinstance(self._value, pandas.Index)
 
+    def invalidate_lengths(self):
+        """Drop the partition's lengths cache."""
+        self._lengths_cache = None
+
     def get(self, return_lengths=False) -> pandas.Index:
         """
         Get the materialized internal representation.

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2401,7 +2401,8 @@ class DataFrame(BasePandasDataset):
         #   before it appears in __dict__.
         if key in ("_query_compiler", "_siblings", "_cache") or key in self.__dict__:
             pass
-        elif key in self and key not in dir(self):
+        # we have to check for the key in `dir(self)` first in order not to trigger columns computation
+        elif key not in dir(self) and key in self:
             self.__setitem__(key, value)
             # Note: return immediately so we don't keep this `key` as dataframe state.
             # `__getattr__` will return the columns not present in `dir(self)`, so we do not need

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -148,9 +148,10 @@ def validate_partitions_cache(df):
             assert df._partitions[i, j].width() == column_widths[j]
 
 
-def remove_axis_cache(df, axis, remove_lengths=True):
+def remove_axis_cache(df: pd.DataFrame, axis: int, remove_lengths: bool = True):
     """
     Remove index/columns cache for the passed dataframe.
+
     Parameters
     ----------
     df : modin.pandas.DataFrame
@@ -170,7 +171,22 @@ def remove_axis_cache(df, axis, remove_lengths=True):
             mf._column_widths_cache = None
 
 
-def has_axis_cache(df, axis, check_lengths=False):
+def has_axis_cache(df: pd.DataFrame, axis: int, check_lengths: bool = False) -> bool:
+    """
+    Check whether the passed dataframe has cached information about the specified axis (index/columns cache).
+
+    Parameters
+    ----------
+    df : modin.pandas.DataFrame
+    axis : int
+        0 - check rows cache, 1 - check columns cache.
+    check_lengths : bool, default: False
+        Also check whether the frame has row lengths/column widths cache.
+
+    Returns
+    -------
+    bool
+    """
     mf = df._query_compiler._modin_frame
     if axis == 0:
         result = mf.has_materialized_index
@@ -1161,6 +1177,7 @@ def test_reindex_preserve_dtypes(kwargs):
 
 @pytest.mark.parametrize("axis", [0, 1])
 def test_computation_free_index_propagation(axis):
+    """Verify that setting new index/columns doesn't trigger the deferred computation of the opposite axis."""
     df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [3, 4, 5, 6]})
 
     remove_axis_cache(df, axis ^ 1)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
