### PR TITLE
PERF-#6696: Use cached dtypes in fillna when possible.

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2058,6 +2058,7 @@ class PandasDataframe(ClassLogger):
         func: Callable,
         dtypes: Optional[str] = None,
         new_columns: Optional[pandas.Index] = None,
+        lazy=False,
     ) -> "PandasDataframe":
         """
         Perform a function that maps across the entire dataset.
@@ -2073,13 +2074,17 @@ class PandasDataframe(ClassLogger):
         new_columns : pandas.Index, optional
             New column labels of the result, its length has to be identical
             to the older columns. If not specified, old column labels are preserved.
+        lazy : bool, default: False
+            Perform the function lazily.
 
         Returns
         -------
         PandasDataframe
             A new dataframe.
         """
-        new_partitions = self._partition_mgr_cls.map_partitions(self._partitions, func)
+        mgr_cls = self._partition_mgr_cls
+        map_func = mgr_cls.lazy_map_partitions if lazy else mgr_cls.map_partitions
+        new_partitions = map_func(self._partitions, func)
         if new_columns is not None and self.has_materialized_columns:
             assert len(new_columns) == len(
                 self.columns

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2058,7 +2058,6 @@ class PandasDataframe(ClassLogger):
         func: Callable,
         dtypes: Optional[str] = None,
         new_columns: Optional[pandas.Index] = None,
-        lazy=False,
     ) -> "PandasDataframe":
         """
         Perform a function that maps across the entire dataset.
@@ -2074,17 +2073,13 @@ class PandasDataframe(ClassLogger):
         new_columns : pandas.Index, optional
             New column labels of the result, its length has to be identical
             to the older columns. If not specified, old column labels are preserved.
-        lazy : bool, default: False
-            Perform the function lazily.
 
         Returns
         -------
         PandasDataframe
             A new dataframe.
         """
-        mgr_cls = self._partition_mgr_cls
-        map_func = mgr_cls.lazy_map_partitions if lazy else mgr_cls.map_partitions
-        new_partitions = map_func(self._partitions, func)
+        new_partitions = self._partition_mgr_cls.map_partitions(self._partitions, func)
         if new_columns is not None and self.has_materialized_columns:
             assert len(new_columns) == len(
                 self.columns

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2490,12 +2490,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
                 if self._modin_frame.has_materialized_dtypes:
                     dtypes = self._modin_frame.dtypes
+                    value_dtypes = pandas.DataFrame(
+                        {k: [v] for (k, v) in value.items()}
+                    ).dtypes
                     if all(
-                        find_common_type([dtypes[c], t]) == dtypes[c]
-                        for (c, t) in pandas.DataFrame(
-                            {k: [v] for (k, v) in value.items()}
-                        ).dtypes.items()
-                        if c in dtypes
+                        find_common_type([dtypes[col], dtype]) == dtypes[col]
+                        for (col, dtype) in value_dtypes.items()
+                        if col in dtypes
                     ):
                         new_dtypes = dtypes
 
@@ -2513,9 +2514,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if full_axis:
             new_modin_frame = self._modin_frame.fold(axis, fillna)
         else:
-            new_modin_frame = self._modin_frame.map(
-                fillna, dtypes=new_dtypes, lazy=True
-            )
+            new_modin_frame = self._modin_frame.map(fillna, dtypes=new_dtypes)
         return self.__constructor__(new_modin_frame)
 
     def quantile_for_list_of_values(self, **kwargs):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6696 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
