### PR TITLE
FIX-#6822: Do not propagate NotImplementedError to a user on a 'set_c…

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -709,11 +709,17 @@ class PandasDataframe(ClassLogger):
                 return
             new_columns = self._validate_set_axis(new_columns, self._columns_cache)
         if isinstance(self._dtypes, ModinDtypes):
-            new_value = self._dtypes.set_index(new_columns)
-            self.set_dtypes_cache(new_value)
+            try:
+                new_dtypes = self._dtypes.set_index(new_columns)
+            except NotImplementedError:
+                # can raise on duplicated labels
+                new_dtypes = None
         elif isinstance(self._dtypes, pandas.Series):
-            self.dtypes.index = new_columns
+            new_dtypes = self.dtypes.set_axis(new_columns)
         self.set_columns_cache(new_columns)
+        # we have to set new dtypes cache after columns,
+        # so the 'self.columns' and 'new_dtypes.index' indices would match
+        self.set_dtypes_cache(new_dtypes)
         self.synchronize_labels(axis=1)
 
     columns = property(_get_columns, _set_columns)

--- a/modin/core/dataframe/pandas/metadata/dtypes.py
+++ b/modin/core/dataframe/pandas/metadata/dtypes.py
@@ -294,6 +294,11 @@ class DtypesDescriptor:
         Calling this method on a descriptor that returns ``None`` for ``.columns_order``
         will result into information lose.
         """
+        if len(new_index) != len(set(new_index)):
+            raise NotImplementedError(
+                "Duplicated column names are not yet supported by DtypesDescriptor"
+            )
+
         if self.columns_order is None:
             # we can't map new columns to old columns and lost all dtypes :(
             return DtypesDescriptor(

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -2171,6 +2171,17 @@ class TestModinDtypes:
                 assert df._dtypes._value.equals(result_dtypes)
         assert df.dtypes.index.equals(pandas.Index(["col1", "col2", "col3"]))
 
+    def test_set_index_with_dupl_labels(self):
+        """Verify that setting duplicated columns doesn't propagate any errors to a user."""
+        df = pd.DataFrame({"a": [1, 2, 3, 4], "b": [3.5, 4.4, 5.5, 6.6]})
+        # making sure that dtypes are represented by an unmaterialized dtypes-descriptor
+        df._query_compiler._modin_frame.set_dtypes_cache(None)
+
+        df.columns = ["a", "a"]
+        assert df.dtypes.equals(
+            pandas.Series([np.dtype(int), np.dtype("float64")], index=["a", "a"])
+        )
+
 
 class TestZeroComputationDtypes:
     """


### PR DESCRIPTION
…olumns()' with dupl labels

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6822 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
