### PR TITLE
TEST-#6593: adapt tests for pandas 2.1.1

### DIFF
--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -817,7 +817,6 @@ def test_convert_dtypes_dtype_backend(dtype_backend):
     StorageFormat.get() == "Hdk",
     reason="HDK does not support columns with different types",
 )
-@pytest.mark.xfail(reason="https://github.com/pandas-dev/pandas/issues/54848")
 def test_convert_dtypes_multiple_row_partitions():
     # Column 0 should have string dtype
     modin_part1 = pd.DataFrame(["a"]).convert_dtypes()

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -625,7 +625,6 @@ def test_unique():
     reason="https://github.com/modin-project/modin/issues/2896",
 )
 @pytest.mark.parametrize("normalize, bins, dropna", [(True, 3, False)])
-@pytest.mark.xfail(reason="https://github.com/pandas-dev/pandas/issues/54857")
 def test_value_counts(normalize, bins, dropna):
     # We sort indices for Modin and pandas result because of issue #1650
     values = np.array([3, 1, 2, 3, 4, np.nan])

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -2717,20 +2717,8 @@ class TestFwf:
         "usecols",
         [
             ["a"],
-            pytest.param(
-                ["a", "b", "d"],
-                marks=pytest.mark.xfail(
-                    Engine.get() != "Python" and StorageFormat.get() != "Hdk",
-                    reason="https://github.com/pandas-dev/pandas/issues/54868",
-                ),
-            ),
-            pytest.param(
-                [0, 1, 3],
-                marks=pytest.mark.xfail(
-                    Engine.get() != "Python" and StorageFormat.get() != "Hdk",
-                    reason="https://github.com/pandas-dev/pandas/issues/54868",
-                ),
-            ),
+            ["a", "b", "d"],
+            [0, 1, 3],
         ],
     )
     def test_fwf_file_usecols(self, make_fwf_file, usecols):
@@ -2797,10 +2785,6 @@ class TestFwf:
         df_equals(modin_df, pd_df)
 
     @pytest.mark.parametrize("nrows", [13, None])
-    @pytest.mark.xfail(
-        Engine.get() != "Python" and StorageFormat.get() != "Hdk",
-        reason="https://github.com/pandas-dev/pandas/issues/54868",
-    )
     def test_fwf_file_skiprows(self, make_fwf_file, nrows):
         unique_filename = make_fwf_file()
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6593 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
