### PR TITLE
FIX-#6855: Make sure read_parquet works with integer columns for pyarrow engine

### DIFF
--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -686,6 +686,14 @@ class ParquetDispatcher(ColumnStoreDispatcher):
             row_lengths = [part.length() for part in remote_parts.T[0]]
         else:
             row_lengths = None
+
+        if (
+            dataset.pandas_metadata
+            and "column_indexes" in dataset.pandas_metadata
+            and dataset.pandas_metadata["column_indexes"][0]["numpy_type"] == "int64"
+        ):
+            columns = pandas.Index(columns).astype("int64").to_list()
+
         frame = cls.frame_cls(
             remote_parts,
             index,

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -2034,6 +2034,17 @@ class TestParquet:
         # both Modin and pandas read column "b" as a category
         df_equals(test_df, read_df.astype("int64"))
 
+    def test_read_parquet_6855(self, tmp_path, engine):
+        if engine == "fastparquet":
+            pytest.skip("integer columns aren't supported")
+        test_df = pandas.DataFrame(np.random.rand(10**2, 10))
+        path = tmp_path / "data"
+        path.mkdir()
+        file_name = "issue6855.parquet"
+        test_df.to_parquet(path / file_name, engine=engine)
+        read_df = pd.read_parquet(path / file_name, engine=engine)
+        df_equals(test_df, read_df)
+
     def test_read_parquet_s3_with_column_partitioning(
         self, s3_resource, engine, s3_storage_options
     ):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6855 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
