### PR TITLE
FIX-#5925: Put a sorting-hack into groupby tests to hide #6875 bug

### DIFF
--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -3230,10 +3230,6 @@ def _apply_transform(df):
 def test_range_groupby_categories(
     observed, func, by_cols, cat_cols, exclude_values, as_index, modify_config
 ):
-    # HACK: there's a bug in range-partitioning impl that can be triggered
-    # here on certain seeds, manually setting the seed so it won't show up
-    # https://github.com/modin-project/modin/issues/6875
-    np.random.seed(0)
     data = {
         "a": ["a", "b", "c", "d", "e", "b", "g", "a"] * 32,
         "b": [1, 2, 3, 4] * 64,
@@ -3248,4 +3244,8 @@ def test_range_groupby_categories(
 
     md_res = func(md_df.groupby(by_cols, observed=observed, as_index=as_index))
     pd_res = func(pd_df.groupby(by_cols, observed=observed, as_index=as_index))
-    df_equals(md_res, pd_res)
+
+    # HACK, FIXME: there's a bug in range-partitioning impl that apparently can
+    # break the order of rows in the result for multi-column groupbys. Placing the sorting-hack for now
+    # https://github.com/modin-project/modin/issues/6875
+    df_equals(md_res.sort_index(axis=0), pd_res.sort_index(axis=0))


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

CI on master started to fail after #6862 was merged (https://github.com/modin-project/modin/actions/runs/7701338108/job/20995335180). The tests are failing because the order of rows doesn't match between modin and pandas. The test fails even if I won't cast the data to categoricals, so I'm blaming #6875 for the failures. The failure isn't stable (fails not always), that's why it wasn't caught before merging #6862.

My current plan is:
1. Merge this hack in order to unblock CI
2. Make the investigation of #6875 my first priority

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #5925 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
