### PR TITLE
FEAT-#6831: Implement read_parquet_glob and to_parquet_glob

### DIFF
--- a/docs/flow/modin/experimental/pandas.rst
+++ b/docs/flow/modin/experimental/pandas.rst
@@ -13,4 +13,6 @@ Experimental API Reference
 .. autofunction:: read_csv_glob
 .. autofunction:: read_custom_text
 .. autofunction:: read_pickle_distributed
+.. autofunction:: read_parquet_glob
 .. automethod:: modin.pandas.DataFrame.modin::to_pickle_distributed
+.. automethod:: modin.pandas.DataFrame.modin::to_parquet_glob

--- a/docs/supported_apis/dataframe_supported.rst
+++ b/docs/supported_apis/dataframe_supported.rst
@@ -421,6 +421,8 @@ default to pandas.
 |                            |                           |                        | ``path`` parameter specifies a directory where one |
 |                            |                           |                        | file is written per row partition of the Modin     |
 |                            |                           |                        | dataframe.                                         |
+|                            |                           |                        | Experimental implementation:                       |
+|                            |                           |                        | DataFrame.modin.to_parquet_glob                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+
 | ``to_period``              | `to_period`_              | D                      |                                                    |
 +----------------------------+---------------------------+------------------------+----------------------------------------------------+

--- a/docs/supported_apis/io_supported.rst
+++ b/docs/supported_apis/io_supported.rst
@@ -46,6 +46,7 @@ default to pandas.
 |                   |                                 | passed via ``**kwargs`` are not supported.             |
 |                   |                                 | ``use_nullable_dtypes`` == True is not supported.      |
 |                   |                                 |                                                        |
+|                   |                                 | Experimental implementation: read_parquet_glob         |
 +-------------------+---------------------------------+--------------------------------------------------------+
 | `read_json`_      | P                               | Implemented for ``lines=True``                         |
 +-------------------+---------------------------------+--------------------------------------------------------+

--- a/docs/usage_guide/advanced_usage/index.rst
+++ b/docs/usage_guide/advanced_usage/index.rst
@@ -30,8 +30,10 @@ Modin also supports these experimental APIs on top of pandas that are under acti
 - :py:func:`~modin.experimental.pandas.read_csv_glob` -- read multiple files in a directory
 - :py:func:`~modin.experimental.pandas.read_sql` -- add optional parameters for the database connection
 - :py:func:`~modin.experimental.pandas.read_custom_text` -- read custom text data from file
-- :py:func:`~modin.experimental.pandas.read_pickle_distributed`  -- read multiple files in a directory
-- :py:meth:`~modin.pandas.DataFrame.modin.to_pickle_distributed` -- write to multiple files in a directory
+- :py:func:`~modin.experimental.pandas.read_pickle_distributed`  -- read multiple pickle files in a directory
+- :py:func:`~modin.experimental.pandas.read_parquet_glob`  -- read multiple parquet files in a directory
+- :py:meth:`~modin.pandas.DataFrame.modin.to_pickle_distributed` -- write to multiple pickle files in a directory
+- :py:meth:`~modin.pandas.DataFrame.modin.to_parquet_glob` -- write to multiple parquet files in a directory
 
 DataFrame partitioning API
 --------------------------

--- a/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/io/io.py
@@ -43,12 +43,13 @@ from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.experimental.core.io import (
     ExperimentalCSVGlobDispatcher,
     ExperimentalCustomTextDispatcher,
-    ExperimentalPickleDispatcher,
+    ExperimentalGlobDispatcher,
     ExperimentalSQLDispatcher,
 )
 from modin.experimental.core.storage_formats.pandas.parsers import (
     ExperimentalCustomTextParser,
     ExperimentalPandasCSVGlobParser,
+    ExperimentalPandasParquetParser,
     ExperimentalPandasPickleParser,
 )
 
@@ -89,10 +90,20 @@ class PandasOnDaskIO(BaseIO):
     read_csv_glob = __make_read(
         ExperimentalPandasCSVGlobParser, ExperimentalCSVGlobDispatcher
     )
