### PR TITLE
PERF-#6583: Remove redundant index reassignment in query()

### DIFF
--- a/modin/pandas/test/dataframe/test_udf.py
+++ b/modin/pandas/test/dataframe/test_udf.py
@@ -446,6 +446,41 @@ def test_query(data, funcs, engine):
         df_equals(modin_result.dtypes, pandas_result.dtypes)
 
 
+def test_query_named_index():
+    eval_general(
+        *(df.set_index("col1") for df in create_test_dfs(test_data["int_data"])),
+        lambda df: df.query("col1 % 2 == 0 | col2 % 2 == 1"),
+        # work around https://github.com/modin-project/modin/issues/6016
+        raising_exceptions=Exception,
+    )
+
+
+def test_query_named_multiindex():
+    eval_general(
+        *(
+            df.set_index(["col1", "col2"])
+            for df in create_test_dfs(test_data["int_data"])
+        ),
+        lambda df: df.query("col1 % 2 == 1 | col2 % 2 == 1"),
+        # work around https://github.com/modin-project/modin/issues/6016
+        raising_exceptions=Exception,
+    )
+
+
+def test_query_multiindex_without_names():
+    def make_df(without_index):
+        new_df = without_index.set_index(["col1", "col2"])
+        new_df.index.names = [None, None]
+        return new_df
+
+    eval_general(
+        *(make_df(df) for df in create_test_dfs(test_data["int_data"])),
+        lambda df: df.query("ilevel_0 % 2 == 0 | ilevel_1 % 2 == 1 | col3 % 2 == 1"),
+        # work around https://github.com/modin-project/modin/issues/6016
+        raising_exceptions=Exception,
+    )
+
+
 def test_empty_query():
     modin_df = pd.DataFrame([1, 2, 3, 4, 5])
 

--- a/modin/pandas/test/dataframe/test_udf.py
+++ b/modin/pandas/test/dataframe/test_udf.py
@@ -449,35 +449,35 @@ def test_query(data, funcs, engine):
 def test_query_named_index():
     eval_general(
         *(df.set_index("col1") for df in create_test_dfs(test_data["int_data"])),
-        lambda df: df.query("col1 % 2 == 0 | col2 % 2 == 1"),
+        lambda df: df.query("col1 % 2 == 0 | col3 % 2 == 1"),
         # work around https://github.com/modin-project/modin/issues/6016
-        raising_exceptions=Exception,
+        raising_exceptions=(Exception,),
     )
 
 
 def test_query_named_multiindex():
     eval_general(
         *(
-            df.set_index(["col1", "col2"])
+            df.set_index(["col1", "col3"])
             for df in create_test_dfs(test_data["int_data"])
         ),
-        lambda df: df.query("col1 % 2 == 1 | col2 % 2 == 1"),
+        lambda df: df.query("col1 % 2 == 1 | col3 % 2 == 1"),
         # work around https://github.com/modin-project/modin/issues/6016
-        raising_exceptions=Exception,
+        raising_exceptions=(Exception,),
     )
 
 
 def test_query_multiindex_without_names():
     def make_df(without_index):
-        new_df = without_index.set_index(["col1", "col2"])
+        new_df = without_index.set_index(["col1", "col3"])
         new_df.index.names = [None, None]
         return new_df
 
     eval_general(
         *(make_df(df) for df in create_test_dfs(test_data["int_data"])),
-        lambda df: df.query("ilevel_0 % 2 == 0 | ilevel_1 % 2 == 1 | col3 % 2 == 1"),
+        lambda df: df.query("ilevel_0 % 2 == 0 | ilevel_1 % 2 == 1 | col4 % 2 == 1"),
         # work around https://github.com/modin-project/modin/issues/6016
-        raising_exceptions=Exception,
+        raising_exceptions=(Exception,),
     )
 
 

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -308,6 +308,9 @@ query_func = {
     "col3 > col4": "col3 > col4",
     "col1 == col2": "col1 == col2",
     "(col2 > col1) and (col1 < col3)": "(col2 > col1) and (col1 < col3)",
+    # this is how to query for values of an unnamed index per
+    # https://pandas.pydata.org/docs/user_guide/indexing.html#multiindex-query-syntax
+    "ilevel_0 % 2 == 1": "ilevel_0 % 2 == 1",
 }
 query_func_keys = list(query_func.keys())
 query_func_values = list(query_func.values())


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6583
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
