### PR TITLE
FIX-#6904: Align levels of partially known dtypes with MultiIndex labels

### DIFF
--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -30,7 +30,12 @@ from modin.core.dataframe.pandas.metadata import (
 )
 from modin.core.storage_formats.pandas.utils import split_result_of_axis_func_pandas
 from modin.distributed.dataframe.pandas import from_partitions
-from modin.pandas.test.utils import create_test_dfs, df_equals, test_data_values
+from modin.pandas.test.utils import (
+    create_test_dfs,
+    df_equals,
+    eval_general,
+    test_data_values,
+)
 from modin.utils import try_cast_to_pandas
 
 NPartitions.put(4)
@@ -2218,6 +2223,32 @@ class TestModinDtypes:
         assert df.dtypes.equals(
             pandas.Series([np.dtype(int), np.dtype("float64")], index=["a", "a"])
         )
+
+    def test_reset_index_mi_columns(self):
+        # reproducer from: https://github.com/modin-project/modin/issues/6904
+        md_df, pd_df = create_test_dfs({"a": [1, 1, 2, 2], "b": [3, 3, 4, 4]})
+        eval_general(
+            md_df,
+            pd_df,
+            lambda df: df.groupby("a").agg({"b": ["min", "std"]}).reset_index().dtypes,
+        )
+
+    def test_concat_mi(self):
+        """
+        Verify that concatenating dfs with non-MultiIndex and MultiIndex columns results into valid indices for lazy dtypes.
+        """
+        md_df1, pd_df1 = create_test_dfs({"a": [1, 1, 2, 2], "b": [3, 3, 4, 4]})
+        md_df2, pd_df2 = create_test_dfs(
+            {("l1", "v1"): [1, 1, 2, 2], ("l1", "v2"): [3, 3, 4, 4]}
+        )
+
+        # Drop actual dtypes in order to use partially-known dtypes
+        md_df1._query_compiler._modin_frame.set_dtypes_cache(None)
+        md_df2._query_compiler._modin_frame.set_dtypes_cache(None)
+
+        md_res = pd.concat([md_df1, md_df2], axis=1)
+        pd_res = pandas.concat([pd_df1, pd_df2], axis=1)
+        df_equals(md_res.dtypes, pd_res.dtypes)
 
 
 class TestZeroComputationDtypes:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The original issue was caused by mixed non-MultiIndex and MultiIndex labels appearing in partial dtypes:
```python
>>> df.columns
MultiIndex([('a', ''),
            ('l1', 'l2')],
           )
>>> df._dtypes_cache
{"a": int, ("l1", "l2"): int}
>>> df._materialize_dtypes() # error
```
The reason why partial dtypes was constructed that way - is unpredictability in how pandas merges non-MultiIndex and MultiIndex columns. 

<details><summary> Few examples of unpredictability</summary>

1. `.reset_index()` case:
    ```python
    >>> df.index.names 
    "a" <--- flat label
    >>> df.columns
    MultiIndex([('l1', 'l2')]) <--- MultiIndex columns
    >>> df.reset_index().columns
    MultiIndex([('a', ''),     <--- when merged, MultiIndex is preserved, missing levels
                ('l1', 'l2')],      are filled with an empty string
            )
    ```
2. `pandas.concat()` case:
    ```python
    >>> df1.columns
    pandas.Index(['a']) <--- Flat columns
    >>> df2.columns
    MultiIndex([('l1', 'l2')]) <--- MultiIndex columns
    >>> pandas.concat([df1, df2], axis=1).columns
    pandas.Index(['a', ('l1', 'l2')]) <--- MultiIndex was downcasted to a flat index
    ```

</details>

The solution for the issue is the following: normalize the label's number of levels at the time when we materialize <b>actual</b> dataframe columns. It was implemented via `DtypesDescriptor._normalize_self_levels()` method, which is called after every materialization of the parent's columns in `DtypesDescriptor`'s logic.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6904 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
