### PR TITLE
FIX-#6791: Pass additional environment variables to MPI workers

### DIFF
--- a/modin/core/execution/unidist/common/utils.py
+++ b/modin/core/execution/unidist/common/utils.py
@@ -45,8 +45,9 @@ def initialize_unidist():
             unidist.init()
             """,
         )
-        # TODO: allow unidist to inherit env variables on initialization
-        # with set_env(PYTHONWARNINGS="ignore::FutureWarning"):
+        unidist_cfg.MpiRuntimeEnv.put(
+            {"env_vars": {"PYTHONWARNINGS": "ignore::FutureWarning"}}
+        )
         unidist.init()
 
     num_cpus = sum(v["CPU"] for v in unidist.cluster_resources().values())


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6791  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
