### PR TITLE
FIX-#6465: Fix `groupby.apply()` for UDFs that change the output's shape

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -19,6 +19,7 @@ for pandas storage format.
 """
 from collections import OrderedDict
 import numpy as np
+import modin.config as cfg
 import pandas
 import datetime
 from pandas.api.types import is_object_dtype
@@ -3649,7 +3650,7 @@ class PandasDataframe(ClassLogger):
 
         align_columns = True
 
-        if align_columns:
+        if align_columns and result._partitions.shape[0] > 1:
             some = True
             if some:
                 def get_common_columns(*dfs):
@@ -3660,7 +3661,8 @@ class PandasDataframe(ClassLogger):
                     return pandas.concat(
                         [df.iloc[:0] for df in non_empty_dfs], axis=0, join="outer"
                     ).columns
-                # breakpoint()
+                # if cfg.AsyncReadMode.get():
+                #     breakpoint()
                 parts = result._partitions.flatten()
                 joined_columns = parts[0].apply(
                     get_common_columns, *[part._data for part in parts[1:]]

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3606,7 +3606,7 @@ class PandasDataframe(ClassLogger):
             on the output desired by the user.
         result_schema : dict, optional
             Mapping from column labels to data types that represents the types of the output dataframe.
-        align_columns : bool, default: False
+        align_result_columns : bool, default: False
             Whether to manually align columns between all the resulted row partitions.
             This flag is helpful when dealing with UDFs as they can change the partition's shape
             and labeling unpredictably, resulting in an invalid dataframe.

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3648,7 +3648,12 @@ class PandasDataframe(ClassLogger):
                     + "https://github.com/modin-project/modin/issues/5925"
                 )
             result = operator(df.groupby(by, **kwargs))
-            if align_result_columns and df.empty and result.empty and df.equals(result):
+            if (
+                align_result_columns
+                and df.empty
+                and result.empty
+                and df.columns.equals(result.columns)
+            ):
                 # We want to align columns only of those frames that actually performed
                 # some groupby aggregation, if an empty frame was originally passed
                 # (an empty bin on reshuffling was created) then there were no groupby

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -550,7 +550,10 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         return np.array(
             [
                 [
-                    part.add_to_apply_calls(preprocessed_map_func, *(tuple() if func_args is None else func_args))
+                    part.add_to_apply_calls(
+                        preprocessed_map_func,
+                        *(tuple() if func_args is None else func_args),
+                    )
                     for part in row
                 ]
                 for row in partitions

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -540,6 +540,8 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             Partitions of Modin Frame.
         map_func : callable
             Function to apply.
+        func_args : iterable, optional
+            Positional arguments for the 'map_func'.
 
         Returns
         -------
@@ -1595,9 +1597,6 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         # we wouldn't know how to split the block partitions that don't contain the shuffling key.
         row_partitions = cls.row_partitions(partitions)
         if len(pivots):
-            # import modin.config as cfg
-            # if cfg.AsyncReadMode.get():
-            #     breakpoint()
             # Gather together all of the sub-partitions
             split_row_partitions = np.array(
                 [

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3558,11 +3558,19 @@ class PandasQueryCompiler(BaseQueryCompiler):
             axis=axis,
             by=by,
             operator=lambda grp: agg_func(grp, *agg_args, **agg_kwargs),
+            # UDFs passed to '.apply()' are allowed to produce results with arbitrary shapes,
+            # that's why we have to align the partition's shapes/labeling across different
+            # row partitions
+            align_result_columns=how == "group_wise",
             **groupby_kwargs,
         )
         result_qc = self.__constructor__(result)
 
-        if not is_transform and not groupby_kwargs.get("as_index", True) and groupby_kwargs.get("group_keys", True):
+        if (
+            not is_transform
+            and not groupby_kwargs.get("as_index", True)
+            and groupby_kwargs.get("group_keys", True)
+        ):
             return result_qc.reset_index(drop=True)
 
         return result_qc

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3566,11 +3566,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         )
         result_qc = self.__constructor__(result)
 
-        if (
-            not is_transform
-            and not groupby_kwargs.get("as_index", True)
-            and groupby_kwargs.get("group_keys", True)
-        ):
+        if not is_transform and not groupby_kwargs.get("as_index", True):
             return result_qc.reset_index(drop=True)
 
         return result_qc

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3562,7 +3562,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         )
         result_qc = self.__constructor__(result)
 
-        if not is_transform and not groupby_kwargs.get("as_index", True):
+        if not is_transform and not groupby_kwargs.get("as_index", True) and groupby_kwargs.get("group_keys", True):
             return result_qc.reset_index(drop=True)
 
         return result_qc

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -19,7 +19,7 @@ from unittest import mock
 import datetime
 
 from modin.config import StorageFormat
-from modin.config.envvars import ExperimentalGroupbyImpl
+from modin.config.envvars import ExperimentalGroupbyImpl, IsRayCluster
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
@@ -2783,3 +2783,53 @@ def test_groupby_deferred_index(func):
         return getattr(grp, func)()
 
     eval_general(pd, pandas, perform)
+
+
+# there are two different implementations of partitions aligning for cluster and non-cluster mode,
+# here we want to test both of them, so simply modifying the config for this test
+@pytest.mark.parametrize(
+    "modify_config", [{IsRayCluster: True}, {IsRayCluster: False}], indirect=True
+)
+def test_shape_changing_udf(modify_config):
+    modin_df, pandas_df = create_test_dfs(
+        {
+            "by_col1": ([1] * 50) + ([10] * 50),
+            "col2": np.arange(100),
+            "col3": np.arange(100),
+        }
+    )
+
+    def func1(group):
+        # changes the original shape and indexing of the 'group'
+        return pandas.Series(
+            [1, 2, 3, 4], index=["new_col1", "new_col2", "new_col4", "new_col3"]
+        )
+
+    eval_general(
+        modin_df.groupby("by_col1"),
+        pandas_df.groupby("by_col1"),
+        lambda df: df.apply(func1),
+    )
+
+    def func2(group):
+        # each group have different shape at the end
+        # (we do .to_frame().T as otherwise this scenario doesn't work in pandas)
+        if group.iloc[0, 0] == 1:
+            return (
+                pandas.Series(
+                    [1, 2, 3, 4], index=["new_col1", "new_col2", "new_col4", "new_col3"]
+                )
+                .to_frame()
+                .T
+            )
+        return (
+            pandas.Series([20, 33, 44], index=["new_col2", "new_col3", "new_col4"])
+            .to_frame()
+            .T
+        )
+
+    eval_general(
+        modin_df.groupby("by_col1"),
+        pandas_df.groupby("by_col1"),
+        lambda df: df.apply(func2),
+    )

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -2788,7 +2788,12 @@ def test_groupby_deferred_index(func):
 # there are two different implementations of partitions aligning for cluster and non-cluster mode,
 # here we want to test both of them, so simply modifying the config for this test
 @pytest.mark.parametrize(
-    "modify_config", [{IsRayCluster: True}, {IsRayCluster: False}], indirect=True
+    "modify_config",
+    [
+        {ExperimentalGroupbyImpl: True, IsRayCluster: True},
+        {ExperimentalGroupbyImpl: True, IsRayCluster: False},
+    ],
+    indirect=True,
 )
 def test_shape_changing_udf(modify_config):
     modin_df, pandas_df = create_test_dfs(
@@ -2832,4 +2837,17 @@ def test_shape_changing_udf(modify_config):
         modin_df.groupby("by_col1"),
         pandas_df.groupby("by_col1"),
         lambda df: df.apply(func2),
+    )
+
+    def func3(group):
+        # one of the groups produce an empty dataframe, in the result we should
+        # have joined columns of both of these dataframes
+        if group.iloc[0, 0] == 1:
+            return pandas.DataFrame([[1, 2, 3]], index=["col1", "col2", "col3"])
+        return pandas.DataFrame(columns=["col2", "col3", "col4", "col5"])
+
+    eval_general(
+        modin_df.groupby("by_col1"),
+        pandas_df.groupby("by_col1"),
+        lambda df: df.apply(func3),
     )

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -117,21 +117,6 @@ def construct_modin_df_by_scheme(pandas_df, partitioning_scheme):
     return md_df
 
 
-@pytest.fixture
-def modify_config(request):
-    values = request.param
-    old_values = {}
-
-    for key, value in values.items():
-        old_values[key] = key.get()
-        key.put(value)
-
-    yield  # waiting for the test to be completed
-    # restoring old parameters
-    for key, value in old_values.items():
-        key.put(value)
-
-
 def validate_partitions_cache(df):
     """Assert that the ``PandasDataframe`` shape caches correspond to the actual partition's shapes."""
     row_lengths = df._row_lengths_cache


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Roughly speaking, reshuffling groupby is performed row-wise. Which means, that if we're dealing with some really complex user-defined function in `.apply()` that produces results with arbitrary shapes/labels, then we can end up with an invalid dataframe at the end:
```python
grp.apply(
    lambda group: (
        pandas.Series([1, 2], index=["a", "b"])
        if random_int() % 2
        else pandas.Series([1, 2, 3, 4], index=["a", "b", "c", "d"])
    )
)

potential result:
    a  b
0   1  2         <---- row partition №1  |                                          in pandas the result would be like:
1   1  2                                 |  two row partitions have different    |    a  b  c   d
2   1  2                                 |  columns, which means that the frame  | 0  1  2  NaN NaN
-------------                            |  is inconsistent and pretty much any  | 1  1  2  NaN NaN
    a  b  c  d                           |  operation with it will fail            2  1  2  NaN NaN
3   1  2  3  4   <---- row partition №2  |                                         3  1  2  3   4
4   1  2  3  4                           |                                         4  1  2  3   4
5   1  2  3  4                           |                                         5  1  2  3   4
```
So, to avoid such situations with inconsistent frames, this PR adds a logic, that aligns column labels across row partitions after `groupby.apply()`.

