### PR TITLE
TEST-#4270: revert disabling `time_groupby_agg_nunique` ASV bench 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,6 +249,14 @@ jobs:
 
               asv machine --yes
 
+              # check Modin on Ray
+              asv run --quick --strict --show-stderr --launch-method=spawn \
+                -b ^benchmarks -b ^io -b ^scalability | tee benchmarks.log
+
+              # check pure pandas
+              MODIN_ASV_USE_IMPL=pandas asv run --quick --strict --show-stderr --launch-method=spawn \
+                -b ^benchmarks -b ^io | tee benchmarks.log
+
               # Otherwise, ASV considers that the environment has already been created, although ASV command is run for another config,
               # which requires the creation of a completely new environment. This step will be required after removing the manual environment setup step.
               rm -f -R .asv/env/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -249,19 +249,6 @@ jobs:
 
               asv machine --yes
 
-              # check Modin on Ray
-              asv run --quick --strict --show-stderr --launch-method=spawn \
-                -b ^benchmarks -b ^io -b ^scalability | tee benchmarks.log
-
-              # check pure pandas
-              MODIN_ASV_USE_IMPL=pandas asv run --quick --strict --show-stderr --launch-method=spawn \
-                -b ^benchmarks -b ^io | tee benchmarks.log
-
-              # HDK: ERR_OUT_OF_CPU_MEM: Not enough host memory to execute the query (MODIN#4270)
-              # just disable test for testing - it works well in a machine with more memory
-              sed -i 's/def time_groupby_agg_nunique(self, \*args, \*\*kwargs):/# def time_groupby_agg_nunique(self, *args, **kwargs):/g' benchmarks/hdk/benchmarks.py
-              sed -i 's/execute(self.df.groupby(by=self.groupby_columns).agg("nunique"))/# execute(self.df.groupby(by=self.groupby_columns).agg("nunique"))/g' benchmarks/hdk/benchmarks.py
-
               # Otherwise, ASV considers that the environment has already been created, although ASV command is run for another config,
               # which requires the creation of a completely new environment. This step will be required after removing the manual environment setup step.
               rm -f -R .asv/env/

--- a/asv_bench/benchmarks/utils/data_shapes.py
+++ b/asv_bench/benchmarks/utils/data_shapes.py
@@ -19,7 +19,12 @@ import os
 from .compatibility import ASV_DATASET_SIZE, ASV_USE_STORAGE_FORMAT
 
 RAND_LOW = 0
-RAND_HIGH = 1_000_000_000 if ASV_USE_STORAGE_FORMAT == "hdk" else 100
+# use a small number of unique values in Github actions to avoid OOM (mostly related to HDK)
+RAND_HIGH = (
+    1_000_000_000
+    if ASV_USE_STORAGE_FORMAT == "hdk" and ASV_DATASET_SIZE == "Big"
+    else 100
+)
 
 BINARY_OP_DATA_SIZE = {
     "big": [


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4270 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
