### PR TITLE
TEST-#6846: Skip unstable Unidist to_csv tests

### DIFF
--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -1103,6 +1103,10 @@ class TestCsv:
     @pytest.mark.parametrize("index_label", [None, False, "New index"])
     @pytest.mark.parametrize("columns", [None, ["col1", "col3", "col5"]])
     @pytest.mark.exclude_in_sanity
+    @pytest.mark.skipif(
+        condition=Engine.get() == "Unidist" and os.name == "nt",
+        reason="https://github.com/modin-project/modin/issues/6846",
+    )
     def test_to_csv(
         self,
         tmp_path,
@@ -1137,6 +1141,10 @@ class TestCsv:
             columns=columns,
         )
 
+    @pytest.mark.skipif(
+        condition=Engine.get() == "Unidist" and os.name == "nt",
+        reason="https://github.com/modin-project/modin/issues/6846",
+    )
     def test_dataframe_to_csv(self, tmp_path):
         pandas_df = pandas.read_csv(pytest.csvs_names["test_read_csv_regular"])
         modin_df = pd.DataFrame(pandas_df)
@@ -1147,6 +1155,10 @@ class TestCsv:
             extension="csv",
         )
 
+    @pytest.mark.skipif(
+        condition=Engine.get() == "Unidist" and os.name == "nt",
+        reason="https://github.com/modin-project/modin/issues/6846",
+    )
     def test_series_to_csv(self, tmp_path):
         pandas_s = pandas.read_csv(
             pytest.csvs_names["test_read_csv_regular"], usecols=["col1"]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6846 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
