### PR TITLE
FIX-#6782: filter pandas warnings when precomputing dtypes

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -13,6 +13,7 @@
 
 """Module houses builder class for Binary operator."""
 
+import warnings
 from typing import Optional
 
 import numpy as np
@@ -120,13 +121,15 @@ def maybe_compute_dtypes_common_cast(
     dtypes = None
     if func is not None:
         try:
-            df1 = pandas.DataFrame([[1] * len(common_columns)]).astype(
-                {i: dtypes_first[col] for i, col in enumerate(common_columns)}
-            )
-            df2 = pandas.DataFrame([[1] * len(common_columns)]).astype(
-                {i: dtypes_second[col] for i, col in enumerate(common_columns)}
-            )
-            dtypes = func(df1, df2).dtypes.set_axis(common_columns)
+            with warnings.catch_warnings():
+                warnings.filterwarnings("ignore")
+                df1 = pandas.DataFrame([[1] * len(common_columns)]).astype(
+                    {i: dtypes_first[col] for i, col in enumerate(common_columns)}
+                )
+                df2 = pandas.DataFrame([[1] * len(common_columns)]).astype(
+                    {i: dtypes_second[col] for i, col in enumerate(common_columns)}
+                )
+                dtypes = func(df1, df2).dtypes.set_axis(common_columns)
         # it sometimes doesn't work correctly with strings, so falling back to
         # the "common_cast" method in this case
         except TypeError:

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -13,6 +13,7 @@
 
 from __future__ import annotations
 
+import datetime
 import json
 import unittest.mock as mock
 
@@ -3349,6 +3350,17 @@ def test_std(request, data, skipna, ddof):
 def test_sub(data):
     modin_series, pandas_series = create_test_series(data)
     inter_df_math_helper(modin_series, pandas_series, "sub")
+
+
+def test_6782():
+    datetime_scalar = datetime.datetime(1970, 1, 1, 0, 0)
+    with pytest.warns(UserWarning) as warns:
+        _ = pd.Series([datetime.datetime(2000, 1, 1)]) - datetime_scalar
+        for warn in warns.list:
+            assert (
+                "Adding/subtracting object-dtype array to DatetimeArray not vectorized"
+                not in str(warn)
+            )
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6782 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
