### PR TITLE
FIX-#6552: avoid `FutureWarning`s in `groupby` unless necessary

### DIFF
--- a/modin/core/dataframe/algebra/default2pandas/groupby.py
+++ b/modin/core/dataframe/algebra/default2pandas/groupby.py
@@ -13,6 +13,7 @@
 
 """Module houses default GroupBy functions builder class."""
 
+import warnings
 from typing import Any
 
 import pandas
@@ -59,7 +60,9 @@ class GroupBy:
     @classmethod
     def _call_groupby(cls, df, *args, **kwargs):  # noqa: PR01
         """Call .groupby() on passed `df`."""
-        return df.groupby(*args, **kwargs)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            return df.groupby(*args, **kwargs)
 
     @classmethod
     def validate_by(cls, by):
@@ -563,7 +566,9 @@ class SeriesGroupBy(GroupBy):
         # In second case surrounding logic will supplement grouping columns,
         # so we need to drop them after grouping is over; our originally
         # selected column is always the first, so use it
-        return df.groupby(*args, **kwargs)[df.columns[0]]
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            return df.groupby(*args, **kwargs)[df.columns[0]]
 
 
 class GroupByDefault(DefaultMethod):

--- a/modin/core/dataframe/algebra/default2pandas/groupby.py
+++ b/modin/core/dataframe/algebra/default2pandas/groupby.py
@@ -598,9 +598,7 @@ class GroupByDefault(DefaultMethod):
             aggregation.
         """
         return super().register(
-            cls._groupby_cls.build_groupby(func),
-            fn_name=func.__name__,
-            **kwargs,
+            cls._groupby_cls.build_groupby(func), fn_name=func.__name__, **kwargs
         )
 
     # This specifies a `pandas.DataFrameGroupBy` method to pass the `agg_func` to,

--- a/modin/core/dataframe/algebra/default2pandas/groupby.py
+++ b/modin/core/dataframe/algebra/default2pandas/groupby.py
@@ -13,7 +13,6 @@
 
 """Module houses default GroupBy functions builder class."""
 
-import functools
 import warnings
 from typing import Any
 
@@ -598,15 +597,8 @@ class GroupByDefault(DefaultMethod):
             Functiom that takes query compiler and defaults to pandas to do GroupBy
             aggregation.
         """
-
-        @functools.wraps(func)
-        def func_catch_warnings(*args, **kwargs):
-            with warnings.catch_warnings():
-                warnings.filterwarnings("ignore", category=FutureWarning)
-                return func(*args, **kwargs)
-
         return super().register(
-            cls._groupby_cls.build_groupby(func_catch_warnings),
+            cls._groupby_cls.build_groupby(func),
             fn_name=func.__name__,
             **kwargs,
         )

--- a/modin/core/dataframe/algebra/default2pandas/groupby.py
+++ b/modin/core/dataframe/algebra/default2pandas/groupby.py
@@ -13,6 +13,7 @@
 
 """Module houses default GroupBy functions builder class."""
 
+import functools
 import warnings
 from typing import Any
 
@@ -597,8 +598,17 @@ class GroupByDefault(DefaultMethod):
             Functiom that takes query compiler and defaults to pandas to do GroupBy
             aggregation.
         """
+
+        @functools.wraps(func)
+        def func_catch_warnings(*args, **kwargs):
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=FutureWarning)
+                return func(*args, **kwargs)
+
         return super().register(
-            cls._groupby_cls.build_groupby(func), fn_name=func.__name__, **kwargs
+            cls._groupby_cls.build_groupby(func_catch_warnings),
+            fn_name=func.__name__,
+            **kwargs,
         )
 
     # This specifies a `pandas.DataFrameGroupBy` method to pass the `agg_func` to,

--- a/modin/core/dataframe/pandas/interchange/dataframe_protocol/column.py
+++ b/modin/core/dataframe/pandas/interchange/dataframe_protocol/column.py
@@ -127,7 +127,7 @@ class PandasProtocolColumn(ProtocolColumn):
         if self._dtype_cache is not None:
             return self._dtype_cache
 
-        dtype = self._col.dtypes[0]
+        dtype = self._col.dtypes.iloc[0]
 
         if isinstance(dtype, pandas.CategoricalDtype):
             pandas_series = self._col.to_pandas().squeeze(axis=1)

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -13,6 +13,8 @@
 
 """The module defines base interface for an axis partition of a Modin DataFrame."""
 
+import warnings
+
 import numpy as np
 import pandas
 
@@ -418,7 +420,9 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
             A list of pandas DataFrames.
         """
         dataframe = pandas.concat(list(partitions), axis=axis, copy=False)
