### PR TITLE
FIX-#6594: fix usage of Modin objects inside UDFs for `apply`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -4119,6 +4119,16 @@ class PandasDataframe(ClassLogger):
         """Wait for all computations to complete without materializing data."""
         self._partition_mgr_cls.wait_partitions(self._partitions.flatten())
 
+    def support_materialization_in_worker_process(self) -> bool:
+        """
+        Whether it's possible to call function `to_pandas` during the pickling process, at the moment of recreating the object.
+
+        Returns
+        -------
+        bool
+        """
+        return True
+
     def __dataframe__(self, nan_as_null: bool = False, allow_copy: bool = True):
         """
         Get a Modin DataFrame that implements the dataframe exchange protocol.

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -131,7 +131,8 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         # When performing a function with Modin objects, it is more profitable to
         # do the conversion to pandas once on the main process than several times
         # on worker processes. Details: https://github.com/modin-project/modin/pull/6673/files#r1391086755
-        need_update = not PersistentPickle.get()
+        # For Dask, otherwise there may be an error: `coroutine 'Client._gather' was never awaited`
+        need_update = not PersistentPickle.get() and Engine.get() != "Dask"
         if need_update:
             PersistentPickle.put(True)
         try:

--- a/modin/core/execution/dask/implementations/pandas_on_dask/dataframe/dataframe.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/dataframe/dataframe.py
@@ -43,7 +43,9 @@ class PandasOnDaskDataframe(PandasDataframe):
     _partition_mgr_cls = PandasOnDaskDataframePartitionManager
 
     @classmethod
-    def reconnect(cls, address, attributes):
+    def reconnect(cls, address, attributes):  # noqa: GL08
+        # The main goal is to configure the client for the worker proces
+        # using the address passed by the custom `__reduce__` function
         try:
             from distributed import default_client
 
@@ -57,7 +59,7 @@ class PandasOnDaskDataframe(PandasDataframe):
         obj.__dict__.update(attributes)
         return obj
 
-    def __reduce__(self):
+    def __reduce__(self):  # noqa: GL08
         from distributed import default_client
 
         address = default_client().scheduler_info()["address"]

--- a/modin/core/execution/dask/implementations/pandas_on_dask/dataframe/dataframe.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/dataframe/dataframe.py
@@ -44,7 +44,7 @@ class PandasOnDaskDataframe(PandasDataframe):
 
     @classmethod
     def reconnect(cls, address, attributes):  # noqa: GL08
-        # The main goal is to configure the client for the worker proces
+        # The main goal is to configure the client for the worker process
         # using the address passed by the custom `__reduce__` function
         try:
             from distributed import default_client

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/dataframe/dataframe.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/dataframe/dataframe.py
@@ -41,3 +41,7 @@ class PandasOnUnidistDataframe(PandasDataframe):
     """
 
     _partition_mgr_cls = PandasOnUnidistDataframePartitionManager
+
+    def support_materialization_in_worker_process(self) -> bool:
+        # more details why this is not `True` in https://github.com/modin-project/modin/pull/6673
+        return False

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -325,6 +325,16 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         """Wait for all computations to complete without materializing data."""
         pass
 
+    def support_materialization_in_worker_process(self) -> bool:
+        """
+        Whether it's possible to call function `to_pandas` during the pickling process, at the moment of recreating the object.
+
+        Returns
+        -------
+        bool
+        """
+        return self._modin_frame.support_materialization_in_worker_process()
+
     # END Data Management Methods
 
     # To/From Pandas

--- a/modin/experimental/core/storage_formats/hdk/query_compiler.py
+++ b/modin/experimental/core/storage_formats/hdk/query_compiler.py
@@ -191,6 +191,9 @@ class DFAlgQueryCompiler(BaseQueryCompiler):
         # HDK-specific method
         self._modin_frame.force_import()
 
+    def support_materialization_in_worker_process(self) -> bool:
+        return True
+
     def to_pandas(self):
         return self._modin_frame.to_pandas()
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import datetime
 import functools
 import itertools
+import os
 import re
 import sys
 import warnings
@@ -3107,7 +3108,7 @@ class DataFrame(BasePandasDataset):
 
     # Persistance support methods - BEGIN
     @classmethod
