### PR TITLE
FIX-#6514: test_sort_cols_str from test_dataframe.py crashed on HDK 0.7.0 and python 3.9

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -31,6 +31,8 @@ from modin.test.interchange.dataframe_protocol.hdk.utils import split_df_into_ch
 from .utils import eval_io, ForceHdkImport, set_execution_mode, run_and_compare
 from pandas.core.dtypes.common import is_list_like
 
+from pyhdk import __version__ as hdk_version
+
 StorageFormat.put("hdk")
 
 import modin.pandas as pd
@@ -2117,6 +2119,10 @@ class TestSort:
             ascending=ascending,
         )
 
+    @pytest.mark.skipif(
+        hdk_version == "0.7.0",
+        reason="https://github.com/modin-project/modin/issues/6514",
+    )
     @pytest.mark.parametrize("ascending", ascending_values)
     def test_sort_cols_str(self, ascending):
         def sort(df, ascending, **kwargs):

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -2064,19 +2064,21 @@ class TestCategory:
 
 
 class TestSort:
+    # In order for the row order to be deterministic after sorting,
+    # the `by` columns should not contain duplicate values.
     data = {
-        "a": [1, 2, 5, 2, 5, 4, 4, 5, 2],
+        "a": [1, 2, 5, -2, -5, 4, -4, 6, 3],
         "b": [1, 2, 3, 6, 5, 1, 4, 5, 3],
         "c": [5, 4, 2, 3, 1, 1, 4, 5, 6],
         "d": ["1", "4", "3", "2", "1", "6", "7", "5", "0"],
     }
     data_nulls = {
-        "a": [1, 2, 5, 2, 5, 4, 4, None, 2],
+        "a": [1, 2, 5, -2, -5, 4, -4, None, 3],
         "b": [1, 2, 3, 6, 5, None, 4, 5, 3],
         "c": [None, 4, 2, 3, 1, 1, 4, 5, 6],
     }
     data_multiple_nulls = {
-        "a": [1, 2, None, 2, 5, 4, 4, None, 2],
+        "a": [1, 2, None, -2, 5, 4, -4, None, 3],
         "b": [1, 2, 3, 6, 5, None, 4, 5, None],
         "c": [None, 4, 2, None, 1, 1, 4, 5, 6],
     }
@@ -2094,6 +2096,7 @@ class TestSort:
         def sort(df, cols, ignore_index, index_cols, ascending, **kwargs):
             if index_cols:
                 df = df.set_index(index_cols)
+                df_equals_with_non_stable_indices()
             return df.sort_values(cols, ignore_index=ignore_index, ascending=ascending)
 
         run_and_compare(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6514 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
