### PR TITLE
FIX-#6840: Call `tolist` function in `DtypesDescriptor._merge_dtypes`

### DIFF
--- a/modin/core/dataframe/pandas/metadata/dtypes.py
+++ b/modin/core/dataframe/pandas/metadata/dtypes.py
@@ -517,7 +517,7 @@ class DtypesDescriptor:
 
         if dtypes_are_unknown:
             return DtypesDescriptor(
-                cols_with_unknown_dtypes=dtypes_matrix.index,
+                cols_with_unknown_dtypes=dtypes_matrix.index.tolist(),
                 know_all_names=know_all_names,
             )
 

--- a/modin/pandas/test/test_concat.py
+++ b/modin/pandas/test/test_concat.py
@@ -197,6 +197,26 @@ def test_concat_5776():
     )
 
 
+def test_concat_6840():
+    groupby_objs = []
+    for idx, lib in enumerate((pd, pandas)):
+        df1 = lib.DataFrame(
+            [["a", 1], ["b", 2], ["b", 4]], columns=["letter", "number"]
+        )
+        df1_g = df1.groupby("letter", as_index=False)["number"].agg("sum")
+
+        df2 = lib.DataFrame(
+            [["a", 3], ["a", 4], ["b", 1]], columns=["letter", "number"]
+        )
+        df2_g = df2.groupby("letter", as_index=False)["number"].agg("sum")
+        groupby_objs.append([df1_g, df2_g])
+
+    df_equals(
+        pd.concat(groupby_objs[0]),
+        pandas.concat(groupby_objs[1]),
+    )
+
+
 def test_concat_with_empty_frame():
     modin_empty_df = pd.DataFrame()
     pandas_empty_df = pandas.DataFrame()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Fixes a problematic case for the user, but we will also need to fix `ModinDtypes.set_index` function. This is more complicated, I leave this for @dchigarev.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6840 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
