### PR TITLE
FIX-#4507: Do not call 'ray.get()' inside of the kernel executing call queues

### DIFF
--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -335,12 +335,12 @@ def deconstruct_call_queue(call_queue):
             was_iterable = True
             if not isinstance(value, (list, tuple)):
                 was_iterable = False
-                value = [value]
+                value = (value,)
             unfolded_queue.extend(value)
             value_lengths.append({"len": len(value), "was_iterable": was_iterable})
         kw_value_lengths.append(value_lengths)
 
-    return num_funcs, arg_lengths, kw_key_lengths, kw_value_lengths, unfolded_queue
+    return num_funcs, arg_lengths, kw_key_lengths, kw_value_lengths, *unfolded_queue
 
 
 def reconstruct_call_queue(
@@ -385,9 +385,9 @@ def reconstruct_call_queue(
         kw_keys = take_n_items(kw_key_lengths[i])
         kwargs = {}
         value_lengths = kw_value_lengths[i]
-        for j, key in enumerate(kw_keys):
-            vals = take_n_items(value_lengths[j]["len"])
-            if value_lengths[j]["len"] == 1 and not value_lengths[j]["was_iterable"]:
+        for key, value_length in zip(kw_keys, value_lengths):
+            vals = take_n_items(value_length["len"])
+            if value_length["len"] == 1 and not value_length["was_iterable"]:
                 vals = vals[0]
             kwargs[key] = vals
 

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -286,3 +286,111 @@ def deserialize(obj):  # pragma: no cover
         return dict(zip(obj.keys(), RayWrapper.materialize(list(obj.values()))))
     else:
         return obj
+
+
+def deconstruct_call_queue(call_queue):
+    """
+    Deconstruct the passed call queue into a 1D list.
+
+    This is required, so the call queue can be then passed to a Ray's kernel
+    as a variable-length argument ``kernel(*queue)`` so the Ray engine
+    automatically materialize all the futures that the queue might have contained.
+
+    Parameters
+    ----------
+    call_queue : list[list[func, args, kwargs], ...]
+
+    Returns
+    -------
+    num_funcs : int
+        The number of functions in the call queue.
+    arg_lengths : list of ints
+        The number of positional arguments for each function in the call queue.
+    kw_key_lengths : list of ints
+        The number of key-word arguments for each function in the call queue.
+    kw_value_lengths : 2D list of dict{"len": int, "was_iterable": bool}
+        Description of keyword arguments for each function. For example, `kw_value_lengths[i][j]`
+        describes the j-th keyword argument of the i-th function in the call queue.
+        The describtion contains of the lengths of the argument and whether it's a list at all
+        (for example, {"len": 1, "was_iterable": False} describes a non-list argument).
+    unfolded_queue : list
+        A 1D call queue that can be reconstructed using ``reconstruct_call_queue`` function.
+    """
+    num_funcs = len(call_queue)
+    arg_lengths = []
+    kw_key_lengths = []
+    kw_value_lengths = []
+    unfolded_queue = []
+    for call in call_queue:
+        unfolded_queue.append(call[0])
+        unfolded_queue.extend(call[1])
+        arg_lengths.append(len(call[1]))
+        # unfold keyword dict
+        ## unfold keys
+        unfolded_queue.extend(call[2].keys())
+        kw_key_lengths.append(len(call[2]))
+        ## unfold values
+        value_lengths = []
+        for value in call[2].values():
+            was_iterable = True
+            if not isinstance(value, (list, tuple)):
+                was_iterable = False
+                value = [value]
+            unfolded_queue.extend(value)
+            value_lengths.append({"len": len(value), "was_iterable": was_iterable})
+        kw_value_lengths.append(value_lengths)
+
+    return num_funcs, arg_lengths, kw_key_lengths, kw_value_lengths, unfolded_queue
+
+
+def reconstruct_call_queue(
+    num_funcs, arg_lengths, kw_key_lengths, kw_value_lengths, unfolded_queue
+):
+    """
+    Reconstruct original call queue from the result of the ``deconstruct_call_queue()``.
+
+    Parameters
+    ----------
+    num_funcs : int
+        The number of functions in the call queue.
+    arg_lengths : list of ints
+        The number of positional arguments for each function in the call queue.
+    kw_key_lengths : list of ints
+        The number of key-word arguments for each function in the call queue.
+    kw_value_lengths : 2D list of dict{"len": int, "was_iterable": bool}
+        Description of keyword arguments for each function. For example, `kw_value_lengths[i][j]`
+        describes the j-th keyword argument of the i-th function in the call queue.
+        The describtion contains of the lengths of the argument and whether it's a list at all
+        (for example, {"len": 1, "was_iterable": False} describes a non-list argument).
+    unfolded_queue : list
+        A 1D call queue that is result of the ``deconstruct_call_queue()`` function.
+
+    Returns
+    -------
+    list[list[func, args, kwargs], ...]
+        Original call queue.
+    """
+    items_took = 0
+
+    def take_n_items(n):
+        nonlocal items_took
+        res = unfolded_queue[items_took : items_took + n]
+        items_took += n
+        return res
+
+    call_queue = []
+    for i in range(num_funcs):
+        func = take_n_items(1)[0]
+        args = take_n_items(arg_lengths[i])
+        kw_keys = take_n_items(kw_key_lengths[i])
+        kwargs = {}
+        value_lengths = kw_value_lengths[i]
+        for j, key in enumerate(kw_keys):
+            vals = take_n_items(value_lengths[j]["len"])
+            if value_lengths[j]["len"] == 1 and not value_lengths[j]["was_iterable"]:
+                vals = vals[0]
+            kwargs[key] = vals
+
+        call_queue.append((func, args, kwargs))
+
+    return call_queue

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -18,7 +18,11 @@ from ray.util import get_node_ip_address
 
 from modin.core.dataframe.pandas.partitioning.partition import PandasDataframePartition
 from modin.core.execution.ray.common import RayWrapper
-from modin.core.execution.ray.common.utils import ObjectIDType
+from modin.core.execution.ray.common.utils import (
+    ObjectIDType,
+    deconstruct_call_queue,
+    reconstruct_call_queue,
+)
 from modin.logging import get_logger
 from modin.pandas.indexing import compute_sliced_len
 
@@ -66,43 +70,6 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             )
         )
 
