### PR TITLE
FIX-#6778: Read parquet files without file extensions using fastparquet

### DIFF
--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -304,7 +304,7 @@ class FastParquetDataset(ColumnStoreDataset):
             # However, we also need to support users passing in explicit files that
             # don't necessarily have the `.parq` or `.parquet` extension -- if a user
             # says that a file is parquet, then we should probably give it a shot.
-            if os.path.isfile(self.path):
+            if self.fs.isfile(self.path):
                 files = self.fs.find(self.path)
             else:
                 files = [

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1464,6 +1464,20 @@ class TestParquet:
                 comparator=comparator,
             )
 
+    # Tests issue #6778
+    def test_read_parquet_no_extension(self, engine, make_parquet_file):
+        with ensure_clean(".parquet") as unique_filename:
+            # Remove the .parquet extension
+            no_ext_fname = unique_filename[: unique_filename.index(".parquet")]
+
+            make_parquet_file(filename=no_ext_fname)
+            eval_io(
+                fn_name="read_parquet",
+                # read_parquet kwargs
+                engine=engine,
+                path=no_ext_fname,
+            )
+
     @pytest.mark.parametrize(
         "filters",
         [None, [], [("col1", "==", 5)], [("col1", "<=", 215), ("col2", ">=", 35)]],


### PR DESCRIPTION
In supporting fastparquet, modin takes the paths provided, globs them, and filters them to only look at files with the .parq or .parquet extension. This commit adds support so that if the path supplied is explicitly a file, it will be included.

Signed-off by: Ari Brown <ari@aribrown.com>


## What do these changes do?

If a a file is passed to `modin.pandas.read_parquet(..., engine='fastparquet')` but the file does not have ".parq" or ".parquet" in the name, it will be ignored when determining the number of partitions. This change looks at all of the paths passed, and if the path is a file, then it considers it to be a parquet file.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s`
- [x] Resolves #6778
- [x] tests added and passing
- [N/A] module layout described at `docs/development/architecture.rst` is up-to-date