### PR TITLE
FIX-#6637: Fix `skiprows` parameter usage for `read_excel`

### DIFF
--- a/modin/core/io/text/excel_dispatcher.py
+++ b/modin/core/io/text/excel_dispatcher.py
@@ -59,6 +59,13 @@ class ExcelDispatcher(TextFileDispatcher):
                 **kwargs
             )
 
+        if kwargs.get("skiprows") is not None:
+            return cls.single_worker_read(
+                io,
+                reason="Modin doesn't support 'skiprows' parameter of `read_excel`",
+                **kwargs
+            )
+
         if isinstance(io, bytes):
             io = BytesIO(io)
 

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -580,7 +580,6 @@ class PandasExcelParser(PandasParser):
         num_splits = kwargs.pop("num_splits", None)
         start = kwargs.pop("start", None)
         end = kwargs.pop("end", None)
-        _skiprows = kwargs.pop("skiprows")
         excel_header = kwargs.get("_header")
         sheet_name = kwargs.get("sheet_name", 0)
         footer = b"</sheetData></worksheet>"
@@ -588,6 +587,8 @@ class PandasExcelParser(PandasParser):
         # Default to pandas case, where we are not splitting or partitioning
         if start is None or end is None:
             return pandas.read_excel(fname, **kwargs)
+
+        _skiprows = kwargs.pop("skiprows")
 
         import re
         from zipfile import ZipFile

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -2198,6 +2198,17 @@ class TestExcel:
         )
 
     @check_file_leaks
+    @pytest.mark.parametrize("skiprows", [2, [1, 3], lambda x: x in [0, 2]])
+    def test_read_excel_skiprows(self, skiprows, make_excel_file):
+        eval_io(
+            fn_name="read_excel",
+            # read_excel kwargs
+            io=make_excel_file(),
+            skiprows=skiprows,
+            check_kwargs_callable=False,
+        )
+
+    @check_file_leaks
     @pytest.mark.parametrize(
         "dtype_backend", [lib.no_default, "numpy_nullable", "pyarrow"]
     )


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Since `skiprows` is not supported, we need to default to pandas if this option is used.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6637 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
