### PR TITLE
FIX-#6635: HDK: read_csv(): treat object dtype as string

### DIFF
--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/io/io.py
@@ -290,7 +290,7 @@ class HdkOnNativeIO(BaseIO, TextFileDispatcher):
         tname = dtype if isinstance(dtype, str) else dtype.name
         if tname == "category":
             return pa.dictionary(index_type=pa.int32(), value_type=pa.string())
-        elif tname == "string":
+        elif tname == "string" or tname == "object":
             return pa.string()
         else:
             return pa.from_numpy_dtype(tname)

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -391,6 +391,19 @@ class TestCSV:
 
         run_and_compare(test, data={})
 
+    def test_read_csv_dtype_object(self):
+        with pytest.warns(UserWarning) as warns:
+            with ensure_clean(".csv") as file:
+                with open(file, "w") as f:
+                    f.write("test\ntest")
+
+                def test(**kwargs):
+                    return pd.read_csv(file, dtype={"test": "object"})
+
+                run_and_compare(test, data={})
+            for warn in warns.list:
+                assert not re.match(r".*defaulting to pandas.*", str(warn))
+
 
 class TestMasks:
     data = {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6635 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
