### PR TITLE
FIX-#6541: fix "ValueError: buffer source array is read-only" for `iloc`

### DIFF
--- a/modin/numpy/test/utils.py
+++ b/modin/numpy/test/utils.py
@@ -16,7 +16,7 @@ import numpy
 import modin.numpy as np
 
 
-def assert_scalar_or_array_equal(x1, x2, err_msg=None):
+def assert_scalar_or_array_equal(x1, x2, err_msg=""):
     """
     Assert whether the result of the numpy and modin computations are the same.
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fix [CI](https://github.com/modin-project/modin/actions/runs/6093900128/job/16536041233) on master branch after upgrading to pandas 2.1.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6541 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
