### PR TITLE
PERF-#6524: Add a 'column' shape hint for the results of 'qc.to_datetime()'

### DIFF
--- a/modin/core/dataframe/algebra/reduce.py
+++ b/modin/core/dataframe/algebra/reduce.py
@@ -20,7 +20,7 @@ class Reduce(Operator):
     """Builder class for Reduce operator."""
 
     @classmethod
-    def register(cls, reduce_function, axis=None):
+    def register(cls, reduce_function, axis=None, shape_hint=None):
         """
         Build Reduce operator that will be performed across rows/columns.
 
@@ -32,6 +32,8 @@ class Reduce(Operator):
             Source function.
         axis : int, optional
             Axis to apply function along.
+        shape_hint : {"row", "column", None}, default: None
+            Shape hint for the results known to be a column or a row, otherwise None.
 
         Returns
         -------
@@ -46,7 +48,8 @@ class Reduce(Operator):
                 query_compiler._modin_frame.reduce(
                     cls.validate_axis(_axis),
                     lambda x: reduce_function(x, *args, **kwargs),
-                )
+                ),
+                shape_hint=shape_hint,
             )
 
         return caller

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1029,10 +1029,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 # to_datetime has inplace side effects, see GH#3063
                 lambda df, *args, **kwargs: pandas.to_datetime(
                     df.squeeze(axis=1), *args, **kwargs
-                ).to_frame()
+                ).to_frame(),
+                shape_hint="column",
             )(self, *args, **kwargs)
         else:
-            return Reduce.register(pandas.to_datetime, axis=1)(self, *args, **kwargs)
+            return Reduce.register(pandas.to_datetime, axis=1, shape_hint="column")(
+                self, *args, **kwargs
+            )
 
     # END Reduce operations
 


### PR DESCRIPTION

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

We always get a single-column qc at the end of `.to_datetime()`, so it's worth adding a shape hint.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6524 <!-- issue must be created for each patch -->
- [x] tests <s>added and</s> are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
