### PR TITLE
FIX-#5164: Fix unwrap_partitions for virtual partitions when `axis=None`

### DIFF
--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -97,7 +97,7 @@ def unwrap_partitions(
             [p.drain_call_queue() for p in modin_frame._partitions.flatten()]
 
             def get_block(partition: PartitionUnionType) -> np.ndarray:
-                if hasattr(partition, "axis"):
+                if hasattr(partition, "force_materialization"):
                     blocks = partition.force_materialization().list_of_blocks
                 else:
                     blocks = partition.list_of_blocks

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -98,7 +98,7 @@ def unwrap_partitions(
 
             def get_block(partition: PartitionUnionType) -> np.ndarray:
                 if hasattr(partition, "axis"):
-                    blocks = partition.force_materialization()
+                    blocks = partition.force_materialization().list_of_blocks
                 else:
                     blocks = partition.list_of_blocks
                 assert (

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -94,6 +94,24 @@ def test_unwrap_partitions(axis, reverse_index, reverse_columns):
                     get_func(expected_partitions[row_idx][col_idx].list_of_blocks[0]),
                     get_func(actual_partitions[row_idx][col_idx]),
                 )
+        df = get_df(pd, data)
+        virtual_partitioned_df = pd.concat([df] * 10)
+        actual_partitions = np.array(
+            unwrap_partitions(virtual_partitioned_df, axis=axis)
+        )
+        assert expected_partitions.shape == actual_partitions.shape
+        expected_df = pd.concat([pd.DataFrame(get_df(pandas, data))] * 10)
+        expected_partitions = expected_df._query_compiler._modin_frame._partitions
+        for row_idx in range(expected_partitions.shape[0]):
+            for col_idx in range(expected_partitions.shape[1]):
+                df_equals(
+                    get_func(
+                        expected_partitions[row_idx][col_idx]
+                        .force_materialization()
+                        .list_of_blocks[0]
+                    ),
+                    get_func(actual_partitions[row_idx][col_idx]),
+                )
     else:
         expected_axis_partitions = (
             expected_df._query_compiler._modin_frame._partition_mgr_cls.axis_partition(

--- a/modin/test/test_partition_api.py
+++ b/modin/test/test_partition_api.py
@@ -94,24 +94,6 @@ def test_unwrap_partitions(axis, reverse_index, reverse_columns):
                     get_func(expected_partitions[row_idx][col_idx].list_of_blocks[0]),
                     get_func(actual_partitions[row_idx][col_idx]),
                 )
-        df = get_df(pd, data)
-        virtual_partitioned_df = pd.concat([df] * 10)
-        actual_partitions = np.array(
-            unwrap_partitions(virtual_partitioned_df, axis=axis)
-        )
-        assert expected_partitions.shape == actual_partitions.shape
-        expected_df = pd.concat([pd.DataFrame(get_df(pandas, data))] * 10)
-        expected_partitions = expected_df._query_compiler._modin_frame._partitions
-        for row_idx in range(expected_partitions.shape[0]):
-            for col_idx in range(expected_partitions.shape[1]):
-                df_equals(
-                    get_func(
-                        expected_partitions[row_idx][col_idx]
-                        .force_materialization()
-                        .list_of_blocks[0]
-                    ),
-                    get_func(actual_partitions[row_idx][col_idx]),
-                )
     else:
         expected_axis_partitions = (
             expected_df._query_compiler._modin_frame._partition_mgr_cls.axis_partition(
@@ -130,6 +112,28 @@ def test_unwrap_partitions(axis, reverse_index, reverse_columns):
                     get_func(expected_axis_partitions[item_idx]),
                     get_func(actual_axis_partitions[item_idx]),
                 )
+
+
+def test_unwrap_virtual_partitions():
+    # see #5164 for details
+    data = test_data["int_data"]
+    df = pd.DataFrame(data)
+    virtual_partitioned_df = pd.concat([df] * 10)
+    actual_partitions = np.array(unwrap_partitions(virtual_partitioned_df, axis=None))
+    expected_df = pd.concat([pd.DataFrame(data)] * 10)
+    expected_partitions = expected_df._query_compiler._modin_frame._partitions
+    assert expected_partitions.shape == actual_partitions.shape
+
+    for row_idx in range(expected_partitions.shape[0]):
+        for col_idx in range(expected_partitions.shape[1]):
+            df_equals(
+                get_func(
+                    expected_partitions[row_idx][col_idx]
+                    .force_materialization()
+                    .list_of_blocks[0]
+                ),
+                get_func(actual_partitions[row_idx][col_idx]),
+            )
 
 
 @pytest.mark.parametrize("column_widths", [None, "column_widths"])


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Continues work started in https://github.com/modin-project/modin/pull/5258. сс @mvashishtha @RehanSD 

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5164 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
