### PR TITLE
PERF-#6727: Remove remaining `result.name = None` in groupby code

### DIFF
--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -1092,8 +1092,6 @@ class DataFrameGroupBy(ClassLogger):
             )
         elif isinstance(self._df, Series):
             result.name = self._df.name
-        else:
-            result.name = None
         return result
 
     def sum(self, numeric_only=False, min_count=0, engine=None, engine_kwargs=None):
@@ -1163,8 +1161,6 @@ class DataFrameGroupBy(ClassLogger):
         if not isinstance(result, Series):
             # The result should always be a Series with name None and type int64
             result = result.squeeze(axis=1)
-        # TODO: this might not hold in the future
-        result.name = None
         return result
 
     def nunique(self, dropna=True):
@@ -1311,7 +1307,6 @@ class DataFrameGroupBy(ClassLogger):
         if not isinstance(result, Series):
             # The result should always be a Series with name None and type int64
             result = result.squeeze(axis=1)
-            result.name = None
         return result
 
     def tail(self, n=5):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6727 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
