### PR TITLE
PERF-#6762: Carry dtypes information in lazy indices

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3911,6 +3911,12 @@ class PandasDataframe(ClassLogger):
                 row_lengths=result._row_lengths_cache,
             )
 
+        if not result.has_materialized_index:
+            by_dtypes = ModinDtypes(self._dtypes).lazy_get(by)
+            if by_dtypes.is_materialized:
+                new_index = ModinIndex(value=result, axis=0, dtypes=by_dtypes)
+                result.set_index_cache(new_index)
+
         if result_schema is not None:
             new_dtypes = pandas.Series(result_schema)
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -4143,6 +4143,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             apply_indices = None
 
         if (
+            # For now handling only simple cases, where 'by' columns are described by a single query compiler
             agg_kwargs.get("as_index", True)
             and len(not_broadcastable_by) == 0
             and len(broadcastable_by) == 1


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR adds `._dtypes` property to `ModinIndex`, one can pass it to the object's constructor and indicate dtypes of index levels, even if the index values are yet unknown.

This was done mainly to preserve dtypes in the following case:
```python
df.dtypes # known_dtypes: {"a": int, ...}
res = df.groupby("a", as_index=True).sum()
res # 'a' column is now in the index, but we lost its dtypes
res = res.reset_index(drop=False)
res.dtypes # cols_with_unknown_dtypes: ["a"]
```
With the changes in this PR, the presented scenario will preserve dtype for "a" column in the end.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6762 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
