### PR TITLE
REFACTOR-#6489: Enforce API-layer bool/integer argument for __invert__

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -20,6 +20,8 @@ from pandas.core.methods.describe import refine_percentiles
 from pandas.core.dtypes.common import (
     is_list_like,
     is_dict_like,
+    is_bool_dtype,
+    is_integer_dtype,
     is_numeric_dtype,
     is_datetime_or_timedelta_dtype,
     is_dtype_equal,
@@ -3693,10 +3695,14 @@ class BasePandasDataset(ClassLogger):
         BasePandasDataset
             New BasePandasDataset containing bitwise inverse to each value.
         """
-        if not all(is_numeric_dtype(d) for d in self._get_dtypes()):
+        if not all(is_bool_dtype(d) or is_integer_dtype(d) for d in self._get_dtypes()):
             raise TypeError(
                 "bad operand type for unary ~: '{}'".format(
-                    next(d for d in self._get_dtypes() if not is_numeric_dtype(d))
+                    next(
+                        d
+                        for d in self._get_dtypes()
+                        if not (is_bool_dtype(d) or is_integer_dtype(d))
+                    )
                 )
             )
         return self.__constructor__(query_compiler=self._query_compiler.invert())

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -1642,6 +1642,15 @@ def test___invert__(data):
         df_equals(modin_result, pandas_result)
 
 
+def test___invert___bool():
+    data = [False]
+    modin_df = pd.DataFrame(data)
+    pandas_df = pandas.DataFrame(data)
+    modin_result = ~modin_df
+    pandas_result = ~pandas_df
+    df_equals(modin_result, pandas_result)
+
+
 def test___hash__():
     data = test_data_values[0]
     pandas_df = pandas.DataFrame(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
As in the linked issue, we now check that the argument to an `__invert__` (`~` operator) is integral or boolean at the API layer. The raised error message slightly differs from that raised by pandas, but is arguably clearer:

```
import modin.pandas as pd
import pandas
>>> ~pd.DataFrame([1.1])
UserWarning: Distributing <class 'list'> object. This may take some time.
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jhshi/code/modin/modin/logging/logger_decorator.py", line 128, in run_and_log
    return obj(*args, **kwargs)
  File "/Users/jhshi/code/modin/modin/pandas/base.py", line 3699, in __invert__
    raise TypeError(
TypeError: bad operand type for unary ~: 'float64'
>>> ~pandas.DataFrame([1.1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
NameError: name 'pandas' is not defined
>>> import pandas
>>> ~pandas.DataFrame([1.1])
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/Users/jhshi/opt/miniconda3/envs/modin-dev/lib/python3.10/site-packages/pandas/core/generic.py", line 1461, in __invert__
    new_data = self._mgr.apply(operator.invert)
  File "/Users/jhshi/opt/miniconda3/envs/modin-dev/lib/python3.10/site-packages/pandas/core/internals/managers.py", line 350, in apply
    applied = b.apply(f, **kwargs)
  File "/Users/jhshi/opt/miniconda3/envs/modin-dev/lib/python3.10/site-packages/pandas/core/internals/blocks.py", line 329, in apply
    result = func(self.values, **kwargs)
TypeError: ufunc 'invert' not supported for the input types, and the inputs could not be safely coerced to any supported types according to the casting rule ''safe''
```

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6489 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