-        result = func(dataframe, *f_args, **f_kwargs)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            result = func(dataframe, *f_args, **f_kwargs)
 
         if num_splits == 1:
             # If we're not going to split the result, we don't need to specify
@@ -497,7 +501,9 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
             for i in range(1, len(other_shape))
         ]
         rt_frame = pandas.concat(combined_axis, axis=axis ^ 1, copy=False)
-        result = func(lt_frame, rt_frame, *f_args, **f_kwargs)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            result = func(lt_frame, rt_frame, *f_args, **f_kwargs)
         return split_result_of_axis_func_pandas(axis, num_splits, result)
 
     @classmethod

--- a/modin/core/execution/dask/common/utils.py
+++ b/modin/core/execution/dask/common/utils.py
@@ -48,6 +48,15 @@ def initialize_dask():
         memory_limit = Memory.get()
         worker_memory_limit = memory_limit // num_cpus if memory_limit else "auto"
         client = Client(n_workers=num_cpus, memory_limit=worker_memory_limit)
+
+        def _disable_warnings():
+            import warnings
+
+            warnings.simplefilter("ignore")
+            os.environ["PYTHONWARNINGS"] = "ignore::FutureWarnings"
+
+        client.run(_disable_warnings)
+
         if GithubCI.get():
             # set these keys to run tests that write to the mock s3 service. this seems
             # to be the way to pass environment variables to the workers:

--- a/modin/core/execution/dask/common/utils.py
+++ b/modin/core/execution/dask/common/utils.py
@@ -23,6 +23,7 @@ from modin.config import (
     Memory,
     NPartitions,
 )
+from modin.core.execution.utils import set_env
 from modin.error_message import ErrorMessage
 
 
@@ -32,6 +33,14 @@ def initialize_dask():
 
     try:
         client = default_client()
+
+        def _disable_warnings():
+            import warnings
+
+            warnings.simplefilter("ignore", category=FutureWarning)
+
+        client.run(_disable_warnings)
+
     except ValueError:
         from distributed import Client
 
@@ -47,15 +56,10 @@ def initialize_dask():
         num_cpus = CpuCount.get()
         memory_limit = Memory.get()
         worker_memory_limit = memory_limit // num_cpus if memory_limit else "auto"
-        client = Client(n_workers=num_cpus, memory_limit=worker_memory_limit)
 
-        def _disable_warnings():
-            import warnings
-
-            warnings.simplefilter("ignore")
-            os.environ["PYTHONWARNINGS"] = "ignore::FutureWarning"
-
-        client.run(_disable_warnings)
+        # when the client is initialized, environment variables are inherited
+        with set_env(PYTHONWARNINGS="ignore::FutureWarning"):
+            client = Client(n_workers=num_cpus, memory_limit=worker_memory_limit)
 
         if GithubCI.get():
             # set these keys to run tests that write to the mock s3 service. this seems

--- a/modin/core/execution/dask/common/utils.py
+++ b/modin/core/execution/dask/common/utils.py
@@ -53,7 +53,7 @@ def initialize_dask():
             import warnings
 
             warnings.simplefilter("ignore")
-            os.environ["PYTHONWARNINGS"] = "ignore::FutureWarnings"
+            os.environ["PYTHONWARNINGS"] = "ignore::FutureWarning"
 
         client.run(_disable_warnings)
 

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/partition.py
@@ -13,6 +13,8 @@
 
 """The module defines interface for a partition with pandas storage format and Python engine."""
 
+import warnings
+
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from modin.core.execution.python.common import PythonWrapper
 
@@ -116,7 +118,9 @@ class PandasOnPythonDataframePartition(PandasDataframePartition):
 
         self._data = call_queue_closure(self._data, self.call_queue)
         self.call_queue = []
