### PR TITLE
FIX-#6781: Use `pandas.api.types.pandas_dtype` to convert to valid numpy and pandas only dtypes

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1960,7 +1960,7 @@ class PandasDataframe(ClassLogger):
             dtypes = self.copy_dtypes_cache()
         elif dtypes is not None:
             dtypes = pandas.Series(
-                [np.dtype(dtypes)] * len(new_axes[1]), index=new_axes[1]
+                [pandas.api.types.pandas_dtype(dtypes)] * len(new_axes[1]), index=new_axes[1]
             )
 
         result = self.__constructor__(

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1960,7 +1960,8 @@ class PandasDataframe(ClassLogger):
             dtypes = self.copy_dtypes_cache()
         elif dtypes is not None:
             dtypes = pandas.Series(
-                [pandas.api.types.pandas_dtype(dtypes)] * len(new_axes[1]), index=new_axes[1]
+                [pandas.api.types.pandas_dtype(dtypes)] * len(new_axes[1]),
+                index=new_axes[1],
             )
 
         result = self.__constructor__(

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -306,6 +306,22 @@ def test_sum(data, axis, skipna, is_transposed):
     df_equals(modin_result, pandas_result)
 
 
+@pytest.mark.parametrize("nptypes", [["int64"]])
+@pytest.mark.parametrize("pdtypes", [["Int64"]])
+def test_dtype_consistency(nptypes, pdtypes):
+    # test for issue #6781
+
+    # Test the resultant dtypes with numpy datatypes
+    for nptype in nptypes:
+        res_dtype = pd.DataFrame([1, 2, 3, 4], dtype=nptype).sum().dtype
+        assert res_dtype == np.dtype(nptype)
+
+    # Test the resultant dtypes with pandas datatypes
+    for pdtype in pdtypes:
+        res_dtype = pd.DataFrame([1, 2, 3, 4], dtype=pdtype).sum().dtype
+        assert res_dtype == pandas.api.types.pandas_dtype(pdtype)
+
+
 @pytest.mark.parametrize("fn", ["prod, sum"])
 @pytest.mark.parametrize(
     "numeric_only", bool_arg_values, ids=arg_keys("numeric_only", bool_arg_keys)

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -18,7 +18,7 @@ import pytest
 from pandas._testing import assert_series_equal
 
 import modin.pandas as pd
-from modin.config import NPartitions, StorageFormat, Engine
+from modin.config import Engine, NPartitions, StorageFormat
 from modin.pandas.test.utils import (
     arg_keys,
     assert_dtypes_equal,

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -18,7 +18,7 @@ import pytest
 from pandas._testing import assert_series_equal
 
 import modin.pandas as pd
-from modin.config import NPartitions, StorageFormat
+from modin.config import NPartitions, StorageFormat, Engine
 from modin.pandas.test.utils import (
     arg_keys,
     assert_dtypes_equal,
@@ -306,20 +306,12 @@ def test_sum(data, axis, skipna, is_transposed):
     df_equals(modin_result, pandas_result)
 
 
-@pytest.mark.parametrize("nptypes", [["int64"]])
-@pytest.mark.parametrize("pdtypes", [["Int64"]])
-def test_dtype_consistency(nptypes, pdtypes):
+@pytest.mark.skipif(Engine.get() == "Native", reason="Fails on HDK")
+@pytest.mark.parametrize("dtype", ["int64", "Int64"])
+def test_dtype_consistency(dtype):
     # test for issue #6781
-
-    # Test the resultant dtypes with numpy datatypes
-    for nptype in nptypes:
-        res_dtype = pd.DataFrame([1, 2, 3, 4], dtype=nptype).sum().dtype
-        assert res_dtype == np.dtype(nptype)
-
-    # Test the resultant dtypes with pandas datatypes
-    for pdtype in pdtypes:
-        res_dtype = pd.DataFrame([1, 2, 3, 4], dtype=pdtype).sum().dtype
-        assert res_dtype == pandas.api.types.pandas_dtype(pdtype)
+    res_dtype = pd.DataFrame([1, 2, 3, 4], dtype=dtype).sum().dtype
+    assert res_dtype == pandas.api.types.pandas_dtype(dtype)
 
 
 @pytest.mark.parametrize("fn", ["prod, sum"])


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6781 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
