### PR TITLE
FEAT-#6890: add consortium standard entrypoint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
       - run: python -m pytest modin/test/test_utils.py
       - run: python -m pytest asv_bench/test/test_utils.py
       - run: python -m pytest modin/test/interchange/dataframe_protocol/base
+      - run: python -m pytest modin/test/test_dataframe_api_standard.py
       - run: python -m pytest modin/test/test_logging.py
       - uses: ./.github/actions/upload-coverage
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -74,6 +74,15 @@ storage formats or for different functionalities of Modin. Here is a list of dep
 
   pip install "modin[mpi]" # If you want to use MPI through unidist execution engine
 
+
+Consortium Standard-compatible implementation based on modin
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+  pip install "modin[consortium-standard]"
+
+
 Installing on Google Colab
 """""""""""""""""""""""""""
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -61,6 +61,7 @@ dependencies:
   - isort>=5.12
 
   - pip:
+      - dataframe-api-compat>=0.2.6
       - asv==0.5.1
       # no conda package for windows so we install it with pip
       - connectorx>=0.2.6a4

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2818,7 +2818,9 @@ class DataFrame(BasePandasDataset):
         This is developed and maintained outside of Modin.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        dataframe_api_compat = import_optional_dependency("dataframe_api_compat")
+        dataframe_api_compat = import_optional_dependency(
+            "dataframe_api_compat", "implementation"
+        )
         convert_to_standard_compliant_dataframe = (
             dataframe_api_compat.modin_standard.convert_to_standard_compliant_dataframe
         )

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -50,6 +50,7 @@ from modin.utils import (
     _inherit_docstrings,
     expanduser_path_arg,
     hashable,
+    import_optional_dependency,
     try_cast_to_pandas,
 )
 
@@ -2807,6 +2808,21 @@ class DataFrame(BasePandasDataset):
         return self._query_compiler.to_dataframe(
             nan_as_null=nan_as_null, allow_copy=allow_copy
         )
+
+    def __dataframe_consortium_standard__(
+        self, *, api_version: str | None = None
+    ):  # noqa: PR01, RT01
+        """
+        Provide entry point to the Consortium DataFrame Standard API.
+
+        This is developed and maintained outside of Modin.
+        Please report any issues to https://github.com/data-apis/dataframe-api-compat.
+        """
+        dataframe_api_compat = import_optional_dependency("dataframe_api_compat")
+        convert_to_standard_compliant_dataframe = (
+            dataframe_api_compat.modin_standard.convert_to_standard_compliant_dataframe
+        )
+        return convert_to_standard_compliant_dataframe(self, api_version=api_version)
 
     @property
     def attrs(self):  # noqa: RT01, D200

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -33,7 +33,11 @@ from pandas.util._validators import validate_bool_kwarg
 from modin.config import PersistentPickle
 from modin.logging import disable_logging
 from modin.pandas.io import from_pandas, to_pandas
-from modin.utils import MODIN_UNNAMED_SERIES_LABEL, _inherit_docstrings
+from modin.utils import (
+    MODIN_UNNAMED_SERIES_LABEL,
+    _inherit_docstrings,
+    import_optional_dependency,
+)
 
 from .accessor import CachedAccessor, SparseAccessor
 from .base import _ATTRS_NO_LOOKUP, BasePandasDataset
@@ -213,6 +217,20 @@ class Series(BasePandasDataset):
         Return the values as a NumPy array.
         """
         return super(Series, self).__array__(dtype).flatten()
+
+    def __column_consortium_standard__(
+        self, *, api_version: str | None = None
+    ):  # noqa: PR01, RT01
+        """
+        Provide entry point to the Consortium DataFrame Standard API.
+
+        This is developed and maintained outside of Modin.
+        Please report any issues to https://github.com/data-apis/dataframe-api-compat.
+        """
+        dataframe_api_compat = import_optional_dependency("dataframe_api_compat")
+        return dataframe_api_compat.modin_standard.convert_to_standard_compliant_column(
+            self, api_version=api_version
+        )
 
     def __contains__(self, key):
         """

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -227,7 +227,9 @@ class Series(BasePandasDataset):
         This is developed and maintained outside of Modin.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        dataframe_api_compat = import_optional_dependency("dataframe_api_compat")
+        dataframe_api_compat = import_optional_dependency(
+            "dataframe_api_compat", "implementation"
+        )
         return dataframe_api_compat.modin_standard.convert_to_standard_compliant_column(
             self, api_version=api_version
         )

--- a/modin/test/test_dataframe_api_standard.py
+++ b/modin/test/test_dataframe_api_standard.py
@@ -1,0 +1,37 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pytest
+
+import modin.pandas
+
+
+def test_dataframe_consortium() -> None:
+    """
+    Test some basic methods of the dataframe consortium standard.
+
+    Full testing is done at https://github.com/data-apis/dataframe-api-compat,
+    this is just to check that the entry point works as expected.
+    """
+    pytest.importorskip("dataframe_api_compat")
+    df_pd = modin.pandas.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df = df_pd.__dataframe_consortium_standard__()
+    result_1 = df.get_column_names()
+    expected_1 = ["a", "b"]
+    assert result_1 == expected_1
+
+    ser = modin.pandas.Series([1, 2, 3])
+    col = ser.__column_consortium_standard__()
+    result_2 = col.get_value(1)
+    expected_2 = 2
+    assert result_2 == expected_2

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,6 +35,7 @@ tqdm>=4.60.0
 numexpr<2.8.5
 # Latest modin-spreadsheet with widget fix
 git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
+dataframe-api-compat>=0.2.6
 
 ## dependencies for making release
 PyGithub>=1.58.0

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -43,5 +43,6 @@ dependencies:
   - mypy>=1.0.0
 
   - pip:
+      - dataframe-api-compat>=0.2.6
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0

--- a/requirements/env_unidist_win.yml
+++ b/requirements/env_unidist_win.yml
@@ -54,6 +54,7 @@ dependencies:
   - pandas-stubs>=2.0.0
 
   - pip:
+      - dataframe-api-compat>=0.2.6
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - connectorx>=0.2.6a4

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -45,6 +45,7 @@ dependencies:
   - flake8-print>=5.0.0
 
   - pip:
+      - dataframe-api-compat>=0.2.6
       - asv==0.5.1
       # no conda package for windows
       - connectorx>=0.2.6a4

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,13 @@ dask_deps = ["dask>=2.22.0", "distributed>=2.22.0"]
 # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
 ray_deps = ["ray[default]>=1.13.0,!=2.5.0", "pyarrow>=7.0.0"]
 mpi_deps = ["unidist[mpi]>=0.2.1"]
+consortium_standard_deps = ['dataframe-api-compat>=0.2.6']
 spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]
 # Currently, Modin does not include `mpi` option in `all`.
 # Otherwise, installation of modin[all] would fail because
 # users need to have a working MPI implementation and
 # certain software installed beforehand.
-all_deps = dask_deps + ray_deps + spreadsheet_deps
+all_deps = dask_deps + ray_deps + spreadsheet_deps + consortium_standard_deps
 
 # Distribute 'modin-autoimport-pandas.pth' along with binary and source distributions.
 # This file provides the "import pandas before Ray init" feature if specific
@@ -62,6 +63,7 @@ setup(
         "dask": dask_deps,
         "ray": ray_deps,
         "mpi": mpi_deps,
+        "consortium-standard": consortium_standard_deps,
         "spreadsheet": spreadsheet_deps,
         "all": all_deps,
     },


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

These changes are waiting for https://github.com/data-apis/dataframe-api-compat/pull/71.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6890 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
