### PR TITLE
FIX-#6824: Invalidate 'ModinIndex._lengths_id' on empty partitions filtering

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -808,8 +808,17 @@ class PandasDataframe(ClassLogger):
                 if i < len(self.row_lengths) and self.row_lengths[i] != 0
             ]
         )
-        self._column_widths_cache = [w for w in self.column_widths if w != 0]
-        self._row_lengths_cache = [r for r in self.row_lengths if r != 0]
+        new_col_widths = [w for w in self.column_widths if w != 0]
+        new_row_lengths = [r for r in self.row_lengths if r != 0]
+
+        # check whether an axis partitioning was modified and if we should reset the lengths id for 'ModinIndex'
+        if new_col_widths != self.column_widths:
+            self.set_columns_cache(self.copy_columns_cache(copy_lengths=False))
+        if new_row_lengths != self.row_lengths:
+            self.set_index_cache(self.copy_index_cache(copy_lengths=False))
+
+        self._column_widths_cache = new_col_widths
+        self._row_lengths_cache = new_row_lengths
 
     def synchronize_labels(self, axis=None):
         """

--- a/modin/core/dataframe/pandas/metadata/index.py
+++ b/modin/core/dataframe/pandas/metadata/index.py
@@ -144,6 +144,10 @@ class ModinIndex:
         new_index = self.copy(copy_lengths=True)
         new_index._axis = axis
         new_index._value = self._get_default_callable(value, new_index._axis)
+        # if the '._value' was 'None' initially, then the '_is_default_callable' flag was
+        # also being set to 'False', since now the '._value' is a default callable,
+        # so we want to ensure that the flag is set to 'True'
+        new_index._is_default_callable = True
         return new_index
 
     @property

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -1282,37 +1282,37 @@ class TestModinIndexIds:
         # case1: partitioning is modified by '._filter_empties()', meaning that '._lengths_id' should be changed
         md_df = construct_modin_df_by_scheme(
             pandas.DataFrame({"a": [1, 1, 2, 2]}),
-            {"row_lengths": [2, 2], "col_widths": [1]},
+            {"row_lengths": [2, 2], "column_widths": [1]},
         )
         mf = md_df.query("a < 2")._query_compiler._modin_frame
+        mf.index  # trigger index materialization
 
         old_cache = mf._index_cache
         assert mf._partitions.shape == (2, 1)
-        assert not mf.has_materialized_index
 
         mf._filter_empties()
         new_cache = mf._index_cache
 
         assert new_cache._index_id == old_cache._index_id
         assert new_cache._lengths_id != old_cache._lengths_id
+        assert new_cache._lengths_cache != old_cache._lengths_cache
 
         # case2: partitioning is NOT modified by '._filter_empties()', meaning that '._lengths_id' should stay the same
         md_df = construct_modin_df_by_scheme(
             pandas.DataFrame({"a": [1, 1, 2, 2]}),
-            {"row_lengths": [2, 2], "col_widths": [1]},
+            {"row_lengths": [2, 2], "column_widths": [1]},
         )
-        remove_axis_cache(md_df)
         mf = md_df._query_compiler._modin_frame
 
         old_cache = mf._index_cache
         assert mf._partitions.shape == (2, 1)
-        assert not mf.has_materialized_index
 
         mf._filter_empties()
         new_cache = mf._index_cache
 
         assert new_cache._index_id == old_cache._index_id
         assert new_cache._lengths_id == old_cache._lengths_id
+        assert new_cache._lengths_cache == old_cache._lengths_cache
 
 
 def test_skip_set_columns():


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Invalidate old row/column lengths stored in `ModinIndex._lengths_cache` and `ModinIndex._lengths_id` if partitioning was modified during the empty partitions filtering.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6824 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