-    @staticmethod
-    def _apply_call_queue(call_queue, data):
-        """
-        Execute call queue over the given `data`.
-
-        Parameters
-        ----------
-        call_queue : list[list[func, args, kwargs], ...]
-        data : ray.ObjectRef
-
-        Returns
-        -------
-        ray.ObjectRef of pandas.DataFrame
-            The resulting pandas DataFrame.
-        ray.ObjectRef of int
-            The number of rows of the resulting pandas DataFrame.
-        ray.ObjectRef of int
-            The number of columns of the resulting pandas DataFrame.
-        ray.ObjectRef of str
-            The node IP address of the worker process.
-        """
-        (
-            num_funcs,
-            arg_lengths,
-            kw_key_lengths,
-            kw_value_lengths,
-            unfolded_queue,
-        ) = deconstruct_call_queue(call_queue)
-        return _apply_list_of_funcs.remote(
-            data,
-            num_funcs,
-            arg_lengths,
-            kw_key_lengths,
-            kw_value_lengths,
-            *unfolded_queue,
-        )
-
     def apply(self, func, *args, **kwargs):
         """
         Apply a function to the object wrapped by this partition.
@@ -134,7 +101,9 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             self._is_debug(log) and log.debug(
                 f"SUBMIT::_apply_list_of_funcs::{self._identity}"
             )
-            result, length, width, ip = self._apply_call_queue(call_queue, data)
+            result, length, width, ip = _apply_list_of_funcs.remote(
+                data, *deconstruct_call_queue(call_queue)
+            )
         else:
             # We handle `len(call_queue) == 1` in a different way because
             # this dramatically improves performance.
@@ -165,7 +134,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 new_length,
                 new_width,
                 self._ip_cache,
-            ) = self._apply_call_queue(call_queue, data)
+            ) = _apply_list_of_funcs.remote(data, *deconstruct_call_queue(call_queue))
         else:
             # We handle `len(call_queue) == 1` in a different way because
             # this dramatically improves performance.
@@ -378,112 +347,6 @@ def _get_index_and_columns(df):  # pragma: no cover
         The number of columns.
     """
     return len(df.index), len(df.columns)
