### PR TITLE
REFACTOR-#6293: Corrected 'missmatch' to 'mismatch' across instances of ErrorMessage.missmatch_with_pandas method 

### DIFF
--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -379,7 +379,7 @@ class GroupByReduce(TreeReduce):
         if not groupby_kwargs.get("sort", True) and isinstance(
             by, type(query_compiler)
         ):
-            ErrorMessage.missmatch_with_pandas(
+            ErrorMessage.mismatch_with_pandas(
                 operation="df.groupby(categorical_by, sort=False)",
                 message=(
                     "the groupby keys will be sorted anyway, although the 'sort=False' was passed. "

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -254,7 +254,7 @@ class PandasParser(ClassLogger):
         frame_dtypes.name = None
 
         if not combined_part_dtypes.eq(frame_dtypes, axis=0).all(axis=None):
-            ErrorMessage.missmatch_with_pandas(
+            ErrorMessage.mismatch_with_pandas(
                 operation="read_*",
                 message="Data types of partitions are different! "
                 + "Please refer to the troubleshooting section of the Modin documentation "

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2706,7 +2706,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         col_level=None,
         ignore_index=True,
     ):
-        ErrorMessage.missmatch_with_pandas(
+        ErrorMessage.mismatch_with_pandas(
             operation="melt", message="Order of rows could be different from pandas"
         )
 
@@ -3785,7 +3785,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
         if is_transform:
             # https://github.com/modin-project/modin/issues/5924
-            ErrorMessage.missmatch_with_pandas(
+            ErrorMessage.mismatch_with_pandas(
                 operation="range-partitioning groupby",
                 message="the order of rows may be shuffled for the result",
             )
@@ -4344,7 +4344,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         observed,
         sort,
     ):
-        ErrorMessage.missmatch_with_pandas(
+        ErrorMessage.mismatch_with_pandas(
             operation="pivot_table",
             message="Order of columns could be different from pandas",
         )

--- a/modin/error_message.py
+++ b/modin/error_message.py
@@ -101,7 +101,7 @@ class ErrorMessage(object):
         )
 
     @classmethod
-    def missmatch_with_pandas(cls, operation: str, message: str) -> None:
+    def mismatch_with_pandas(cls, operation: str, message: str) -> None:
         get_logger().debug(
             f"Modin Warning: {operation} mismatch with pandas: {message}"
         )

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -778,7 +778,7 @@ class DataFrameGroupBy(ClassLogger):
         if make_dataframe:
             internal_by = frozenset(self._internal_by)
             if len(internal_by.intersection(key)) != 0:
-                ErrorMessage.missmatch_with_pandas(
+                ErrorMessage.mismatch_with_pandas(
                     operation="GroupBy.__getitem__",
                     message=(
                         "intersection of the selection and 'by' columns is not yet supported, "
@@ -933,7 +933,7 @@ class DataFrameGroupBy(ClassLogger):
                 and not self._as_index
                 and any(col in func_dict for col in self._internal_by)
             ):
-                ErrorMessage.missmatch_with_pandas(
+                ErrorMessage.mismatch_with_pandas(
                     operation="GroupBy.aggregate(**dictionary_renaming_aggregation)",
                     message=(
                         "intersection of the columns to aggregate and 'by' is not yet supported when 'as_index=False', "

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -951,7 +951,7 @@ def eval_io(
     comparator: obj
         Function to perform comparison.
     cast_to_str: bool
-        There could be some missmatches in dtypes, so we're
+        There could be some mismatches in dtypes, so we're
         casting the whole frame to `str` before comparison.
         See issue #1931 for details.
     check_exception_type: bool

--- a/modin/pandas/window.py
+++ b/modin/pandas/window.py
@@ -272,7 +272,7 @@ class RollingGroupby(Rolling):
         super().__init__(self._groupby_obj._df, *args, **kwargs)
 
     def sem(self, *args, **kwargs):
-        ErrorMessage.missmatch_with_pandas(
+        ErrorMessage.mismatch_with_pandas(
             operation="RollingGroupby.sem() when 'as_index=False'",
             message=(
                 "The group columns won't be involved in the aggregation.\n"

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -772,7 +772,7 @@ def test_groupby_with_empty_partition():
     )
     md_res = md_df.query("a > 1", engine="python")
     grp_obj = md_res.groupby("a")
-    # check index error due to partitioning missmatching
+    # check index error due to partitioning mismatching
     grp_obj.count()
 
     md_df = construct_modin_df_by_scheme(


### PR DESCRIPTION
## What do these changes do?
Refactored code in response to issue #6293, addressing a typographical error. I corrected 'missmatch' to 'mismatch' across instances of  ```ErrorMessage.missmatch_with_pandas``` method as well as in some comments. 

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #[REFACTOR: Corrected 'missmatch' to 'mismatch' in ErrorMessage.m… #6293](https://github.com/modin-project/modin/issues/6293)
 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
