### PR TITLE
PERF-#6362: Implement 2D setitem without to-pandas conversion

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2594,7 +2594,7 @@ class DataFrame(BasePandasDataset):
                             if len(to_take):
                                 to_concat.append(src_obj[to_take])
                             to_take = [col]
-                            is_col_in_key ^= 1
+                            is_col_in_key = not is_col_in_key
                             src_obj = value if is_col_in_key else self
                         else:
                             to_take.append(col)

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2586,16 +2586,16 @@ class DataFrame(BasePandasDataset):
                     # columns to take for this chunk
                     to_take = []
                     # whether columns in this chunk are in the 'key' and has to be taken from the 'value'
-                    is_col_in_key = False
+                    get_cols_from_value = False
                     # an object to take columns from for this chunk
                     src_obj = self
                     for col in self.columns:
-                        if (col in key) != is_col_in_key:
+                        if (col in key) != get_cols_from_value:
                             if len(to_take):
                                 to_concat.append(src_obj[to_take])
                             to_take = [col]
-                            is_col_in_key = not is_col_in_key
-                            src_obj = value if is_col_in_key else self
+                            get_cols_from_value = not get_cols_from_value
+                            src_obj = value if get_cols_from_value else self
                         else:
                             to_take.append(col)
                     if len(to_take):

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2574,6 +2574,11 @@ class DataFrame(BasePandasDataset):
                     # importing here to avoid circular import
                     from .general import concat
 
+                    if not value.columns.equals(pandas.Index(key)):
+                        # we only need to change the labels, so shallow copy here
+                        value = value.copy(deep=False)
+                        value.columns = key
+
                     # here we iterate over every column in the 'self' frame, then check if it's in the 'key'
                     # and so has to be taken from either from the 'value' or from the 'self'. After that,
                     # we concatenate those mixed column chunks and get a dataframe with updated columns
@@ -2587,14 +2592,14 @@ class DataFrame(BasePandasDataset):
                     for col in self.columns:
                         if (col in key) != is_col_in_key:
                             if len(to_take):
-                                to_concat.append(src_obj.loc[:, to_take])
+                                to_concat.append(src_obj[to_take])
                             to_take = [col]
                             is_col_in_key ^= 1
                             src_obj = value if is_col_in_key else self
                         else:
                             to_take.append(col)
                     if len(to_take):
-                        to_concat.append(src_obj.loc[:, to_take])
+                        to_concat.append(src_obj[to_take])
 
                     new_qc = concat(to_concat, axis=1)._query_compiler
                 else:

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -2390,8 +2390,8 @@ def test_setitem_2d_insertion():
 
 def test_setitem_2d_update():
     def test(df, iloc):
+        """Update columns on the given numeric indices."""
         cols = df.columns[iloc].tolist()
-
         df[cols] = df[cols] + 10
         return df
 

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -2388,23 +2388,41 @@ def test_setitem_2d_insertion():
     )
 
 
-def test_setitem_2d_update():
-    def test(df, iloc):
+@pytest.mark.parametrize("does_value_have_different_columns", [True, False])
+def test_setitem_2d_update(does_value_have_different_columns):
+    def test(dfs, iloc):
         """Update columns on the given numeric indices."""
-        cols = df.columns[iloc].tolist()
-        df[cols] = df[cols] + 10
-        return df
+        df1, df2 = dfs
+        cols1 = df1.columns[iloc].tolist()
+        cols2 = df2.columns[iloc].tolist()
+        df1[cols1] = df2[cols2]
+        return df1
 
     modin_df, pandas_df = create_test_dfs(test_data["int_data"])
