### PR TITLE
FIX-#6558: Normalize the number of partitions after `.read_parquet()`

### DIFF
--- a/modin/core/io/column_stores/column_store_dispatcher.py
+++ b/modin/core/io/column_stores/column_store_dispatcher.py
@@ -174,10 +174,10 @@ class ColumnStoreDispatcher(FileDispatcher):
         else:
             num_remaining_parts = round(NPartitions.get() / num_row_parts)
             min_block_size = min(
-                len(columns) // num_remaining_parts, MinPartitionSize.get()
+                columns_length // num_remaining_parts, MinPartitionSize.get()
             )
         column_splits = compute_chunksize(
-            len(columns), NPartitions.get(), max(1, min_block_size)
+            columns_length, NPartitions.get(), max(1, min_block_size)
         )
         col_partitions = [
             columns[i : i + column_splits]

--- a/modin/core/io/column_stores/column_store_dispatcher.py
+++ b/modin/core/io/column_stores/column_store_dispatcher.py
@@ -22,7 +22,7 @@ used as base class for dipatchers of specific columnar store formats.
 import numpy as np
 import pandas
 
-from modin.config import NPartitions, MinPartitionSize
+from modin.config import MinPartitionSize, NPartitions
 from modin.core.io.file_dispatcher import FileDispatcher
 from modin.core.storage_formats.pandas.utils import compute_chunksize
 

--- a/modin/core/io/column_stores/column_store_dispatcher.py
+++ b/modin/core/io/column_stores/column_store_dispatcher.py
@@ -24,7 +24,7 @@ import pandas
 
 from modin.core.storage_formats.pandas.utils import compute_chunksize
 from modin.core.io.file_dispatcher import FileDispatcher
-from modin.config import NPartitions
+from modin.config import NPartitions, MinPartitionSize
 
 
 class ColumnStoreDispatcher(FileDispatcher):
@@ -143,7 +143,7 @@ class ColumnStoreDispatcher(FileDispatcher):
         return index, row_lengths
 
     @classmethod
-    def build_columns(cls, columns):
+    def build_columns(cls, columns, num_row_parts=None):
         """
         Split columns into chunks that should be read by workers.
 
@@ -151,6 +151,10 @@ class ColumnStoreDispatcher(FileDispatcher):
         ----------
         columns : list
             List of columns that should be read from file.
+        num_row_parts : int, optional
+            Number of parts the dataset is split into. This parameter is used
+            to align the column partitioning with it so we won't end up with an
+            over partitioned frame.
 
         Returns
         -------
@@ -163,11 +167,17 @@ class ColumnStoreDispatcher(FileDispatcher):
         columns_length = len(columns)
         if columns_length == 0:
             return [], []
-        num_partitions = NPartitions.get()
-        column_splits = (
-            columns_length // num_partitions
-            if columns_length % num_partitions == 0
-            else columns_length // num_partitions + 1
+        if num_row_parts is None:
+            # in column formats we mostly read columns in parallel rather than rows,
+            # so we try to chunk columns as much as possible
+            min_block_size = 1
+        else:
+            num_remaining_parts = round(NPartitions.get() / num_row_parts)
+            min_block_size = min(
+                len(columns) // num_remaining_parts, MinPartitionSize.get()
+            )
+        column_splits = compute_chunksize(
+            len(columns), NPartitions.get(), max(1, min_block_size)
         )
         col_partitions = [
             columns[i : i + column_splits]

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -370,6 +370,7 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         """
         from modin.core.storage_formats.pandas.parsers import ParquetFileToRead
 
+        parquet_files = dataset.files
         row_groups_per_file = dataset.row_groups_per_file
         num_row_groups = sum(row_groups_per_file)
 
@@ -377,14 +378,13 @@ class ParquetDispatcher(ColumnStoreDispatcher):
             return []
 
         num_splits = min(NPartitions.get(), num_row_groups)
-        parquet_files = dataset.files
-        step = num_row_groups // num_splits
+        part_size = num_row_groups // num_splits
         # If 'num_splits' does not divide 'num_row_groups' then we can't cover all of
-        # the row groups using the original 'step'. According to the 'reminder'
+        # the row groups using the original 'part_size'. According to the 'reminder'
         # there has to be that number of partitions that should read 'step + 1'
         # number of row groups.
         reminder = num_row_groups % num_splits
-        part_sizes = [step] * (num_splits - reminder) + [step + 1] * reminder
+        part_sizes = [part_size] * (num_splits - reminder) + [part_size + 1] * reminder
 
         partition_files = []
         file_idx = 0

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -381,7 +381,7 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         part_size = num_row_groups // num_splits
         # If 'num_splits' does not divide 'num_row_groups' then we can't cover all of
         # the row groups using the original 'part_size'. According to the 'reminder'
-        # there has to be that number of partitions that should read 'step + 1'
+        # there has to be that number of partitions that should read 'part_size + 1'
         # number of row groups.
         reminder = num_row_groups % num_splits
         part_sizes = [part_size] * (num_splits - reminder) + [part_size + 1] * reminder

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -20,18 +20,22 @@ import json
 import fsspec
 from fsspec.core import url_to_fs
 from fsspec.spec import AbstractBufferedFile
+from modin.error_message import ErrorMessage
 import numpy as np
 from pandas.io.common import stringify_path
 import pandas
 import pandas._libs.lib as lib
 from packaging import version
+from typing import TYPE_CHECKING
 
-from modin.core.storage_formats.pandas.utils import compute_chunksize
 from modin.config import NPartitions
 
 
 from modin.core.io.column_stores.column_store_dispatcher import ColumnStoreDispatcher
 from modin.utils import _inherit_docstrings
+
+if TYPE_CHECKING:
+    from modin.core.storage_formats.pandas.parsers import ParquetFileToRead
 
 
 class ColumnStoreDataset:
@@ -351,19 +355,102 @@ class ParquetDispatcher(ColumnStoreDispatcher):
             raise ValueError("engine must be one of 'pyarrow', 'fastparquet'")
 
     @classmethod
-    def call_deploy(cls, dataset, col_partitions, storage_options, **kwargs):
+    def _determine_partitioning(
+        cls, dataset: ColumnStoreDataset
+    ) -> "list[list[ParquetFileToRead]]":
+        """
+        Determine which partition will read certain files/row groups of the dataset.
+
+        Parameters
+        ----------
+        dataset : ColumnStoreDataset
+
+        Returns
+        -------
+        list[list[ParquetFileToRead]]
+            Each element in the returned list describes a list of files that a partition has to read.
+        """
+        from modin.core.storage_formats.pandas.parsers import ParquetFileToRead
+
+        row_groups_per_file = dataset.row_groups_per_file
+        num_row_groups = sum(row_groups_per_file)
+
+        if num_row_groups == 0:
+            return []
+
+        num_splits = min(NPartitions.get(), num_row_groups)
+        parquet_files = dataset.files
+        step = num_row_groups // num_splits
+        # If 'num_splits' does not divide 'num_row_groups' then we can't cover all of
+        # the row groups using the original 'step'. According to the 'reminder'
+        # there has to be that number of partitions that should read 'step + 1'
+        # number of row groups.
+        reminder = num_row_groups % num_splits
+        part_sizes = [step] * (num_splits - reminder) + [step + 1] * reminder
+
+        partition_files = []
+        file_idx = 0
+        row_group_idx = 0
+        row_groups_left_in_current_file = row_groups_per_file[file_idx]
+        # this is used for sanity check at the end, verifying that we indeed added all of the row groups
+        total_row_groups_added = 0
+        for size in part_sizes:
+            row_groups_taken = 0
+            part_files = []
+            while row_groups_taken != size:
+                if row_groups_left_in_current_file < 1:
+                    file_idx += 1
+                    row_group_idx = 0
+                    row_groups_left_in_current_file = row_groups_per_file[file_idx]
+
+                to_take = min(size - row_groups_taken, row_groups_left_in_current_file)
+                part_files.append(
+                    ParquetFileToRead(
+                        parquet_files[file_idx],
+                        row_group_start=row_group_idx,
+                        row_group_end=row_group_idx + to_take,
+                    )
+                )
+                row_groups_left_in_current_file -= to_take
+                row_groups_taken += to_take
+                row_group_idx += to_take
+
+            total_row_groups_added += row_groups_taken
+            partition_files.append(part_files)
+
+        sanity_check = (
+            len(partition_files) == num_splits
+            and total_row_groups_added == num_row_groups
+        )
+        ErrorMessage.catch_bugs_and_request_email(
+            failure_condition=not sanity_check,
+            extra_log="row groups added does not match total num of row groups across parquet files",
+        )
+        return partition_files
+
+    @classmethod
+    def call_deploy(
+        cls,
+        partition_files: "list[list[ParquetFileToRead]]",
+        col_partitions: "list[list[str]]",
+        storage_options: dict,
+        engine: str,
+        **kwargs,
+    ):
         """
         Deploy remote tasks to the workers with passed parameters.
 
         Parameters
         ----------
-        dataset : Dataset
-            Dataset object of Parquet file/files.
-        col_partitions : list
+        partition_files : list[list[ParquetFileToRead]]
+            List of arrays with files that should be read by each partition.
+        col_partitions : list[list[str]]
             List of arrays with columns names that should be read
             by each partition.
         storage_options : dict
             Parameters for specific storage engine.
+        engine : {"auto", "pyarrow", "fastparquet"}
+            Parquet library to use for reading.
         **kwargs : dict
             Parameters of deploying read_* function.
 
@@ -372,66 +459,10 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         List
             Array with references to the task deploy result for each partition.
         """
-        from modin.core.storage_formats.pandas.parsers import ParquetFileToRead
-
         # If we don't have any columns to read, we should just return an empty
         # set of references.
         if len(col_partitions) == 0:
             return []
-
-        row_groups_per_file = dataset.row_groups_per_file
-        num_row_groups = sum(row_groups_per_file)
-        parquet_files = dataset.files
-
-        # step determines how many row groups are going to be in a partition
-        step = compute_chunksize(
-            num_row_groups,
-            NPartitions.get(),
-            min_block_size=1,
-        )
-        current_partition_size = 0
-        file_index = 0
-        partition_files = []  # 2D array - each element contains list of chunks to read
-        row_groups_used_in_current_file = 0
-        total_row_groups_added = 0
-        # On each iteration, we add a chunk of one file. That will
-        # take us either to the end of a partition, or to the end
-        # of a file.
-        while total_row_groups_added < num_row_groups:
-            if current_partition_size == 0:
-                partition_files.append([])
-            partition_file = partition_files[-1]
-            file_path = parquet_files[file_index]
-            row_group_start = row_groups_used_in_current_file
-            row_groups_left_in_file = (
-                row_groups_per_file[file_index] - row_groups_used_in_current_file
-            )
-            row_groups_left_for_this_partition = step - current_partition_size
-            if row_groups_left_for_this_partition <= row_groups_left_in_file:
-                # File has at least what we need to finish partition
-                # So finish this partition and start a new one.
-                num_row_groups_to_add = row_groups_left_for_this_partition
-                current_partition_size = 0
-            else:
-                # File doesn't have enough to complete this partition. Add
-                # it into current partition and go to next file.
-                num_row_groups_to_add = row_groups_left_in_file
-                current_partition_size += num_row_groups_to_add
-            if num_row_groups_to_add == row_groups_left_in_file:
-                file_index += 1
-                row_groups_used_in_current_file = 0
-            else:
-                row_groups_used_in_current_file += num_row_groups_to_add
-            partition_file.append(
-                ParquetFileToRead(
-                    file_path, row_group_start, row_group_start + num_row_groups_to_add
-                )
-            )
-            total_row_groups_added += num_row_groups_to_add
-
-        assert (
-            total_row_groups_added == num_row_groups
-        ), "row groups added does not match total num of row groups across parquet files"
 
         all_partitions = []
         for files_to_read in partition_files:
@@ -442,7 +473,7 @@ class ParquetDispatcher(ColumnStoreDispatcher):
                         f_kwargs={
                             "files_for_parser": files_to_read,
                             "columns": cols,
-                            "engine": dataset.engine,
+                            "engine": engine,
                             "storage_options": storage_options,
                             **kwargs,
                         },
@@ -627,9 +658,13 @@ class ParquetDispatcher(ColumnStoreDispatcher):
         storage_options = kwargs.pop("storage_options", {}) or {}
         filters = kwargs.get("filters", None)
 
-        col_partitions, column_widths = cls.build_columns(columns)
+        partition_files = cls._determine_partitioning(dataset)
+        col_partitions, column_widths = cls.build_columns(
+            columns,
+            num_row_parts=len(partition_files),
+        )
         partition_ids = cls.call_deploy(
-            dataset, col_partitions, storage_options, **kwargs
+            partition_files, col_partitions, storage_options, dataset.engine, **kwargs
         )
         index, sync_index = cls.build_index(
             dataset, partition_ids, index_columns, filters

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -16,11 +16,10 @@
 import json
 import os
 import re
+from typing import TYPE_CHECKING
 
 import fsspec
 import numpy as np
-from modin.error_message import ErrorMessage
-from typing import TYPE_CHECKING
 import pandas
 import pandas._libs.lib as lib
 from fsspec.core import url_to_fs
@@ -30,7 +29,7 @@ from pandas.io.common import stringify_path
 
 from modin.config import NPartitions
 from modin.core.io.column_stores.column_store_dispatcher import ColumnStoreDispatcher
-from modin.core.storage_formats.pandas.utils import compute_chunksize
+from modin.error_message import ErrorMessage
 from modin.utils import _inherit_docstrings
 
 if TYPE_CHECKING:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR brings the following changes to how parquet reading is being distributed:
1. <b>The number of column partitions is now depended on the number of row partitions.</b> Before, the implementation tended to create as much column partitions as possible (it often resulted into that column partitions consisted of only one column) which worked relatively fine if there were no row-groups in the parquet file (and so no row partitions):
    ```python
    NUM_CPUS=16
    parquet_file # has 1 row group and 16 columns
    pd.read_parquet(parquet_file)._partitions.shape # (1, 16) - 1 row partition and 16 column parts
    ```
    However, if there were enough row groups to keep all the workers busy, this excessive amount of column partitions resulted into an over partitioned frame:
    ```python
    file1 # has 9 row groups and 16 columns
    pd.read_parquet(file1)._partitions.shape # (9, 16)
    
    file2 # has 24 row groups and 16 columns
    pd.read_parquet(file2)._partitions.shape # (16, 16) - square partitioned frame
    ```
    Not only this logic generates much more reading kernels than the cores user potentially have, thus slowing down the reading part, but this also tends to generate over partitioned frames that further will slow other operations in the workflow (#5394).

    This logic was changed, so now we first determine how many row parts the output dataframe will have and then depending on the number of remaining partitions (`NPartitions.get() / num_row_parts`) create that number of column partitions. BUT, if the number of columns is greater than the `cfg.MinPartitionSize` parameter, then the columns splitting logic is the same as in [`.from_pandas()`](https://github.com/modin-project/modin/blob/aa752565fad37b0259785d639a0a5bf317f55c24/modin/core/dataframe/pandas/partitioning/partition_manager.py#L788-L789), allowing to create more column partitions (up to the square partitioning).

    Here are few examples of how the new splitting logic for `.read_parquet()` works:
    ```python
    NUM_CPUS = 16
    MIN_PARTITION_SIZE = 32
    
    parquet file schema -> partitioning of modin df
    (row_grps=1, columns=9) -> (row_parts=1, col_parts=9) # no row parts, create col parts as much as possible
    (row_grps=1, columns=18) -> (row_parts=1, col_parts=16) # no row parts, create col parts as much as possible
    (row_grps=9, columns=9) -> (row_parts=9, col_parts=2) # 9 row parts, so only 2 col parts
    (row_grps=9, columns=64) -> (row_parts=9, col_parts=2) # 9 row parts, so only 2 col parts according to MIN_PARTITION_SIZE param
    (row_grps=9, columns=65) -> (row_parts=9, col_parts=3) # 9 row parts, so only 3 col parts according to MIN_PARTITION_SIZE param
    (row_grps=100, columns=9) -> (row_parts=16, col_parts=1) # 16 row parts, so only 1 col part
    (row_grps=100, columns=32) -> (row_parts=16, col_parts=1) # 16 row parts, so only 1 col part according to MIN_PARTITION_SIZE param
    (row_grps=100, columns=1_000) -> (row_parts=16, col_parts=16) # 16 row parts and 16 col parts according to MIN_PARTITION_SIZE param
    ```

2. **More distributed reading across the row groups.** Before, if the number of row groups was greater than `NPartitions` but didn't divide without reminder (18 row groups and 16 `NPartitions`) then the resulted dataframe will have LESS than 16 row partitions:
    ```python
    step = ceil(num_row_groups / npartitions) # ceil(18 / 16) = ceil(1.125) = 2
    row_parts = [
        row_groups[i * step : i * (step + 1)] for i in range(num_row_groups / step)
    ] # len(row_parts) == 9
    ```
    It was changed to allow unequal row partition sizes in order to fill all the row partitions:
    ```python
    step = num_row_groups // npartitions # 18 // 16 = 1
    reminder = num_row_groups % npartitions # 18 % 16 = 2
    row_partition_sizes = [step] * (npartitions - reminder) + [step + 1] * reminder
    # here we will have that 14 workers will read 1 row group and the last 2 workers will read 2 row groups
    ```

### Performance difference

![image](https://github.com/modin-project/modin/assets/62142979/c86af52a-b7c3-4c93-a758-7b5ad77d00c9)

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6558 <!-- issue must be created for each patch -->
- [x] tests <s>added and</s> are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
