### PR TITLE
PERF-#6754: Merge partial dtype caches on '.concat(axis=0)'

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3686,7 +3686,7 @@ class PandasDataframe(ClassLogger):
                 new_index = self.index.append([other.index for other in others])
             new_columns = joined_index
             frames = [self] + others
-            new_dtypes = ModinDtypes.concat([frame._dtypes for frame in frames], axis=0)
+            new_dtypes = ModinDtypes.concat([frame._dtypes for frame in frames], axis=1)
             # If we have already cached the length of each row in at least one
             # of the row's partitions, we can build new_lengths for the new
             # frame. Typically, if we know the length for any partition in a

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3686,16 +3686,7 @@ class PandasDataframe(ClassLogger):
                 new_index = self.index.append([other.index for other in others])
             new_columns = joined_index
             frames = [self] + others
-            if all(frame.has_materialized_dtypes for frame in frames):
-                all_dtypes = [frame.dtypes for frame in frames]
-                if not all(dtypes.empty for dtypes in all_dtypes):
-                    new_dtypes = pandas.concat(all_dtypes, axis=1)
-                    # 'nan' value will be placed in a row if a column doesn't exist in all frames;
-                    # this value is np.float64 type so we need an explicit conversion
-                    new_dtypes.fillna(np.dtype("float64"), inplace=True)
-                    new_dtypes = new_dtypes.apply(
-                        lambda row: find_common_type(row.values), axis=1
-                    )
+            new_dtypes = ModinDtypes.concat([frame._dtypes for frame in frames], axis=0)
             # If we have already cached the length of each row in at least one
             # of the row's partitions, we can build new_lengths for the new
             # frame. Typically, if we know the length for any partition in a

--- a/modin/core/dataframe/pandas/metadata/dtypes.py
+++ b/modin/core/dataframe/pandas/metadata/dtypes.py
@@ -445,7 +445,7 @@ class DtypesDescriptor:
         return known_dtypes
 
     @classmethod
-    def _merge_row_dtypes(
+    def _merge_dtypes(
         cls, values: list[Union["DtypesDescriptor", pandas.Series, None]]
     ) -> "DtypesDescriptor":
         """
@@ -537,7 +537,7 @@ class DtypesDescriptor:
 
     @classmethod
     def concat(
-        cls, values: list[Union["DtypesDescriptor", pandas.Series, None]], axis: int = 1
+        cls, values: list[Union["DtypesDescriptor", pandas.Series, None]], axis: int = 0
     ) -> "DtypesDescriptor":
         """
         Concatenate dtypes descriptors into a single descriptor.
@@ -545,10 +545,10 @@ class DtypesDescriptor:
         Parameters
         ----------
         values : list of DtypesDescriptors and pandas.Series
-        axis : int, default: 1
-            If ``axis == 1``: concatenate column names. This implements the logic of
+        axis : int, default: 0
+            If ``axis == 0``: concatenate column names. This implements the logic of
             how dtypes are combined on ``pd.concat([df1, df2], axis=1)``.
-            If ``axis == 0``: perform a union join for the column names described by
+            If ``axis == 1``: perform a union join for the column names described by
             `values` and then find common dtypes for the columns appeared to be in
             an intersection. This implements the logic of how dtypes are combined on
             ``pd.concat([df1, df2], axis=0).dtypes``.
@@ -557,8 +557,8 @@ class DtypesDescriptor:
         -------
         DtypesDescriptor
         """
-        if axis == 0:
-            return cls._merge_row_dtypes(values)
+        if axis == 1:
+            return cls._merge_dtypes(values)
         known_dtypes = {}
         cols_with_unknown_dtypes = []
         schema_is_known = True
@@ -726,17 +726,17 @@ class ModinDtypes:
         return ModinDtypes(self._value.iloc[ids] if numeric_index else self._value[ids])
 
     @classmethod
-    def concat(cls, values: list, axis: int = 1) -> "ModinDtypes":
+    def concat(cls, values: list, axis: int = 0) -> "ModinDtypes":
         """
         Concatenate dtypes.
 
         Parameters
         ----------
         values : list of DtypesDescriptors, pandas.Series, ModinDtypes and Nones
-        axis : int, default: 1
-            If ``axis == 1``: concatenate column names. This implements the logic of
+        axis : int, default: 0
+            If ``axis == 0``: concatenate column names. This implements the logic of
             how dtypes are combined on ``pd.concat([df1, df2], axis=1)``.
-            If ``axis == 0``: perform a union join for the column names described by
+            If ``axis == 1``: perform a union join for the column names described by
             `values` and then find common dtypes for the columns appeared to be in
             an intersection. This implements the logic of how dtypes are combined on
             ``pd.concat([df1, df2], axis=0).dtypes``.

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ tag_prefix =
 parentdir_prefix = modin-
 
 [tool:pytest]
-addopts = 
+addopts = --cov-config=setup.cfg --cov=modin --cov-append --cov-report=
 xfail_strict=true
 markers =
     xfail_executions

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,7 +12,7 @@ tag_prefix =
 parentdir_prefix = modin-
 
 [tool:pytest]
-addopts = --cov-config=setup.cfg --cov=modin --cov-append --cov-report=
+addopts = 
 xfail_strict=true
 markers =
     xfail_executions


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR adds `ModinDtypes.concat(axis=0)` method, that allows to merge partial dtypes on `pd.concat(axis=0)`

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6754  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
