### PR TITLE
FIX-#6768: make sure `to_numpy` use `**kwargs` after #6704

### DIFF
--- a/modin/core/dataframe/pandas/partitioning/partition.py
+++ b/modin/core/dataframe/pandas/partitioning/partition.py
@@ -209,7 +209,7 @@ class PandasDataframePartition(ABC):  # pragma: no cover
         If the underlying object is a pandas DataFrame, this will return
         a 2D NumPy array.
         """
-        return self.apply(lambda df, **kwargs: df.to_numpy(**kwargs)).get()
+        return self.apply(lambda df: df.to_numpy(**kwargs)).get()
 
     @staticmethod
     def _iloc(df, row_labels, col_labels):  # noqa: RT01, PR01

--- a/modin/core/execution/ray/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/generic/partitioning/partition_manager.py
@@ -42,7 +42,7 @@ class GenericRayDataframePartitionManager(PandasDataframePartitionManager):
         """
         if partitions.shape[1] == 1:
             parts = cls.get_objects_from_partitions(partitions.flatten())
-            parts = [part.to_numpy() for part in parts]
+            parts = [part.to_numpy(**kwargs) for part in parts]
         else:
             parts = RayWrapper.materialize(
                 [

--- a/modin/core/execution/unidist/generic/partitioning/partition_manager.py
+++ b/modin/core/execution/unidist/generic/partitioning/partition_manager.py
@@ -42,7 +42,7 @@ class GenericUnidistDataframePartitionManager(PandasDataframePartitionManager):
         """
         if partitions.shape[1] == 1:
             parts = cls.get_objects_from_partitions(partitions.flatten())
-            parts = [part.to_numpy() for part in parts]
+            parts = [part.to_numpy(**kwargs) for part in parts]
         else:
             parts = UnidistWrapper.materialize(
                 [

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3478,7 +3478,9 @@ def test_to_numpy(data):
 def test_to_numpy_dtype():
     modin_series, pandas_series = create_test_series(test_data["float_nan_data"])
     assert_array_equal(
-        modin_series.to_numpy(dtype="int64"), pandas_series.to_numpy(dtype="int64")
+        modin_series.to_numpy(dtype="int64"),
+        pandas_series.to_numpy(dtype="int64"),
+        strict=True,
     )
 
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -3475,6 +3475,13 @@ def test_to_numpy(data):
     assert_array_equal(modin_series.to_numpy(), pandas_series.to_numpy())
 
 
+def test_to_numpy_dtype():
+    modin_series, pandas_series = create_test_series(test_data["float_nan_data"])
+    assert_array_equal(
+        modin_series.to_numpy(dtype="int64"), pandas_series.to_numpy(dtype="int64")
+    )
+
+
 @pytest.mark.parametrize(
     "data",
     test_data_values + test_data_large_categorical_series_values,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6768 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