-    def _inflate_light(cls, query_compiler):
+    def _inflate_light(cls, query_compiler, source_pid):
         """
         Re-creates the object from previously-serialized lightweight representation.
 
@@ -3117,16 +3118,23 @@ class DataFrame(BasePandasDataset):
         ----------
         query_compiler : BaseQueryCompiler
             Query compiler to use for object re-creation.
+        source_pid : int
+            Determines whether a Modin or pandas object needs to be created.
+            Modin objects are created only on the main process.
 
         Returns
         -------
         DataFrame
             New ``DataFrame`` based on the `query_compiler`.
         """
+        if os.getpid() != source_pid:
+            return query_compiler.to_pandas()
+        # The current logic does not involve creating Modin objects
+        # and manipulation with them in worker processes
         return cls(query_compiler=query_compiler)
 
     @classmethod
-    def _inflate_full(cls, pandas_df):
+    def _inflate_full(cls, pandas_df, source_pid):
         """
         Re-creates the object from previously-serialized disk-storable representation.
 
@@ -3134,18 +3142,29 @@ class DataFrame(BasePandasDataset):
         ----------
         pandas_df : pandas.DataFrame
             Data to use for object re-creation.
+        source_pid : int
+            Determines whether a Modin or pandas object needs to be created.
+            Modin objects are created only on the main process.
 
         Returns
         -------
         DataFrame
             New ``DataFrame`` based on the `pandas_df`.
         """
+        if os.getpid() != source_pid:
+            return pandas_df
+        # The current logic does not involve creating Modin objects
+        # and manipulation with them in worker processes
         return cls(data=from_pandas(pandas_df))
 
     def __reduce__(self):
         self._query_compiler.finalize()
-        if PersistentPickle.get():
-            return self._inflate_full, (self._to_pandas(),)
-        return self._inflate_light, (self._query_compiler,)
+        pid = os.getpid()
+        if (
+            PersistentPickle.get()
+            or not self._query_compiler.support_materialization_in_worker_process()
+        ):
+            return self._inflate_full, (self._to_pandas(), pid)
+        return self._inflate_light, (self._query_compiler, pid)
 
     # Persistance support methods - END

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -31,7 +31,6 @@ from pandas.io.formats.info import SeriesInfo
 from pandas.util._validators import validate_bool_kwarg
 
 from modin.config import PersistentPickle
-from modin.core.storage_formats.base.query_compiler import BaseQueryCompiler
 from modin.logging import disable_logging
 from modin.utils import MODIN_UNNAMED_SERIES_LABEL, _inherit_docstrings, to_pandas
 
@@ -80,7 +79,6 @@ class Series(BasePandasDataset):
 
     _pandas_class = pandas.Series
     __array_priority__ = pandas.Series.__array_priority__
