### PR TITLE
FIX-#6786: properly d2p for cross `DataFrame.join`

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1163,7 +1163,7 @@ class DataFrame(BasePandasDataset):
             if other.name is None:
                 raise ValueError("Other Series must have a name")
             other = self.__constructor__(other)
-        if on is not None:
+        if on is not None or how == "cross":
             return self.__constructor__(
                 query_compiler=self._query_compiler.join(
                     other._query_compiler,

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -167,6 +167,19 @@ def test_join(test_data, test_data2):
         df_equals(modin_join, pandas_join)
 
 
+def test_join_cross_6786():
+    data = [[7, 8, 9], [10, 11, 12]]
+    modin_df, pandas_df = create_test_dfs(data, columns=["x", "y", "z"])
+
+    modin_join = modin_df.join(
+        modin_df[["x"]].set_axis(["p", "q"], axis=0), how="cross", lsuffix="p"
+    )
+    pandas_join = pandas_df.join(
+        pandas_df[["x"]].set_axis(["p", "q"], axis=0), how="cross", lsuffix="p"
+    )
+    df_equals(modin_join, pandas_join)
+
+
 def test_join_5203():
     data = np.ones([2, 4])
     kwargs = {"columns": ["a", "b", "c", "d"]}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6786 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
