### PR TITLE
PERF-#6464: Improve reshuffling for multi-column groupby in low-cardinality cases

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/utils.py
+++ b/modin/core/dataframe/pandas/dataframe/utils.py
@@ -42,7 +42,7 @@ class ShuffleFunctions:
     ascending : bool
         Whether the ranges should be in ascending or descending order.
     ideal_num_new_partitions : int
-        The ideal number of bins.
+        The ideal number of new partitions.
     **kwargs : dict
         Additional keyword arguments.
     """
@@ -118,7 +118,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
     ascending : bool
         Whether the ranges should be in ascending or descending order.
     ideal_num_new_partitions : int
-        The ideal number of bins.
+        The ideal number of new partitions.
     **kwargs : dict
         Additional keyword arguments.
     """
@@ -158,13 +158,8 @@ class ShuffleSortFunctions(ShuffleFunctions):
             cols.append(col)
             is_numeric = is_numeric_dtype(column_val.dtype)
 
-            if is_numeric:
-                method = "linear"
-            else:
-                # This means we are not sorting numbers, so we need our quantiles to not try
-                # arithmetic on the values.
-                method = "inverted_cdf"
-
+            # When we are not sorting numbers, we need our quantiles to not do arithmetic on the values
+            method = "linear" if is_numeric else "inverted_cdf"
             pivots = self.pick_pivots_from_samples_for_sort(
                 column_val, num_pivots, method, key
             )

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1580,7 +1580,14 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         masked_partitions = partitions[:, index]
         # Sample each partition
         sample_func = cls.preprocess_func(shuffle_functions.sample_function)
-        samples = [partition.apply(sample_func) for partition in masked_partitions]
+        if masked_partitions.ndim == 1:
+            samples = [partition.apply(sample_func) for partition in masked_partitions]
+        else:
+            breakpoint()
+            samples = [
+                cls._row_partition_class(row_part, full_axis=False).apply(sample_func)
+                for row_part in masked_partitions
+            ]
         # Get each sample to pass in to the pivot function
         samples = cls.get_objects_from_partitions(samples)
         pivots = np.unique(shuffle_functions.pivot_function(samples))

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1323,7 +1323,6 @@ def eval___getitem__(md_grp, pd_grp, item):
         lambda grp: grp[item].mean(),
         comparator=build_types_asserter(df_equals),
     )
