### PR TITLE
PERF-#6614: HDK: Use MODIN_CPUS instead of os.cpu_count() for the fragment size calculation

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/hdk_worker.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/hdk_worker.py
@@ -12,7 +12,6 @@
 # governing permissions and limitations under the License.
 
 """Module provides ``HdkWorker`` class."""
-import os
 from typing import List, Optional, Tuple, Union
 
 import pyarrow as pa
@@ -20,7 +19,7 @@ import pyhdk
 from packaging import version
 from pyhdk.hdk import HDK, ExecutionResult, QueryNode, RelAlgExecutor
 
-from modin.config import HdkFragmentSize, HdkLaunchParameters
+from modin.config import CpuCount, HdkFragmentSize, HdkLaunchParameters
 from modin.utils import _inherit_docstrings
 
 from .base_worker import BaseDbWorker, DbTable
@@ -143,7 +142,7 @@ class HdkWorker(BaseDbWorker):  # noqa: PR01
         fragment_size = HdkFragmentSize.get()
         if fragment_size is None:
             if cls._preferred_device == "CPU":
-                cpu_count = os.cpu_count()
+                cpu_count = CpuCount.get()
                 if cpu_count is not None:
                     fragment_size = table.num_rows // cpu_count
                     fragment_size = min(fragment_size, 2**25)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6614 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
