### PR TITLE
PERF-#6590: Chunk axes independently in '.from_pandas()'

### DIFF
--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -27,7 +27,7 @@ import numpy as np
 import pandas
 from pandas._libs.lib import no_default
 
-from modin.config import BenchmarkMode, NPartitions, ProgressBar, Engine
+from modin.config import BenchmarkMode, Engine, NPartitions, ProgressBar
 from modin.core.dataframe.pandas.utils import concatenate
 from modin.core.storage_formats.pandas.utils import compute_chunksize
 from modin.error_message import ErrorMessage


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR changes the logic of partitioning pandas dataframes in `.from_pandas()`. We used to call `.iloc` in a loop with two arguments - row and column slice, the new logic now first splits a dataframe into column chunks and then each column chunk into row chunks.

### Why?

A [recently introduced regression in pandas 2.1](https://github.com/pandas-dev/pandas/issues/55202) highlighted that columns slicing may sometimes be quite expensive, that's why it might not be a good idea to call it in a loop.

So here is the performance comparison showing the difference between the old and the new approach of slicing a pandas dataframe, note that the new approach is also better even on pandas 2.0.3 where the problem of columns slicing was not yet that visible.

<details><summary>performance difference</summary>

![image](https://github.com/modin-project/modin/assets/62142979/539d0477-cf3a-438f-a72d-5032292d2d87)

![image](https://github.com/modin-project/modin/assets/62142979/76e0050c-61c1-42b4-9d1b-fefef7ca2cb4)

</details>

<details><summary>benchmark</summary>

```python
import timeit

def split_new_way(df, col_chunksize, row_chunksize):
    if col_chunksize >= len(df.columns):
        col_parts = [df]
    else:
        col_parts = [
            df.iloc[:, i : i + col_chunksize]
            for i in range(0, len(df.columns), col_chunksize)
        ]
    parts = [
        [
            col_part.iloc[i : i + row_chunksize]
            for col_part in col_parts
        ]
        for i in range(0, len(df), row_chunksize)
    ]
    return parts

def split_old_way(df, col_chunksize, row_chunksize):
    parts = [
        [
            df.iloc[i : i + row_chunksize, j : j + col_chunksize]
            for j in range(0, len(df.columns), col_chunksize)
        ]
        for i in range(0, len(df), row_chunksize)
    ]
    return parts

import pandas as pd
import numpy as np

shapes = [
    (1000, 4),
    (5000, 5000),
    (500_000, 128),
    (1_000_000, 128),
    (10_000_000, 4),
    (10_000_000, 32),
]
min_col_chunk_sizes = [
    16,
    32
]
is_multiple_numpy_col_blocks = [
    True,
    False
]
num_partitions = [
    4,
    16,
    32
]

res = pd.DataFrame()

total_tests = len(shapes) * len(num_partitions) * len(min_col_chunk_sizes) * len(is_multiple_numpy_col_blocks)
passed_tests = 0

for nrows, ncols in shapes:
    for nchunks in num_partitions:
        keys = []
        values = []
        for min_col_chunk in min_col_chunk_sizes:
            for is_partitioned in is_multiple_numpy_col_blocks:
                print((nrows, ncols), nchunks, min_col_chunk, is_partitioned, f"({passed_tests}/{total_tests} ~ {round(passed_tests / total_tests * 100, 2)}%)")
                if is_partitioned:
                    df = pd.concat([pd.DataFrame(np.random.randint(0, 1_000_000, (nrows, ncols // 2))), pd.DataFrame(np.random.randint(0, 1_000_000, (nrows, ncols // 2)))], axis=1)
                    assert len(df._mgr.blocks) > 1
                    # this case works very slow, so only 3 runs
                    num_runs = 3
                else:
                    df = pd.DataFrame(np.random.randint(0, 1_000_000, (nrows, ncols // 2)))
                    num_runs = 100
                
                row_ch = max(len(df) // nchunks, 32)
                col_ch = max(len(df.columns) // nchunks, min_col_chunk)
                new_t = timeit.timeit(lambda: split_new_way(df, col_ch, row_ch), number=num_runs)
                old_t = timeit.timeit(lambda: split_old_way(df, col_ch, row_ch), number=num_runs)

                new_res = f"NEW IMPL: total time for {num_runs} calls: {new_t} | ~{new_t / num_runs} per call"
                old_res = f"OLD IMPL: total time for {num_runs} calls: {old_t} | ~{old_t / num_runs} per call"

                keys.append((min_col_chunk, is_partitioned, "new impl"))
                keys.append((min_col_chunk, is_partitioned, "old impl"))
                values.append(new_t)
                values.append(old_t)
                passed_tests += 1

        res.loc[f"shape={(nrows, ncols)}; nparts={nchunks}", keys] = values

res.to_excel("test.xlsx")
```

</details>

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6590 <!-- issue must be created for each patch -->
- [x] tests <s>added and</s> are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
