### PR TITLE
FIX-#6773: make sure `_to_pandas` return mutable pandas objects

### DIFF
--- a/modin/core/dataframe/pandas/utils.py
+++ b/modin/core/dataframe/pandas/utils.py
@@ -44,4 +44,8 @@ def concatenate(dfs):
                 i, pandas.Categorical(df.iloc[:, i], categories=union.categories)
             )
     # `ValueError: buffer source array is read-only` if copy==False
+    if len(dfs) == 1:
+        # concat doesn't make a copy if len(dfs) == 1,
+        # so do it explicitly
+        return dfs[0].copy()
     return pandas.concat(dfs, copy=True)

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -835,6 +835,36 @@ def test_to_pandas_indices(data):
         ), f"Levels of indices at axis {axis} are different!"
 
 
+def test_to_pandas_read_only_issue():
+    df = pd.DataFrame(
+        [
+            [np.nan, 2, np.nan, 0],
+            [3, 4, np.nan, 1],
+            [np.nan, np.nan, np.nan, np.nan],
+            [np.nan, 3, np.nan, 4],
+        ],
+        columns=list("ABCD"),
+    )
+    pdf = df._to_pandas()
+    # there shouldn't be `ValueError: putmask: output array is read-only`
+    pdf.fillna(0, inplace=True)
+
+
+def test_to_numpy_read_only_issue():
+    df = pd.DataFrame(
+        [
+            [np.nan, 2, np.nan, 0],
+            [3, 4, np.nan, 1],
+            [np.nan, np.nan, np.nan, np.nan],
+            [np.nan, 3, np.nan, 4],
+        ],
+        columns=list("ABCD"),
+    )
+    arr = df.to_numpy()
+    # there shouldn't be `ValueError: putmask: output array is read-only`
+    np.putmask(arr, np.isnan(arr), 0)
+
+
 def test_create_categorical_dataframe_with_duplicate_column_name():
     # This tests for https://github.com/modin-project/modin/issues/4312
     pd_df = pandas.DataFrame(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6773 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
