### PR TITLE
REFACTOR-#6918: Docstring and type hints fixes

### DIFF
--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/partition.py
@@ -99,7 +99,7 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         if isinstance(self._data_ref, DeferredExecution):
             self._data_ref.unsubscribe()
 
-    def apply(self, func: Callable, *args, **kwargs):
+    def apply(self, func: Union[Callable, ray.ObjectRef], *args, **kwargs):
         """
         Apply a function to the object wrapped by this partition.
 
@@ -121,9 +121,6 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         -----
         It does not matter if `func` is callable or an ``ray.ObjectRef``. Ray will
         handle it correctly either way. The keyword arguments are sent as a dictionary.
-
-        If ``LazyExecution`` is enabled, the function is not applied immediately,
-        but is added to the execution tree.
         """
         log = get_logger()
         self._is_debug(log) and log.debug(f"ENTER::Partition.apply::{self._identity}")
@@ -133,7 +130,14 @@ class PandasOnRayDataframePartition(PandasDataframePartition):
         return self.__constructor__(data, meta=meta, meta_offset=meta_offset)
 
     @_inherit_docstrings(PandasDataframePartition.add_to_apply_calls)
-    def add_to_apply_calls(self, func, *args, length=None, width=None, **kwargs):
+    def add_to_apply_calls(
+        self,
+        func: Union[Callable, ray.ObjectRef],
+        *args,
+        length=None,
+        width=None,
+        **kwargs,
+    ):
         return self.__constructor__(
             data=DeferredExecution(self._data_ref, func, args, kwargs),
             length=length,


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
