### PR TITLE
PERF-#6876: Skip the masking stage on 'iloc' where beneficial

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1186,7 +1186,7 @@ class PandasDataframe(ClassLogger):
             if self.has_materialized_index:
                 all_rows = len(self.index)
             elif self._row_lengths_cache or must_sort_row_pos:
-                all_rows = sum(self._row_lengths_cache)
+                all_rows = sum(self.row_lengths)
 
             # 'base_num_cols' specifies the number of columns that the dataframe should have
             # in order to jump to 'reordered_labels' in case of len(row_positions) / len(self) >= base_ratio;


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR extends the idea originally introduced in #6423.

<b> What's the idea </b>

The masking pipeline consists of two stages:
1. Compute individual indexers for each partition and mask them.
2. If the indexing forces reordering, apply a full-column reordering function to the result of the first stage.

In theory, the second stage can function without the first one, the first stage is needed in order to reduce the dimension of the input for the second stage. However, sometimes the first stage can be quite expensive, and it could be reasonable to skip it and jump to the second one right away.

This PR extends the number of cases where we skip the first stage with the cases where we know for sure that the reordering stage will be required. Based on the measurements below, I found out the following condition that controls this:

```python
# 'base_num_cols' specifies the number of columns that the dataframe should have
# in order to jump to 'reordered_labels' in case of len(row_positions) / len(self) >= base_ratio;
# these variables may be a subject to change in order to tune performance more accurately
base_num_cols = 10
base_ratio = 0.2
# Example:
#   len(self.columns): 10 == base_num_cols -> min ratio to jump to reorder_labels: 0.2 == base_ratio
#   len(self.columns): 15 -> min ratio to jump to reorder_labels: 0.3
#   len(self.columns): 20 -> min ratio to jump to reorder_labels: 0.4
#   ...
#   len(self.columns): 49 -> min ratio to jump to reorder_labels: 0.98
#   len(self.columns): 50 -> min ratio to jump to reorder_labels: 1.0
#   len(self.columns): 55 -> min ratio to jump to reorder_labels: 1.0
#   ...
if rows_reordering_required and len(row_positions) * base_num_cols >= min(
    all_rows * len(self.columns) * base_ratio, len(row_positions) * base_num_cols
):
    # jump to reorder_labels
```

<details><summary>measurements with MODIN_CPUS=44</summary>

![image](https://github.com/modin-project/modin/assets/62142979/fd2df3f2-6e1b-478c-8602-57c986dbd550)

</details>

The reproducer from the issue (#6876) now performs like this:

![image](https://github.com/modin-project/modin/assets/62142979/79662ca8-637e-4e19-a508-ece6f5753e40)

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6876 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
