### PR TITLE
FIX-#6684: Adapt to pandas 2.1.2

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2188,13 +2188,13 @@ class BasePandasDataset(ClassLogger):
         """
         Percentage change between the current and a prior element.
         """
-        if fill_method is not lib.no_default or limit is not lib.no_default:
+        if fill_method not in (lib.no_default, None) or limit is not lib.no_default:
             warnings.warn(
-                "The 'fill_method' and 'limit' keywords in "
-                + f"{type(self).__name__}.pct_change are deprecated and will be "
-                + "removed in a future version. Call "
-                + f"{'bfill' if fill_method in ('backfill', 'bfill') else 'ffill'} "
-                + "before calling pct_change instead.",
+                "The 'fill_method' keyword being not None and the 'limit' keyword in "
+                + f"{type(self).__name__}.pct_change are deprecated and will be removed "
+                + "in a future version. Either fill in any non-leading NA values prior "
+                + "to calling pct_change or specify 'fill_method=None' to not fill NA "
+                + "values.",
                 FutureWarning,
             )
         if fill_method is lib.no_default:

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -559,13 +559,13 @@ class DataFrameGroupBy(ClassLogger):
     ):
         from .dataframe import DataFrame
 
-        if fill_method is not lib.no_default or limit is not lib.no_default:
+        if fill_method not in (lib.no_default, None) or limit is not lib.no_default:
             warnings.warn(
-                "The 'fill_method' and 'limit' keywords in "
-                + f"{type(self).__name__}.pct_change are deprecated and will be "
-                + "removed in a future version. Call "
-                + f"{'bfill' if fill_method in ('backfill', 'bfill') else 'ffill'} "
-                + "before calling pct_change instead.",
+                "The 'fill_method' keyword being not None and the 'limit' keyword in "
+                + f"{type(self).__name__}.pct_change are deprecated and will be removed "
+                + "in a future version. Either fill in any non-leading NA values prior "
+                + "to calling pct_change or specify 'fill_method=None' to not fill NA "
+                + "values.",
                 FutureWarning,
             )
         if fill_method is lib.no_default:

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -77,7 +77,8 @@ pytestmark = [
         "ignore:DataFrameGroupBy.pct_change with axis=1 is deprecated:FutureWarning"
     ),
     pytest.mark.filterwarnings(
-        "ignore:The 'fill_method' and 'limit' keywords in (DataFrame|DataFrameGroupBy).pct_change are deprecated:FutureWarning"
+        "ignore:The 'fill_method' keyword being not None and the 'limit' keyword "
+        + "in (DataFrame|DataFrameGroupBy).pct_change are deprecated:FutureWarning"
     ),
     pytest.mark.filterwarnings(
         "ignore:DataFrameGroupBy.shift with axis=1 is deprecated:FutureWarning"
@@ -3061,14 +3062,19 @@ def test_groupby_pct_change_parameters_warning():
     modin_groupby = modin_df.groupby(by="col1")
     pandas_groupby = pandas_df.groupby(by="col1")
 
+    match_string = (
+        "The 'fill_method' keyword being not None and the 'limit' keyword "
+        + "in (DataFrame|DataFrameGroupBy).pct_change are deprecated"
+    )
+
     with pytest.warns(
         FutureWarning,
-        match="The 'fill_method' and 'limit' keywords in (DataFrame|DataFrameGroupBy).pct_change are deprecated",
+        match=match_string,
     ):
         modin_groupby.pct_change(fill_method="bfill", limit=1)
     with pytest.warns(
         FutureWarning,
-        match="The 'fill_method' and 'limit' keywords in (DataFrame|DataFrameGroupBy).pct_change are deprecated",
+        match=match_string,
     ):
         pandas_groupby.pct_change(fill_method="bfill", limit=1)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The changes according to https://pandas.pydata.org/pandas-docs/version/2.1.2/whatsnew/v2.1.2.html#deprecations.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6684 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
