### PR TITLE
FIX-#6516: HDK: test_dataframe.py is crashed if Calcite is disabled

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_algebra.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_algebra.py
@@ -146,14 +146,19 @@ class CalciteBaseNode(abc.ABC):
         self.relOp = relOp
 
     @classmethod
-    def reset_id(cls):
+    def reset_id(cls, next_id=0):
         """
-        Reset ID to be used for the next new node to 0.
+        Reset ID to be used for the next new node to `next_id`.
 
         Can be used to have a zero-based numbering for each
         generated query.
+
+        Parameters
+        ----------
+        next_id : int, default: 0
+            Next node id.
         """
-        cls._next_id[0] = 0
+        cls._next_id[0] = next_id
 
 
 class CalciteScanNode(CalciteBaseNode):

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
@@ -757,7 +757,7 @@ class CalciteBuilder:
             # translate the input refs. The `id` attribute is preserved.
             last = self.res.pop()
             exprs = last.exprs
-            type(last).reset_id(int(last.id))
+            last.reset_id(int(last.id))
             node = CalciteProjectionNode(
                 node.fields, [exprs[expr.input] for expr in node.exprs]
             )

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
@@ -754,8 +754,10 @@ class CalciteBuilder:
             and all(isinstance(expr, CalciteInputRefExpr) for expr in node.exprs)
         ):
             # Replace the last CalciteProjectionNode with this one and
-            # translate the input refs.
-            exprs = self.res.pop().exprs
+            # translate the input refs. The `id` attribute is preserved.
+            last = self.res.pop()
+            exprs = last.exprs
+            type(last)._next_id[0] = int(last.id)
             node = CalciteProjectionNode(
                 node.fields, [exprs[expr.input] for expr in node.exprs]
             )

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/calcite_builder.py
@@ -757,7 +757,7 @@ class CalciteBuilder:
             # translate the input refs. The `id` attribute is preserved.
             last = self.res.pop()
             exprs = last.exprs
-            type(last)._next_id[0] = int(last.id)
+            type(last).reset_id(int(last.id))
             node = CalciteProjectionNode(
                 node.fields, [exprs[expr.input] for expr in node.exprs]
             )


### PR DESCRIPTION

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6516 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
