### PR TITLE
TEST-#0000: remove test for deprecated `reshape` func

### DIFF
--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3021,15 +3021,6 @@ def test_reset_index(data, drop, name, inplace):
     )
 
 
-@pytest.mark.xfail(reason="Using pandas Series.")
-@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_reshape(data):
-    modin_series = create_test_series(data)
-
-    with pytest.raises(NotImplementedError):
-        modin_series.reshape(None)
-
-
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_rfloordiv(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

I believe that such low-level commits need not be shown in the change notes. That’s why I don’t create a separate issue so that later I can (or someone) exclude commits that have the `#0000` number.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
