### PR TITLE
TEST-#6705: Don't compare `pkl` files

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -3061,14 +3061,14 @@ class TestPickle:
         )
 
     def test_to_pickle(self, tmp_path):
-        modin_df, pandas_df = create_test_dfs(TEST_DATA)
-        eval_to_file(
-            tmp_path,
-            modin_obj=modin_df,
-            pandas_obj=pandas_df,
-            fn="to_pickle",
-            extension="pkl",
-        )
+        modin_df, _ = create_test_dfs(TEST_DATA)
+
+        unique_filename_modin = get_unique_filename(extension="pkl", data_dir=tmp_path)
+
+        modin_df.to_pickle(unique_filename_modin)
+        recreated_modin_df = pd.read_pickle(unique_filename_modin)
+
+        df_equals(modin_df, recreated_modin_df)
 
 
 @pytest.mark.filterwarnings(default_to_pandas_ignore_string)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6705 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
