### PR TITLE
FIX-#6779: pass only one indexer into `Series.__getitem__`

### DIFF
--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -568,6 +568,8 @@ class _LocationIndexerBase(ClassLogger):
         masked_df = self.df.__constructor__(
             query_compiler=self.qc.getitem_array(row_loc._query_compiler)
         )
+        if isinstance(masked_df, Series):
+            return type(self)(masked_df)[col_loc]
         # Passing `slice(None)` as a row indexer since we've just applied it
         return type(self)(masked_df)[(slice(None), col_loc)]
 

--- a/modin/pandas/indexing.py
+++ b/modin/pandas/indexing.py
@@ -569,7 +569,8 @@ class _LocationIndexerBase(ClassLogger):
             query_compiler=self.qc.getitem_array(row_loc._query_compiler)
         )
         if isinstance(masked_df, Series):
-            return type(self)(masked_df)[col_loc]
+            assert col_loc == slice(None)
+            return masked_df
         # Passing `slice(None)` as a row indexer since we've just applied it
         return type(self)(masked_df)[(slice(None), col_loc)]
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -2363,6 +2363,14 @@ def test_loc(data):
     df_equals(modin_result, pandas_result)
 
 
+def test_loc_with_boolean_series():
+    modin_series, pandas_series = create_test_series([1, 2, 3])
+    modin_mask, pandas_mask = create_test_series([True, False, False])
+    modin_result = modin_series.loc[modin_mask]
+    pandas_result = pandas_series.loc[pandas_mask]
+    df_equals(modin_result, pandas_result)
+
+
 # This tests the bug from https://github.com/modin-project/modin/issues/3736
 def test_loc_setting_categorical_series():
     modin_series = pd.Series(["a", "b", "c"], dtype="category")


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6779 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
