### PR TITLE
TEST-#6729: Use custom pytest mark instead of `--extra-test-parameters` option

### DIFF
--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -90,12 +90,6 @@ def pytest_addoption(parser):
         default=None,
         help="specifies execution to run tests on",
     )
-    parser.addoption(
-        "--extra-test-parameters",
-        action="store_true",
-        help="activate extra test parameter combinations",
-        default=False,
-    )
 
 
 def set_experimental_env(mode):
@@ -256,10 +250,6 @@ def get_unique_base_execution():
 
 
 def pytest_configure(config):
-    import modin.pandas.test.utils as utils
-
-    utils.extra_test_parameters = config.getoption("--extra-test-parameters")
-
     execution = config.option.execution
 
     if execution is None:

--- a/modin/pandas/test/dataframe/test_indexing.py
+++ b/modin/pandas/test/dataframe/test_indexing.py
@@ -34,7 +34,6 @@ from modin.pandas.test.utils import (
     default_to_pandas_ignore_string,
     df_equals,
     eval_general,
-    extra_test_parameters,
     generate_multiindex,
     int_arg_keys,
     int_arg_values,
@@ -1448,7 +1447,7 @@ def test_reset_index_multiindex_groupby(data):
     [
         pytest.param(
             test_data["int_data"],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         test_data["float_nan_data"],
     ],
@@ -1469,23 +1468,23 @@ def test_reset_index_multiindex_groupby(data):
         [1, 0],
         pytest.param(
             [2, 1, 2],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         pytest.param(
             [0, 0, 0, 0],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         pytest.param(
             ["level_name_1"],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         pytest.param(
             ["level_name_2", "level_name_1"],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         pytest.param(
             [2, "level_name_0"],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
     ],
 )
@@ -1498,12 +1497,8 @@ def test_reset_index_multiindex_groupby(data):
         0,
         1,
         2,
-        pytest.param(
-            3, marks=pytest.mark.skipif(not extra_test_parameters, reason="extra")
-        ),
-        pytest.param(
-            4, marks=pytest.mark.skipif(not extra_test_parameters, reason="extra")
-        ),
+        pytest.param(3, marks=pytest.mark.exclude_by_default),
+        pytest.param(4, marks=pytest.mark.exclude_by_default),
     ],
 )
 @pytest.mark.parametrize(
@@ -1511,13 +1506,13 @@ def test_reset_index_multiindex_groupby(data):
     [
         pytest.param(
             False,
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         True,
         "mixed_1st_None",
         pytest.param(
             "mixed_2nd_None",
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
     ],
 )
@@ -1606,7 +1601,7 @@ def test_reset_index_with_multi_index_no_drop(
     [
         pytest.param(
             test_data["int_data"],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         test_data["float_nan_data"],
     ],
@@ -1626,23 +1621,23 @@ def test_reset_index_with_multi_index_no_drop(
         [1, 0],
         pytest.param(
             [2, 1, 2],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         pytest.param(
             [0, 0, 0, 0],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         pytest.param(
             ["level_name_1"],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         pytest.param(
             ["level_name_2", "level_name_1"],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         pytest.param(
             [2, "level_name_0"],
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
     ],
 )
@@ -1652,12 +1647,8 @@ def test_reset_index_with_multi_index_no_drop(
         0,
         1,
         2,
-        pytest.param(
-            3, marks=pytest.mark.skipif(not extra_test_parameters, reason="extra")
-        ),
-        pytest.param(
-            4, marks=pytest.mark.skipif(not extra_test_parameters, reason="extra")
-        ),
+        pytest.param(3, marks=pytest.mark.exclude_by_default),
+        pytest.param(4, marks=pytest.mark.exclude_by_default),
     ],
 )
 @pytest.mark.parametrize(
@@ -1665,13 +1656,13 @@ def test_reset_index_with_multi_index_no_drop(
     [
         pytest.param(
             False,
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         True,
         "mixed_1st_None",
         pytest.param(
             "mixed_2nd_None",
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
     ],
 )

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -30,7 +30,6 @@ from modin.pandas.test.utils import (
     default_to_pandas_ignore_string,
     df_equals,
     eval_general,
-    extra_test_parameters,
     generate_multiindex,
     random_state,
     rotate_decimal_digits_or_symbols,
@@ -542,11 +541,11 @@ def test_sort_multiindex(sort_remaining):
     [
         pytest.param(
             "first",
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         pytest.param(
             "first,last",
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         "first,last,middle",
     ],
@@ -565,12 +564,12 @@ def test_sort_multiindex(sort_remaining):
     [
         pytest.param(
             "mergesort",
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
         "quicksort",
         pytest.param(
             "heapsort",
-            marks=pytest.mark.skipif(not extra_test_parameters, reason="extra"),
+            marks=pytest.mark.exclude_by_default,
         ),
     ],
 )

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -46,10 +46,6 @@ import modin.pandas as pd
 from modin.config import MinPartitionSize, NPartitions, TestDatasetSize, TrackFileLeaks
 from modin.utils import to_pandas, try_cast_to_pandas
 
-# Flag activated on command line with "--extra-test-parameters" option.
-# Used in some tests to perform additional parameter combinations.
-extra_test_parameters = False
-
 random_state = np.random.RandomState(seed=42)
 
 DATASET_SIZE_DICT = {

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,9 +15,8 @@ parentdir_prefix = modin-
 addopts = --cov-config=setup.cfg --cov=modin --cov-append --cov-report=
 xfail_strict=true
 markers =
-    xfail_executions
-    skip_executions
     exclude_in_sanity
+    exclude_by_default
 filterwarnings =
     error:.*defaulting to pandas.*:UserWarning
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ tag_prefix =
 parentdir_prefix = modin-
 
 [tool:pytest]
-addopts = --cov-config=setup.cfg --cov=modin --cov-append --cov-report=
+addopts = --cov-config=setup.cfg --cov=modin --cov-append --cov-report= -m "not exclude_by_default"
 xfail_strict=true
 markers =
     exclude_in_sanity


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6729 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