-    # breakpoint()
     eval_general(
         md_grp,
         pd_grp,
@@ -2103,7 +2102,6 @@ def test_multi_column_groupby_different_partitions(
         md_df.groupby(by, as_index=as_index),
         pd_df.groupby(by, as_index=as_index),
     )
-    # breakpoint()
     eval_general(
         md_grp,
         pd_grp,

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1323,6 +1323,7 @@ def eval___getitem__(md_grp, pd_grp, item):
         lambda grp: grp[item].mean(),
         comparator=build_types_asserter(df_equals),
     )
+    # breakpoint()
     eval_general(
         md_grp,
         pd_grp,

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -2103,6 +2103,7 @@ def test_multi_column_groupby_different_partitions(
         md_df.groupby(by, as_index=as_index),
         pd_df.groupby(by, as_index=as_index),
     )
+    # breakpoint()
     eval_general(
         md_grp,
         pd_grp,

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -21,6 +21,10 @@ from modin.config import NPartitions, Engine, MinPartitionSize, ExperimentalGrou
 from modin.distributed.dataframe.pandas import from_partitions
 from modin.core.storage_formats.pandas.utils import split_result_of_axis_func_pandas
 from modin.utils import try_cast_to_pandas
+from modin.core.dataframe.pandas.dataframe.utils import (
+    ShuffleSortFunctions,
+    ColumnInfo,
+)
 
 import numpy as np
 import pandas
@@ -841,11 +845,6 @@ def test_split_partitions_kernel(
         Duplicate pivot values cause empty partitions to be produced. This parameter helps
         to verify that the function still behaves correctly in such cases.
     """
-    from modin.core.dataframe.pandas.dataframe.utils import (
-        ShuffleSortFunctions,
-        ColumnInfo,
-    )
-
     random_state = np.random.RandomState(42)
 
     df = pandas.DataFrame(
@@ -909,11 +908,6 @@ def test_split_partitions_with_empty_pivots(col_name, ascending):
     This test verifies that the splitting function performs correctly when an empty pivots list is passed.
     The expected behavior is to return a single split consisting of the exact copy of the input dataframe.
     """
-    from modin.core.dataframe.pandas.dataframe.utils import (
-        ShuffleSortFunctions,
-        ColumnInfo,
-    )
-
     df = pandas.DataFrame(
         {
             "numeric_col": range(9),
@@ -949,10 +943,6 @@ def test_shuffle_partitions_with_empty_pivots(ascending):
 
     assert modin_frame._partitions.shape == (1, 1)
 
-    from modin.core.dataframe.pandas.dataframe.utils import (
-        ShuffleSortFunctions,
-    )
-
     column_name = modin_frame.columns[1]
 
     shuffle_functions = ShuffleSortFunctions(
@@ -982,11 +972,6 @@ def test_split_partition_preserve_names(ascending):
     This test verifies that the dataframes being split by ``split_partitions_using_pivots_for_sort``
     preserve their index/column names.
     """
-    from modin.core.dataframe.pandas.dataframe.utils import (
-        ShuffleSortFunctions,
-        ColumnInfo,
-    )
-
     df = pandas.DataFrame(
         {
             "numeric_col": range(9),

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -823,9 +823,7 @@ def test_split_partitions_kernel(
         Duplicate pivot values cause empty partitions to be produced. This parameter helps
         to verify that the function still behaves correctly in such cases.
     """
-    from modin.core.dataframe.pandas.dataframe.utils import (
-        split_partitions_using_pivots_for_sort,
-    )
+    from modin.core.dataframe.pandas.dataframe.utils import ShuffleSortFunctions
 
     random_state = np.random.RandomState(42)
 
@@ -847,7 +845,7 @@ def test_split_partitions_kernel(
 
     # Randomly reordering rows in the dataframe
     df = df.reindex(random_state.permutation(df.index))
-    bins = split_partitions_using_pivots_for_sort(
+    bins = ShuffleSortFunctions.split_partitions_using_pivots_for_sort(
         df,
         col_name,
         is_numeric_column=pandas.api.types.is_numeric_dtype(df.dtypes[col_name]),
@@ -886,9 +884,7 @@ def test_split_partitions_with_empty_pivots(col_name, ascending):
     This test verifies that the splitting function performs correctly when an empty pivots list is passed.
     The expected behavior is to return a single split consisting of the exact copy of the input dataframe.
     """
-    from modin.core.dataframe.pandas.dataframe.utils import (
-        split_partitions_using_pivots_for_sort,
-    )
+    from modin.core.dataframe.pandas.dataframe.utils import ShuffleSortFunctions
 
     df = pandas.DataFrame(
         {
@@ -897,7 +893,7 @@ def test_split_partitions_with_empty_pivots(col_name, ascending):
         }
     )
 
-    result = split_partitions_using_pivots_for_sort(
+    result = ShuffleSortFunctions.split_partitions_using_pivots_for_sort(
         df,
         col_name,
         is_numeric_column=pandas.api.types.is_numeric_dtype(df.dtypes[col_name]),
@@ -930,8 +926,7 @@ def test_shuffle_partitions_with_empty_pivots(ascending):
     shuffle_functions = build_sort_functions(
         # These are the parameters we pass in the `.sort_by()` implementation
         modin_frame,
-        column=column_name,
-        method="inverted_cdf",
+        columns=column_name,
         ascending=ascending,
         ideal_num_new_partitions=1,
     )
@@ -955,9 +950,7 @@ def test_split_partition_preserve_names(ascending):
     This test verifies that the dataframes being split by ``split_partitions_using_pivots_for_sort``
     preserve their index/column names.
     """
-    from modin.core.dataframe.pandas.dataframe.utils import (
-        split_partitions_using_pivots_for_sort,
-    )
+    from modin.core.dataframe.pandas.dataframe.utils import ShuffleSortFunctions
 
     df = pandas.DataFrame(
         {
@@ -971,7 +964,7 @@ def test_split_partition_preserve_names(ascending):
 
     # Pivots that contain empty bins
     pivots = [2, 2, 5, 7]
-    splits = split_partitions_using_pivots_for_sort(
+    splits = ShuffleSortFunctions.split_partitions_using_pivots_for_sort(
         df,
         column="numeric_col",
         is_numeric_column=True,

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -841,7 +841,10 @@ def test_split_partitions_kernel(
         Duplicate pivot values cause empty partitions to be produced. This parameter helps
         to verify that the function still behaves correctly in such cases.
     """
-    from modin.core.dataframe.pandas.dataframe.utils import ShuffleSortFunctions
+    from modin.core.dataframe.pandas.dataframe.utils import (
+        ShuffleSortFunctions,
+        ColumnInfo,
+    )
 
     random_state = np.random.RandomState(42)
 
@@ -865,9 +868,13 @@ def test_split_partitions_kernel(
     df = df.reindex(random_state.permutation(df.index))
     bins = ShuffleSortFunctions.split_partitions_using_pivots_for_sort(
         df,
-        col_name,
-        is_numeric_column=pandas.api.types.is_numeric_dtype(df.dtypes[col_name]),
-        pivots=pivots,
+        [
+            ColumnInfo(
+                name=col_name,
+                is_numeric=pandas.api.types.is_numeric_dtype(df.dtypes[col_name]),
+                pivots=pivots,
+            )
+        ],
         ascending=ascending,
     )
 
@@ -902,7 +909,10 @@ def test_split_partitions_with_empty_pivots(col_name, ascending):
     This test verifies that the splitting function performs correctly when an empty pivots list is passed.
     The expected behavior is to return a single split consisting of the exact copy of the input dataframe.
     """
-    from modin.core.dataframe.pandas.dataframe.utils import ShuffleSortFunctions
+    from modin.core.dataframe.pandas.dataframe.utils import (
+        ShuffleSortFunctions,
+        ColumnInfo,
+    )
 
     df = pandas.DataFrame(
         {
@@ -913,9 +923,13 @@ def test_split_partitions_with_empty_pivots(col_name, ascending):
 
     result = ShuffleSortFunctions.split_partitions_using_pivots_for_sort(
         df,
-        col_name,
-        is_numeric_column=pandas.api.types.is_numeric_dtype(df.dtypes[col_name]),
-        pivots=[],
+        [
+            ColumnInfo(
+                name=col_name,
+                is_numeric=pandas.api.types.is_numeric_dtype(df.dtypes[col_name]),
+                pivots=[],
+            )
+        ],
         ascending=ascending,
     )
     # We're expecting to recieve a single split here
@@ -936,12 +950,12 @@ def test_shuffle_partitions_with_empty_pivots(ascending):
     assert modin_frame._partitions.shape == (1, 1)
 
     from modin.core.dataframe.pandas.dataframe.utils import (
-        build_sort_functions,
+        ShuffleSortFunctions,
     )
 
     column_name = modin_frame.columns[1]
 
-    shuffle_functions = build_sort_functions(
+    shuffle_functions = ShuffleSortFunctions(
         # These are the parameters we pass in the `.sort_by()` implementation
         modin_frame,
         columns=column_name,
@@ -968,7 +982,10 @@ def test_split_partition_preserve_names(ascending):
     This test verifies that the dataframes being split by ``split_partitions_using_pivots_for_sort``
     preserve their index/column names.
     """
-    from modin.core.dataframe.pandas.dataframe.utils import ShuffleSortFunctions
+    from modin.core.dataframe.pandas.dataframe.utils import (
+        ShuffleSortFunctions,
+        ColumnInfo,
+    )
 
     df = pandas.DataFrame(
         {
@@ -984,9 +1001,7 @@ def test_split_partition_preserve_names(ascending):
     pivots = [2, 2, 5, 7]
     splits = ShuffleSortFunctions.split_partitions_using_pivots_for_sort(
         df,
-        column="numeric_col",
-        is_numeric_column=True,
-        pivots=pivots,
+        [ColumnInfo(name="numeric_col", is_numeric=True, pivots=pivots)],
         ascending=ascending,
     )
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What's the problem?

The current implementation of reshuffling groupby takes the first column that was specified as the `by` argument (for example, if `groupby(["col1", "col2"])` was called, then the "col1" will be taken) and builds range partitioning based on that picked column. The problem here is that, if the "col1" has very low cardinality (too few unique values) then there will be too few range partitions at the end and so poor cores utilization.
```python
>>> df
  col1  col2  # 'col1' has only 2 unique values, meaning that there will be only 2
0    Y     1  # range partitions, so no matter how many cores we have, we couldn't
1    Y     2  # use more than 2 to process this groupby
2    N     3
3    Y     4
```

We can't do much about this problem (at least in terms of range-partitioning implementation) when grouping on a single column, however, when multiple columns are used when grouping, we can try using all the `by` columns to build the range partitioning and potentially increase the number of range-bins being generated.

## How was it solved?

The reshuffling implementation now samples all the `by` columns instead of a single one in order to compute their quantile ranges. It then goes through the columns one by one and compute boundaries (pivots) for the range-bins. Once the required amount of bins is created, it terminates.
```python
# pseudo-code of how it works
number_of_bins = 1
for col in df_sample.columns:
    ideal_num_new_pivots = int(self.ideal_num_new_partitions / number_of_bins)

    if ideal_num_new_pivots <= 2:
        # we already created the required amount of bins and can exit
        break

    # the 'pick_pivots' function may return less pivots than we requested if
    # the data cardinality is too low
    pivots = pick_pivots(df_sample[col], desired_num_pivots=ideal_num_new_pivots)
    resulted_pivots.append(pivots)
    number_of_bins *= len(pivots) + 1
```

Then at the splitting stage these range-bins are combined and then in the result we get more bins (some of them more likely will be empty though):
```python
col1: [(-inf, 2), (2, inf)] # 2 bins
col2: [(-inf, 0), (0, 5), (5, 10), (10, inf)] # 4 bins
# ideally we would have 8 bins when combined
# bin1: col1 < 2 and col2 < 0
# bin2: col1 < 2 and 0 < col2 < 5
# bin3: col1 < 2 and 5 < col2 < 10
# bin4: col1 < 2 and 10 < col2
# bin5: 2 < col1 and col2 < 0
# bin6: 2 < col1 and 0 < col2 < 5
# bin7: 2 < col1 and 5 < col2 < 10
# bin8: 2 < col1 and 10 < col2
```

## Is performance better now?

I went through some multi-column groupby cases from the benchmarks we usually run on our side (found such cases in nyc-taxi, h2o + also included our internal customer's workload for which these changes were initially intended), surprisingly to me, most of the cases had this problem with low-cardinality (it mostly only visible on MODIN_CPUS=112 though).

Under the spoilers, you may see the detailed report for each of the workload (including details regarding original data sizes and data cardinality). Here's just an aggregated table with time measurements:

![image](https://github.com/modin-project/modin/assets/62142979/392891b2-b73e-4a02-a93d-73d24f958455)

The bar-charts under the spoilers show the data portions distribution between range-bins (buckets):
(if the charts are too small, you can click on them to open in full-size)

<details><summary>Scenario when NUM_CPUS=112</summary>

### NYC-taxi cases
In the first query, the data cardinality for the first column in `by` is already pretty good, so the introduced changes don't make any difference:
![image](https://github.com/modin-project/modin/assets/62142979/686921e4-dc79-4afc-9be5-0c5e251bf5f0)

In the second query, the first column "passenger_count" has very low cardinality (the values are in the range of 0-10) so the data distribution between buckets (bins) is quite unbalanced. After the changes, the 14% of buckets received more or less equal portions of data (quantile 0.86), although there are a lot of really small buckets (quantile 0.1), performance has improved more than 2x:
![image](https://github.com/modin-project/modin/assets/62142979/d786b2ef-db90-4734-bc98-79ad2cf301c4)

### H2O cases

Here each "id*" has values in the range of (0-10), so introducing the changes helps a lot in improving the data balance between the buckets:
![image](https://github.com/modin-project/modin/assets/62142979/2de1234b-29ea-459e-b15b-dbeaf746d0d6)

Actually, the situation is identical for all of the h2o multi-column queries:
![image](https://github.com/modin-project/modin/assets/62142979/28a8a68a-a2fe-4c8a-8d00-0580d100572a)
![image](https://github.com/modin-project/modin/assets/62142979/bfebde77-3137-44a4-bd7f-cee9acde8534)
![image](https://github.com/modin-project/modin/assets/62142979/c08552df-21d0-43cf-bf2d-6127a934a5a0)

### Our internal workload

Here we have "col1" having really low cardinality (range from 0-3), so the changes really helps to balance the buckets:
![image](https://github.com/modin-project/modin/assets/62142979/535b3c73-5808-42bd-8dab-750e46f25f40)
![image](https://github.com/modin-project/modin/assets/62142979/213938e7-6f35-452a-afaa-6dccf7a2e4af)
![image](https://github.com/modin-project/modin/assets/62142979/c2add77c-7800-477e-b82a-50551e5d555b)
![image](https://github.com/modin-project/modin/assets/62142979/820d5376-8b3f-43a0-b1e1-f0bf465bfced)

</details>

<details><summary>Scenario when NUM_CPUS=16</summary>

### NYC-taxi cases

Again, the data cardinality for the first `by` column is really good, so the changes don't make a difference:
![image](https://github.com/modin-project/modin/assets/62142979/a29545ef-15e2-4a1f-866f-1e9a3bad4fbf)

Data cardinality for the 'passenger_count' is low (0-10), combined with unlucky sampling it used to result into having only 4 non-empty buckets and poor parallelization. The introduced changes generate much more non-empty buckets, helping to balance the load between cores:
![image](https://github.com/modin-project/modin/assets/62142979/bb74dfbb-bde5-46ea-a913-6a03a2fb1e2a)

### H2O cases

In comparison with the NUM_CPUS=112 case, the cardinality of "id*" cols is just about right for the 16-cores case, so the changes don't make any difference.

![image](https://github.com/modin-project/modin/assets/62142979/b38f8bce-b6a0-4df4-814d-3190a11d47ff)
![image](https://github.com/modin-project/modin/assets/62142979/28658e8c-c068-4112-8a54-ac2d87e50068)
![image](https://github.com/modin-project/modin/assets/62142979/9e9d8df2-4d88-418b-9646-89fba1853945)
![image](https://github.com/modin-project/modin/assets/62142979/8b4c72c9-d66c-4f82-bb85-8d799e37a3b6)

### Our internal workload

Here we have "col1" having really low cardinality (range from 0-3), so the changes really helps to balance the buckets even for the 16-cores case:

![image](https://github.com/modin-project/modin/assets/62142979/952fb7f1-a250-4ad5-9c23-41dadba4660b)
![image](https://github.com/modin-project/modin/assets/62142979/d62aa6e2-a184-402f-b883-7af8e66e1417)
![image](https://github.com/modin-project/modin/assets/62142979/ef16489a-3bf5-48d1-822c-268f6e53b6e1)
![image](https://github.com/modin-project/modin/assets/62142979/6f9f06c3-13b9-4637-84e6-685fbb381243)



</details>

## Check-list

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6464 <!-- issue must be created for each patch -->
- [x] tests <s>added and</s> are passing (the existing multi-column groupby tests should cover new functionality)
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