-
-
-def deconstruct_call_queue(call_queue):
-    """
-    Deconstruct the passed call queue into a 1D list.
-
-    This is required, so the call queue can be then passed to a Ray's kernel
-    as a variable-length argument ``kernel(*queue)`` so the Ray engine
-    automatically materialize all the futures that the queue might have contained.
-
-    Parameters
-    ----------
-    call_queue : list[list[func, args, kwargs], ...]
-
-    Returns
-    -------
-    num_funcs : int
-        The number of functions in the call queue.
-    arg_lengths : list of ints
-        The number of positional arguments for each function in the call queue.
-    kw_key_lengths : list of ints
-        The number of key-word arguments for each function in the call queue.
-    kw_value_lengths : 2D list of dict{"len": int, "was_iterable": bool}
-        Description of keyword arguments for each function. For example, `kw_value_lengths[i][j]`
-        describes the j-th keyword argument of the i-th function in the call queue.
-        The describtion contains of the lengths of the argument and whether it's a list at all
-        (for example, {"len": 1, "was_iterable": False} describes a non-list argument).
-    unfolded_queue : list
-        A 1D call queue that can be reconstructed using ``reconstruct_call_queue`` function.
-    """
-    num_funcs = len(call_queue)
-    arg_lengths = []
-    kw_key_lengths = []
-    kw_value_lengths = []
-    unfolded_queue = []
-    for call in call_queue:
-        unfolded_queue.append(call[0])
-        unfolded_queue.extend(call[1])
-        unfolded_queue.extend(call[2].keys())
-        value_lengths = []
-        for value in call[2].values():
-            was_iterable = True
-            if not isinstance(value, (list, tuple)):
-                was_iterable = False
-                value = [value]
-            unfolded_queue.extend(value)
-            value_lengths.append({"len": len(value), "was_iterable": was_iterable})
-
-        arg_lengths.append(len(call[1]))
-        kw_key_lengths.append(len(call[2]))
-        kw_value_lengths.append(value_lengths)
-
-    return num_funcs, arg_lengths, kw_key_lengths, kw_value_lengths, unfolded_queue
-
-
-def reconstruct_call_queue(
-    num_funcs, arg_lengths, kw_key_lengths, kw_value_lengths, unfolded_queue
-):
-    """
-    Reconstruct original call queue from the result of the ``deconstruct_call_queue()``.
-
-    Parameters
-    ----------
-    num_funcs : int
-        The number of functions in the call queue.
-    arg_lengths : list of ints
-        The number of positional arguments for each function in the call queue.
-    kw_key_lengths : list of ints
-        The number of key-word arguments for each function in the call queue.
-    kw_value_lengths : 2D list of dict{"len": int, "was_iterable": bool}
-        Description of keyword arguments for each function. For example, `kw_value_lengths[i][j]`
-        describes the j-th keyword argument of the i-th function in the call queue.
-        The describtion contains of the lengths of the argument and whether it's a list at all
-        (for example, {"len": 1, "was_iterable": False} describes a non-list argument).
-    unfolded_queue : list
-        A 1D call queue that is result of the ``deconstruct_call_queue()`` function.
-
-    Returns
-    -------
-    list[list[func, args, kwargs], ...]
-        Original call queue.
-    """
-    items_took = 0
-
-    def take_n_items(n):
-        nonlocal items_took
-        res = unfolded_queue[items_took : items_took + n]
-        items_took += n
-        return res
-
-    call_queue = []
-    for i in range(num_funcs):
-        func = take_n_items(1)[0]
-        args = take_n_items(arg_lengths[i])
-        kw_keys = take_n_items(kw_key_lengths[i])
-        kwargs = {}
-        value_lengths = kw_value_lengths[i]
-        for j, key in enumerate(kw_keys):
-            vals = take_n_items(value_lengths[j]["len"])
-            if value_lengths[j]["len"] == 1 and not value_lengths[j]["was_iterable"]:
-                vals = vals[0]
-            kwargs[key] = vals
-
-        call_queue.append((func, args, kwargs))
-
-    return call_queue
 
 
 @ray.remote(num_returns=4)

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -70,6 +70,43 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             )
         )
 
