### PR TITLE
REFACTOR-#6805: Move all IO functions to 'modin.pandas.io' module

### DIFF
--- a/asv_bench/benchmarks/scalability/scalability_benchmarks.py
+++ b/asv_bench/benchmarks/scalability/scalability_benchmarks.py
@@ -14,13 +14,20 @@
 """These benchmarks are supposed to be run only for modin, since they do not make sense for pandas."""
 
 import modin.pandas as pd
-from modin.pandas.utils import from_pandas
 
 try:
-    from modin.utils import to_numpy, to_pandas
+    from modin.pandas.io import from_pandas
 except ImportError:
-    # This provides compatibility with older versions of the Modin, allowing us to test old commits.
-    from modin.pandas.utils import to_pandas
+    from modin.pandas.utils import from_pandas
+
+try:
+    from modin.pandas.io import to_numpy, to_pandas
+except ImportError:
+    try:
+        from modin.utils import to_numpy, to_pandas
+    except ImportError:
+        # This provides compatibility with older versions of the Modin, allowing us to test old commits.
+        from modin.pandas.utils import to_pandas
 
 import pandas
 

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/test/test_dataframe.py
@@ -45,6 +45,7 @@ from modin.experimental.core.execution.native.implementations.hdk_on_native.df_a
 from modin.experimental.core.execution.native.implementations.hdk_on_native.partitioning.partition_manager import (
     HdkOnNativeDataframePartitionManager,
 )
