### PR TITLE
REFACTOR-#6576: Don't use deprecated `is_int64_dtype` and `is_period_dtype` functions

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/expr.py
@@ -26,7 +26,6 @@ from pandas.core.dtypes.common import (
     is_datetime64_any_dtype,
     is_datetime64_dtype,
     is_float_dtype,
-    is_int64_dtype,
     is_integer_dtype,
     is_list_like,
     is_numeric_dtype,
@@ -69,8 +68,8 @@ def _get_common_dtype(lhs_dtype, rhs_dtype):
         return _get_dtype(int)
     if is_datetime64_dtype(lhs_dtype) and is_datetime64_dtype(rhs_dtype):
         return np.promote_types(lhs_dtype, rhs_dtype)
-    if (is_datetime64_dtype(lhs_dtype) and is_int64_dtype(rhs_dtype)) or (
-        is_datetime64_dtype(rhs_dtype) and is_int64_dtype(lhs_dtype)
+    if (is_datetime64_dtype(lhs_dtype) and rhs_dtype == np.int64) or (
+        is_datetime64_dtype(rhs_dtype) and (lhs_dtype == np.int64)
     ):
         return _get_dtype(int)
     raise NotImplementedError(

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -32,7 +32,6 @@ from pandas.core.dtypes.common import (
     is_list_like,
     is_numeric_dtype,
     is_object_dtype,
-    is_period_dtype,
     is_string_dtype,
     is_timedelta64_dtype,
 )
@@ -650,7 +649,7 @@ def assert_dtypes_equal(df1, df2):
         lambda obj: isinstance(obj, pandas.CategoricalDtype),
         is_datetime64_any_dtype,
         is_timedelta64_dtype,
-        is_period_dtype,
+        lambda obj: isinstance(obj, pandas.PeriodDtype),
     )
 
     for col in dtypes1.keys():


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6576 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
