### PR TITLE
TEST-#6868: Remove tests for 'gs' remote protocol since Modin rely on 'fsspec'

### DIFF
--- a/modin/experimental/pandas/test/test_io_exp.py
+++ b/modin/experimental/pandas/test/test_io_exp.py
@@ -179,14 +179,9 @@ class TestCsvGlob:
     "path",
     [
         "s3://modin-test/modin-bugs/multiple_csv/test_data*.csv",
-        "gs://modin-testing/testing/multiple_csv/test_data*.csv",
     ],
 )
 def test_read_multiple_csv_cloud_store(path, s3_resource, s3_storage_options):
-    storage_options_new = {"anon": True}
-    if path.startswith("s3"):
-        storage_options_new = s3_storage_options
-
     def _pandas_read_csv_glob(path, storage_options):
         pandas_dfs = [
             pandas.read_csv(
@@ -202,7 +197,7 @@ def test_read_multiple_csv_cloud_store(path, s3_resource, s3_storage_options):
         lambda module, **kwargs: pd.read_csv_glob(path, **kwargs).reset_index(drop=True)
         if hasattr(module, "read_csv_glob")
         else _pandas_read_csv_glob(path, **kwargs),
-        storage_options=storage_options_new,
+        storage_options=s3_storage_options,
     )
 
 

--- a/modin/pandas/test/test_io.py
+++ b/modin/pandas/test/test_io.py
@@ -882,13 +882,6 @@ class TestCsv:
             dtype={"one": "int64", "two": "category"},
         )
 
-    def test_read_csv_google_cloud_storage(self):
-        eval_io(
-            fn_name="read_csv",
-            # read_csv kwargs
-            filepath_or_buffer="gs://modin-testing/testing/multiple_csv/test_data0.csv",
-        )
-
     @pytest.mark.parametrize("encoding", [None, "utf-8"])
     @pytest.mark.parametrize("encoding_errors", ["strict", "ignore"])
     @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6868 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