The PR actually introduces 2 implementations of the 'aligning-logic', one of them is more beneficial when running in a single node and the other one - when running on a cluster. There's a dispatching between these two implementations basing on the `cfg.IsRayCluster` configuration variable.

The logic certainly brings some overhead to all the `groupby.apply()` calls. The overhead can be measured like this and it seems to not be that high, considering that the new modin's `groupby.apply()` is usually much faster than pandas:

![image](https://github.com/modin-project/modin/assets/62142979/6ae537a4-23dc-4b5a-a0de-2107746c70be)

<details><summary>script to measure</summary>

```python
import modin.pandas as pd
import numpy as np

import modin.config as cfg
from asv_bench.benchmarks.utils.common import execute

cfg.ExperimentalGroupbyImpl.put(True)
pd.DataFrame(range(cfg.CpuCount.get() * cfg.MinPartitionSize().get())).to_numpy() # init the engine and start all the workers

NGROUPS = 1_000_000
NROWS = 10_000_000
NCOLS = 128

data = {f"col{i}": np.arange(NROWS) for i in range(NCOLS - 1)}
data["by_col1"] = np.tile(np.arange(NGROUPS), NROWS // NGROUPS)

from timeit import default_timer as timer

NRUNS = 10
reses = []
for _ in range(NRUNS):
    df = pd.DataFrame(data)
    t1 = timer()
    df = df.groupby("by_col1").apply(lambda df: (df ** 2).mean())
    execute(df)
    reses.append(timer() - t1)

print(np.max(reses), np.median(reses))
```

</details>


- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6465 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
