### PR TITLE
FEAT-#6500: HDK: Add support for datetime64 to int64 cast

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
@@ -25,6 +25,7 @@ from pandas.core.dtypes.common import (
     is_list_like,
     get_dtype,
     is_float_dtype,
+    is_int64_dtype,
     is_integer_dtype,
     is_numeric_dtype,
     is_string_dtype,
@@ -69,6 +70,10 @@ def _get_common_dtype(lhs_dtype, rhs_dtype):
         return get_dtype(int)
     if is_datetime64_dtype(lhs_dtype) and is_datetime64_dtype(rhs_dtype):
         return np.promote_types(lhs_dtype, rhs_dtype)
+    if (is_datetime64_dtype(lhs_dtype) and is_int64_dtype(rhs_dtype)) or (
+        is_datetime64_dtype(rhs_dtype) and is_int64_dtype(lhs_dtype)
+    ):
+        return get_dtype(int)
     raise NotImplementedError(
         f"Cannot perform operation on types: {lhs_dtype}, {rhs_dtype}"
     )


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6500 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
