### PR TITLE
FIX-#4687: change 'Column.null_count' to return a builtin int instead of NumPy scalar

### DIFF
--- a/modin/core/dataframe/pandas/interchange/dataframe_protocol/column.py
+++ b/modin/core/dataframe/pandas/interchange/dataframe_protocol/column.py
@@ -251,7 +251,7 @@ class PandasProtocolColumn(ProtocolColumn):
         # Otherwise, we get mismatching internal and external indices for both axes
         intermediate_df.index = pandas.RangeIndex(1)
         intermediate_df.columns = pandas.RangeIndex(1)
-        self._null_count_cache = intermediate_df.to_pandas().squeeze()
+        self._null_count_cache = intermediate_df.to_pandas().squeeze(axis=1).item()
         return self._null_count_cache
 
     @property

--- a/modin/test/interchange/dataframe_protocol/test_general.py
+++ b/modin/test/interchange/dataframe_protocol/test_general.py
@@ -82,6 +82,14 @@ def test_na_float(df_from_dict):
     assert colX.null_count == 1
 
 
+def test_null_count(df_from_dict):
+    df = df_from_dict({"foo": [42]})
+    dfX = df.__dataframe__()
+    colX = dfX.get_column_by_name("foo")
+    null_count = colX.null_count
+    assert null_count == 0 and type(null_count) is int
+
+
 def test_noncategorical(df_from_dict):
     df = df_from_dict({"a": [1, 2, 3]})
     dfX = df.__dataframe__()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4687 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
