### PR TITLE
REFACTOR-#6833: Remove `SocksProxy`, `DoLogRpyc`, `DoTraceRpyc` outdated classes

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -370,24 +370,6 @@ class NPartitions(EnvironmentVariable, type=int):
             return CpuCount.get()
 
 
-class SocksProxy(EnvironmentVariable, type=ExactStr):
-    """SOCKS proxy address if it is needed for SSH to work."""
-
-    varname = "MODIN_SOCKS_PROXY"
-
-
-class DoLogRpyc(EnvironmentVariable, type=bool):
-    """Whether to gather RPyC logs (applicable for remote context)."""
-
-    varname = "MODIN_LOG_RPYC"
-
-
-class DoTraceRpyc(EnvironmentVariable, type=bool):
-    """Whether to trace RPyC calls (applicable for remote context)."""
-
-    varname = "MODIN_TRACE_RPYC"
-
-
 class HdkFragmentSize(EnvironmentVariable, type=int):
     """How big a fragment in HDK should be when creating a table (in rows)."""
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6833 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
