### PR TITLE
FEAT-#6835: Do not put binary functions to the Ray storage multiple times.

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -415,7 +415,9 @@ class Binary(Operator):
                     ):
                         shape_hint = "column"
                     new_modin_frame = query_compiler._modin_frame.map(
-                        lambda df: func(df, other, *args, **kwargs),
+                        func,
+                        func_args=(other, *args),
+                        func_kwargs=kwargs,
                         dtypes=dtypes,
                     )
                 return query_compiler.__constructor__(

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2093,6 +2093,8 @@ class PandasDataframe(ClassLogger):
         func: Callable,
         dtypes: Optional[str] = None,
         new_columns: Optional[pandas.Index] = None,
+        func_args=None,
+        func_kwargs=None,
     ) -> "PandasDataframe":
         """
         Perform a function that maps across the entire dataset.
@@ -2108,13 +2110,19 @@ class PandasDataframe(ClassLogger):
         new_columns : pandas.Index, optional
             New column labels of the result, its length has to be identical
             to the older columns. If not specified, old column labels are preserved.
+        func_args : iterable, optional
+            Positional arguments for the 'func' callable.
+        func_kwargs : dict, optional
+            Keyword arguments for the 'func' callable.
 
         Returns
         -------
         PandasDataframe
             A new dataframe.
         """
-        new_partitions = self._partition_mgr_cls.map_partitions(self._partitions, func)
+        new_partitions = self._partition_mgr_cls.map_partitions(
+            self._partitions, func, func_args, func_kwargs
+        )
         if new_columns is not None and self.has_materialized_columns:
             assert len(new_columns) == len(
                 self.columns

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -566,7 +566,13 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
 
     @classmethod
     @wait_computations_if_benchmark_mode
-    def map_partitions(cls, partitions, map_func):
+    def map_partitions(
+        cls,
+        partitions,
+        map_func,
+        func_args=None,
+        func_kwargs=None,
+    ):
         """
         Apply `map_func` to every partition in `partitions`.
 
@@ -576,6 +582,10 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             Partitions housing the data of Modin Frame.
         map_func : callable
             Function to apply.
+        func_args : iterable, optional
+            Positional arguments for the 'map_func'.
+        func_kwargs : dict, optional
+            Keyword arguments for the 'map_func'.
 
         Returns
         -------
@@ -585,14 +595,23 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
         preprocessed_map_func = cls.preprocess_func(map_func)
         return np.array(
             [
-                [part.apply(preprocessed_map_func) for part in row_of_parts]
+                [
+                    part.apply(
+                        preprocessed_map_func,
+                        *func_args if func_args is not None else (),
+                        **func_kwargs if func_kwargs is not None else {},
+                    )
+                    for part in row_of_parts
+                ]
                 for row_of_parts in partitions
             ]
         )
 
     @classmethod
     @wait_computations_if_benchmark_mode
-    def lazy_map_partitions(cls, partitions, map_func, func_args=None):
+    def lazy_map_partitions(
+        cls, partitions, map_func, func_args=None, func_kwargs=None
+    ):
         """
         Apply `map_func` to every partition in `partitions` *lazily*.
 
@@ -604,6 +623,8 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
             Function to apply.
         func_args : iterable, optional
             Positional arguments for the 'map_func'.
+        func_kwargs : dict, optional
+            Keyword arguments for the 'map_func'.
 
         Returns
         -------
@@ -616,7 +637,8 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 [
                     part.add_to_apply_calls(
                         preprocessed_map_func,
-                        *(tuple() if func_args is None else func_args),
+                        *func_args if func_args is not None else (),
+                        **func_kwargs if func_kwargs is not None else {},
                     )
                     for part in row
                 ]

--- a/modin/core/execution/ray/common/engine_wrapper.py
+++ b/modin/core/execution/ray/common/engine_wrapper.py
@@ -18,7 +18,7 @@ To be used as a piece of building a Ray-based engine.
 """
 
 import asyncio
-from os import environ
+import os
 from types import FunctionType
 
 import ray
@@ -143,7 +143,7 @@ class RayWrapper:
                         cls._func_cache[data] = ref
                     else:
                         msg = "To many functions in the RayWrapper cache!"
-                        assert "MODIN_GITHUB_CI" not in environ, msg
+                        assert "MODIN_GITHUB_CI" not in os.environ, msg
                         ErrorMessage.warn(msg)
                 return ref
         return ray.put(data, **kwargs)


### PR DESCRIPTION
Added functions cache to RayWrapper.
Removed lambda wrapper for the binary functions.

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6835 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