-    eval_general(modin_df, pandas_df, test, iloc=[0, 1, 2])
-    eval_general(modin_df, pandas_df, test, iloc=[0, -1])
-    eval_general(modin_df, pandas_df, test, iloc=slice(1, None))  # (start=1, stop=None)
+    modin_df2, pandas_df2 = create_test_dfs(test_data["int_data"])
+    modin_df2 *= 10
+    pandas_df2 *= 10
+
+    if does_value_have_different_columns:
+        new_columns = [f"{col}_new" for col in modin_df.columns]
+        modin_df2.columns = new_columns
+        pandas_df2.columns = new_columns
+
+    modin_dfs = (modin_df, modin_df2)
+    pandas_dfs = (pandas_df, pandas_df2)
+
+    eval_general(modin_dfs, pandas_dfs, test, iloc=[0, 1, 2])
+    eval_general(modin_dfs, pandas_dfs, test, iloc=[0, -1])
     eval_general(
-        modin_df, pandas_df, test, iloc=slice(None, -2)
+        modin_dfs, pandas_dfs, test, iloc=slice(1, None)
+    )  # (start=1, stop=None)
+    eval_general(
+        modin_dfs, pandas_dfs, test, iloc=slice(None, -2)
     )  # (start=None, stop=-2)
-    eval_general(modin_df, pandas_df, test, iloc=[0, 1, 5, 6, 9, 10, -2, -1])
+    eval_general(modin_dfs, pandas_dfs, test, iloc=[0, 1, 5, 6, 9, 10, -2, -1])
+    eval_general(modin_dfs, pandas_dfs, test, iloc=[5, 4, 0, 10, 1, -1])
     eval_general(
-        modin_df, pandas_df, test, iloc=slice(None, None, 2)
+        modin_dfs, pandas_dfs, test, iloc=slice(None, None, 2)
     )  # (start=None, stop=None, step=2)
 
 

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -2388,6 +2388,26 @@ def test_setitem_2d_insertion():
     )
 
 
+def test_setitem_2d_update():
+    def test(df, iloc):
+        cols = df.columns[iloc].tolist()
+
+        df[cols] = df[cols] + 10
+        return df
+
+    modin_df, pandas_df = create_test_dfs(test_data["int_data"])
+    eval_general(modin_df, pandas_df, test, iloc=[0, 1, 2])
+    eval_general(modin_df, pandas_df, test, iloc=[0, -1])
+    eval_general(modin_df, pandas_df, test, iloc=slice(1, None))  # (start=1, stop=None)
+    eval_general(
+        modin_df, pandas_df, test, iloc=slice(None, -2)
+    )  # (start=None, stop=-2)
+    eval_general(modin_df, pandas_df, test, iloc=[0, 1, 5, 6, 9, 10, -2, -1])
+    eval_general(
+        modin_df, pandas_df, test, iloc=slice(None, None, 2)
+    )  # (start=None, stop=None, step=2)
+
+
 def test___setitem__single_item_in_series():
     # Test assigning a single item in a Series for issue
     # https://github.com/modin-project/modin/issues/3860

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -926,6 +926,7 @@ def eval_general(
     values = execute_callable(
         operation, md_kwargs=md_kwargs, pd_kwargs=pd_kwargs, inplace=__inplace__
     )
+    breakpoint()
     if values is not None:
         comparator(*values, **(comparator_kwargs or {}))
 

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -926,7 +926,6 @@ def eval_general(
     values = execute_callable(
         operation, md_kwargs=md_kwargs, pd_kwargs=pd_kwargs, inplace=__inplace__
     )
-    breakpoint()
     if values is not None:
         comparator(*values, **(comparator_kwargs or {}))
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This PR changes logic of `__setitem__` on assigning multiple columns. 

![image](https://github.com/modin-project/modin/assets/62142979/85c7c4be-cc4a-4754-a708-3ba212057afa)


<details><summary>micro-benchmark</summary>

```python
import modin.pandas as pd
import modin.config as cfg
from timeit import default_timer as timer

cfg.BenchmarkMode.put(True)

shapes = [(1_000_000, 10), (1_000_000, 100), (10_000_000, 10), (10_000_000, 100)]

for nrows, ncols in shapes:
    df = pd.DataFrame({f"col{i}": range(nrows) for i in range(ncols)})
    subset = df.columns[[0, 1, 2, 4, 6, -1, -2, -3]].tolist()

    item = df[subset] * 10

    t1 = timer()
    df[subset] = item
    print(timer() - t1)
```

</details>

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6362 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
