### PR TITLE
PERF-#6728: In the case of narrow dataframes, it is cheaper to convert partitions to numpy in the main process.

### DIFF
--- a/modin/core/execution/ray/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/generic/partitioning/partition_manager.py
@@ -18,7 +18,7 @@ import numpy as np
 from modin.core.dataframe.pandas.partitioning.partition_manager import (
     PandasDataframePartitionManager,
 )
-from modin.core.execution.ray.common.engine_wrapper import RayWrapper
+from modin.core.execution.ray.common import RayWrapper
 
 
 class GenericRayDataframePartitionManager(PandasDataframePartitionManager):

--- a/modin/core/execution/ray/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/generic/partitioning/partition_manager.py
@@ -18,7 +18,7 @@ import numpy as np
 from modin.core.dataframe.pandas.partitioning.partition_manager import (
     PandasDataframePartitionManager,
 )
-from modin.core.execution.ray.common import RayWrapper
+from modin.core.execution.ray.common.engine_wrapper import RayWrapper
 
 
 class GenericRayDataframePartitionManager(PandasDataframePartitionManager):
@@ -40,15 +40,19 @@ class GenericRayDataframePartitionManager(PandasDataframePartitionManager):
         -------
         NumPy array
         """
-        parts = RayWrapper.materialize(
-            [
-                obj.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).list_of_blocks[0]
-                for row in partitions
-                for obj in row
-            ]
-        )
-        n = partitions.shape[1]
-        parts = [parts[i * n : (i + 1) * n] for i in list(range(partitions.shape[0]))]
-
-        arr = np.block(parts)
-        return arr
+        if partitions.shape[1] == 1:
+            parts = cls.get_objects_from_partitions(partitions.flatten())
+            parts = [part.to_numpy() for part in parts]
+        else:
+            parts = RayWrapper.materialize(
+                [
+                    obj.apply(
+                        lambda df, **kwargs: df.to_numpy(**kwargs)
+                    ).list_of_blocks[0]
+                    for row in partitions
+                    for obj in row
+                ]
+            )
+        rows, cols = partitions.shape
+        parts = [parts[i * cols : (i + 1) * cols] for i in range(rows)]
+        return np.block(parts)

--- a/modin/core/execution/unidist/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/generic/partitioning/partition_manager.py
@@ -18,7 +18,7 @@ import numpy as np
 from modin.core.dataframe.pandas.partitioning.partition_manager import (
     PandasDataframePartitionManager,
 )
-from modin.core.execution.unidist.common.engine_wrapper import UnidistWrapper
+from modin.core.execution.unidist.common import UnidistWrapper
 
 
 class GenericUnidistDataframePartitionManager(PandasDataframePartitionManager):

--- a/modin/core/execution/unidist/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/generic/partitioning/partition_manager.py
@@ -18,7 +18,7 @@ import numpy as np
 from modin.core.dataframe.pandas.partitioning.partition_manager import (
     PandasDataframePartitionManager,
 )
-from modin.core.execution.unidist.common import UnidistWrapper
+from modin.core.execution.unidist.common.engine_wrapper import UnidistWrapper
 
 
 class GenericUnidistDataframePartitionManager(PandasDataframePartitionManager):
@@ -40,13 +40,19 @@ class GenericUnidistDataframePartitionManager(PandasDataframePartitionManager):
         -------
         NumPy array
         """
-        parts = UnidistWrapper.materialize(
-            [
-                obj.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).list_of_blocks[0]
-                for row in partitions
-                for obj in row
-            ]
-        )
+        if partitions.shape[1] == 1:
+            parts = cls.get_objects_from_partitions(partitions.flatten())
+            parts = [part.to_numpy() for part in parts]
+        else:
+            parts = UnidistWrapper.materialize(
+                [
+                    obj.apply(
+                        lambda df, **kwargs: df.to_numpy(**kwargs)
+                    ).list_of_blocks[0]
+                    for row in partitions
+                    for obj in row
+                ]
+            )
         rows, cols = partitions.shape
         parts = [parts[i * cols : (i + 1) * cols] for i in range(rows)]
         return np.block(parts)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

8 cores Ray: 2.54 (Master) vs 1.24 (PR)
8 cores Unidist: 6.11 (Master) vs 0.22 (PR)

Benchmark:

```python
import modin.pandas as pd
import numpy as np
from time import time


for _ in range(5):
    df = pd.DataFrame(np.random.rand(10 ** 6, 10).astype(str))
    start = time()
    arr = df.to_numpy()
    print(f"to_numpy conversion: {time()-start}, {arr.size=}")

```

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6728 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
