### PR TITLE
PERF-#6747: Preserve columns/dtypes cache when merging on a single index level

### DIFF
--- a/modin/core/dataframe/base/dataframe/utils.py
+++ b/modin/core/dataframe/base/dataframe/utils.py
@@ -105,9 +105,9 @@ def join_columns(
             right_on = []
         # in other cases, we can simply add the index name to columns and proceed as normal
         elif left_on[0] not in left:
-            left = cast(pandas.Index, left.insert(loc=0, item=left_on[0]))
+            left = left.insert(loc=0, item=left_on[0])  # type: ignore
         elif right_on[0] not in right:
-            right = cast(pandas.Index, right.insert(loc=0, item=right_on[0]))
+            right = right.insert(loc=0, item=right_on[0])  # type: ignore
 
     if any(col not in left for col in left_on) or any(
         col not in right for col in right_on

--- a/modin/core/dataframe/base/dataframe/utils.py
+++ b/modin/core/dataframe/base/dataframe/utils.py
@@ -96,6 +96,19 @@ def join_columns(
         Sequence[IndexLabel], [right_on] if is_scalar(right_on) else right_on
     )
 
+    # handling a simple case of merging on one column and when the column is located in an index
+    if len(left_on) == 1 and len(right_on) == 1 and left_on[0] == right_on[0]:
+        if left_on[0] not in left and right_on[0] not in right:
+            # in this case the 'on' column will stay in the index, so we can simply
+            # drop the 'left/right_on' values and proceed as normal
+            left_on = []
+            right_on = []
+        # in other cases, we can simply add the index name to columns and proceed as normal
+        elif left_on[0] not in left:
+            left = left.insert(loc=0, item=left_on[0])
+        elif right_on[0] not in right:
+            right = right.insert(loc=0, item=right_on[0])
+
     if any(col not in left for col in left_on) or any(
         col not in right for col in right_on
     ):

--- a/modin/core/dataframe/base/dataframe/utils.py
+++ b/modin/core/dataframe/base/dataframe/utils.py
@@ -105,9 +105,9 @@ def join_columns(
             right_on = []
         # in other cases, we can simply add the index name to columns and proceed as normal
         elif left_on[0] not in left:
-            left = left.insert(loc=0, item=left_on[0])
+            left = cast(pandas.Index, left.insert(loc=0, item=left_on[0]))
         elif right_on[0] not in right:
-            right = right.insert(loc=0, item=right_on[0])
+            right = cast(pandas.Index, right.insert(loc=0, item=right_on[0]))
 
     if any(col not in left for col in left_on) or any(
         col not in right for col in right_on

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -58,6 +58,7 @@ from modin.core.dataframe.algebra.default2pandas.groupby import (
     SeriesGroupByDefault,
 )
 from modin.core.dataframe.base.dataframe.utils import join_columns
+from modin.core.dataframe.pandas.metadata import ModinDtypes
 from modin.core.storage_formats.base.query_compiler import BaseQueryCompiler
 from modin.error_message import ErrorMessage
 from modin.utils import (
@@ -572,13 +573,37 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     # is really complicated in this case, so we're not computing resulted columns for now.
                     pass
                 else:
-                    if self._modin_frame.has_materialized_dtypes:
-                        new_dtypes = []
-                        for old_col in left_renamer.keys():
-                            new_dtypes.append(self.dtypes[old_col])
-                        for old_col in right_renamer.keys():
-                            new_dtypes.append(right_pandas.dtypes[old_col])
-                        new_dtypes = pandas.Series(new_dtypes, index=new_columns)
+                    # renamers may return renamers that contain columns from 'index',
+                    # so trying to merge index and column dtypes here
+                    right_index_dtypes = (
+                        right_pandas.index.dtypes
+                        if isinstance(right_pandas.index, pandas.MultiIndex)
+                        else pandas.Series(
+                            [right_pandas.index.dtype], index=[right_pandas.index.name]
+                        )
+                    )
+                    right_dtypes = pandas.concat(
+                        [right_pandas.dtypes, right_index_dtypes]
+                    )[right_renamer.keys()].rename(right_renamer)
+
+                    left_index_dtypes = None
+                    if self._modin_frame.has_materialized_index:
+                        left_index_dtypes = (
+                            self.index.dtypes
+                            if isinstance(self.index, pandas.MultiIndex)
+                            else pandas.Series(
+                                [self.index.dtype], index=[self.index.name]
+                            )
+                        )
+
+                    left_dtypes = (
+                        ModinDtypes.concat(
+                            [self._modin_frame._dtypes, left_index_dtypes]
+                        )
+                        .lazy_get(left_renamer.keys())
+                        .set_index(list(left_renamer.values()))
+                    )
+                    new_dtypes = ModinDtypes.concat([left_dtypes, right_dtypes])
 
             new_self = self.__constructor__(
                 self._modin_frame.apply_full_axis(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -573,8 +573,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     # is really complicated in this case, so we're not computing resulted columns for now.
                     pass
                 else:
-                    # renamers may return renamers that contain columns from 'index',
-                    # so trying to merge index and column dtypes here
+                    # renamers may contain columns from 'index', so trying to merge index and column dtypes here
                     right_index_dtypes = (
                         right_pandas.index.dtypes
                         if isinstance(right_pandas.index, pandas.MultiIndex)

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -494,7 +494,6 @@ def test_merge_on_single_index(left_index, right_index):
     if len(right_index):
         modin_df2 = modin_df2.set_index(right_index)
         pandas_df2 = pandas_df2.set_index(right_index)
-    # breakpoint()
     eval_general(
         (modin_df1, modin_df2),
         (pandas_df1, pandas_df2),

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -471,6 +471,37 @@ def test_merge_on_index(has_index_cache):
         )
 
 
+@pytest.mark.parametrize(
+    "left_index", [[], ["key"], ["key", "b"], ["key", "b", "c"], ["b"], ["b", "c"]]
+)
+@pytest.mark.parametrize(
+    "right_index", [[], ["key"], ["key", "e"], ["key", "e", "f"], ["e"], ["e", "f"]]
+)
+def test_merge_on_single_index(left_index, right_index):
+    """
+    Test ``.merge()`` method when merging on a single column, that is located in an index level of one of the frames.
+    """
+    modin_df1, pandas_df1 = create_test_dfs(
+        {"b": [3, 4, 4, 5], "key": [1, 1, 2, 2], "c": [2, 3, 2, 2], "d": [2, 1, 3, 1]}
+    )
+    if len(left_index):
+        modin_df1 = modin_df1.set_index(left_index)
+        pandas_df1 = pandas_df1.set_index(left_index)
+
+    modin_df2, pandas_df2 = create_test_dfs(
+        {"e": [3, 4, 4, 5], "f": [2, 3, 2, 2], "key": [1, 1, 2, 2], "h": [2, 1, 3, 1]}
+    )
+    if len(right_index):
+        modin_df2 = modin_df2.set_index(right_index)
+        pandas_df2 = pandas_df2.set_index(right_index)
+    # breakpoint()
+    eval_general(
+        (modin_df1, modin_df2),
+        (pandas_df1, pandas_df2),
+        lambda dfs: dfs[0].merge(dfs[1], on="key"),
+    )
+
+
 @pytest.mark.parametrize("axis", [0, 1])
 @pytest.mark.parametrize(
     "ascending", bool_arg_values, ids=arg_keys("ascending", bool_arg_keys)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Add logic handling simple cases of joining on an index level in `join_columns()` and rewrite logic of dtypes preserving so it would also consider index dtypes where possible

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6747 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