+    @staticmethod
+    def _apply_call_queue(call_queue, data):
+        """
+        Execute call queue over the given `data`.
+
+        Parameters
+        ----------
+        call_queue : list[list[func, args, kwargs], ...]
+        data : ray.ObjectRef
+
+        Returns
+        -------
+        ray.ObjectRef of pandas.DataFrame
+            The resulting pandas DataFrame.
+        ray.ObjectRef of int
+            The number of rows of the resulting pandas DataFrame.
+        ray.ObjectRef of int
+            The number of columns of the resulting pandas DataFrame.
+        ray.ObjectRef of str
+            The node IP address of the worker process.
+        """
+        (
+            num_funcs,
+            arg_lengths,
+            kw_key_lengths,
+            kw_value_lengths,
+            unfolded_queue,
+        ) = deconstruct_call_queue(call_queue)
+        return _apply_list_of_funcs.remote(
+            data,
+            num_funcs,
+            arg_lengths,
+            kw_key_lengths,
+            kw_value_lengths,
+            *unfolded_queue,
+        )
+
     def apply(self, func, *args, **kwargs):
         """
         Apply a function to the object wrapped by this partition.
@@ -101,9 +138,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
             self._is_debug(log) and log.debug(
                 f"SUBMIT::_apply_list_of_funcs::{self._identity}"
             )
-            result, length, width, ip = _apply_list_of_funcs.remote(
-                data, *deconstruct_call_queue(call_queue)
-            )
+            result, length, width, ip = self._apply_call_queue(call_queue, data)
         else:
             # We handle `len(call_queue) == 1` in a different way because
             # this dramatically improves performance.
@@ -134,7 +169,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
                 new_length,
                 new_width,
                 self._ip_cache,
-            ) = _apply_list_of_funcs.remote(data, *deconstruct_call_queue(call_queue))
+            ) = self._apply_call_queue(call_queue, data)
         else:
             # We handle `len(call_queue) == 1` in a different way because
             # this dramatically improves performance.

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -115,13 +115,13 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             else num_splits,
         ).remote(
             cls._get_deploy_split_func(),
-            axis,
-            func,
-            len(f_args),
-            f_kwargs,
-            num_splits,
             *f_args,
+            num_splits,
             *partitions,
+            axis=axis,
+            f_to_deploy=func,
+            f_len_args=len(f_args),
+            f_kwargs=f_kwargs,
             extract_metadata=extract_metadata,
         )
 
@@ -177,14 +177,14 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             **({"max_retries": max_retries} if max_retries is not None else {}),
         ).remote(
             cls._get_deploy_axis_func(),
-            axis,
-            func,
-            len(f_args),
-            f_kwargs,
+            *f_args,
             num_splits,
             maintain_partitioning,
-            *f_args,
             *partitions,
+            axis=axis,
+            f_to_deploy=func,
+            f_len_args=len(f_args),
+            f_kwargs=f_kwargs,
             manual_partition=manual_partition,
             lengths=lengths,
         )
@@ -233,15 +233,15 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             num_returns=num_splits * (1 + cls._PARTITIONS_METADATA_LEN)
         ).remote(
             PandasDataframeAxisPartition.deploy_func_between_two_axis_partitions,
-            axis,
-            func,
-            len(f_args),
-            f_kwargs,
+            *f_args,
             num_splits,
             len_of_left,
             other_shape,
-            *f_args,
             *partitions,
+            axis=axis,
+            f_to_deploy=func,
+            f_len_args=len(f_args),
+            f_kwargs=f_kwargs,
         )
 
     def wait(self):
@@ -264,11 +264,11 @@ class PandasOnRayDataframeRowPartition(PandasOnRayDataframeVirtualPartition):
 @ray.remote
 def _deploy_ray_func(
     deployer,
+    *positional_args,
     axis,
     f_to_deploy,
     f_len_args,
     f_kwargs,
-    *futures,
     extract_metadata=True,
     **kwargs,
 ):  # pragma: no cover
@@ -277,31 +277,32 @@ def _deploy_ray_func(
 
     This is ALWAYS called on either ``PandasDataframeAxisPartition.deploy_axis_func``
     or ``PandasDataframeAxisPartition.deploy_func_between_two_axis_partitions``, which both
-    serve to deploy another dataframe function on a Ray worker process. The provided ``f_args``
-    is thus are deserialized here (on the Ray worker) before the function is called (``f_kwargs``
-    will never contain more Ray objects, and thus does not require deserialization).
+    serve to deploy another dataframe function on a Ray worker process. The provided `positional_args`
+    contains positional arguments for both: `deployer` and for `f_to_deploy`, the parameters can be separated
+    using the `f_len_args` value. The parameters are combined so they will be deserialized by Ray before the
+    kernel is executed (`f_kwargs` will never contain more Ray objects, and thus does not require deserialization).
 
     Parameters
     ----------
     deployer : callable
         A `PandasDataFrameAxisPartition.deploy_*` method that will call ``f_to_deploy``.
-    axis : {0, 1}
-        The axis to perform the function along.
-    f_to_deploy : callable or RayObjectID
-        The function to deploy.
-    f_len_args : int
-        Number of positional arguments to pass to ``f_to_deploy``.
-    f_kwargs : dict
-        Keyword arguments to pass to ``f_to_deploy``.
-    *futures : list
+    *positional_args : list
         The first `f_len_args` elements in this list represent positional arguments
-        to pass to the `f_to_deploy`. The rest are partitions that will be passed as
-        positional arguments to `deployer`.
+        to pass to the `f_to_deploy`. The rest are positional arguments that will be
+        passed to `deployer`.
+    axis : {0, 1}
+        The axis to perform the function along. This argument is keyword only.
+    f_to_deploy : callable or RayObjectID
+        The function to deploy. This argument is keyword only.
+    f_len_args : int
+        Number of positional arguments to pass to ``f_to_deploy``. This argument is keyword only.
+    f_kwargs : dict
+        Keyword arguments to pass to ``f_to_deploy``. This argument is keyword only.
     extract_metadata : bool, default: True
         Whether to return metadata (length, width, ip) of the result. Passing `False` may relax
         the load on object storage as the remote function would return 4 times fewer futures.
         Passing `False` makes sense for temporary results where you know for sure that the
-        metadata will never be requested.
+        metadata will never be requested. This argument is keyword only.
     **kwargs : dict
         Keyword arguments to pass to ``deployer``.
 
@@ -314,9 +315,9 @@ def _deploy_ray_func(
     -----
     Ray functions are not detected by codecov (thus pragma: no cover).
     """
