### PR TITLE
FIX-#6561: remove `MODIN_OMNISCI_*` env vars in favor of `MODIN_HDK_*`

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -301,14 +301,8 @@ class HdkFragmentSize(EnvironmentVariable, type=int):
     varname = "MODIN_HDK_FRAGMENT_SIZE"
 
 
-class OmnisciFragmentSize(EnvironmentVariable, type=int):
-    """How big a fragment in OmniSci should be when creating a table (in rows)."""
-
-    varname = "MODIN_OMNISCI_FRAGMENT_SIZE"
-
-
 class DoUseCalcite(EnvironmentVariable, type=bool):
-    """Whether to use Calcite for OmniSci queries execution."""
+    """Whether to use Calcite for HDK queries execution."""
 
     varname = "MODIN_USE_CALCITE"
     default = True
@@ -530,24 +524,6 @@ class HdkLaunchParameters(EnvironmentVariable, type=dict):
         dict
             Decoded and verified config value.
         """
-        if cls == OmnisciLaunchParameters or (
-            OmnisciLaunchParameters.varname in os.environ
-            and HdkLaunchParameters.varname not in os.environ
-        ):
-            return OmnisciLaunchParameters._get()
-        else:
-            return HdkLaunchParameters._get()
-
-    @classmethod
-    def _get(cls) -> dict:
-        """
-        Get the resulted command-line options.
-
-        Returns
-        -------
-        dict
-            Decoded and verified config value.
-        """
         custom_parameters = super().get()
         result = cls._get_default().copy()
         result.update(
@@ -587,17 +563,6 @@ class HdkLaunchParameters(EnvironmentVariable, type=dict):
                 # if pyhdk is not available, do not show any additional options
                 pass
         return default
-
-
-class OmnisciLaunchParameters(HdkLaunchParameters, type=dict):
-    """
-    Additional command line options for the OmniSci engine.
-
-    Please visit OmniSci documentation for the description of available parameters:
-    https://docs.omnisci.com/installation-and-configuration/config-parameters#configuration-parameters-for-omniscidb
-    """
-
-    varname = "MODIN_OMNISCI_LAUNCH_PARAMETERS"
 
 
 class MinPartitionSize(EnvironmentVariable, type=int):

--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -77,14 +77,6 @@ def test_hdk_envvar():
         # This test is intended to check pyhdk internals. If pyhdk is not available, skip the version check test.
         pass
 
-    os.environ[
-        cfg.OmnisciLaunchParameters.varname
-    ] = "enable_union=2,enable_thrift_logs=3"
-    del cfg.OmnisciLaunchParameters._value
-    params = cfg.OmnisciLaunchParameters.get()
-    assert params["enable_union"] == 2
-    assert params["enable_thrift_logs"] == 3
-
     params = cfg.HdkLaunchParameters.get()
     assert params["enable_union"] == 2
     assert params["enable_thrift_logs"] == 3
@@ -110,13 +102,3 @@ def test_hdk_envvar():
     assert params["enable_union"] == 4
     assert params["enable_thrift_logs"] == 5
     assert params["enable_lazy_dict_materialization"] == 6
-
-    params = cfg.OmnisciLaunchParameters.get()
-    assert params["enable_union"] == 2
-    assert params["enable_thrift_logs"] == 3
-
-    del os.environ[cfg.OmnisciLaunchParameters.varname]
-    del cfg.OmnisciLaunchParameters._value
-    params = cfg.OmnisciLaunchParameters.get()
-    assert params["enable_union"] == 4
-    assert params["enable_thrift_logs"] == 5

--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -77,11 +77,13 @@ def test_hdk_envvar():
         # This test is intended to check pyhdk internals. If pyhdk is not available, skip the version check test.
         pass
 
+    os.environ[cfg.HdkLaunchParameters.varname] = "enable_union=2,enable_thrift_logs=3"
     params = cfg.HdkLaunchParameters.get()
     assert params["enable_union"] == 2
     assert params["enable_thrift_logs"] == 3
 
     os.environ[cfg.HdkLaunchParameters.varname] = "unsupported=X"
+    del cfg.HdkLaunchParameters._value
     params = cfg.HdkLaunchParameters.get()
     assert params["unsupported"] == "X"
     try:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/hdk_worker.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/hdk_worker.py
@@ -25,7 +25,7 @@ from pyhdk.hdk import HDK, QueryNode, ExecutionResult, RelAlgExecutor
 from .base_worker import DbTable, BaseDbWorker
 
 from modin.utils import _inherit_docstrings
-from modin.config import HdkLaunchParameters, OmnisciFragmentSize, HdkFragmentSize
+from modin.config import HdkLaunchParameters, HdkFragmentSize
 
 _CAST_DICT = version.parse(pyhdk.__version__) <= version.parse("0.7.0")
 
@@ -143,8 +143,6 @@ class HdkWorker(BaseDbWorker):  # noqa: PR01
             Fragment size to use for import.
         """
         fragment_size = HdkFragmentSize.get()
-        if fragment_size is None:
-            fragment_size = OmnisciFragmentSize.get()
         if fragment_size is None:
             if cls._preferred_device == "CPU":
                 cpu_count = os.cpu_count()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6561 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
