### PR TITLE
FIX-#6624: Add `FutureWarning`s for `first/last/bool`

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1130,6 +1130,11 @@ class BasePandasDataset(ClassLogger):
         """
         Return the bool of a single element `BasePandasDataset`.
         """
+        warnings.warn(
+            f"{type(self).__name__}.bool is now deprecated and will be removed "
+            + "in future version of pandas",
+            FutureWarning,
+        )
         shape = self.shape
         if shape != (1,) and shape != (1, 1):
             raise ValueError(
@@ -1757,6 +1762,11 @@ class BasePandasDataset(ClassLogger):
         """
         Select initial periods of time series data based on a date offset.
         """
+        warnings.warn(
+            "first is deprecated and will be removed in a future version. "
+            + "Please create a mask and filter using `.loc` instead",
+            FutureWarning,
+        )
         return self._create_or_update_from_compiler(
             self._query_compiler.first(offset=to_offset(offset))
         )
@@ -1913,6 +1923,12 @@ class BasePandasDataset(ClassLogger):
         """
         Select final periods of time series data based on a date offset.
         """
+        warnings.warn(
+            "last is deprecated and will be removed in a future version. "
+            + "Please create a mask and filter using `.loc` instead",
+            FutureWarning,
+        )
+
         return self._create_or_update_from_compiler(
             self._query_compiler.last(offset=to_offset(offset))
         )

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -53,7 +53,19 @@ matplotlib.use("Agg")
 # Our configuration in pytest.ini requires that we explicitly catch all
 # instances of defaulting to pandas, but some test modules, like this one,
 # have too many such instances.
-pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+pytestmark = [
+    pytest.mark.filterwarnings(default_to_pandas_ignore_string),
+    # IGNORE FUTUREWARNINGS MARKS TO CLEANUP OUTPUT
+    pytest.mark.filterwarnings(
+        "ignore:.*bool is now deprecated and will be removed:FutureWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:first is deprecated and will be removed:FutureWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:last is deprecated and will be removed:FutureWarning"
+    ),
+]
 
 
 @pytest.mark.parametrize(
@@ -188,9 +200,12 @@ def test_bfill(data):
 def test_bool(data):
     modin_df = pd.DataFrame(data)
 
-    with pytest.raises(ValueError):
-        modin_df.bool()
-        modin_df.__bool__()
+    with pytest.warns(
+        FutureWarning, match="bool is now deprecated and will be removed"
+    ):
+        with pytest.raises(ValueError):
+            modin_df.bool()
+            modin_df.__bool__()
 
     single_bool_pandas_df = pandas.DataFrame([True])
     single_bool_modin_df = pd.DataFrame([True])
@@ -446,7 +461,9 @@ def test_first():
     pandas_df = pandas.DataFrame(
         {"A": list(range(400)), "B": list(range(400))}, index=i
     )
-    df_equals(modin_df.first("3D"), pandas_df.first("3D"))
+    with pytest.warns(FutureWarning, match="first is deprecated and will be removed"):
+        modin_result = modin_df.first("3D")
+    df_equals(modin_result, pandas_df.first("3D"))
     df_equals(modin_df.first("20D"), pandas_df.first("20D"))
 
 
@@ -522,7 +539,9 @@ def test_last():
     pandas_df = pandas.DataFrame(
         {"A": list(range(400)), "B": list(range(400))}, index=pandas_index
     )
-    df_equals(modin_df.last("3D"), pandas_df.last("3D"))
+    with pytest.warns(FutureWarning, match="last is deprecated and will be removed"):
+        modin_result = modin_df.last("3D")
+    df_equals(modin_result, pandas_df.last("3D"))
     df_equals(modin_df.last("20D"), pandas_df.last("20D"))
 
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -89,7 +89,19 @@ from .utils import (
 # have too many such instances.
 # TODO(https://github.com/modin-project/modin/issues/3655): catch all instances
 # of defaulting to pandas.
-pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+pytestmark = [
+    pytest.mark.filterwarnings(default_to_pandas_ignore_string),
+    # IGNORE FUTUREWARNINGS MARKS TO CLEANUP OUTPUT
+    pytest.mark.filterwarnings(
+        "ignore:.*bool is now deprecated and will be removed:FutureWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:first is deprecated and will be removed:FutureWarning"
+    ),
+    pytest.mark.filterwarnings(
+        "ignore:last is deprecated and will be removed:FutureWarning"
+    ),
+]
 
 NPartitions.put(4)
 
@@ -1237,8 +1249,11 @@ def test_bfill(data):
 def test_bool(data):
     modin_series, _ = create_test_series(data)
 
-    with pytest.raises(ValueError):
-        modin_series.bool()
+    with pytest.warns(
+        FutureWarning, match="bool is now deprecated and will be removed"
+    ):
+        with pytest.raises(ValueError):
+            modin_series.bool()
     with pytest.raises(ValueError):
         modin_series.__bool__()
 
@@ -2034,7 +2049,9 @@ def test_first():
     i = pd.date_range("2010-04-09", periods=400, freq="2D")
     modin_series = pd.Series(list(range(400)), index=i)
     pandas_series = pandas.Series(list(range(400)), index=i)
-    df_equals(modin_series.first("3D"), pandas_series.first("3D"))
+    with pytest.warns(FutureWarning, match="first is deprecated and will be removed"):
+        modin_result = modin_series.first("3D")
+    df_equals(modin_result, pandas_series.first("3D"))
     df_equals(modin_series.first("20D"), pandas_series.first("20D"))
 
 
@@ -2277,7 +2294,9 @@ def test_last():
     pandas_index = pandas.date_range("2010-04-09", periods=400, freq="2D")
     modin_series = pd.Series(list(range(400)), index=modin_index)
     pandas_series = pandas.Series(list(range(400)), index=pandas_index)
-    df_equals(modin_series.last("3D"), pandas_series.last("3D"))
+    with pytest.warns(FutureWarning, match="last is deprecated and will be removed"):
+        modin_result = modin_series.last("3D")
+    df_equals(modin_result, pandas_series.last("3D"))
     df_equals(modin_series.last("20D"), pandas_series.last("20D"))
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6624 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
