### PR TITLE
PERF-#6645: avoid label synchronization for `dot` operation

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2247,6 +2247,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
             new_columns = [MODIN_UNNAMED_SERIES_LABEL] if num_cols == 1 else None
             axis = 1
 
+        # If either new index or new columns are supposed to be a single-dimensional,
+        # then we use a special labeling for them. Besides setting the new labels as
+        # a metadata to the resulted frame, we also want to set them inside the kernel,
+        # so actual partitions would be labeled accordingly (there's a 'sync_label'
+        # parameter that can do the same, but doing it manually is faster)
         align_index = isinstance(new_index, list) and new_index == [
             MODIN_UNNAMED_SERIES_LABEL
         ]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Manually aligning indexes is much cheaper than using `sync_label` option, which creates a copy for each partition with an updated index (lazy map operation).

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6645 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