-    f_args = futures[:f_len_args]
-    partitions = futures[f_len_args:]
-    result = deployer(axis, f_to_deploy, f_args, f_kwargs, *partitions, **kwargs)
+    f_args = positional_args[:f_len_args]
+    deploy_args = positional_args[f_len_args:]
+    result = deployer(axis, f_to_deploy, f_args, f_kwargs, *deploy_args, **kwargs)
     if not extract_metadata:
         return result
     ip = get_node_ip_address()

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -1502,7 +1502,7 @@ def test_call_queue_serialization(call_queue):
         arg_lengths,
         kw_key_lengths,
         kw_value_lengths,
-        queue,
+        *queue,
     ) = deconstruct_call_queue(call_queue)
     queue = materialize_queue(*queue)
     reconstructed_queue = reconstruct_call_queue(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The PR was brought to eliminate `ray.get()` calls from inside the ray kernel that executes the partitions call queue, which sometimes triggered a deadlock. Before this PR, materialization of all the futures was explicitly triggered inside the kernel using `ray.get()`, and now all the futures are being passed to the kernel as a variable-length parameter, allowing for Ray [to materialize them implicitly beforehand](https://docs.ray.io/en/latest/ray-core/walkthrough.html#passing-an-object).

Testing performance shows no major difference for other cases:
![image](https://github.com/modin-project/modin/assets/62142979/9fe39137-6308-45d3-b69f-bc5ee7792878)


<details><summary>case 1 (getitem + transpose); 29 elements in queue</summary>

```python
import numpy as np
import modin.pandas as pd
from asv_bench.benchmarks.utils.common import execute

from timeit import default_timer as timer

import modin.config as cfg
pd.DataFrame([np.arange(cfg.NPartitions.get() * cfg.MinPartitionSize.get())]).to_numpy()

NROWS, NCOLS = (5_000_000, 64)
df = pd.DataFrame({f"col{i}": np.random.randint(0, 1_000_000, NROWS) for i in range(NCOLS)})

cols = df.columns.tolist()

for i in range(1, 20):
    df = df[cols[:-i]]

for i in range(10):
    df = df.T

print(
    f"call queue len: {len(df._query_compiler._modin_frame._partitions[-1, -1].call_queue)}"
) # 29
t1 = timer()
res = df + 10
execute(res)
print(timer() - t1)
```

</details>

<details><summary>case 2 (various funcs); 4 elements in the queue</summary>

```python
import numpy as np
import modin.pandas as pd
from asv_bench.benchmarks.utils.common import execute

from timeit import default_timer as timer

import modin.config as cfg
pd.DataFrame([np.arange(cfg.NPartitions.get() * cfg.MinPartitionSize.get())]).to_numpy()

NROWS, NCOLS = (5_000_000, 64)
df = pd.DataFrame({f"col{i}": np.random.randint(0, 1_000_000, NROWS) for i in range(NCOLS)})

def lazy_apply(df, func, func_args):
    mf = df._query_compiler._modin_frame
    new_parts = mf._partition_mgr_cls.lazy_map_partitions(mf._partitions, func, func_args)
    new_mf = mf.__constructor__(
        new_parts,
        mf.copy_index_cache(copy_lengths=True),
        mf.copy_columns_cache(copy_lengths=True),
        mf._row_lengths_cache,
        mf._column_widths_cache,
        dtypes=mf.copy_dtypes_cache(),
    )
    return type(df)(query_compiler=type(df._query_compiler)(new_mf))


df = lazy_apply(df, lambda df: df + 100, ())
df = lazy_apply(df, lambda df, arg: df * arg, [np.arange(32)])
# df = lazy_apply(df, lambda df, arg: df - arg, [df._query_compiler._modin_frame._partitions[0, 0]._data])
df = lazy_apply(df, lambda df, arg: df.fillna(arg), [10])
df = lazy_apply(df, lambda df, arg: df.astype(arg), ["float"])
# df = lazy_apply(df, lambda df, arg: df * arg, [df._query_compiler._modin_frame._partitions[0, 0]._data])

print("call queue len", len(df._query_compiler._modin_frame._partitions[0, 0].call_queue))
t1 = timer()
execute(df)
print(timer() - t1)
```

</details>

<details><summary>case 3 (various funcs, including those that has modin df as a parameter); 6 elements in the queue</summary>

```python
import numpy as np
import modin.pandas as pd
from asv_bench.benchmarks.utils.common import execute

from timeit import default_timer as timer

import modin.config as cfg
pd.DataFrame([np.arange(cfg.NPartitions.get() * cfg.MinPartitionSize.get())]).to_numpy()

NROWS, NCOLS = (5_000_000, 64)
df = pd.DataFrame({f"col{i}": np.random.randint(0, 1_000_000, NROWS) for i in range(NCOLS)})

def lazy_apply(df, func, func_args):
    mf = df._query_compiler._modin_frame
    new_parts = mf._partition_mgr_cls.lazy_map_partitions(mf._partitions, func, func_args)
    new_mf = mf.__constructor__(
        new_parts,
        mf.copy_index_cache(copy_lengths=True),
        mf.copy_columns_cache(copy_lengths=True),
        mf._row_lengths_cache,
        mf._column_widths_cache,
        dtypes=mf.copy_dtypes_cache(),
    )
    return type(df)(query_compiler=type(df._query_compiler)(new_mf))


df = lazy_apply(df, lambda df: df + 100, ())
df = lazy_apply(df, lambda df, arg: df * arg, [np.arange(32)])
df = lazy_apply(df, lambda df, arg: df - arg, [df._query_compiler._modin_frame._partitions[0, 0]._data])
df = lazy_apply(df, lambda df, arg: df.fillna(arg), [10])
df = lazy_apply(df, lambda df, arg: df.astype(arg), ["float"])
df = lazy_apply(df, lambda df, arg: df * arg, [df._query_compiler._modin_frame._partitions[0, 0]._data])

print("call queue len", len(df._query_compiler._modin_frame._partitions[0, 0].call_queue))
t1 = timer()
execute(df)
print(timer() - t1)
```

</details>

<details><summary>case 4 (various funcs, including those that has modin df as a parameter); 60 elements in the queue</summary>

```python
import numpy as np
import modin.pandas as pd
from asv_bench.benchmarks.utils.common import execute

from timeit import default_timer as timer

import modin.config as cfg
pd.DataFrame([np.arange(cfg.NPartitions.get() * cfg.MinPartitionSize.get())]).to_numpy()

NROWS, NCOLS = (5_000_000, 64)
df = pd.DataFrame({f"col{i}": np.random.randint(0, 1_000_000, NROWS) for i in range(NCOLS)})

def lazy_apply(df, func, func_args):
    mf = df._query_compiler._modin_frame
    new_parts = mf._partition_mgr_cls.lazy_map_partitions(mf._partitions, func, func_args)
    new_mf = mf.__constructor__(
        new_parts,
        mf.copy_index_cache(copy_lengths=True),
        mf.copy_columns_cache(copy_lengths=True),
        mf._row_lengths_cache,
        mf._column_widths_cache,
        dtypes=mf.copy_dtypes_cache(),
    )
    return type(df)(query_compiler=type(df._query_compiler)(new_mf))


for i in range(10):
    df = lazy_apply(df, lambda df: df + 100, ())
    df = lazy_apply(df, lambda df, arg: df * arg, [np.arange(32)])
    df = lazy_apply(df, lambda df, arg: df - arg, [df._query_compiler._modin_frame._partitions[0, 0]._data])
    df = lazy_apply(df, lambda df, arg: df.fillna(arg), [10])
    df = lazy_apply(df, lambda df, arg: df.astype(arg), ["float"])
    df = lazy_apply(df, lambda df, arg: df * arg, [df._query_compiler._modin_frame._partitions[0, 0]._data])

print("call queue len", len(df._query_compiler._modin_frame._partitions[0, 0].call_queue))
t1 = timer()
execute(df)
print(timer() - t1)
```

</details>

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4507 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