+from modin.pandas.io import from_arrow
 from modin.pandas.test.utils import (
     bool_arg_values,
     df_equals,
@@ -56,7 +57,6 @@ from modin.pandas.test.utils import (
     time_parsing_csv_path,
     to_pandas,
 )
-from modin.pandas.utils import from_arrow
 from modin.utils import try_cast_to_pandas
 
 # Our configuration in pytest.ini requires that we explicitly catch all

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -44,12 +44,12 @@ from modin.config import PersistentPickle
 from modin.error_message import ErrorMessage
 from modin.logging import disable_logging
 from modin.pandas import Categorical
+from modin.pandas.io import from_non_pandas, from_pandas, to_pandas
 from modin.utils import (
     MODIN_UNNAMED_SERIES_LABEL,
     _inherit_docstrings,
     expanduser_path_arg,
     hashable,
-    to_pandas,
     try_cast_to_pandas,
 )
 
@@ -62,8 +62,6 @@ from .utils import (
     SET_DATAFRAME_ATTRIBUTE_WARNING,
     _doc_binary_op,
     cast_function_modin2pandas,
-    from_non_pandas,
-    from_pandas,
 )
 
 

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -25,7 +25,8 @@ from pandas.core.dtypes.common import is_list_like
 from modin.core.storage_formats.base.query_compiler import BaseQueryCompiler
 from modin.error_message import ErrorMessage
 from modin.logging import enable_logging
-from modin.utils import _inherit_docstrings, to_pandas
+from modin.pandas.io import to_pandas
+from modin.utils import _inherit_docstrings
 
 from .base import BasePandasDataset
 from .dataframe import DataFrame

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -1106,4 +1106,6 @@ __all__ = [
     "from_arrow",
     "from_dataframe",
     "to_pickle",
+    "to_pandas",
+    "to_numpy",
 ]

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -73,8 +73,8 @@ from modin.utils import (
     SupportsPrivateToPandas,
     SupportsPublicToNumPy,
     _inherit_docstrings,
-    expanduser_path_arg,
     classproperty,
+    expanduser_path_arg,
 )
 
 # below logic is to handle circular imports without errors

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -1033,9 +1033,7 @@ def from_dataframe(df):
     """
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return ModinObjects.DataFrame(
-        query_compiler=FactoryDispatcher.from_ModinObjects.DataFrame(df)
-    )
+    return ModinObjects.DataFrame(query_compiler=FactoryDispatcher.from_dataframe(df))
 
 
 def to_pandas(modin_obj: SupportsPrivateToPandas) -> Any:

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -28,6 +28,7 @@ import pickle
 from collections import OrderedDict
 from typing import (
     IO,
+    TYPE_CHECKING,
     Any,
     AnyStr,
     Callable,
@@ -43,6 +44,7 @@ from typing import (
     Union,
 )
 
+import numpy as np
 import pandas
 from pandas._libs.lib import NoDefault, no_default
 from pandas._typing import (
@@ -63,12 +65,37 @@ from pandas._typing import (
 from pandas.io.parsers import TextFileReader
 from pandas.io.parsers.readers import _c_parser_defaults
 
+from modin.config import ExperimentalNumPyAPI
 from modin.error_message import ErrorMessage
 from modin.logging import ClassLogger, enable_logging
-from modin.utils import _inherit_docstrings, expanduser_path_arg
+from modin.utils import (
+    SupportsPrivateToNumPy,
+    SupportsPrivateToPandas,
+    SupportsPublicToNumPy,
+    _inherit_docstrings,
+    expanduser_path_arg,
+)
 
-from .dataframe import DataFrame
-from .series import Series
+# below logic is to handle circular imports without errors
+if TYPE_CHECKING:
+    from .dataframe import DataFrame
+    from .series import Series
+
+
+class ModinObjects:
+    """Lazily import Modin classes and provide an access to them."""
+
+    _dataframe = None
+
+    @classmethod
+    @property
+    def DataFrame(cls):
+        """Get ``modin.pandas.DataFrame`` class."""
+        if cls._dataframe is None:
+            from .dataframe import DataFrame
+
+            cls._dataframe = DataFrame
+        return cls._dataframe
 
 
 def _read(**kwargs):
@@ -91,11 +118,11 @@ def _read(**kwargs):
     # This happens when `read_csv` returns a TextFileReader object for iterating through
     if isinstance(pd_obj, TextFileReader):
         reader = pd_obj.read
-        pd_obj.read = lambda *args, **kwargs: DataFrame(
+        pd_obj.read = lambda *args, **kwargs: ModinObjects.DataFrame(
             query_compiler=reader(*args, **kwargs)
         )
         return pd_obj
-    result = DataFrame(query_compiler=pd_obj)
+    result = ModinObjects.DataFrame(query_compiler=pd_obj)
     if squeeze:
         return result.squeeze(axis=1)
     return result
@@ -122,10 +149,10 @@ def read_xml(
     compression: CompressionOptions = "infer",
     storage_options: StorageOptions = None,
     dtype_backend: Union[DtypeBackend, NoDefault] = no_default,
-) -> DataFrame:
+) -> "DataFrame":
     ErrorMessage.default_to_pandas("read_xml")
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
-    return DataFrame(pandas.read_xml(**kwargs))
+    return ModinObjects.DataFrame(pandas.read_xml(**kwargs))
 
 
 @_inherit_docstrings(pandas.read_csv, apilink="pandas.read_csv")
@@ -190,7 +217,7 @@ def read_csv(
     float_precision: Literal["high", "legacy"] | None = None,
     storage_options: StorageOptions = None,
     dtype_backend: Union[DtypeBackend, NoDefault] = no_default,
-) -> DataFrame | TextFileReader:
+) -> "DataFrame" | TextFileReader:
     # ISSUE #2408: parse parameter shared with pandas read_csv and read_table and update with provided args
     _pd_read_csv_signature = {
         val.name for val in inspect.signature(pandas.read_csv).parameters.values()
@@ -262,7 +289,7 @@ def read_table(
     float_precision: str | None = None,
     storage_options: StorageOptions = None,
     dtype_backend: Union[DtypeBackend, NoDefault] = no_default,
-) -> DataFrame | TextFileReader:
+) -> "DataFrame" | TextFileReader:
     # ISSUE #2408: parse parameter shared with pandas read_csv and read_table and update with provided args
     _pd_read_table_signature = {
         val.name for val in inspect.signature(pandas.read_table).parameters.values()
@@ -287,7 +314,7 @@ def read_parquet(
     filesystem=None,
     filters=None,
     **kwargs,
-) -> DataFrame:
+) -> "DataFrame":
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     if engine == "fastparquet" and dtype_backend is not no_default:
@@ -295,7 +322,7 @@ def read_parquet(
             "The 'dtype_backend' argument is not supported for the fastparquet engine"
         )
 
-    return DataFrame(
+    return ModinObjects.DataFrame(
         query_compiler=FactoryDispatcher.read_parquet(
             path=path,
             engine=engine,
@@ -333,12 +360,12 @@ def read_json(
     storage_options: StorageOptions = None,
     dtype_backend: Union[DtypeBackend, NoDefault] = no_default,
     engine="ujson",
-) -> DataFrame | Series | pandas.io.json._json.JsonReader:
+) -> "DataFrame" | "Series" | pandas.io.json._json.JsonReader:
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(query_compiler=FactoryDispatcher.read_json(**kwargs))
+    return ModinObjects.DataFrame(query_compiler=FactoryDispatcher.read_json(**kwargs))
 
 
 @_inherit_docstrings(pandas.read_gbq, apilink="pandas.read_gbq")
@@ -357,13 +384,13 @@ def read_gbq(
     use_bqstorage_api: bool | None = None,
     max_results: int | None = None,
     progress_bar_type: str | None = None,
-) -> DataFrame:
+) -> "DataFrame":
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     kwargs.update(kwargs.pop("kwargs", {}))
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(query_compiler=FactoryDispatcher.read_gbq(**kwargs))
+    return ModinObjects.DataFrame(query_compiler=FactoryDispatcher.read_gbq(**kwargs))
 
 
 @_inherit_docstrings(pandas.read_html, apilink="pandas.read_html")
@@ -389,7 +416,7 @@ def read_html(
     extract_links: Literal[None, "header", "footer", "body", "all"] = None,
     dtype_backend: Union[DtypeBackend, NoDefault] = no_default,
     storage_options: StorageOptions = None,
-) -> list[DataFrame]:  # noqa: PR01, RT01, D200
+) -> list["DataFrame"]:  # noqa: PR01, RT01, D200
     """
     Read HTML tables into a ``DataFrame`` object.
     """
@@ -398,7 +425,7 @@ def read_html(
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     qcs = FactoryDispatcher.read_html(**kwargs)
-    return [DataFrame(query_compiler=qc) for qc in qcs]
+    return [ModinObjects.DataFrame(query_compiler=qc) for qc in qcs]
 
 
 @_inherit_docstrings(pandas.read_clipboard, apilink="pandas.read_clipboard")
@@ -416,7 +443,9 @@ def read_clipboard(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(query_compiler=FactoryDispatcher.read_clipboard(**kwargs))
+    return ModinObjects.DataFrame(
+        query_compiler=FactoryDispatcher.read_clipboard(**kwargs)
+    )
 
 
 @_inherit_docstrings(pandas.read_excel, apilink="pandas.read_excel")
@@ -456,7 +485,7 @@ def read_excel(
     storage_options: StorageOptions = None,
     dtype_backend: Union[DtypeBackend, NoDefault] = no_default,
     engine_kwargs: Optional[dict] = None,
-) -> DataFrame | dict[IntStrT, DataFrame]:
+) -> "DataFrame" | dict[IntStrT, "DataFrame"]:
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
@@ -465,10 +494,10 @@ def read_excel(
     if isinstance(intermediate, (OrderedDict, dict)):
         parsed = type(intermediate)()
         for key in intermediate.keys():
-            parsed[key] = DataFrame(query_compiler=intermediate.get(key))
+            parsed[key] = ModinObjects.DataFrame(query_compiler=intermediate.get(key))
         return parsed
     else:
-        return DataFrame(query_compiler=intermediate)
+        return ModinObjects.DataFrame(query_compiler=intermediate)
 
 
 @_inherit_docstrings(pandas.read_hdf, apilink="pandas.read_hdf")
@@ -495,7 +524,7 @@ def read_hdf(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(query_compiler=FactoryDispatcher.read_hdf(**kwargs))
+    return ModinObjects.DataFrame(query_compiler=FactoryDispatcher.read_hdf(**kwargs))
 
 
 @_inherit_docstrings(pandas.read_feather, apilink="pandas.read_feather")
@@ -512,7 +541,9 @@ def read_feather(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(query_compiler=FactoryDispatcher.read_feather(**kwargs))
+    return ModinObjects.DataFrame(
+        query_compiler=FactoryDispatcher.read_feather(**kwargs)
+    )
 
 
 @_inherit_docstrings(pandas.read_stata)
@@ -532,12 +563,12 @@ def read_stata(
     iterator: bool = False,
     compression: CompressionOptions = "infer",
     storage_options: StorageOptions = None,
-) -> DataFrame | pandas.io.stata.StataReader:
+) -> "DataFrame" | pandas.io.stata.StataReader:
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(query_compiler=FactoryDispatcher.read_stata(**kwargs))
+    return ModinObjects.DataFrame(query_compiler=FactoryDispatcher.read_stata(**kwargs))
 
 
 @_inherit_docstrings(pandas.read_sas, apilink="pandas.read_sas")
@@ -552,13 +583,13 @@ def read_sas(
     chunksize: int | None = None,
     iterator: bool = False,
     compression: CompressionOptions = "infer",
-) -> DataFrame | pandas.io.sas.sasreader.ReaderBase:  # noqa: PR01, RT01, D200
+) -> "DataFrame" | pandas.io.sas.sasreader.ReaderBase:  # noqa: PR01, RT01, D200
     """
     Read SAS files stored as either XPORT or SAS7BDAT format files.
     """
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(
+    return ModinObjects.DataFrame(
         query_compiler=FactoryDispatcher.read_sas(
             filepath_or_buffer=filepath_or_buffer,
             format=format,
@@ -583,7 +614,9 @@ def read_pickle(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(query_compiler=FactoryDispatcher.read_pickle(**kwargs))
+    return ModinObjects.DataFrame(
+        query_compiler=FactoryDispatcher.read_pickle(**kwargs)
+    )
 
 
 @_inherit_docstrings(pandas.read_sql, apilink="pandas.read_sql")
@@ -611,9 +644,10 @@ def read_sql(
         ErrorMessage.default_to_pandas("Parameters provided [chunksize]")
         df_gen = pandas.read_sql(**kwargs)
         return (
-            DataFrame(query_compiler=FactoryDispatcher.from_pandas(df)) for df in df_gen
+            ModinObjects.DataFrame(query_compiler=FactoryDispatcher.from_pandas(df))
+            for df in df_gen
         )
-    return DataFrame(query_compiler=FactoryDispatcher.read_sql(**kwargs))
+    return ModinObjects.DataFrame(query_compiler=FactoryDispatcher.read_sql(**kwargs))
 
 
 @_inherit_docstrings(pandas.read_fwf, apilink="pandas.read_fwf")
@@ -643,11 +677,11 @@ def read_fwf(
     # When `read_fwf` returns a TextFileReader object for iterating through
     if isinstance(pd_obj, TextFileReader):
         reader = pd_obj.read
-        pd_obj.read = lambda *args, **kwargs: DataFrame(
+        pd_obj.read = lambda *args, **kwargs: ModinObjects.DataFrame(
             query_compiler=reader(*args, **kwargs)
         )
         return pd_obj
-    return DataFrame(query_compiler=pd_obj)
+    return ModinObjects.DataFrame(query_compiler=pd_obj)
 
 
 @_inherit_docstrings(pandas.read_sql_table, apilink="pandas.read_sql_table")
@@ -670,7 +704,9 @@ def read_sql_table(
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(query_compiler=FactoryDispatcher.read_sql_table(**kwargs))
+    return ModinObjects.DataFrame(
+        query_compiler=FactoryDispatcher.read_sql_table(**kwargs)
+    )
 
 
 @_inherit_docstrings(pandas.read_sql_query, apilink="pandas.read_sql_query")
@@ -685,12 +721,14 @@ def read_sql_query(
     chunksize: int | None = None,
     dtype: DtypeArg | None = None,
     dtype_backend: Union[DtypeBackend, NoDefault] = no_default,
-) -> DataFrame | Iterator[DataFrame]:
+) -> "DataFrame" | Iterator["DataFrame"]:
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
 
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(query_compiler=FactoryDispatcher.read_sql_query(**kwargs))
+    return ModinObjects.DataFrame(
+        query_compiler=FactoryDispatcher.read_sql_query(**kwargs)
+    )
 
 
 @_inherit_docstrings(pandas.to_pickle)
@@ -705,7 +743,7 @@ def to_pickle(
 ) -> None:
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    if isinstance(obj, DataFrame):
+    if isinstance(obj, ModinObjects.DataFrame):
         obj = obj._query_compiler
     return FactoryDispatcher.to_pickle(
         obj,
@@ -730,7 +768,7 @@ def read_spss(
     """
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    return DataFrame(
+    return ModinObjects.DataFrame(
         query_compiler=FactoryDispatcher.read_spss(
             path=path,
             usecols=usecols,
@@ -751,12 +789,12 @@ def json_normalize(
     errors: Optional[str] = "raise",
     sep: str = ".",
     max_level: Optional[int] = None,
-) -> DataFrame:  # noqa: PR01, RT01, D200
+) -> "DataFrame":  # noqa: PR01, RT01, D200
     """
     Normalize semi-structured JSON data into a flat table.
     """
     ErrorMessage.default_to_pandas("json_normalize")
-    return DataFrame(
+    return ModinObjects.DataFrame(
         pandas.json_normalize(
             data, record_path, meta, meta_prefix, record_prefix, errors, sep, max_level
         )
@@ -772,12 +810,12 @@ def read_orc(
     dtype_backend: Union[DtypeBackend, NoDefault] = no_default,
     filesystem=None,
     **kwargs,
-) -> DataFrame:  # noqa: PR01, RT01, D200
+) -> "DataFrame":  # noqa: PR01, RT01, D200
     """
     Load an ORC object from the file path, returning a DataFrame.
     """
     ErrorMessage.default_to_pandas("read_orc")
-    return DataFrame(
+    return ModinObjects.DataFrame(
         pandas.read_orc(
             path,
             columns=columns,
@@ -819,25 +857,27 @@ class HDFStore(ClassLogger, pandas.HDFStore):  # noqa: PR01, D200
                     does not accept Modin DataFrame objects, so we must convert to
                     pandas.
                     """
-                    from modin.utils import to_pandas
+                    from modin.pandas.io import to_pandas
 
                     # We don't want to constantly be giving this error message for
                     # internal methods.
                     if item[0] != "_":
                         ErrorMessage.default_to_pandas("`{}`".format(item))
                     args = [
-                        to_pandas(arg) if isinstance(arg, DataFrame) else arg
+                        to_pandas(arg)
+                        if isinstance(arg, ModinObjects.DataFrame)
+                        else arg
                         for arg in args
                     ]
                     kwargs = {
-                        k: to_pandas(v) if isinstance(v, DataFrame) else v
+                        k: to_pandas(v) if isinstance(v, ModinObjects.DataFrame) else v
                         for k, v in kwargs.items()
                     }
                     obj = super(HDFStore, self).__getattribute__(item)(*args, **kwargs)
                     if self._return_modin_dataframe and isinstance(
                         obj, pandas.DataFrame
                     ):
-                        return DataFrame(obj)
+                        return ModinObjects.DataFrame(obj)
                     return obj
 
                 # We replace the method with `return_handler` for inplace operations
@@ -883,28 +923,160 @@ class ExcelFile(ClassLogger, pandas.ExcelFile):  # noqa: PR01, D200
                     methods of ExcelFile with the pandas equivalent. It will convert
                     Modin DataFrame to pandas DataFrame, etc.
                     """
-                    from modin.utils import to_pandas
+                    from modin.pandas.io import to_pandas
 
                     # We don't want to constantly be giving this error message for
                     # internal methods.
                     if item[0] != "_":
                         ErrorMessage.default_to_pandas("`{}`".format(item))
                     args = [
-                        to_pandas(arg) if isinstance(arg, DataFrame) else arg
+                        to_pandas(arg)
+                        if isinstance(arg, ModinObjects.DataFrame)
+                        else arg
                         for arg in args
                     ]
                     kwargs = {
-                        k: to_pandas(v) if isinstance(v, DataFrame) else v
+                        k: to_pandas(v) if isinstance(v, ModinObjects.DataFrame) else v
                         for k, v in kwargs.items()
                     }
                     obj = super(ExcelFile, self).__getattribute__(item)(*args, **kwargs)
                     if isinstance(obj, pandas.DataFrame):
-                        return DataFrame(obj)
+                        return ModinObjects.DataFrame(obj)
                     return obj
 
                 # We replace the method with `return_handler` for inplace operations
                 method = return_handler
         return method
+
+
+def from_non_pandas(df, index, columns, dtype):
+    """
+    Convert a non-pandas DataFrame into Modin DataFrame.
+
+    Parameters
+    ----------
+    df : object
+        Non-pandas DataFrame.
+    index : object
+        Index for non-pandas DataFrame.
+    columns : object
+        Columns for non-pandas DataFrame.
+    dtype : type
+        Data type to force.
+
+    Returns
+    -------
+    modin.pandas.DataFrame
+        Converted DataFrame.
+    """
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
+
+    new_qc = FactoryDispatcher.from_non_pandas(df, index, columns, dtype)
+    if new_qc is not None:
+        return ModinObjects.DataFrame(query_compiler=new_qc)
+    return new_qc
+
+
+def from_pandas(df):
+    """
+    Convert a pandas DataFrame to a Modin DataFrame.
+
+    Parameters
+    ----------
+    df : pandas.DataFrame
+        The pandas DataFrame to convert.
+
+    Returns
+    -------
+    modin.pandas.DataFrame
+        A new Modin DataFrame object.
+    """
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
+
+    return ModinObjects.DataFrame(query_compiler=FactoryDispatcher.from_pandas(df))
+
+
+def from_arrow(at):
+    """
+    Convert an Arrow Table to a Modin DataFrame.
+
+    Parameters
+    ----------
+    at : Arrow Table
+        The Arrow Table to convert from.
+
+    Returns
+    -------
+    DataFrame
+        A new Modin DataFrame object.
+    """
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
+
+    return ModinObjects.DataFrame(query_compiler=FactoryDispatcher.from_arrow(at))
+
+
+def from_dataframe(df):
+    """
+    Convert a DataFrame implementing the dataframe exchange protocol to a Modin DataFrame.
+
+    See more about the protocol in https://data-apis.org/dataframe-protocol/latest/index.html.
+
+    Parameters
+    ----------
+    df : DataFrame
+        The DataFrame object supporting the dataframe exchange protocol.
+
+    Returns
+    -------
+    DataFrame
+        A new Modin DataFrame object.
+    """
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
+
+    return ModinObjects.DataFrame(
+        query_compiler=FactoryDispatcher.from_ModinObjects.DataFrame(df)
+    )
+
+
+def to_pandas(modin_obj: SupportsPrivateToPandas) -> Any:
+    """
+    Convert a Modin DataFrame/Series to a pandas DataFrame/Series.
+
+    Parameters
+    ----------
+    modin_obj : modin.DataFrame, modin.Series
+        The Modin DataFrame/Series to convert.
+
+    Returns
+    -------
+    pandas.DataFrame or pandas.Series
+        Converted object with type depending on input.
+    """
+    return modin_obj._to_pandas()
+
+
+def to_numpy(
+    modin_obj: Union[SupportsPrivateToNumPy, SupportsPublicToNumPy]
+) -> np.ndarray:
+    """
+    Convert a Modin object to a NumPy array.
+
+    Parameters
+    ----------
+    modin_obj : modin.DataFrame, modin."Series", modin.numpy.array
+        The Modin distributed object to convert.
+
+    Returns
+    -------
+    numpy.array
+        Converted object with type depending on input.
+    """
+    if isinstance(modin_obj, SupportsPrivateToNumPy):
+        return modin_obj._to_numpy()
+    array = modin_obj.to_numpy()
+    if ExperimentalNumPyAPI.get():
+        array = array._to_numpy()
+    return array
 
 
 __all__ = [
@@ -931,5 +1103,9 @@ __all__ = [
     "read_stata",
     "read_table",
     "read_xml",
+    "from_non_pandas",
+    "from_pandas",
+    "from_arrow",
+    "from_dataframe",
     "to_pickle",
 ]

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -88,14 +88,26 @@ class ModinObjects:
     _dataframe = None
 
     @classmethod
-    @property
-    def DataFrame(cls):
-        """Get ``modin.pandas.DataFrame`` class."""
+    def DataFrame(cls, *args, **kwargs):
+        """
+        Build ``modin.pandas.DataFrame`` object with the passed arguments.
+
+        Parameters
+        ----------
+        *args : tuple
+            Positional arguments to pass to the ``modin.pandas.DataFrame`` constructor.
+        **kwargs : dict
+            Keyword arguments to pass to the ``modin.pandas.DataFrame`` constructor.
+
+        Returns
+        -------
+        modin.pandas.DataFrame
+        """
         if cls._dataframe is None:
             from .dataframe import DataFrame
 
             cls._dataframe = DataFrame
-        return cls._dataframe
+        return cls._dataframe(*args, **kwargs)
 
 
 def _read(**kwargs):
@@ -857,8 +869,6 @@ class HDFStore(ClassLogger, pandas.HDFStore):  # noqa: PR01, D200
                     does not accept Modin DataFrame objects, so we must convert to
                     pandas.
                     """
-                    from modin.pandas.io import to_pandas
-
                     # We don't want to constantly be giving this error message for
                     # internal methods.
                     if item[0] != "_":
@@ -923,8 +933,6 @@ class ExcelFile(ClassLogger, pandas.ExcelFile):  # noqa: PR01, D200
                     methods of ExcelFile with the pandas equivalent. It will convert
                     Modin DataFrame to pandas DataFrame, etc.
                     """
-                    from modin.pandas.io import to_pandas
-
                     # We don't want to constantly be giving this error message for
                     # internal methods.
                     if item[0] != "_":

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -74,6 +74,7 @@ from modin.utils import (
     SupportsPublicToNumPy,
     _inherit_docstrings,
     expanduser_path_arg,
+    classproperty,
 )
 
 # below logic is to handle circular imports without errors
@@ -87,27 +88,14 @@ class ModinObjects:
 
     _dataframe = None
 
-    @classmethod
-    def DataFrame(cls, *args, **kwargs):
-        """
-        Build ``modin.pandas.DataFrame`` object with the passed arguments.
-
-        Parameters
-        ----------
-        *args : tuple
-            Positional arguments to pass to the ``modin.pandas.DataFrame`` constructor.
-        **kwargs : dict
-            Keyword arguments to pass to the ``modin.pandas.DataFrame`` constructor.
-
-        Returns
-        -------
-        modin.pandas.DataFrame
-        """
+    @classproperty
+    def DataFrame(cls):
+        """Get ``modin.pandas.DataFrame`` class."""
         if cls._dataframe is None:
             from .dataframe import DataFrame
 
             cls._dataframe = DataFrame
-        return cls._dataframe(*args, **kwargs)
+        return cls._dataframe
 
 
 def _read(**kwargs):

--- a/modin/pandas/plotting.py
+++ b/modin/pandas/plotting.py
@@ -16,7 +16,8 @@
 from pandas import plotting as pdplot
 
 from modin.logging import ClassLogger
-from modin.utils import instancer, to_pandas
+from modin.pandas.io import to_pandas
+from modin.utils import instancer
 
 from .dataframe import DataFrame
 

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -32,13 +32,14 @@ from pandas.util._validators import validate_bool_kwarg
 
 from modin.config import PersistentPickle
 from modin.logging import disable_logging
-from modin.utils import MODIN_UNNAMED_SERIES_LABEL, _inherit_docstrings, to_pandas
+from modin.pandas.io import from_pandas, to_pandas
+from modin.utils import MODIN_UNNAMED_SERIES_LABEL, _inherit_docstrings
 
 from .accessor import CachedAccessor, SparseAccessor
 from .base import _ATTRS_NO_LOOKUP, BasePandasDataset
 from .iterator import PartitionIterator
 from .series_utils import CategoryMethods, DatetimeProperties, StringMethods
-from .utils import _doc_binary_op, cast_function_modin2pandas, from_pandas, is_scalar
+from .utils import _doc_binary_op, cast_function_modin2pandas, is_scalar
 
 if TYPE_CHECKING:
     from .dataframe import DataFrame

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -22,6 +22,7 @@ from numpy.testing import assert_array_equal
 
 import modin.pandas as pd
 from modin.config import Engine, NPartitions, StorageFormat
+from modin.pandas.io import to_pandas
 from modin.pandas.test.utils import (
     axis_keys,
     axis_values,
@@ -43,7 +44,7 @@ from modin.pandas.test.utils import (
     test_data_values,
 )
 from modin.test.test_utils import warns_that_defaulting_to_pandas
-from modin.utils import get_current_execution, to_pandas
+from modin.utils import get_current_execution
 
 NPartitions.put(4)
 

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -20,6 +20,7 @@ import pytest
 
 import modin.pandas as pd
 from modin.config import Engine, NPartitions, StorageFormat
+from modin.pandas.io import to_pandas
 from modin.pandas.test.utils import (
     arg_keys,
     axis_keys,
@@ -39,7 +40,6 @@ from modin.pandas.test.utils import (
     test_data_values,
 )
 from modin.test.test_utils import warns_that_defaulting_to_pandas
-from modin.utils import to_pandas
 
 NPartitions.put(4)
 

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -602,7 +602,7 @@ class TestCategoricalProxyDtype:
         elif StorageFormat.get() == "Hdk":
             import pyarrow as pa
 
-            from modin.pandas.utils import from_arrow
+            from modin.pandas.io import from_arrow
 
             at = pa.concat_tables(
                 [

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -21,8 +21,9 @@ from pandas.testing import assert_frame_equal
 
 import modin.pandas as pd
 from modin.config import StorageFormat
+from modin.pandas.io import to_pandas
 from modin.test.test_utils import warns_that_defaulting_to_pandas
-from modin.utils import get_current_execution, to_pandas
+from modin.utils import get_current_execution
 
 from .utils import (
     bool_arg_keys,

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -27,7 +27,8 @@ from modin.core.dataframe.algebra.default2pandas.groupby import GroupBy
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
-from modin.pandas.utils import from_pandas, is_scalar
+from modin.pandas.io import from_pandas
+from modin.pandas.utils import is_scalar
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 from modin.utils import (
     MODIN_UNNAMED_SERIES_LABEL,

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -47,9 +47,8 @@ from modin.config import (
 )
 from modin.config.envvars import MinPartitionSize
 from modin.db_conn import ModinDatabaseConnection, UnsupportedDatabaseException
-from modin.pandas.utils import from_arrow
+from modin.pandas.io import from_arrow, to_pandas
 from modin.test.test_utils import warns_that_defaulting_to_pandas
-from modin.utils import to_pandas
 
 from .utils import (
     COMP_TO_EXT,

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -28,8 +28,9 @@ from pandas.errors import SpecificationError
 
 import modin.pandas as pd
 from modin.config import NPartitions, StorageFormat
+from modin.pandas.io import to_pandas
 from modin.test.test_utils import warns_that_defaulting_to_pandas
-from modin.utils import get_current_execution, to_pandas, try_cast_to_pandas
+from modin.utils import get_current_execution, try_cast_to_pandas
 
 from .utils import (
     RAND_HIGH,

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -44,7 +44,8 @@ from pandas.testing import (
 
 import modin.pandas as pd
 from modin.config import MinPartitionSize, NPartitions, TestDatasetSize, TrackFileLeaks
-from modin.utils import to_pandas, try_cast_to_pandas
+from modin.pandas.io import to_pandas
+from modin.utils import try_cast_to_pandas
 
 # Flag activated on command line with "--extra-test-parameters" option.
 # Used in some tests to perform additional parameter combinations.

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -43,22 +43,26 @@ SET_DATAFRAME_ATTRIBUTE_WARNING = (
 from_pandas = func_from_deprecated_location(
     "from_pandas",
     "modin.pandas.io",
-    "Importing ``from_pandas`` from ``modin.pandas.utils`` is deprecated and will be removed in 0.28.0 release. This function was moved to ``modin.pandas.io``, please import it from there instead.",
+    "Importing ``from_pandas`` from ``modin.pandas.utils`` is deprecated and will be removed in a future version. "
+    + "This function was moved to ``modin.pandas.io``, please import it from there instead.",
 )
 from_arrow = func_from_deprecated_location(
     "from_arrow",
     "modin.pandas.io",
-    "Importing ``from_arrow`` from ``modin.pandas.utils`` is deprecated and will be removed in 0.28.0 release. This function was moved to ``modin.pandas.io``, please import it from there instead.",
+    "Importing ``from_arrow`` from ``modin.pandas.utils`` is deprecated and will be removed in a future version. "
+    + "This function was moved to ``modin.pandas.io``, please import it from there instead.",
 )
 from_dataframe = func_from_deprecated_location(
     "from_dataframe",
     "modin.pandas.io",
-    "Importing ``from_dataframe`` from ``modin.pandas.utils`` is deprecated and will be removed in 0.28.0 release. This function was moved to ``modin.pandas.io``, please import it from there instead.",
+    "Importing ``from_dataframe`` from ``modin.pandas.utils`` is deprecated and will be removed in a future version. "
+    + "This function was moved to ``modin.pandas.io``, please import it from there instead.",
 )
 from_non_pandas = func_from_deprecated_location(
     "from_non_pandas",
     "modin.pandas.io",
-    "Importing ``from_non_pandas`` from ``modin.pandas.utils`` is deprecated and will be removed in 0.28.0 release. This function was moved to ``modin.pandas.io``, please import it from there instead.",
+    "Importing ``from_non_pandas`` from ``modin.pandas.utils`` is deprecated and will be removed in a future version. "
+    + "This function was moved to ``modin.pandas.io``, please import it from there instead.",
 )
 
 

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -20,7 +20,7 @@ import pandas
 from pandas._typing import AggFuncType, AggFuncTypeBase, AggFuncTypeDict, IndexLabel
 from pandas.util._decorators import doc
 
-from modin.utils import hashable
+from modin.utils import func_from_deprecated_location, hashable
 
 _doc_binary_operation = """
 Return {operation} of {left} and `{right}` (binary operator `{bin_op}`).
@@ -40,100 +40,26 @@ SET_DATAFRAME_ATTRIBUTE_WARNING = (
     + "https://pandas.pydata.org/pandas-docs/stable/indexing.html#attribute-access"
 )
 
-
-def from_non_pandas(df, index, columns, dtype):
-    """
-    Convert a non-pandas DataFrame into Modin DataFrame.
-
-    Parameters
-    ----------
-    df : object
-        Non-pandas DataFrame.
-    index : object
-        Index for non-pandas DataFrame.
-    columns : object
-        Columns for non-pandas DataFrame.
-    dtype : type
-        Data type to force.
-
-    Returns
-    -------
-    modin.pandas.DataFrame
-        Converted DataFrame.
-    """
-    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
-
-    new_qc = FactoryDispatcher.from_non_pandas(df, index, columns, dtype)
-    if new_qc is not None:
-        from .dataframe import DataFrame
-
-        return DataFrame(query_compiler=new_qc)
-    return new_qc
-
-
-def from_pandas(df):
-    """
-    Convert a pandas DataFrame to a Modin DataFrame.
-
-    Parameters
-    ----------
-    df : pandas.DataFrame
-        The pandas DataFrame to convert.
-
-    Returns
-    -------
-    modin.pandas.DataFrame
-        A new Modin DataFrame object.
-    """
-    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
-
-    from .dataframe import DataFrame
-
-    return DataFrame(query_compiler=FactoryDispatcher.from_pandas(df))
-
-
-def from_arrow(at):
-    """
-    Convert an Arrow Table to a Modin DataFrame.
-
-    Parameters
-    ----------
-    at : Arrow Table
-        The Arrow Table to convert from.
-
-    Returns
-    -------
-    DataFrame
-        A new Modin DataFrame object.
-    """
-    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
-
-    from .dataframe import DataFrame
-
-    return DataFrame(query_compiler=FactoryDispatcher.from_arrow(at))
-
-
-def from_dataframe(df):
-    """
-    Convert a DataFrame implementing the dataframe exchange protocol to a Modin DataFrame.
-
-    See more about the protocol in https://data-apis.org/dataframe-protocol/latest/index.html.
-
-    Parameters
-    ----------
-    df : DataFrame
-        The DataFrame object supporting the dataframe exchange protocol.
-
-    Returns
-    -------
-    DataFrame
-        A new Modin DataFrame object.
-    """
-    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
-
-    from .dataframe import DataFrame
-
-    return DataFrame(query_compiler=FactoryDispatcher.from_dataframe(df))
+from_pandas = func_from_deprecated_location(
+    "from_pandas",
+    "modin.pandas.io",
+    "Importing ``from_pandas`` from ``modin.pandas.utils`` is deprecated and will be removed in 0.28.0 release. This function was moved to ``modin.pandas.io``, please import it from there instead.",
+)
+from_arrow = func_from_deprecated_location(
+    "from_arrow",
+    "modin.pandas.io",
+    "Importing ``from_arrow`` from ``modin.pandas.utils`` is deprecated and will be removed in 0.28.0 release. This function was moved to ``modin.pandas.io``, please import it from there instead.",
+)
+from_dataframe = func_from_deprecated_location(
+    "from_dataframe",
+    "modin.pandas.io",
+    "Importing ``from_dataframe`` from ``modin.pandas.utils`` is deprecated and will be removed in 0.28.0 release. This function was moved to ``modin.pandas.io``, please import it from there instead.",
+)
+from_non_pandas = func_from_deprecated_location(
+    "from_non_pandas",
+    "modin.pandas.io",
+    "Importing ``from_non_pandas`` from ``modin.pandas.utils`` is deprecated and will be removed in 0.28.0 release. This function was moved to ``modin.pandas.io``, please import it from there instead.",
+)
 
 
 def cast_function_modin2pandas(func):

--- a/modin/test/interchange/dataframe_protocol/base/test_sanity.py
+++ b/modin/test/interchange/dataframe_protocol/base/test_sanity.py
@@ -41,7 +41,7 @@ def test_basic_io(get_unique_base_execution):
     query_compiler_cls.from_dataframe = dummy_io_method
     query_compiler_cls.to_dataframe = dummy_io_method
 
-    from modin.pandas.utils import from_dataframe
+    from modin.pandas.io import from_dataframe
 
     with pytest.raises(TestPassed):
         from_dataframe(None)

--- a/modin/test/interchange/dataframe_protocol/hdk/test_protocol.py
+++ b/modin/test/interchange/dataframe_protocol/hdk/test_protocol.py
@@ -24,8 +24,8 @@ from modin.core.dataframe.pandas.interchange.dataframe_protocol.from_dataframe i
     primitive_column_to_ndarray,
     set_nulls,
 )
+from modin.pandas.io import from_arrow, from_dataframe
 from modin.pandas.test.utils import df_equals
-from modin.pandas.utils import from_arrow, from_dataframe
 from modin.test.test_utils import warns_that_defaulting_to_pandas
 
 from .utils import export_frame, get_data_of_all_types, split_df_into_chunks

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -850,3 +850,30 @@ class ModinAssumptionError(Exception):
     """An exception that allows us defaults to pandas if any assumption fails."""
 
     pass
+
+
+class classproperty:
+    """
+    Decorator that allows creating read-only class properties.
+
+    Parameters
+    ----------
+    func : method
+
+    Examples
+    --------
+    >>> class A:
+    ...     field = 10
+    ...     @classproperty
+    ...     def field_x2(cls):
+    ...             return cls.field * 2
+    ...
+    >>> print(A.field_x2)
+    20
+    """
+
+    def __init__(self, func: Any):
+        self.fget = func
+
+    def __get__(self, instance: Any, owner: Any) -> Any:  # noqa: GL08
+        return self.fget(owner)

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -524,12 +524,14 @@ def func_from_deprecated_location(
 to_numpy = func_from_deprecated_location(
     "to_numpy",
     "modin.pandas.io",
-    "Importing ``to_numpy`` from ``modin.pandas.utils`` is deprecated and will be removed in 0.28.0 release. This function was moved to ``modin.pandas.io``, please import it from there instead.",
+    "Importing ``to_numpy`` from ``modin.pandas.utils`` is deprecated and will be removed in a future version. "
+    + "This function was moved to ``modin.pandas.io``, please import it from there instead.",
 )
 to_pandas = func_from_deprecated_location(
     "to_pandas",
     "modin.pandas.io",
-    "Importing ``to_pandas`` from ``modin.pandas.utils`` is deprecated and will be removed in 0.28.0 release. This function was moved to ``modin.pandas.io``, please import it from there instead.",
+    "Importing ``to_pandas`` from ``modin.pandas.utils`` is deprecated and will be removed in a future version. "
+    + "This function was moved to ``modin.pandas.io``, please import it from there instead.",
 )
 
 

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -49,7 +49,7 @@ from pandas.util._print_versions import (  # type: ignore[attr-defined]
 )
 
 from modin._version import get_versions
-from modin.config import Engine, ExperimentalNumPyAPI, IsExperimental, StorageFormat
+from modin.config import Engine, IsExperimental, StorageFormat
 
 T = TypeVar("T")
 """Generic type parameter"""
@@ -491,7 +491,9 @@ def expanduser_path_arg(argname: str) -> Callable[[Fn], Fn]:
     return decorator
 
 
-def func_from_deprecated_location(func_name, module, deprecation_message):
+def func_from_deprecated_location(
+    func_name: str, module: str, deprecation_message: str
+) -> Callable:
     """
     Create a function that decorates a function ``module.func_name`` with a ``FutureWarning``.
 
@@ -509,7 +511,7 @@ def func_from_deprecated_location(func_name, module, deprecation_message):
     callable
     """
 
-    def deprecated_func(*args, **kwargs):
+    def deprecated_func(*args: tuple[Any], **kwargs: dict[Any, Any]) -> Any:
         """Call deprecated function."""
         func = getattr(importlib.import_module(module), func_name)
         # using 'FutureWarning' as 'DeprecationWarnings' are filtered out by default


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR moves the following IO function to the `modin.pandas.io` module:
- `from_pandas()`
- `from_arrow()`
- `from_dataframe()`
- `from_non_pandas()`
- `to_pandas()`
- `to_numpy()`

The `try_cast_to_pandas()` function was not moved as IMO it's more of a utility function rather than a pure IO. However, if reviewers think differently, I still can move it to the IO module.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6805 <!-- issue must be created for each patch -->
- [x] tests are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
