### PR TITLE
PERF-#6721: Use `keep_partitioning=True`, for `duplicated` implementation

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3047,7 +3047,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             new_index=self._modin_frame.copy_index_cache(),
             new_columns=[MODIN_UNNAMED_SERIES_LABEL],
             dtypes=np.bool_,
-            keep_partitioning=False,
+            keep_partitioning=True,
         )
         return self.__constructor__(new_modin_frame, shape_hint="column")
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The main idea is that the resulting mask (from `duplicated`) is often used on the same dataframe, for example in the implementation of `drop_duplicates` function, and if we do not change the partitioning, we will be able to avoid the co-partitioning phase.

**Results (best):** 19.39 (master) vs 17.35 (PR)

Benchmark
```python
import modin.pandas as pd
import numpy as np
from time import time
from modin.utils import execute

np.random.seed = 42

df = pd.DataFrame(np.random.rand(10 ** 7, 10))

for _ in range(5):
    start = time()
    execute(df.drop_duplicates())
    print(f"drop_duplicates time: {time()-start}")

```

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6721 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
