### PR TITLE
FEAT-#6784: Add d2p implementations for `DataFrame.__rdivmod__/__divmod__`

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -60,6 +60,7 @@ from .iterator import PartitionIterator
 from .series import Series
 from .utils import (
     SET_DATAFRAME_ATTRIBUTE_WARNING,
+    _doc_binary_op,
     cast_function_modin2pandas,
     from_non_pandas,
     from_pandas,
@@ -2719,6 +2720,23 @@ class DataFrame(BasePandasDataset):
         if key not in self:
             raise KeyError(key)
         self._update_inplace(new_query_compiler=self._query_compiler.delitem(key))
+
+    @_doc_binary_op(
+        operation="integer division and modulo",
+        bin_op="divmod",
+        returns="tuple of two DataFrames",
+    )
+    def __divmod__(self, right):
+        return self._default_to_pandas(pandas.DataFrame.__divmod__, right)
+
+    @_doc_binary_op(
+        operation="integer division and modulo",
+        bin_op="divmod",
+        right="left",
+        returns="tuple of two DataFrames",
+    )
+    def __rdivmod__(self, left):
+        return self._default_to_pandas(pandas.DataFrame.__rdivmod__, left)
 
     __add__ = add
     __iadd__ = add  # pragma: no cover

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -93,10 +93,12 @@ def test_math_functions(other, axis, op):
 @pytest.mark.parametrize("other", [lambda df: 2, lambda df: df])
 def test___divmod__(other):
     data = test_data["float_nan_data"]
-
     eval_general(*create_test_dfs(data), lambda df: divmod(df, other(df)))
-    # test __rdivmod__
-    eval_general(*create_test_dfs(data), lambda df: divmod(other(df), df))
+
+
+def test___rdivmod__():
+    data = test_data["float_nan_data"]
+    eval_general(*create_test_dfs(data), lambda df: divmod(2, df))
 
 
 @pytest.mark.parametrize(

--- a/modin/pandas/test/dataframe/test_binary.py
+++ b/modin/pandas/test/dataframe/test_binary.py
@@ -90,6 +90,15 @@ def test_math_functions(other, axis, op):
     )
 
 
+@pytest.mark.parametrize("other", [lambda df: 2, lambda df: df])
+def test___divmod__(other):
+    data = test_data["float_nan_data"]
+
+    eval_general(*create_test_dfs(data), lambda df: divmod(df, other(df)))
+    # test __rdivmod__
+    eval_general(*create_test_dfs(data), lambda df: divmod(other(df), df))
+
+
 @pytest.mark.parametrize(
     "other",
     [lambda df: df[: -(2**4)], lambda df: df[df.columns[0]].reset_index(drop=True)],


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6784 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