-        return self.__constructor__(func(self._data.copy(), *args, **kwargs))
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            return self.__constructor__(func(self._data.copy(), *args, **kwargs))
 
     def drain_call_queue(self):
         """Execute all operations stored in the call queue on the object wrapped by this partition."""

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -82,7 +82,10 @@ def initialize_ray(
     # the `pandas` module has been fully imported inside of each process before
     # any execution begins:
     # https://github.com/modin-project/modin/pull/4603
-    env_vars = {"__MODIN_AUTOIMPORT_PANDAS__": "1"}
+    env_vars = {
+        "__MODIN_AUTOIMPORT_PANDAS__": "1",
+        "PYTHONWARNINGS": "ignore::FutureWarning",
+    }
     if GithubCI.get():
         # need these to write parquet to the moto service mocking s3.
         env_vars.update(
@@ -146,6 +149,8 @@ def initialize_ray(
             for key, value in env_vars.items():
                 os.environ[key] = value
             ray.init(**ray_init_kwargs)
+            # so as not to affect the main process
+            del os.environ["PYTHONWARNINGS"]
 
         if StorageFormat.get() == "Cudf":
             from modin.core.execution.ray.implementations.cudf_on_ray.partitioning import (

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -36,6 +36,7 @@ from modin.config import (
     StorageFormat,
     ValueSource,
 )
+from modin.core.execution.utils import set_env
 from modin.error_message import ErrorMessage
 
 from .engine_wrapper import RayWrapper
@@ -146,11 +147,8 @@ def initialize_ray(
             # time and doesn't enforce us with any overhead that Ray's native `runtime_env`
             # is usually causing. You can visit this gh-issue for more info:
             # https://github.com/modin-project/modin/issues/5157#issuecomment-1500225150
-            for key, value in env_vars.items():
-                os.environ[key] = value
-            ray.init(**ray_init_kwargs)
-            # so as not to affect the main process
-            del os.environ["PYTHONWARNINGS"]
+            with set_env(**env_vars):
+                ray.init(**ray_init_kwargs)
 
         if StorageFormat.get() == "Cudf":
             from modin.core.execution.ray.implementations.cudf_on_ray.partitioning import (

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -166,12 +166,7 @@ def initialize_ray(
     runtime_env_vars = ray.get_runtime_context().runtime_env.get("env_vars", {})
     for varname, varvalue in env_vars.items():
         if str(runtime_env_vars.get(varname, "")) != str(varvalue):
-            if is_cluster or (
-                # Here we relax our requirements for a non-cluster case allowing for the `env_vars`
-                # to be set at least as a process environment variable
-                not is_cluster
-                and os.environ.get(varname, "") != str(varvalue)
-            ):
+            if is_cluster:
                 ErrorMessage.single_warning(
                     "When using a pre-initialized Ray cluster, please ensure that the runtime env "
                     + f"sets environment variable {varname} to {varvalue}"

--- a/modin/core/execution/unidist/common/utils.py
+++ b/modin/core/execution/unidist/common/utils.py
@@ -45,7 +45,8 @@ def initialize_unidist():
             unidist.init()
             """,
         )
-
+        # TODO: allow unidist to inherit env variables on initialization
+        # with set_env(PYTHONWARNINGS="ignore::FutureWarning"):
         unidist.init()
 
     num_cpus = sum(v["CPU"] for v in unidist.cluster_resources().values())

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/partition.py
@@ -13,6 +13,8 @@
 
 """Module houses class that wraps data (block partition) and its metadata."""
 
+import warnings
+
 import unidist
 
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
@@ -351,12 +353,16 @@ def _apply_func(partition, func, *args, **kwargs):  # pragma: no cover
     destructuring it causes a performance penalty.
     """
     try:
-        result = func(partition, *args, **kwargs)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            result = func(partition, *args, **kwargs)
     # Sometimes Arrow forces us to make a copy of an object before we operate on it. We
     # don't want the error to propagate to the user, and we want to avoid copying unless
     # we absolutely have to.
     except ValueError:
-        result = func(partition.copy(), *args, **kwargs)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            result = func(partition.copy(), *args, **kwargs)
     return (
         result,
         len(result) if hasattr(result, "__len__") else 0,
@@ -393,12 +399,16 @@ def _apply_list_of_funcs(call_queue, partition):  # pragma: no cover
         args = deserialize(f_args)
         kwargs = deserialize(f_kwargs)
         try:
-            partition = func(partition, *args, **kwargs)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=FutureWarning)
+                partition = func(partition, *args, **kwargs)
         # Sometimes Arrow forces us to make a copy of an object before we operate on it. We
         # don't want the error to propagate to the user, and we want to avoid copying unless
         # we absolutely have to.
         except ValueError:
-            partition = func(partition.copy(), *args, **kwargs)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore", category=FutureWarning)
+                partition = func(partition.copy(), *args, **kwargs)
 
     return (
         partition,

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -13,6 +13,8 @@
 
 """Module houses classes responsible for storing a virtual partition and applying a function to it."""
 
+import warnings
+
 import pandas
 import unidist
 
@@ -310,7 +312,9 @@ def _deploy_unidist_func(
     Unidist functions are not detected by codecov (thus pragma: no cover).
     """
     f_args = deserialize(f_args)
-    result = deployer(axis, f_to_deploy, f_args, f_kwargs, *args, **kwargs)
+    with warnings.catch_warnings():
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        result = deployer(axis, f_to_deploy, f_args, f_kwargs, *args, **kwargs)
     if not extract_metadata:
         return result
     ip = unidist.get_ip()

--- a/modin/core/execution/utils.py
+++ b/modin/core/execution/utils.py
@@ -1,0 +1,31 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+"""General utils for execution module."""
+
+import contextlib
+import os
+
+
+@contextlib.contextmanager
+def set_env(**environ):
+    """
+    Temporarily set the process environment variables.
+    """
+    old_environ = os.environ.copy()
+    os.environ.update(environ)
+    try:
+        yield
+    finally:
+        os.environ.clear()
+        os.environ.update(old_environ)

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -18,6 +18,7 @@ Module contains class ``BaseQueryCompiler``.
 """
 
 import abc
+import warnings
 from typing import Hashable, List, Optional
 
 import numpy as np
@@ -164,7 +165,9 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         args = try_cast_to_pandas(args)
         kwargs = try_cast_to_pandas(kwargs)
 
-        result = pandas_op(try_cast_to_pandas(self), *args, **kwargs)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            result = pandas_op(try_cast_to_pandas(self), *args, **kwargs)
         if isinstance(result, (tuple, list)):
             return [self.__wrap_in_qc(obj) for obj in result]
         return self.__wrap_in_qc(result)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2721,7 +2721,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             # here we check for a subset of bool indexers only to simplify the code;
             # there could (potentially) be more of those, but we assume the most frequent
             # ones are just of bool dtype
-            if len(key.dtypes) == 1 and is_bool_dtype(key.dtypes[0]):
+            if len(key.dtypes) == 1 and is_bool_dtype(key.dtypes.iloc[0]):
                 self.__validate_bool_indexer(key.index)
                 return self.__getitem_bool(key, broadcast=True, dtypes="copy")
 

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -2779,8 +2779,8 @@ class TestFromArrow:
         at = mdf._query_compiler._modin_frame._partitions[0][0].get()
         assert len(at.column(0).chunks) == nchunks
 
-        mdt = mdf.dtypes[0]
-        pdt = pdf.dtypes[0]
+        mdt = mdf.dtypes.iloc[0]
+        pdt = pdf.dtypes.iloc[0]
         assert mdt == "category"
         assert isinstance(mdt, pandas.CategoricalDtype)
         assert str(mdt) == str(pdt)

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -845,7 +845,7 @@ def test_convert_dtypes_5653():
         assert modin_df._query_compiler._modin_frame._partitions.shape == (2, 1)
     modin_df = modin_df.convert_dtypes()
     assert len(modin_df.dtypes) == 1
-    assert modin_df.dtypes[0] == "string"
+    assert modin_df.dtypes.iloc[0] == "string"
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -61,7 +61,9 @@ NPartitions.put(4)
 # of defaulting to pandas.
 pytestmark = [
     pytest.mark.filterwarnings(default_to_pandas_ignore_string),
-    # IGNORE WARNINGS MARKS TO CLEANUP OUTPUT
+    # TO MAKE SURE ALL FUTUREWARNINGS ARE CONSIDERED
+    pytest.mark.filterwarnings("error::FutureWarning"),
+    # IGNORE FUTUREWARNINGS MARKS TO CLEANUP OUTPUT
     pytest.mark.filterwarnings(
         "ignore:DataFrame.groupby with axis=1 is deprecated:FutureWarning"
     ),

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -91,10 +91,10 @@ pytestmark = [
         "ignore:The default of observed=False is deprecated:FutureWarning"
     ),
     pytest.mark.filterwarnings(
-        "ignore:DataFrame.idxmax with all-NA values, or any-NA and skipna=False, is deprecated:FutureWarning"
+        "ignore:.*DataFrame.idxmax with all-NA values, or any-NA and skipna=False, is deprecated:FutureWarning"
     ),
     pytest.mark.filterwarnings(
-        "ignore:DataFrame.idxmin with all-NA values, or any-NA and skipna=False, is deprecated:FutureWarning"
+        "ignore:.*DataFrame.idxmin with all-NA values, or any-NA and skipna=False, is deprecated:FutureWarning"
     ),
     pytest.mark.filterwarnings(
         "ignore:.*In a future version of pandas, the provided callable will be used directly.*:FutureWarning"
@@ -302,6 +302,7 @@ def test_mixed_dtypes_groupby(as_index):
             lambda df: df.cov(numeric_only=True),
             modin_df_almost_equals_pandas,
         )
+
         transform_functions = [lambda df: df, lambda df: df + df]
         for func in transform_functions:
             eval_transform(modin_groupby, pandas_groupby, func)
@@ -316,7 +317,6 @@ def test_mixed_dtypes_groupby(as_index):
             lambda df: df.corr(numeric_only=True),
             modin_df_almost_equals_pandas,
         )
-
         eval_fillna(modin_groupby, pandas_groupby)
         eval_count(modin_groupby, pandas_groupby)
         eval_general(
@@ -1656,7 +1656,6 @@ def test_shift_freq(groupby_axis, shift_axis, groupby_sort):
     for _by in by:
         pandas_groupby = pandas_df.groupby(by=_by, axis=groupby_axis, sort=groupby_sort)
         modin_groupby = modin_df.groupby(by=_by, axis=groupby_axis, sort=groupby_sort)
-
         eval_general(
             modin_groupby,
             pandas_groupby,

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -296,15 +296,12 @@ def test_mixed_dtypes_groupby(as_index):
         )
         eval_cumprod(modin_groupby, pandas_groupby, numeric_only=True)
         # numeric_only=False doesn't work
-
-        # FIXME:  ValueError: cannot join with no overlapping index names
-        # eval_general(
-        #    modin_groupby,
-        #    pandas_groupby,
-        #    lambda df: df.cov(numeric_only=True),
-        #    modin_df_almost_equals_pandas,
-        # )
-
+        eval_general(
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.cov(numeric_only=True),
+            modin_df_almost_equals_pandas,
+        )
         transform_functions = [lambda df: df, lambda df: df + df]
         for func in transform_functions:
             eval_transform(modin_groupby, pandas_groupby, func)
@@ -313,13 +310,12 @@ def test_mixed_dtypes_groupby(as_index):
         for func in pipe_functions:
             eval_pipe(modin_groupby, pandas_groupby, func)
 
-        # FIXME:  ValueError: cannot join with no overlapping index names
-        # eval_general(
-        #    modin_groupby,
-        #    pandas_groupby,
-        #    lambda df: df.corr(numeric_only=True),
-        #    modin_df_almost_equals_pandas,
-        # )
+        eval_general(
+            modin_groupby,
+            pandas_groupby,
+            lambda df: df.corr(numeric_only=True),
+            modin_df_almost_equals_pandas,
+        )
 
         eval_fillna(modin_groupby, pandas_groupby)
         eval_count(modin_groupby, pandas_groupby)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -64,6 +64,22 @@ NPartitions.put(4)
 pytestmark = [
     pytest.mark.filterwarnings(default_to_pandas_ignore_string),
     pytest.mark.filterwarnings("error::FutureWarning"),
+    # FIXME: these cases inconsistent between modin and pandas
+    pytest.mark.filterwarnings(
+        "ignore:A grouping was used that is not in the columns of the DataFrame and so was excluded from the result:FutureWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:The default of observed=False is deprecated:FutureWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:.*DataFrame.idxmax with all-NA values, or any-NA and skipna=False, is deprecated.*:FutureWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:.*DataFrame.idxmin with all-NA values, or any-NA and skipna=False, is deprecated.*:FutureWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:.*In a future version of pandas, the provided callable will be used directly.*:FutureWarning"
+    ),
 ]
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ tag_prefix =
 parentdir_prefix = modin-
 
 [tool:pytest]
-addopts = --cov-config=setup.cfg --cov=modin --cov-append --cov-report=
+addopts = --disable-pytest-warnings --cov-config=setup.cfg --cov=modin --cov-append --cov-report=
 xfail_strict=true
 markers =
     xfail_executions

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ tag_prefix =
 parentdir_prefix = modin-
 
 [tool:pytest]
-addopts = --disable-pytest-warnings --cov-config=setup.cfg --cov=modin --cov-append --cov-report=
+addopts = --cov-config=setup.cfg --cov=modin --cov-append --cov-report=
 xfail_strict=true
 markers =
     xfail_executions


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The unwanted `FutureWarning`s can occur in the main process or in workers:
* For worker processes, the simplest solution is to use `PYTHONWARNINGS` environment variable (for example, `PYTHONWARNINGS="ignore::FutureWarning"`).
* For the main process, we cannot use this variable because otherwise we will not be able to show the necessary warnings (warnings that are explicitly defined by us at the upper levels, not lower than the compiler version). Another solution is to use a context manager and an warnings filter (by warning type and content). The main difficulty here is that there are a lot of points where these warnings occur - potentially any place where we use pandas functions. I believe that the most convenient level for catching warnings will be the partition level (the basis through which we perform most operations). However, we will also have to add warning processing to all places where defaulting occurs in pandas. For example:
```python
        with warnings.catch_warnings():
            warnings.filterwarnings("ignore", category=FutureWarning)
```

Also fixes #6578

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6552 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
