### PR TITLE
PERF-#6718: Use `_get_axis_lengths` func instead of `_axes_lengths` property

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -223,18 +223,6 @@ class PandasDataframe(ClassLogger):
                 self._column_widths_cache = []
         return self._column_widths_cache
 
-    @property
-    def _axes_lengths(self):
-        """
-        Get a pair of row partitions lengths and column partitions widths.
-
-        Returns
-        -------
-        list
-            The pair of row partitions lengths and column partitions widths.
-        """
-        return [self.row_lengths, self.column_widths]
-
     def _set_axis_lengths_cache(self, value, axis=0):
         """
         Set the row/column lengths cache for the specified axis.
@@ -1969,7 +1957,7 @@ class PandasDataframe(ClassLogger):
         new_axes[axis ^ 1] = self.get_axis(axis ^ 1)
 
         new_axes_lengths[axis] = [1]
-        new_axes_lengths[axis ^ 1] = self._axes_lengths[axis ^ 1]
+        new_axes_lengths[axis ^ 1] = self._get_axis_lengths(axis ^ 1)
 
         if dtypes == "copy":
             dtypes = self.copy_dtypes_cache()
@@ -3439,7 +3427,7 @@ class PandasDataframe(ClassLogger):
             reindexed_base = base_frame._partitions
             base_lengths = base_frame.column_widths if axis else base_frame.row_lengths
 
-        others_lengths = [o._axes_lengths[axis] for o in other_frames]
+        others_lengths = [o._get_axis_lengths(axis) for o in other_frames]
 
         # define conditions for reindexing and repartitioning `other` frames
         do_reindex_others = [


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6718 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