-    _query_compiler: BaseQueryCompiler
 
     def __init__(
         self,
@@ -2513,7 +2511,7 @@ class Series(BasePandasDataset):
         name : str
             The name to give to the new object.
         source_pid : int
-            Determines whether a Modin or Pandas object needs to be created.
+            Determines whether a Modin or pandas object needs to be created.
             Modin objects are created only on the main process.
 
         Returns

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -2535,7 +2535,7 @@ class Series(BasePandasDataset):
         pandas_series : pandas.Series
             Data to use for object re-creation.
         source_pid : int
-            Determines whether a Modin or Pandas object needs to be created.
+            Determines whether a Modin or pandas object needs to be created.
             Modin objects are created only on the main process.
 
         Returns
@@ -2545,6 +2545,8 @@ class Series(BasePandasDataset):
         """
         if os.getpid() != source_pid:
             return pandas_series
+        # The current logic does not involve creating Modin objects
+        # and manipulation with them in worker processes
         return cls(data=pandas_series)
 
     def __reduce__(self):

--- a/modin/pandas/test/dataframe/test_pickle.py
+++ b/modin/pandas/test/dataframe/test_pickle.py
@@ -18,7 +18,7 @@ import pytest
 
 import modin.pandas as pd
 from modin.config import PersistentPickle
-from modin.pandas.test.utils import df_equals
+from modin.pandas.test.utils import create_test_dfs, df_equals
 
 
 @pytest.fixture
@@ -45,6 +45,33 @@ def persistent(request):
 def test_dataframe_pickle(modin_df, persistent):
     other = pickle.loads(pickle.dumps(modin_df))
     df_equals(modin_df, other)
+
+
+def test__reduce__():
+    # `Series.__reduce__` will be called implicitly when lambda expressions are
+    # pre-processed for the distributed engine.
+    dataframe_data = ["Major League Baseball", "National Basketball Association"]
+    abbr_md, abbr_pd = create_test_dfs(dataframe_data, index=["MLB", "NBA"])
+    # breakpoint()
+
+    dataframe_data = {
+        "name": ["Mariners", "Lakers"] * 500,
+        "league_abbreviation": ["MLB", "NBA"] * 500,
+    }
+    teams_md, teams_pd = create_test_dfs(dataframe_data)
+
+    result_md = (
+        teams_md.set_index("name")
+        .league_abbreviation.apply(lambda abbr: abbr_md[0].loc[abbr])
+        .rename("league")
+    )
+
+    result_pd = (
+        teams_pd.set_index("name")
+        .league_abbreviation.apply(lambda abbr: abbr_pd[0].loc[abbr])
+        .rename("league")
+    )
+    df_equals(result_md, result_pd)
 
 
 def test_column_pickle(modin_column, modin_df, persistent):

--- a/modin/pandas/test/dataframe/test_pickle.py
+++ b/modin/pandas/test/dataframe/test_pickle.py
@@ -48,7 +48,7 @@ def test_dataframe_pickle(modin_df, persistent):
 
 
 def test__reduce__():
-    # `Series.__reduce__` will be called implicitly when lambda expressions are
+    # `DataFrame.__reduce__` will be called implicitly when lambda expressions are
     # pre-processed for the distributed engine.
     dataframe_data = ["Major League Baseball", "National Basketball Association"]
     abbr_md, abbr_pd = create_test_dfs(dataframe_data, index=["MLB", "NBA"])

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -27,7 +27,7 @@ from pandas.core.indexing import IndexingError
 from pandas.errors import SpecificationError
 
 import modin.pandas as pd
-from modin.config import Engine, NPartitions, StorageFormat
+from modin.config import NPartitions, StorageFormat
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 from modin.utils import get_current_execution, to_pandas, try_cast_to_pandas
 
@@ -4796,7 +4796,6 @@ def test_binary_numpy_universal_function_issue_6483():
     )
 
 
-@pytest.mark.skipif(Engine.get() == "Unidist", reason="Unidist doesn't work for now.")
 def test__reduce__():
     abbreviations = pd.Series(
         ["Major League Baseball", "National Basketball Association"],

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4796,7 +4796,7 @@ def test_binary_numpy_universal_function_issue_6483():
     )
 
 
-@pytest.mark.xfail(Engine.get() != "Ray", reason="reason")
+@pytest.mark.skipif(Engine.get() == "Unidist", reason="Unidist doesn't work for now.")
 def test__reduce__():
     abbreviations = pd.Series(
         ["Major League Baseball", "National Basketball Association"],

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -27,7 +27,7 @@ from pandas.core.indexing import IndexingError
 from pandas.errors import SpecificationError
 
 import modin.pandas as pd
-from modin.config import NPartitions, StorageFormat
+from modin.config import Engine, NPartitions, StorageFormat
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 from modin.utils import get_current_execution, to_pandas, try_cast_to_pandas
 
@@ -4796,6 +4796,7 @@ def test_binary_numpy_universal_function_issue_6483():
     )
 
 
+@pytest.mark.xfail(Engine.get() != "Ray", reason="reason")
 def test__reduce__():
     abbreviations = pd.Series(
         ["Major League Baseball", "National Basketball Association"],

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -4794,3 +4794,22 @@ def test_binary_numpy_universal_function_issue_6483():
         *create_test_series(test_data["float_nan_data"]),
         lambda series: np.arctan2(series, np.sin(series)),
     )
+
+
+def test__reduce__():
+    abbreviations = pd.Series(
+        ["Major League Baseball", "National Basketball Association"],
+        index=["MLB", "NBA"],
+    )
+    teams = pd.DataFrame(
+        {
+            "name": ["Mariners", "Lakers"] * 500,
+            "league_abbreviation": ["MLB", "NBA"] * 500,
+        }
+    )
+    result = (
+        teams.set_index("name")
+        .league_abbreviation.apply(lambda abbr: abbreviations.loc[abbr])
+        .rename("league")
+    )
+    result._to_pandas()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The PR also fixes https://github.com/modin-project/modin/issues/4919

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6594 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
