### PR TITLE
PERF-#2813: Distributed 'from_pandas()' for numerical data in Ray

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -660,8 +660,20 @@ class AsyncReadMode(EnvironmentVariable, type=bool):
     """
     It does not wait for the end of reading information from the source.
 
-    Can break situations when reading occurs in a context, when exiting
-    from which the source is deleted.
+    It basically means, that the reading function only launches tasks for the dataframe
+    to be read/created, but not ensures that the construction is finalized by the time
+    the reading function returns a dataframe.
+
+    This option was brought to improve performance of reading/construction
+    of Modin DataFrames, however it may also:
+
+    1. Increase the peak memory consumption. Since the garbage collection of the
+    temporary objects created during the reading is now also lazy and will only
+    be performed when the reading/construction is actually finished.
+
+    2. Can break situations when the source is manually deleted after the reading
+    function returns a result, for example, when reading inside of a context-block
+    that deletes the file on ``__exit__()``.
     """
 
     varname = "MODIN_ASYNC_READ_MODE"

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -832,7 +832,6 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         np.ndarray or (np.ndarray, row_lengths, col_widths)
             A NumPy array with partitions (with dimensions or not).
         """
-
         num_splits = NPartitions.get()
         row_chunksize = compute_chunksize(df.shape[0], num_splits)
         col_chunksize = compute_chunksize(df.shape[1], num_splits)

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -767,6 +767,53 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         )
 
     @classmethod
+    def split_pandas_df_into_partitions(
+        cls, df, row_chunksize, col_chunksize, update_bar
+    ):
+        """
+        Split given pandas DataFrame according to the row/column chunk sizes into distributed partitions.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+        row_chunksize : int
+        col_chunksize : int
+        update_bar : callable(x) -> x
+            Function that updates a progress bar.
+
+        Returns
+        -------
+        2D np.ndarray[PandasDataframePartition]
+        """
+        put_func = cls._partition_class.put
+        # even a full-axis slice can cost something (https://github.com/pandas-dev/pandas/issues/55202)
+        # so we try not to do it if unnecessary.
+        # FIXME: it appears that this optimization doesn't work for Unidist correctly as it
+        # doesn't explicitly copy the data when putting it into storage (as the rest engines do)
+        # causing it to eventially share memory with a pandas object that was provided by user.
+        # Everything works fine if we do this column slicing as pandas then would set some flags
+        # to perform in COW mode apparently (and so it wouldn't crash our tests).
+        # @YarShev promised that this will be eventially fixed on Unidist's side, but for now there's
+        # this hacky condition
+        if col_chunksize >= len(df.columns) and Engine.get() != "Unidist":
+            col_parts = [df]
+        else:
+            col_parts = [
+                df.iloc[:, i : i + col_chunksize]
+                for i in range(0, len(df.columns), col_chunksize)
+            ]
+        parts = [
+            [
+                update_bar(
+                    put_func(col_part.iloc[i : i + row_chunksize]),
+                )
+                for col_part in col_parts
+            ]
+            for i in range(0, len(df), row_chunksize)
+        ]
+        return np.array(parts)
+
+    @classmethod
     @wait_computations_if_benchmark_mode
     def from_pandas(cls, df, return_dims=False):
         """
