### PR TITLE
PERF-#4804: Preserve lengths/widths caches in `broadcast_apply_full_axis`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3272,6 +3272,25 @@ class PandasDataframe(ClassLogger):
                         kw["column_widths"] = self._column_widths_cache
                     elif len(new_columns) == 1 and new_partitions.shape[1] == 1:
                         kw["column_widths"] = [1]
+        else:
+            if (
+                kw["row_lengths"] is None
+                and new_index is not None
+                and self._row_lengths_cache is not None
+                and len(new_index) == sum(self._row_lengths_cache)
+                # to avoid problems that may arise when filtering empty dataframes
+                and all(r != 0 for r in self._row_lengths_cache)
+            ):
+                kw["row_lengths"] = self._row_lengths_cache
+            if (
+                kw["column_widths"] is None
+                and new_columns is not None
+                and self._column_widths_cache is not None
+                and len(new_columns) == sum(self._column_widths_cache)
+                # to avoid problems that may arise when filtering empty dataframes
+                and all(w != 0 for w in self._column_widths_cache)
+            ):
+                kw["column_widths"] = self._column_widths_cache
 
         result = self.__constructor__(
             new_partitions, index=new_index, columns=new_columns, **kw

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3276,8 +3276,8 @@ class PandasDataframe(ClassLogger):
             if (
                 axis == 0
                 and kw["row_lengths"] is None
-                and new_index is not None
                 and self._row_lengths_cache is not None
+                and ModinIndex.is_materialized_index(new_index)
                 and len(new_index) == sum(self._row_lengths_cache)
                 # to avoid problems that may arise when filtering empty dataframes
                 and all(r != 0 for r in self._row_lengths_cache)
@@ -3286,8 +3286,8 @@ class PandasDataframe(ClassLogger):
             if (
                 axis == 1
                 and kw["column_widths"] is None
-                and new_columns is not None
                 and self._column_widths_cache is not None
+                and ModinIndex.is_materialized_index(new_columns)
                 and len(new_columns) == sum(self._column_widths_cache)
                 # to avoid problems that may arise when filtering empty dataframes
                 and all(w != 0 for w in self._column_widths_cache)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3274,7 +3274,8 @@ class PandasDataframe(ClassLogger):
                         kw["column_widths"] = [1]
         else:
             if (
-                kw["row_lengths"] is None
+                axis == 0
+                and kw["row_lengths"] is None
                 and new_index is not None
                 and self._row_lengths_cache is not None
                 and len(new_index) == sum(self._row_lengths_cache)
@@ -3283,7 +3284,8 @@ class PandasDataframe(ClassLogger):
             ):
                 kw["row_lengths"] = self._row_lengths_cache
             if (
-                kw["column_widths"] is None
+                axis == 1
+                and kw["column_widths"] is None
                 and new_columns is not None
                 and self._column_widths_cache is not None
                 and len(new_columns) == sum(self._column_widths_cache)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -61,7 +61,6 @@ from modin.core.dataframe.base.dataframe.utils import join_columns
 from modin.core.dataframe.pandas.metadata import (
     DtypesDescriptor,
     ModinDtypes,
-    ModinIndex,
     extract_dtype,
 )
 from modin.core.storage_formats.base.query_compiler import BaseQueryCompiler

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -61,6 +61,7 @@ from modin.core.dataframe.base.dataframe.utils import join_columns
 from modin.core.dataframe.pandas.metadata import (
     DtypesDescriptor,
     ModinDtypes,
+    ModinIndex,
     extract_dtype,
 )
 from modin.core.storage_formats.base.query_compiler import BaseQueryCompiler

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -1444,17 +1444,15 @@ def test_apply_full_axis_preserve_lengths():
 
     def func(df):
         if df.iloc[0, 0] == 1:
-            return pandas.DataFrame(
-                {"a": [1, 2, 3], "b": [3, 4, 5], "c": [6, 7, 8], "d": [0, 1, 2]}
-            )
+            return pandas.DataFrame({"a": [3, 2, 3, 4], "b": [3, 4, 5, 6]})
         else:
-            return pandas.DataFrame({"a": [4], "b": [6], "c": [9], "d": [3]})
+            return pandas.DataFrame({"c": [9, 5, 6, 7]})
 
     res = md_df.apply_full_axis(
         func=func,
         axis=0,
         new_index=[0, 1, 2, 3],
-        new_columns=["a", "b", "c", "d"],
+        new_columns=["a", "b", "c"],
         keep_partitioning=True,
     )
 

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -1424,10 +1424,10 @@ def test_apply_full_axis_preserve_widths():
         new_columns=["a", "b", "c", "d"],
         keep_partitioning=True,
     )
-
+    col_widths_cache = res._column_widths_cache
     actual_column_widths = [part.width() for part in res._partitions[0]]
 
-    assert res._column_widths_cache == actual_column_widths
+    assert col_widths_cache == actual_column_widths
     assert res._row_lengths_cache is None
 
 
@@ -1456,9 +1456,10 @@ def test_apply_full_axis_preserve_lengths():
         keep_partitioning=True,
     )
 
+    row_lengths_cache = res._row_lengths_cache
     actual_row_lengths = [part.length() for part in res._partitions[:, 0]]
 
-    assert res._row_lengths_cache == actual_row_lengths
+    assert row_lengths_cache == actual_row_lengths
     assert res._column_widths_cache is None
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #4804 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
