### PR TITLE
FEAT-#6838: Prefer lazy execution for binary operations with scalar.

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -419,6 +419,7 @@ class Binary(Operator):
                         func_args=(other, *args),
                         func_kwargs=kwargs,
                         dtypes=dtypes,
+                        lazy=True,
                     )
                 return query_compiler.__constructor__(
                     new_modin_frame, shape_hint=shape_hint

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2153,7 +2153,7 @@ class PandasDataframe(ClassLogger):
         func_kwargs : dict, optional
             Keyword arguments for the 'func' callable.
         lazy : bool, default: False
-            Prefer lazy execution.
+            Whether to prefer lazy execution or not.
 
         Returns
         -------

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2132,6 +2132,7 @@ class PandasDataframe(ClassLogger):
         new_columns: Optional[pandas.Index] = None,
         func_args=None,
         func_kwargs=None,
+        lazy=False,
     ) -> "PandasDataframe":
         """
         Perform a function that maps across the entire dataset.
@@ -2151,15 +2152,20 @@ class PandasDataframe(ClassLogger):
             Positional arguments for the 'func' callable.
         func_kwargs : dict, optional
             Keyword arguments for the 'func' callable.
+        lazy : bool, default: False
+            Prefer lazy execution.
 
         Returns
         -------
         PandasDataframe
             A new dataframe.
         """
-        new_partitions = self._partition_mgr_cls.map_partitions(
-            self._partitions, func, func_args, func_kwargs
+        map_fn = (
+            self._partition_mgr_cls.lazy_map_partitions
+            if lazy
+            else self._partition_mgr_cls.map_partitions
         )
+        new_partitions = map_fn(self._partitions, func, func_args, func_kwargs)
         if new_columns is not None and self.has_materialized_columns:
             assert len(new_columns) == len(
                 self.columns


### PR DESCRIPTION
**Depends on #6836.**

## What do these changes do?

Multiple binary operations are faster to execute lazy, in a single batch. Here is an example:

```python
import ray
ray.init()

import time
import modin.pandas as pd
from modin.utils import execute

df = pd.Series(range(100000))
start = time.time()
for i in range(100):
    df = df + i
execute(df)
print(f"Time: {time.time() - start}")
```
Time: 2.4991016387939453
Time on master: 5.286777019500732
- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6838 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
