### PR TITLE
FIX-#6392: Compute detypes for the DataFrame.mean() result

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -972,9 +972,25 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 count_cols = count_cols.sum(axis=axis, skipna=False)
             return sum_cols / count_cols
 
+        def compute_dtypes_fn(dtypes, axis, **kwargs):
+            """
+            Compute the resulting Series dtype.
+
+            When computing along rows and there are numeric and boolean columns
+            Pandas returns `object`. In all other cases - `float64`.
+            """
+            if (
+                axis == 1
+                and any(is_bool_dtype(t) for t in dtypes)
+                and any(is_numeric_dtype(t) for t in dtypes)
+            ):
+                return "object"
+            return "float64"
+
         return TreeReduce.register(
             map_fn,
             reduce_fn,
+            compute_dtypes=compute_dtypes_fn,
         )(self, axis=axis, **kwargs)
 
     # END TreeReduce operations


### PR DESCRIPTION
## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6392 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
