### PR TITLE
REFACTOR-#0000: cleanup one todo and flake8 issues in `modin/utils.py`

### DIFF
--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -21,6 +21,7 @@ from typing import Optional
 import psutil
 import ray
 from packaging import version
+from ray.util.client.common import ClientObjectRef
 
 from modin.config import (
     CIAWSAccessKeyID,
@@ -49,13 +50,7 @@ _MAC_OBJECT_STORE_LIMIT_BYTES = 2 * 2**30
 
 _RAY_IGNORE_UNHANDLED_ERRORS_VAR = "RAY_IGNORE_UNHANDLED_ERRORS"
 
-ObjectIDType = ray.ObjectRef
-# TODO: Minimum version of Ray - 1.13
-# `if` branch can be deleted
-if version.parse(ray.__version__) >= version.parse("1.2.0"):
-    from ray.util.client.common import ClientObjectRef
-
-    ObjectIDType = (ray.ObjectRef, ClientObjectRef)
+ObjectIDType = (ray.ObjectRef, ClientObjectRef)
 
 
 def initialize_ray(

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -49,7 +49,7 @@ from pandas.util._print_versions import (  # type: ignore[attr-defined]
 )
 
 from modin._version import get_versions
-from modin.config import Engine, IsExperimental, StorageFormat
+from modin.config import Engine, StorageFormat
 
 T = TypeVar("T")
 """Generic type parameter"""
@@ -97,12 +97,10 @@ MIN_UNIDIST_VERSION = version.parse("0.2.1")
 
 PANDAS_API_URL_TEMPLATE = f"https://pandas.pydata.org/pandas-docs/version/{pandas.__version__}/reference/api/{{}}.html"
 
+# The '__reduced__' name is used internally by the query compiler as a column name to
+# represent pandas Series objects that are not explicitly assigned a name, so as to
+# distinguish between an N-element series and 1xN dataframe.
 MODIN_UNNAMED_SERIES_LABEL = "__reduced__"
-"""
-The '__reduced__' name is used internally by the query compiler as a column name to
-represent pandas Series objects that are not explicitly assigned a name, so as to
-distinguish between an N-element series and 1xN dataframe.
-"""
 
 
 def _make_api_url(token: str) -> str:
@@ -788,8 +786,6 @@ def _get_modin_deps_info() -> Mapping[str, Optional[JSONSerializable]]:
     return result
 
 
-# Disable flake8 checks for print() in this file
-# flake8: noqa: T001
 def show_versions(as_json: Union[str, bool] = False) -> None:
     """
     Provide useful information, important for bug reports.
@@ -836,14 +832,13 @@ def show_versions(as_json: Union[str, bool] = False) -> None:
         sys_info["LOCALE"] = f"{language_code}.{encoding}"
 
         maxlen = max(max(len(x) for x in d) for d in (deps, modin_deps))
-        print("\nINSTALLED VERSIONS")
-        print("------------------")
+        print("\nINSTALLED VERSIONS\n------------------")  # noqa: T201
         for k, v in sys_info.items():
-            print(f"{k:<{maxlen}}: {v}")
+            print(f"{k:<{maxlen}}: {v}")  # noqa: T201
         for name, d in (("Modin", modin_deps), ("pandas", deps)):
-            print(f"\n{name} dependencies\n{'-' * (len(name) + 13)}")
+            print(f"\n{name} dependencies\n{'-' * (len(name) + 13)}")  # noqa: T201
             for k, v in d.items():
-                print(f"{k:<{maxlen}}: {v}")
+                print(f"{k:<{maxlen}}: {v}")  # noqa: T201
 
 
 class ModinAssumptionError(Exception):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
