### PR TITLE
TEST-#4348: use `psycopg2-binary` for testing and developing purpose

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,7 +26,7 @@ pandas-gbq>=0.15.0
 tables>=3.7.0
 # pymssql==2.2.8 broken: https://github.com/modin-project/modin/issues/6429
 pymssql>=2.1.5,!=2.2.8
-psycopg2>=2.9.3
+psycopg2-binary>=2.9.3
 connectorx>=0.2.6a4
 fastparquet>=0.8.1
 flask-cors

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -26,6 +26,8 @@ pandas-gbq>=0.15.0
 tables>=3.7.0
 # pymssql==2.2.8 broken: https://github.com/modin-project/modin/issues/6429
 pymssql>=2.1.5,!=2.2.8
+# psycopg devs recommend the other way of installation for production
+# but this is ok for testing and development
 psycopg2-binary>=2.9.3
 connectorx>=0.2.6a4
 fastparquet>=0.8.1


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

I guess we don't have to worry about how users install this dependency in production.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4348 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
