### PR TITLE
PERF-#6666: Avoid internal `reset_index` for left `merge`

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -499,7 +499,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
             kwargs["sort"] = False
 
-            def keep_index_or_not(left, right):
+            def whether_keep_index(left, right):
                 keep_index = False
                 if left_on is not None and right_on is not None:
                     keep_index = any(
@@ -522,7 +522,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 if kwargs["how"] == "left":
                     partition_idx = service_kwargs["partition_idx"]
                     if len(axis_lengths):
-                        if not keep_index_or_not(left, right):
+                        if not whether_keep_index(left, right):
                             # Doesn't work for "inner" case, since the partition sizes of the
                             # left dataframe may change
                             start = sum(axis_lengths[:partition_idx])
@@ -578,7 +578,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 self._modin_frame.apply_full_axis(
                     axis=1,
                     func=map_func,
-                    enumerate_partitions=how=="left",
+                    enumerate_partitions=how == "left",
                     # We're going to explicitly change the shape across the 1-axis,
                     # so we want for partitioning to adapt as well
                     keep_partitioning=False,
@@ -588,7 +588,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     new_columns=new_columns,
                     dtypes=new_dtypes,
                     sync_labels=False,
-                    pass_axis_lengths_to_partitions=how=="left",
+                    pass_axis_lengths_to_partitions=how == "left",
                 )
             )
 
@@ -598,7 +598,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             # materialized quite often compared to the indexes.
             keep_index = False
             if self._modin_frame.has_materialized_index:
-                keep_index = keep_index_or_not(self, right_pandas)
+                keep_index = whether_keep_index(self, right_pandas)
             else:
                 # Have to trigger columns materialization. Hope they're already available at this point.
                 if left_on is not None and right_on is not None:

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -578,7 +578,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 self._modin_frame.apply_full_axis(
                     axis=1,
                     func=map_func,
-                    enumerate_partitions=True if how == "left" else False,
+                    enumerate_partitions=how=="left",
                     # We're going to explicitly change the shape across the 1-axis,
                     # so we want for partitioning to adapt as well
                     keep_partitioning=False,
@@ -588,7 +588,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     new_columns=new_columns,
                     dtypes=new_dtypes,
                     sync_labels=False,
-                    pass_axis_lengths_to_partitions=True if how == "left" else False,
+                    pass_axis_lengths_to_partitions=how=="left",
                 )
             )
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -499,7 +499,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
             kwargs["sort"] = False
 
-            def whether_keep_index(left, right):
+            def should_keep_index(left, right):
                 keep_index = False
                 if left_on is not None and right_on is not None:
                     keep_index = any(
@@ -522,7 +522,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 if kwargs["how"] == "left":
                     partition_idx = service_kwargs["partition_idx"]
                     if len(axis_lengths):
-                        if not whether_keep_index(left, right):
+                        if not should_keep_index(left, right):
                             # Doesn't work for "inner" case, since the partition sizes of the
                             # left dataframe may change
                             start = sum(axis_lengths[:partition_idx])
@@ -598,7 +598,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             # materialized quite often compared to the indexes.
             keep_index = False
             if self._modin_frame.has_materialized_index:
-                keep_index = whether_keep_index(self, right_pandas)
+                keep_index = should_keep_index(self, right_pandas)
             else:
                 # Have to trigger columns materialization. Hope they're already available at this point.
                 if left_on is not None and right_on is not None:

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -521,7 +521,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
                 if kwargs["how"] == "left":
                     partition_idx = service_kwargs["partition_idx"]
-                    if partition_idx and len(axis_lengths):
+                    if len(axis_lengths):
                         if not keep_index_or_not(left, right):
                             # Doesn't work for "inner" case, since the partition sizes of the
                             # left dataframe may change


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

IIUC `reset_index` [was needed](https://github.com/modin-project/modin/pull/1695#discussion_r453586525) to build the correct RangeIndex. However, this can be done in a cheaper way by passing the lengths to internal partitions.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6666 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