@@ -786,13 +833,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             A NumPy array with partitions (with dimensions or not).
         """
 
-        def update_bar(pbar, f):
-            if ProgressBar.get():
-                pbar.update(1)
-            return f
-
         num_splits = NPartitions.get()
-        put_func = cls._partition_class.put
         row_chunksize = compute_chunksize(df.shape[0], num_splits)
         col_chunksize = compute_chunksize(df.shape[1], num_splits)
 
@@ -820,36 +861,18 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         else:
             pbar = None
 
-        # even a full-axis slice can cost something (https://github.com/pandas-dev/pandas/issues/55202)
-        # so we try not to do it if unnecessary.
-        # FIXME: it appears that this optimization doesn't work for Unidist correctly as it
-        # doesn't explicitly copy the data when putting it into storage (as the rest engines do)
-        # causing it to eventially share memory with a pandas object that was provided by user.
-        # Everything works fine if we do this column slicing as pandas then would set some flags
-        # to perform in COW mode apparently (and so it wouldn't crash our tests).
-        # @YarShev promised that this will be eventially fixed on Unidist's side, but for now there's
-        # this hacky condition
-        if col_chunksize >= len(df.columns) and Engine.get() != "Unidist":
-            col_parts = [df]
-        else:
-            col_parts = [
-                df.iloc[:, i : i + col_chunksize]
-                for i in range(0, len(df.columns), col_chunksize)
-            ]
-        parts = [
-            [
-                update_bar(
-                    pbar,
-                    put_func(col_part.iloc[i : i + row_chunksize]),
-                )
-                for col_part in col_parts
-            ]
-            for i in range(0, len(df), row_chunksize)
-        ]
+        def update_bar(f):
+            if ProgressBar.get():
+                pbar.update(1)
+            return f
+
+        parts = cls.split_pandas_df_into_partitions(
+            df, row_chunksize, col_chunksize, update_bar
+        )
         if ProgressBar.get():
             pbar.close()
         if not return_dims:
-            return np.array(parts)
+            return parts
         else:
             row_lengths = [
                 row_chunksize
@@ -863,7 +886,7 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 else len(df.columns) % col_chunksize or col_chunksize
                 for i in range(0, len(df.columns), col_chunksize)
             ]
-            return np.array(parts), row_lengths, col_widths
+            return parts, row_lengths, col_widths
 
     @classmethod
     def from_arrow(cls, at, return_dims=False):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -14,8 +14,8 @@
 """Module houses class that implements ``GenericRayDataframePartitionManager`` using Ray."""
 
 import numpy as np
-from pandas.core.dtypes.common import is_numeric_dtype
 import psutil
+from pandas.core.dtypes.common import is_numeric_dtype
 
 from modin.core.execution.modin_aqp import progress_bar_wrapper
 from modin.core.execution.ray.common import RayWrapper

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -22,8 +22,8 @@ from modin.core.execution.ray.common import RayWrapper
 from modin.core.execution.ray.generic.partitioning import (
     GenericRayDataframePartitionManager,
 )
-from modin.utils import _inherit_docstrings
 from modin.logging import get_logger
+from modin.utils import _inherit_docstrings
 
 from .partition import PandasOnRayDataframePartition
 from .virtual_partition import (

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -73,11 +73,11 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         #   3. The distributed splitting consumes more memory that the sequential one.
         #   It was estimated that it requires ~2.5x of the dataframe size, so to avoid
         #   OOM problems, we fall back to sequential implementation in case it doesn't
-        #   fit into memory (using 3x threshold to be on the safe side).
+        #   fit into memory (using 3.5x threshold to be on the safe side).
         enough_elements = (len(df) * len(df.columns)) > 6_000_000
         all_numeric_types = all(is_numeric_dtype(dtype) for dtype in df.dtypes)
         three_copies_fits_into_memory = psutil.virtual_memory().available > (
-            df.memory_usage().sum() * 3
+            df.memory_usage().sum() * 3.5
         )
         distributed_splitting = (
             enough_elements and all_numeric_types and three_copies_fits_into_memory

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition_manager.py
@@ -87,7 +87,7 @@ class PandasOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
 
         if not distributed_splitting:
             log.info(
-                "Using sequential splitting in '.from_pandas()' because of some of the condition is False: "
+                "Using sequential splitting in '.from_pandas()' because of some of the conditions are False: "
                 + f"{enough_elements=}; {all_numeric_types=}; {async_mode_on=}"
             )
             return super().split_pandas_df_into_partitions(

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -3135,6 +3135,17 @@ def test_from_arrow():
     df_equals(modin_df, pandas_df)
 
 
+@pytest.mark.skipif(
+    condition=Engine.get() != "Ray",
+    reason="Distributed 'from_pandas' is only available for Ray engine",
+)
+@pytest.mark.parametrize("modify_config", [{AsyncReadMode: True}], indirect=True)
+def test_distributed_from_pandas(modify_config):
+    pandas_df = pandas.DataFrame({f"col{i}": np.arange(200_000) for i in range(64)})
+    modin_df = pd.DataFrame(pandas_df)
+    df_equals(modin_df, pandas_df)
+
+
 @pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 def test_from_spmatrix():
     data = sparse.eye(3)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

So I've implemented the distributed `from_pandas()` approach suggested in [this comment](https://github.com/modin-project/modin/issues/2813#issuecomment-1753024035) and ran some perf testing with it. 

The first observation being made, is that the new approach seems to work better only with numerical data, as with python strings, putting the whole big dataframe into the storage takes too much time. I believe it's a topic for a further fine-grained tuning to determine how much of string columns in a dataframe is okay for the distributed implementation. As for now, I suggest proceeding with only numericals.

Then I ran this micro benchmark for each engine, in order to determine with what data sizes of numerical data it makes sense to use the distributed implementation.

<details><summary>the micro-benchmark</summary>

```python
import pandas
import modin.pandas as pd
import numpy as np
import modin.config as cfg
from asv_bench.benchmarks.utils.common import execute
from timeit import default_timer as timer

# initialize the workers
pd.DataFrame([np.arange(cfg.NPartitions.get() * cfg.MinPartitionSize.get())]).to_numpy()

NROWS = 100
NCOLS = 32

import warnings
warnings.filterwarnings("ignore")

for i in range(20):
    pandas_df = pandas.DataFrame({f"col{i}": np.arange(NROWS) for i in range(NCOLS)})

    t1 = timer()
    modin_df = pd.DataFrame(pandas_df)
    execute(modin_df)
    print(timer() - t1)
    # print((NROWS, NCOLS), f"~ {round((NROWS * NCOLS * 8) / 1024 / 1024 / 1024, 4)}gb")
    NROWS *= 2
```

</details>

**Perf results for Ray:**

For Ray, it seems to make sense to use the distributed implementation, when there's more that 6mln elements (nrows * ncols) in a dataframe.

<details><summary>2 columns data</summary>

![image](https://github.com/modin-project/modin/assets/62142979/14fd057d-4268-44bb-95e2-b5f0ec94d979)


</details>

<details><summary>32 columns data</summary>

![image](https://github.com/modin-project/modin/assets/62142979/b6c9e5a0-c9b4-47ed-9a4f-11649773540f)

</details>

<details><summary>128 columns data</summary>

![image](https://github.com/modin-project/modin/assets/62142979/bbf0561b-d1f2-4af1-a184-1dc4b12d8ea9)

</details>

**Perf results for Dask:**

With Dask it starts failing with OOM [(potential reason)](https://github.com/modin-project/modin/pull/6640#issuecomment-1755623100), so it's proposed we won't use this approach with it:

<details><summary>32 columns data</summary>

![image](https://github.com/modin-project/modin/assets/62142979/7a2418f1-33bd-4d98-824c-d67a3e746b02)

</details>

**Perf results for Unidist on MPI:**

With Unidist on MPI it works slower with the new approach and also fails on a medium-sized data, so we won't use the new approach with MPI:

<details><summary>32 columns data</summary>

![image](https://github.com/modin-project/modin/assets/62142979/9947abcc-6885-4afc-acd1-4f0719cbbb27)


</details>

### So...

So, summing up the results, it seems that the new distributed implementation of `.from_pandas()` should be engaged only for numerical data, only for Ray, and only when there are more than 6mln elements in a dataframe.


- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #2813 <!-- issue must be created for each patch -->
- [x] tests <s>added and</s> are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