-    read_pickle_distributed = __make_read(
-        ExperimentalPandasPickleParser, ExperimentalPickleDispatcher
+    read_parquet_glob = __make_read(
+        ExperimentalPandasParquetParser, ExperimentalGlobDispatcher
     )
-    to_pickle_distributed = __make_write(ExperimentalPickleDispatcher)
+    to_parquet_glob = __make_write(
+        ExperimentalGlobDispatcher,
+        build_args={**build_args, "base_write": BaseIO.to_parquet},
+    )
+    read_pickle_distributed = __make_read(
+        ExperimentalPandasPickleParser, ExperimentalGlobDispatcher
+    )
+    to_pickle_distributed = __make_write(
+        ExperimentalGlobDispatcher,
+        build_args={**build_args, "base_write": BaseIO.to_pickle},
+    )
     read_custom_text = __make_read(
         ExperimentalCustomTextParser, ExperimentalCustomTextDispatcher
     )

--- a/modin/core/execution/dispatching/factories/dispatcher.py
+++ b/modin/core/execution/dispatching/factories/dispatcher.py
@@ -297,6 +297,16 @@ class FactoryDispatcher(object):
         return cls.get_factory()._to_pickle_distributed(*args, **kwargs)
 
     @classmethod
+    # @_inherit_docstrings(factories.PandasOnRayFactory._read_parquet_glob)
+    def read_parquet_glob(cls, *args, **kwargs):
+        return cls.get_factory()._read_parquet_glob(*args, **kwargs)
+
+    @classmethod
+    # @_inherit_docstrings(factories.PandasOnRayFactory._to_parquet_glob)
+    def to_parquet_glob(cls, *args, **kwargs):
+        return cls.get_factory()._to_parquet_glob(*args, **kwargs)
+
+    @classmethod
     @_inherit_docstrings(factories.PandasOnRayFactory._read_custom_text)
     def read_custom_text(cls, **kwargs):
         return cls.get_factory()._read_custom_text(**kwargs)

--- a/modin/core/execution/dispatching/factories/dispatcher.py
+++ b/modin/core/execution/dispatching/factories/dispatcher.py
@@ -297,12 +297,12 @@ class FactoryDispatcher(object):
         return cls.get_factory()._to_pickle_distributed(*args, **kwargs)
 
     @classmethod
-    # @_inherit_docstrings(factories.PandasOnRayFactory._read_parquet_glob)
+    @_inherit_docstrings(factories.PandasOnRayFactory._read_parquet_glob)
     def read_parquet_glob(cls, *args, **kwargs):
         return cls.get_factory()._read_parquet_glob(*args, **kwargs)
 
     @classmethod
-    # @_inherit_docstrings(factories.PandasOnRayFactory._to_parquet_glob)
+    @_inherit_docstrings(factories.PandasOnRayFactory._to_parquet_glob)
     def to_parquet_glob(cls, *args, **kwargs):
         return cls.get_factory()._to_parquet_glob(*args, **kwargs)
 

--- a/modin/core/execution/dispatching/factories/factories.py
+++ b/modin/core/execution/dispatching/factories/factories.py
@@ -517,20 +517,31 @@ class BaseFactory(object):
         return cls.io_cls.to_pickle_distributed(*args, **kwargs)
 
     @classmethod
-    # @_inherit_docstrings(factories.PandasOnRayFactory._read_parquet_glob)
-    def _read_parquet_glob(cls, *args, **kwargs):
-        # TODO: add docstring
+    @doc(
+        _doc_io_method_raw_template,
+        source="Parquet files",
+        params=_doc_io_method_kwargs_params,
+    )
+    def _read_parquet_glob(cls, **kwargs):
         current_execution = get_current_execution()
         if current_execution not in supported_executions:
             raise NotImplementedError(
                 f"`_read_parquet_glob()` is not implemented for {current_execution} execution."
             )
-        return cls.io_cls.read_parquet_glob(*args, **kwargs)
+        return cls.io_cls.read_parquet_glob(**kwargs)
 
     @classmethod
-    # @_inherit_docstrings(factories.PandasOnRayFactory._to_parquet_glob)
     def _to_parquet_glob(cls, *args, **kwargs):
-        # TODO: add docstring
+        """
+        Write query compiler content to several parquet files.
+
+        Parameters
+        ----------
+        *args : args
+            Arguments to pass to the writer method.
+        **kwargs : kwargs
+            Arguments to pass to the writer method.
+        """
         current_execution = get_current_execution()
         if current_execution not in supported_executions:
             raise NotImplementedError(

--- a/modin/core/execution/dispatching/factories/factories.py
+++ b/modin/core/execution/dispatching/factories/factories.py
@@ -516,6 +516,28 @@ class BaseFactory(object):
             )
         return cls.io_cls.to_pickle_distributed(*args, **kwargs)
 
+    @classmethod
+    # @_inherit_docstrings(factories.PandasOnRayFactory._read_parquet_glob)
+    def _read_parquet_glob(cls, *args, **kwargs):
+        # TODO: add docstring
+        current_execution = get_current_execution()
+        if current_execution not in supported_executions:
+            raise NotImplementedError(
+                f"`_read_parquet_glob()` is not implemented for {current_execution} execution."
+            )
+        return cls.io_cls.read_parquet_glob(*args, **kwargs)
+
+    @classmethod
+    # @_inherit_docstrings(factories.PandasOnRayFactory._to_parquet_glob)
+    def _to_parquet_glob(cls, *args, **kwargs):
+        # TODO: add docstring
+        current_execution = get_current_execution()
+        if current_execution not in supported_executions:
+            raise NotImplementedError(
+                f"`_to_parquet_glob()` is not implemented for {current_execution} execution."
+            )
+        return cls.io_cls.to_parquet_glob(*args, **kwargs)
+
 
 @doc(_doc_factory_class, execution_name="PandasOnRay")
 class PandasOnRayFactory(BaseFactory):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/io/io.py
@@ -42,12 +42,13 @@ from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.experimental.core.io import (
     ExperimentalCSVGlobDispatcher,
     ExperimentalCustomTextDispatcher,
-    ExperimentalPickleDispatcher,
+    ExperimentalGlobDispatcher,
     ExperimentalSQLDispatcher,
 )
 from modin.experimental.core.storage_formats.pandas.parsers import (
     ExperimentalCustomTextParser,
     ExperimentalPandasCSVGlobParser,
+    ExperimentalPandasParquetParser,
     ExperimentalPandasPickleParser,
 )
 
@@ -91,10 +92,20 @@ class PandasOnRayIO(RayIO):
     read_csv_glob = __make_read(
         ExperimentalPandasCSVGlobParser, ExperimentalCSVGlobDispatcher
     )
-    read_pickle_distributed = __make_read(
-        ExperimentalPandasPickleParser, ExperimentalPickleDispatcher
+    read_parquet_glob = __make_read(
+        ExperimentalPandasParquetParser, ExperimentalGlobDispatcher
     )
-    to_pickle_distributed = __make_write(ExperimentalPickleDispatcher)
+    to_parquet_glob = __make_write(
+        ExperimentalGlobDispatcher,
+        build_args={**build_args, "base_write": RayIO.to_parquet},
+    )
+    read_pickle_distributed = __make_read(
+        ExperimentalPandasPickleParser, ExperimentalGlobDispatcher
+    )
+    to_pickle_distributed = __make_write(
+        ExperimentalGlobDispatcher,
+        build_args={**build_args, "base_write": RayIO.to_pickle},
+    )
     read_custom_text = __make_read(
         ExperimentalCustomTextParser, ExperimentalCustomTextDispatcher
     )

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/io/io.py
@@ -42,12 +42,13 @@ from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 from modin.experimental.core.io import (
     ExperimentalCSVGlobDispatcher,
     ExperimentalCustomTextDispatcher,
-    ExperimentalPickleDispatcher,
+    ExperimentalGlobDispatcher,
     ExperimentalSQLDispatcher,
 )
 from modin.experimental.core.storage_formats.pandas.parsers import (
     ExperimentalCustomTextParser,
     ExperimentalPandasCSVGlobParser,
+    ExperimentalPandasParquetParser,
     ExperimentalPandasPickleParser,
 )
 
@@ -91,10 +92,20 @@ class PandasOnUnidistIO(UnidistIO):
     read_csv_glob = __make_read(
         ExperimentalPandasCSVGlobParser, ExperimentalCSVGlobDispatcher
     )
-    read_pickle_distributed = __make_read(
-        ExperimentalPandasPickleParser, ExperimentalPickleDispatcher
+    read_parquet_glob = __make_read(
+        ExperimentalPandasParquetParser, ExperimentalGlobDispatcher
     )
-    to_pickle_distributed = __make_write(ExperimentalPickleDispatcher)
+    to_parquet_glob = __make_write(
+        ExperimentalGlobDispatcher,
+        build_args={**build_args, "base_write": UnidistIO.to_parquet},
+    )
+    read_pickle_distributed = __make_read(
+        ExperimentalPandasPickleParser, ExperimentalGlobDispatcher
+    )
+    to_pickle_distributed = __make_write(
+        ExperimentalGlobDispatcher,
+        build_args={**build_args, "base_write": UnidistIO.to_pickle},
+    )
     read_custom_text = __make_read(
         ExperimentalCustomTextParser, ExperimentalCustomTextDispatcher
     )

--- a/modin/core/io/io.py
+++ b/modin/core/io/io.py
@@ -652,7 +652,7 @@ class BaseIO:
     @_inherit_docstrings(
         pandas.DataFrame.to_parquet, apilink="pandas.DataFrame.to_parquet"
     )
-    def to_parquet(cls, obj, **kwargs):  # noqa: PR01
+    def to_parquet(cls, obj, path, **kwargs):  # noqa: PR01
         """
         Write object to the binary parquet format using pandas.
 
@@ -662,4 +662,4 @@ class BaseIO:
         if isinstance(obj, BaseQueryCompiler):
             obj = obj.to_pandas()
 
-        return obj.to_parquet(**kwargs)
+        return obj.to_parquet(path, **kwargs)

--- a/modin/experimental/core/io/__init__.py
+++ b/modin/experimental/core/io/__init__.py
@@ -13,7 +13,7 @@
 
 """Experimental IO functions implementations."""
 
-from .pickle.pickle_dispatcher import ExperimentalPickleDispatcher
+from .glob.glob_dispatcher import ExperimentalGlobDispatcher
 from .sql.sql_dispatcher import ExperimentalSQLDispatcher
 from .text.csv_glob_dispatcher import ExperimentalCSVGlobDispatcher
 from .text.custom_text_dispatcher import ExperimentalCustomTextDispatcher
@@ -21,6 +21,7 @@ from .text.custom_text_dispatcher import ExperimentalCustomTextDispatcher
 __all__ = [
     "ExperimentalCSVGlobDispatcher",
     "ExperimentalSQLDispatcher",
-    "ExperimentalPickleDispatcher",
+    "ExperimentalGlobDispatcher",
+    "ExperimentalGlobDispatcher",
     "ExperimentalCustomTextDispatcher",
 ]

--- a/modin/experimental/core/io/__init__.py
+++ b/modin/experimental/core/io/__init__.py
@@ -22,6 +22,5 @@ __all__ = [
     "ExperimentalCSVGlobDispatcher",
     "ExperimentalSQLDispatcher",
     "ExperimentalGlobDispatcher",
-    "ExperimentalGlobDispatcher",
     "ExperimentalCustomTextDispatcher",
 ]

--- a/modin/experimental/core/io/glob/__init__.py
+++ b/modin/experimental/core/io/glob/__init__.py
@@ -11,4 +11,4 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-"""Experimental Glob format type IO functions implementations."""
+"""Experimental module that allows to work with various formats using glob syntax."""

--- a/modin/experimental/core/io/glob/__init__.py
+++ b/modin/experimental/core/io/glob/__init__.py
@@ -11,4 +11,4 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-"""Experimental Pickle format type IO functions implementations."""
+"""Experimental Glob format type IO functions implementations."""

--- a/modin/experimental/core/io/glob/glob_dispatcher.py
+++ b/modin/experimental/core/io/glob/glob_dispatcher.py
@@ -108,9 +108,9 @@ class ExperimentalGlobDispatcher(FileDispatcher):
         ----------
         qc : BaseQueryCompiler
             The query compiler of the Modin dataframe that we want
-            to run ``to_[format]_glob`` on.
+            to run ``to_<format>_glob`` on.
         **kwargs : dict
-            Parameters for ``pandas.to_[format](**kwargs)``.
+            Parameters for ``pandas.to_<format>(**kwargs)``.
         """
         path_key = "filepath_or_buffer" if "filepath_or_buffer" in kwargs else "path"
         filepath_or_buffer = kwargs.pop(path_key)

--- a/modin/experimental/core/io/glob/glob_dispatcher.py
+++ b/modin/experimental/core/io/glob/glob_dispatcher.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-"""Module houses ``ExperimentalGlobDispatcher`` class that is used to read files of different formats in parallel."""
+"""Module houses ``ExperimentalGlobDispatcher`` class that is used to read/write files of different formats in parallel."""
 
 import glob
 import warnings
@@ -25,7 +25,7 @@ from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 
 
 class ExperimentalGlobDispatcher(FileDispatcher):
-    """Class implements reading different formats, parallelizing by the number of files."""
+    """Class implements reading/writing different formats, parallelizing by the number of files."""
 
     @classmethod
     def _read(cls, **kwargs):

--- a/modin/experimental/core/io/glob/glob_dispatcher.py
+++ b/modin/experimental/core/io/glob/glob_dispatcher.py
@@ -124,6 +124,7 @@ class ExperimentalGlobDispatcher(FileDispatcher):
 
         # Be careful, this is a kind of limitation, but at the time of the first implementation,
         # getting a name in this way is quite convenient.
+        # We can use this attribute because the names of the BaseIO's methods match pandas API.
         write_func_name = cls.base_write.__name__
 
         def func(df, **kw):  # pragma: no cover

--- a/modin/experimental/core/io/glob/glob_dispatcher.py
+++ b/modin/experimental/core/io/glob/glob_dispatcher.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-"""Module houses ``ExperimentalPickleDispatcher`` class that is used for reading `.pkl` files."""
+"""Module houses ``ExperimentalGlobDispatcher`` class that is used to read files of different formats in parallel."""
 
 import glob
 import warnings
@@ -24,20 +24,20 @@ from modin.core.io.file_dispatcher import FileDispatcher
 from modin.core.storage_formats.pandas.query_compiler import PandasQueryCompiler
 
 
-class ExperimentalPickleDispatcher(FileDispatcher):
-    """Class handles utils for reading pickle files."""
+class ExperimentalGlobDispatcher(FileDispatcher):
+    """Class implements reading different formats, parallelizing by the number of files."""
 
     @classmethod
-    def _read(cls, filepath_or_buffer, **kwargs):
+    def _read(cls, **kwargs):
         """
         Read data from `filepath_or_buffer` according to `kwargs` parameters.
 
         Parameters
         ----------
         filepath_or_buffer : str, path object or file-like object
-            `filepath_or_buffer` parameter of `read_pickle` function.
+            `filepath_or_buffer` parameter of `read_*` function.
         **kwargs : dict
-            Parameters of `read_pickle` function.
+            Parameters of `read_*` function.
 
         Returns
         -------
@@ -46,10 +46,10 @@ class ExperimentalPickleDispatcher(FileDispatcher):
 
         Notes
         -----
-        In experimental mode, we can use `*` in the filename.
-
         The number of partitions is equal to the number of input files.
         """
+        path_key = "filepath_or_buffer" if "filepath_or_buffer" in kwargs else "path"
+        filepath_or_buffer = kwargs.pop(path_key)
         filepath_or_buffer = stringify_path(filepath_or_buffer)
         if not (isinstance(filepath_or_buffer, str) and "*" in filepath_or_buffer):
             return cls.single_worker_read(
@@ -104,37 +104,31 @@ class ExperimentalPickleDispatcher(FileDispatcher):
         - if `*` is in the filename, then it will be replaced by the ascending sequence 0, 1, 2, …
         - if `*` is not in the filename, then the default implementation will be used.
 
-        Example: 4 partitions and input filename="partition*.pkl.gz", then filenames will be:
-        `partition0.pkl.gz`, `partition1.pkl.gz`, `partition2.pkl.gz`, `partition3.pkl.gz`.
-
         Parameters
         ----------
         qc : BaseQueryCompiler
             The query compiler of the Modin dataframe that we want
-            to run ``to_pickle_distributed`` on.
+            to run ``to_[format]_glob`` on.
         **kwargs : dict
-            Parameters for ``pandas.to_pickle(**kwargs)``.
+            Parameters for ``pandas.to_[format](**kwargs)``.
         """
-        kwargs["filepath_or_buffer"] = stringify_path(kwargs["filepath_or_buffer"])
+        path_key = "filepath_or_buffer" if "filepath_or_buffer" in kwargs else "path"
+        filepath_or_buffer = kwargs.pop(path_key)
+        filepath_or_buffer = stringify_path(filepath_or_buffer)
         if not (
-            isinstance(kwargs["filepath_or_buffer"], str)
-            and "*" in kwargs["filepath_or_buffer"]
+            isinstance(filepath_or_buffer, str) and "*" in filepath_or_buffer
         ) or not isinstance(qc, PandasQueryCompiler):
             warnings.warn("Defaulting to Modin core implementation")
-            cls.base_io.to_pickle(qc, **kwargs)
+            cls.base_write(qc, filepath_or_buffer, **kwargs)
             return
+
+        # just to try
+        write_func_name = cls.base_write.__name__
 
         def func(df, **kw):  # pragma: no cover
             idx = str(kw["partition_idx"])
-            # dask doesn't make a copy of kwargs on serialization;
-            # so take a copy ourselves, otherwise the error is:
-            #  kwargs["path"] = kwargs.pop("filepath_or_buffer").replace("*", idx)
-            #  KeyError: 'filepath_or_buffer'
-            dask_kwargs = dict(kwargs)
-            dask_kwargs["path"] = dask_kwargs.pop("filepath_or_buffer").replace(
-                "*", idx
-            )
-            df.to_pickle(**dask_kwargs)
+            path = filepath_or_buffer.replace("*", idx)
+            getattr(df, write_func_name)(path, **kwargs)
             return pandas.DataFrame()
 
         result = qc._modin_frame.apply_full_axis(

--- a/modin/experimental/core/io/glob/glob_dispatcher.py
+++ b/modin/experimental/core/io/glob/glob_dispatcher.py
@@ -122,7 +122,8 @@ class ExperimentalGlobDispatcher(FileDispatcher):
             cls.base_write(qc, filepath_or_buffer, **kwargs)
             return
 
-        # just to try
+        # Be careful, this is a kind of limitation, but at the time of the first implementation,
+        # getting a name in this way is quite convenient.
         write_func_name = cls.base_write.__name__
 
         def func(df, **kw):  # pragma: no cover

--- a/modin/experimental/core/storage_formats/pandas/parsers.py
+++ b/modin/experimental/core/storage_formats/pandas/parsers.py
@@ -114,6 +114,24 @@ class ExperimentalPandasPickleParser(PandasParser):
         return _split_result_for_readers(1, num_splits, df) + [length, width]
 
 
+@doc(_doc_pandas_parser_class, data_type="parquet files")
+class ExperimentalPandasParquetParser(PandasParser):
+    @staticmethod
+    @doc(_doc_parse_func, parameters=_doc_parse_parameters_common)
+    def parse(fname, **kwargs):
+        warnings.filterwarnings("ignore")
+        num_splits = 1
+        single_worker_read = kwargs.pop("single_worker_read", None)
+        df = pandas.read_parquet(fname, **kwargs)
+        if single_worker_read:
+            return df
+
+        length = len(df)
+        width = len(df.columns)
+
+        return _split_result_for_readers(1, num_splits, df) + [length, width]
+
+
 @doc(_doc_pandas_parser_class, data_type="custom text")
 class ExperimentalCustomTextParser(PandasParser):
     @staticmethod

--- a/modin/experimental/pandas/__init__.py
+++ b/modin/experimental/pandas/__init__.py
@@ -40,6 +40,7 @@ from modin.pandas import *  # noqa F401, F403
 from .io import (  # noqa F401
     read_csv_glob,
     read_custom_text,
+    read_parquet_glob,
     read_pickle_distributed,
     read_sql,
     to_pickle_distributed,

--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -460,7 +460,7 @@ def to_parquet_glob(
     """
     Write a DataFrame to the binary parquet format.
 
-    This experimental feature provides parallel writing into multiple pickle files which are
+    This experimental feature provides parallel writing into multiple parquet files which are
     defined by glob pattern, otherwise (without glob pattern) default pandas implementation is used.
 
     Notes

--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -354,7 +354,7 @@ def to_pickle_distributed(
     compression: CompressionOptions = "infer",
     protocol: int = pickle.HIGHEST_PROTOCOL,
     storage_options: StorageOptions = None,
-):
+) -> None:
     """
     Pickle (serialize) object to file.
 
@@ -363,7 +363,7 @@ def to_pickle_distributed(
 
     Parameters
     ----------
-    filepath_or_buffer : str, path object or file-like object
+    filepath_or_buffer : str
         File path where the pickled object will be stored.
     compression : {{'infer', 'gzip', 'bz2', 'zip', 'xz', None}}, default: 'infer'
         A string representing the compression to use in the output file. By
@@ -412,8 +412,23 @@ def read_parquet_glob(
     filesystem=None,
     filters=None,
     **kwargs,
-):
-    # TODO: add docstring
+) -> DataFrame:  # noqa: PR01
+    """
+    Load a parquet object from the file path, returning a DataFrame.
+
+    This experimental feature provides parallel reading from multiple parquet files which are
+    defined by glob pattern. The files must contain parts of one dataframe, which can be
+    obtained, for example, by `DataFrame.modin.to_parquet_glob` function.
+
+    Returns
+    -------
+    DataFrame
+
+    Notes
+    -----
+    * Only string type supported for `path` argument.
+    * The rest of the arguments are the same as for `pandas.read_parquet`.
+    """
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     return DataFrame(
@@ -434,15 +449,25 @@ def read_parquet_glob(
 @expanduser_path_arg("path")
 def to_parquet_glob(
     self,
-    path=None,
+    path,
     engine="auto",
     compression="snappy",
     index=None,
     partition_cols=None,
     storage_options: StorageOptions = None,
     **kwargs,
-):
-    # TODO: add docstring
+) -> None:  # noqa: PR01
+    """
+    Write a DataFrame to the binary parquet format.
+
+    This experimental feature provides parallel writing into multiple pickle files which are
+    defined by glob pattern, otherwise (without glob pattern) default pandas implementation is used.
+
+    Notes
+    -----
+    * Only string type supported for `path` argument.
+    * The rest of the arguments are the same as for `pandas.to_parquet`.
+    """
     obj = self
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 

--- a/modin/experimental/pandas/io.py
+++ b/modin/experimental/pandas/io.py
@@ -13,6 +13,8 @@
 
 """Implement experimental I/O public API."""
 
+from __future__ import annotations
+
 import inspect
 import pathlib
 import pickle
@@ -396,4 +398,63 @@ def to_pickle_distributed(
         compression=compression,
         protocol=protocol,
         storage_options=storage_options,
+    )
+
+
+@expanduser_path_arg("path")
+def read_parquet_glob(
+    path,
+    engine: str = "auto",
+    columns: list[str] | None = None,
+    storage_options: StorageOptions = None,
+    use_nullable_dtypes: bool = lib.no_default,
+    dtype_backend=lib.no_default,
+    filesystem=None,
+    filters=None,
+    **kwargs,
+):
+    # TODO: add docstring
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
+
+    return DataFrame(
+        query_compiler=FactoryDispatcher.read_parquet_glob(
+            path=path,
+            engine=engine,
+            columns=columns,
+            storage_options=storage_options,
+            use_nullable_dtypes=use_nullable_dtypes,
+            dtype_backend=dtype_backend,
+            filesystem=filesystem,
+            filters=filters,
+            **kwargs,
+        )
+    )
+
+
+@expanduser_path_arg("path")
+def to_parquet_glob(
+    self,
+    path=None,
+    engine="auto",
+    compression="snappy",
+    index=None,
+    partition_cols=None,
+    storage_options: StorageOptions = None,
+    **kwargs,
+):
+    # TODO: add docstring
+    obj = self
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
+
+    if isinstance(self, DataFrame):
+        obj = self._query_compiler
+    FactoryDispatcher.to_parquet_glob(
+        obj,
+        path=path,
+        engine=engine,
+        compression=compression,
+        index=index,
+        partition_cols=partition_cols,
+        storage_options=storage_options,
+        **kwargs,
     )

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -295,8 +295,8 @@ def test_parquet_glob(filename):
         read_df = pd.read_parquet_glob(filename)
     df_equals(read_df, df)
 
-    pickle_files = glob.glob(str(filename))
-    teardown_test_files(pickle_files)
+    parquet_files = glob.glob(str(filename))
+    teardown_test_files(parquet_files)
 
 
 @pytest.mark.skipif(

--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -274,6 +274,33 @@ def test_distributed_pickling(filename, compression, pathlike):
 
 @pytest.mark.skipif(
     Engine.get() not in ("Ray", "Unidist", "Dask"),
+    reason=f"{Engine.get()} does not have experimental API",
+)
+@pytest.mark.parametrize(
+    "filename",
+    ["test_parquet_glob.parquet", "test_parquet_glob*.parquet"],
+)
+def test_parquet_glob(filename):
+    data = test_data["int_data"]
+    df = pd.DataFrame(data)
+
+    filename_param = filename
+
+    with (
+        warns_that_defaulting_to_pandas()
+        if filename_param == "test_parquet_glob.parquet"
+        else contextlib.nullcontext()
+    ):
+        df.modin.to_parquet_glob(filename)
+        read_df = pd.read_parquet_glob(filename)
+    df_equals(read_df, df)
+
+    pickle_files = glob.glob(str(filename))
+    teardown_test_files(pickle_files)
+
+
+@pytest.mark.skipif(
+    Engine.get() not in ("Ray", "Unidist", "Dask"),
     reason=f"{Engine.get()} does not have experimental read_custom_text API",
 )
 @pytest.mark.parametrize("set_async_read_mode", [False, True], indirect=True)

--- a/modin/pandas/accessor.py
+++ b/modin/pandas/accessor.py
@@ -257,3 +257,27 @@ class ExperimentalFunctions:
             protocol=protocol,
             storage_options=storage_options,
         )
+
+    def to_parquet_glob(
+        self,
+        path=None,
+        engine="auto",
+        compression="snappy",
+        index=None,
+        partition_cols=None,
+        storage_options: StorageOptions = None,
+        **kwargs,
+    ):
+        # TODO: add docstring
+        from modin.experimental.pandas.io import to_parquet_glob
+
+        to_parquet_glob(
+            self._data,
+            path=path,
+            engine=engine,
+            compression=compression,
+            index=index,
+            partition_cols=partition_cols,
+            storage_options=storage_options,
+            **kwargs,
+        )

--- a/modin/pandas/accessor.py
+++ b/modin/pandas/accessor.py
@@ -215,7 +215,7 @@ class ExperimentalFunctions:
         compression: CompressionOptions = "infer",
         protocol: int = pickle.HIGHEST_PROTOCOL,
         storage_options: StorageOptions = None,
-    ):
+    ) -> None:
         """
         Pickle (serialize) object to file.
 
@@ -224,7 +224,7 @@ class ExperimentalFunctions:
 
         Parameters
         ----------
-        filepath_or_buffer : str, path object or file-like object
+        filepath_or_buffer : str
             File path where the pickled object will be stored.
         compression : {{'infer', 'gzip', 'bz2', 'zip', 'xz', None}}, default: 'infer'
             A string representing the compression to use in the output file. By
@@ -260,16 +260,36 @@ class ExperimentalFunctions:
 
     def to_parquet_glob(
         self,
-        path=None,
+        path,
         engine="auto",
         compression="snappy",
         index=None,
         partition_cols=None,
         storage_options: StorageOptions = None,
         **kwargs,
-    ):
-        # TODO: add docstring
+    ) -> None:  # noqa: PR01
+        """
+        Load a parquet object from the file path, returning a DataFrame.
+
+        This experimental feature provides parallel reading from multiple parquet files which are
+        defined by glob pattern. The files must contain parts of one dataframe, which can be
+        obtained, for example, by `DataFrame.modin.to_parquet_glob` function.
+
+        Returns
+        -------
+        DataFrame
+
+        Notes
+        -----
+        * Only string type supported for `path` argument.
+        * The rest of the arguments are the same as for `pandas.read_parquet`.
+        """
         from modin.experimental.pandas.io import to_parquet_glob
+
+        if path is None:
+            raise NotImplementedError(
+                "`to_parquet_glob` doesn't support path=None, use `to_parquet` in that case."
+            )
 
         to_parquet_glob(
             self._data,

--- a/modin/pandas/accessor.py
+++ b/modin/pandas/accessor.py
@@ -269,7 +269,7 @@ class ExperimentalFunctions:
         **kwargs,
     ) -> None:  # noqa: PR01
         """
-        Load a parquet object from the file path, returning a DataFrame.
+        Write a DataFrame to the binary parquet format.
 
         This experimental feature provides parallel reading from multiple parquet files which are
         defined by glob pattern. The files must contain parts of one dataframe, which can be

--- a/modin/pandas/accessor.py
+++ b/modin/pandas/accessor.py
@@ -271,18 +271,13 @@ class ExperimentalFunctions:
         """
         Write a DataFrame to the binary parquet format.
 
-        This experimental feature provides parallel reading from multiple parquet files which are
-        defined by glob pattern. The files must contain parts of one dataframe, which can be
-        obtained, for example, by `DataFrame.modin.to_parquet_glob` function.
-
-        Returns
-        -------
-        DataFrame
+        This experimental feature provides parallel writing into multiple parquet files which are
+        defined by glob pattern, otherwise (without glob pattern) default pandas implementation is used.
 
         Notes
         -----
         * Only string type supported for `path` argument.
-        * The rest of the arguments are the same as for `pandas.read_parquet`.
+        * The rest of the arguments are the same as for `pandas.to_parquet`.
         """
         from modin.experimental.pandas.io import to_parquet_glob
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -3187,4 +3187,4 @@ class DataFrame(BasePandasDataset):
     # Persistance support methods - END
 
     # Namespace for experimental functions
-    modin = CachedAccessor("modin", ExperimentalFunctions)
+    modin: ExperimentalFunctions = CachedAccessor("modin", ExperimentalFunctions)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6831 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
