### PR TITLE
TEST-#4477: add tests for `df.eval` with scalar and `groupby.transform` call in the expr

### DIFF
--- a/modin/pandas/test/dataframe/test_udf.py
+++ b/modin/pandas/test/dataframe/test_udf.py
@@ -338,6 +338,18 @@ def test_eval_df_arithmetic_subexpression():
     df_equals(modin_df, df)
 
 
+def test_eval_groupby_transform():
+    # see #5511 for details
+    df = pd.DataFrame({"num": range(1, 1001), "group": ["A"] * 500 + ["B"] * 500})
+    assert df.eval("num.groupby(group).transform('min')").unique().tolist() == [1, 501]
+
+
+def test_eval_scalar():
+    # see #4477 for details
+    df = pd.DataFrame([[2]])
+    assert df.eval("1") == 1
+
+
 TEST_VAR = 2
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Looks like #4477 is resolved, so I'll just add a test (the same for #5511 which I closed recently).

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4477 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
