### PR TITLE
TEST-#6497: remove `boto3` from environments to speedup creation

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -47,7 +47,6 @@ dependencies:
   - pygit2>=1.9.2
 
   # test dependencies
-  - boto3>=1.26.0
   - coverage>=7.1.0
   - moto>=4.1.0
   - pytest>=7.2.1

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -41,7 +41,6 @@ PyGithub>=1.58.0
 pygit2>=1.9.2
 
 ## test dependencies
-boto3>=1.26.0
 coverage>=7.1.0
 # experimental version of fuzzydata requires at least 0.0.6 to successfully resolve all dependencies
 fuzzydata>=0.0.6

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -30,7 +30,6 @@ dependencies:
   - pygithub>=v1.58.0
 
   # test dependencies
-  - boto3>=1.26.0
   - coverage>=7.1.0
   - moto>=4.1.0
   - pytest>=7.2.1

--- a/requirements/env_unidist.yml
+++ b/requirements/env_unidist.yml
@@ -39,7 +39,6 @@ dependencies:
   - pygit2>=1.9.2
 
   # test dependencies
-  - boto3>=1.26.0
   - coverage>=7.1.0
   - moto>=4.1.0
   - pytest>=7.2.1

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -33,7 +33,6 @@ dependencies:
   - pygit2>=1.9.2
 
   # test dependencies
-  - boto3>=1.26.0
   - coverage>=7.1.0
   - moto>=4.1.0
   - pytest>=7.2.1


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

`boto3` is still installed as an implicit dependency.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6497 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
