### PR TITLE
FEAT-#0000: Implement DataFrame API standard

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,7 +127,7 @@ jobs:
       - run: python -m pytest modin/test/test_utils.py
       - run: python -m pytest asv_bench/test/test_utils.py
       - run: python -m pytest modin/test/interchange/dataframe_protocol/base
-      - run: python -m pytest modin/test/test_dataframe_api_standard.py
+      - run: python -m pytest modin/dataframe_api_standard/tests
       - run: python -m pytest modin/test/test_logging.py
       - uses: ./.github/actions/upload-coverage
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -127,6 +127,7 @@ jobs:
       - run: python -m pytest modin/test/test_utils.py
       - run: python -m pytest asv_bench/test/test_utils.py
       - run: python -m pytest modin/test/interchange/dataframe_protocol/base
+      - run: python -m pytest modin/test/test_dataframe_api_standard.py
       - run: python -m pytest modin/test/test_logging.py
       - uses: ./.github/actions/upload-coverage
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -74,15 +74,6 @@ storage formats or for different functionalities of Modin. Here is a list of dep
 
   pip install "modin[mpi]" # If you want to use MPI through unidist execution engine
 
-
-Consortium Standard-compatible implementation based on modin
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-.. code-block:: bash
-
-  pip install "modin[consortium-standard]"
-
-
 Installing on Google Colab
 """""""""""""""""""""""""""
 

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -74,6 +74,15 @@ storage formats or for different functionalities of Modin. Here is a list of dep
 
   pip install "modin[mpi]" # If you want to use MPI through unidist execution engine
 
+
+Consortium Standard-compatible implementation based on modin
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+  pip install "modin[consortium-standard]"
+
+
 Installing on Google Colab
 """""""""""""""""""""""""""
 

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -61,7 +61,6 @@ dependencies:
   - isort>=5.12
 
   - pip:
-      - dataframe-api-compat>=0.2.6
       - asv==0.5.1
       # no conda package for windows so we install it with pip
       - connectorx>=0.2.6a4

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -61,6 +61,7 @@ dependencies:
   - isort>=5.12
 
   - pip:
+      - dataframe-api-compat>=0.2.6
       - asv==0.5.1
       # no conda package for windows so we install it with pip
       - connectorx>=0.2.6a4

--- a/modin/dataframe_api_standard/__init__.py
+++ b/modin/dataframe_api_standard/__init__.py
@@ -1,0 +1,525 @@
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
+from __future__ import annotations
+
+import datetime as dt
+import re
+from functools import reduce
+from typing import TYPE_CHECKING, Any, Literal, cast
+
+import modin.pandas as pd
+from modin.dataframe_api_standard.column_object import Column
+from modin.dataframe_api_standard.dataframe_object import DataFrame
+from modin.dataframe_api_standard.scalar_object import Scalar
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from dataframe_api.groupby_object import Aggregation as AggregationT
+    from dataframe_api.typing import Column as ColumnT
+    from dataframe_api.typing import DataFrame as DataFrameT
+    from dataframe_api.typing import DType
+    from dataframe_api.typing import Namespace as NamespaceT
+    from dataframe_api.typing import Scalar as ScalarT
+
+    BoolT = NamespaceT.Bool
+    DateT = NamespaceT.Date
+    DatetimeT = NamespaceT.Datetime
+    DurationT = NamespaceT.Duration
+    Float32T = NamespaceT.Float32
+    Float64T = NamespaceT.Float64
+    Int8T = NamespaceT.Int8
+    Int16T = NamespaceT.Int16
+    Int32T = NamespaceT.Int32
+    Int64T = NamespaceT.Int64
+    StringT = NamespaceT.String
+    UInt8T = NamespaceT.UInt8
+    UInt16T = NamespaceT.UInt16
+    UInt32T = NamespaceT.UInt32
+    UInt64T = NamespaceT.UInt64
+    NullTypeT = NamespaceT.NullType
+else:
+    NamespaceT = object
+    BoolT = object
+    DateT = object
+    DatetimeT = object
+    DurationT = object
+    Float32T = object
+    Float64T = object
+    Int8T = object
+    Int16T = object
+    Int32T = object
+    Int64T = object
+    StringT = object
+    UInt8T = object
+    UInt16T = object
+    UInt32T = object
+    UInt64T = object
+    AggregationT = object
+    NullTypeT = object
+
+SUPPORTED_VERSIONS = frozenset({"2023.11-beta"})
+
+
+def map_pandas_dtype_to_standard_dtype(dtype: Any) -> DType:
+    if dtype == "int64":
+        return Namespace.Int64()
+    if dtype == "Int64":
+        return Namespace.Int64()
+    if dtype == "int32":
+        return Namespace.Int32()
+    if dtype == "Int32":
+        return Namespace.Int32()
+    if dtype == "int16":
+        return Namespace.Int16()
+    if dtype == "Int16":
+        return Namespace.Int16()
+    if dtype == "int8":
+        return Namespace.Int8()
+    if dtype == "Int8":
+        return Namespace.Int8()
+    if dtype == "uint64":
+        return Namespace.UInt64()
+    if dtype == "UInt64":
+        return Namespace.UInt64()
+    if dtype == "uint32":
+        return Namespace.UInt32()
+    if dtype == "UInt32":
+        return Namespace.UInt32()
+    if dtype == "uint16":
+        return Namespace.UInt16()
+    if dtype == "UInt16":
+        return Namespace.UInt16()
+    if dtype == "uint8":
+        return Namespace.UInt8()
+    if dtype == "UInt8":
+        return Namespace.UInt8()
+    if dtype == "float64":
+        return Namespace.Float64()
+    if dtype == "Float64":
+        return Namespace.Float64()
+    if dtype == "float32":
+        return Namespace.Float32()
+    if dtype == "Float32":
+        return Namespace.Float32()
+    if dtype in ("bool", "boolean"):
+        # Also for `pandas.core.arrays.boolean.BooleanDtype`
+        return Namespace.Bool()
+    if dtype == "object":
+        return Namespace.String()
+    if dtype == "string":
+        return Namespace.String()
+    if hasattr(dtype, "name"):
+        # For types like `numpy.dtypes.DateTime64DType`
+        dtype = dtype.name
+    if dtype.startswith("datetime64["):
+        match = re.search(r"datetime64\[(\w{1,2})", dtype)
+        assert match is not None
+        time_unit = cast(Literal["ms", "us"], match.group(1))
+        return Namespace.Datetime(time_unit)
+    if dtype.startswith("timedelta64["):
+        match = re.search(r"timedelta64\[(\w{1,2})", dtype)
+        assert match is not None
+        time_unit = cast(Literal["ms", "us"], match.group(1))
+        return Namespace.Duration(time_unit)
+    msg = f"Unsupported dtype! {dtype}"  # pragma: no cover
+    raise AssertionError(msg)
+
+
+def map_standard_dtype_to_pandas_dtype(dtype: DType) -> Any:
+    if isinstance(dtype, Namespace.Int64):
+        return "int64"
+    if isinstance(dtype, Namespace.Int32):
+        return "int32"
+    if isinstance(dtype, Namespace.Int16):
+        return "int16"
+    if isinstance(dtype, Namespace.Int8):
+        return "int8"
+    if isinstance(dtype, Namespace.UInt64):
+        return "uint64"
+    if isinstance(dtype, Namespace.UInt32):
+        return "uint32"
+    if isinstance(dtype, Namespace.UInt16):
+        return "uint16"
+    if isinstance(dtype, Namespace.UInt8):
+        return "uint8"
+    if isinstance(dtype, Namespace.Float64):
+        return "float64"
+    if isinstance(dtype, Namespace.Float32):
+        return "float32"
+    if isinstance(dtype, Namespace.Bool):
+        return "bool"
+    if isinstance(dtype, Namespace.String):
+        return "object"
+    if isinstance(dtype, Namespace.Datetime):
+        if dtype.time_zone is not None:  # pragma: no cover (todo)
+            return f"datetime64[{dtype.time_unit}, {dtype.time_zone}]"
+        return f"datetime64[{dtype.time_unit}]"
+    if isinstance(dtype, Namespace.Duration):
+        return f"timedelta64[{dtype.time_unit}]"
+    msg = f"Unknown dtype: {dtype}"  # pragma: no cover
+    raise AssertionError(msg)
+
+
+def convert_to_standard_compliant_column(
+    ser: pd.Series[Any],
+    api_version: str | None = None,
+) -> Column:
+    if ser.name is not None and not isinstance(ser.name, str):
+        msg = f"Expected column with string name, got: {ser.name}"
+        raise ValueError(msg)
+    if ser.name is None:
+        ser = ser.rename("")
+    return Column(
+        ser,
+        api_version=api_version or "2023.11-beta",
+        df=None,
+        is_persisted=True,
+    )
+
+
+def convert_to_standard_compliant_dataframe(
+    df: pd.DataFrame,
+    api_version: str | None = None,
+) -> DataFrame:
+    return DataFrame(df, api_version=api_version or "2023.11-beta")
+
+
+class Namespace(NamespaceT):
+    def __init__(self, *, api_version: str) -> None:
+        self.__dataframe_api_version__ = api_version
+        self._api_version = api_version
+
+    class Int64(Int64T):
+        pass
+
+    class Int32(Int32T):
+        pass
+
+    class Int16(Int16T):
+        pass
+
+    class Int8(Int8T):
+        pass
+
+    class UInt64(UInt64T):
+        pass
+
+    class UInt32(UInt32T):
+        pass
+
+    class UInt16(UInt16T):
+        pass
+
+    class UInt8(UInt8T):
+        pass
+
+    class Float64(Float64T):
+        pass
+
+    class Float32(Float32T):
+        pass
+
+    class Bool(BoolT):
+        pass
+
+    class String(StringT):
+        pass
+
+    class Date(DateT):
+        pass
+
+    class Datetime(DatetimeT):
+        def __init__(
+            self,
+            time_unit: Literal["ms", "us"],
+            time_zone: str | None = None,
+        ) -> None:
+            self.time_unit = time_unit
+            # TODO validate time zone
+            self.time_zone = time_zone
+
+    class Duration(DurationT):
+        def __init__(self, time_unit: Literal["ms", "us"]) -> None:
+            self.time_unit = time_unit
+
+    class NullType(NullTypeT):
+        pass
+
+    null = NullType()
+
+    def dataframe_from_columns(
+        self,
+        *columns: ColumnT,
+    ) -> DataFrame:
+        data = {}
+        api_versions: set[str] = set()
+        for col in columns:
+            ser = col._materialise()  # type: ignore[attr-defined]
+            data[ser.name] = ser
+            api_versions.add(col._api_version)  # type: ignore[attr-defined]
+        return DataFrame(pd.DataFrame(data), api_version=list(api_versions)[0])
+
+    def column_from_1d_array(  # type: ignore[override]
+        self,
+        data: Any,
+        *,
+        name: str | None = None,
+    ) -> Column:
+        ser = pd.Series(data, name=name)
+        return Column(ser, api_version=self._api_version, df=None, is_persisted=True)
+
+    def column_from_sequence(
+        self,
+        sequence: Sequence[Any],
+        *,
+        dtype: DType | None = None,
+        name: str = "",
+    ) -> Column:
+        if dtype is not None:
+            ser = pd.Series(
+                sequence,
+                dtype=map_standard_dtype_to_pandas_dtype(dtype),
+                name=name,
+            )
+        else:
+            ser = pd.Series(sequence, name=name)
+        return Column(ser, api_version=self._api_version, df=None, is_persisted=True)
+
+    def concat(
+        self,
+        dataframes: Sequence[DataFrameT],
+    ) -> DataFrame:
+        dataframes = cast("Sequence[DataFrame]", dataframes)
+        dtypes = dataframes[0].dataframe.dtypes
+        dfs: list[pd.DataFrame] = []
+        api_versions: set[str] = set()
+        for df in dataframes:
+            # TODO: implement `testing` module in modin
+            # For example: `pd.testing.assert_series_equal`
+            if not df.dataframe.dtypes.equals(dtypes):
+                msg = "Expected matching columns"
+                raise ValueError(msg)
+            dfs.append(df.dataframe)
+            api_versions.add(df._api_version)
+        if len(api_versions) > 1:  # pragma: no cover
+            msg = f"Multiple api versions found: {api_versions}"
+            raise ValueError(msg)
+        return DataFrame(
+            pd.concat(
+                dfs,
+                axis=0,
+                ignore_index=True,
+            ),
+            api_version=api_versions.pop(),
+        )
+
+    def dataframe_from_2d_array(
+        self,
+        data: Any,
+        *,
+        names: Sequence[str],
+    ) -> DataFrame:
+        df = pd.DataFrame(data, columns=list(names))
+        return DataFrame(df, api_version=self._api_version)
+
+    def is_null(self, value: Any) -> bool:
+        return value is self.null
+
+    def is_dtype(self, dtype: DType, kind: str | tuple[str, ...]) -> bool:
+        if isinstance(kind, str):
+            kind = (kind,)
+        dtypes: set[Any] = set()
+        for _kind in kind:
+            if _kind == "bool":
+                dtypes.add(Namespace.Bool)
+            if _kind == "signed integer" or _kind == "integral" or _kind == "numeric":
+                dtypes |= {
+                    Namespace.Int64,
+                    Namespace.Int32,
+                    Namespace.Int16,
+                    Namespace.Int8,
+                }
+            if _kind == "unsigned integer" or _kind == "integral" or _kind == "numeric":
+                dtypes |= {
+                    Namespace.UInt64,
+                    Namespace.UInt32,
+                    Namespace.UInt16,
+                    Namespace.UInt8,
+                }
+            if _kind == "floating" or _kind == "numeric":
+                dtypes |= {Namespace.Float64, Namespace.Float32}
+            if _kind == "string":
+                dtypes.add(Namespace.String)
+        return isinstance(dtype, tuple(dtypes))
+
+    def date(self, year: int, month: int, day: int) -> Scalar:
+        return Scalar(
+            pd.Timestamp(dt.date(year, month, day)),
+            api_version=self._api_version,
+            df=None,
+            is_persisted=True,
+        )
+
+    # --- horizontal reductions
+
+    def all_horizontal(self, *columns: ColumnT, skip_nulls: bool = True) -> ColumnT:
+        return reduce(lambda x, y: x & y, columns)
+
+    def any_horizontal(self, *columns: ColumnT, skip_nulls: bool = True) -> ColumnT:
+        return reduce(lambda x, y: x | y, columns)
+
+    def sorted_indices(
+        self,
+        *columns: ColumnT,
+        ascending: Sequence[bool] | bool = True,
+        nulls_position: Literal["first", "last"] = "last",
+    ) -> Column:
+        raise NotImplementedError
+
+    def unique_indices(
+        self,
+        *columns: ColumnT,
+        skip_nulls: bool | ScalarT = True,
+    ) -> Column:
+        raise NotImplementedError
+
+    class Aggregation(AggregationT):
+        def __init__(
+            self, column_name: str, output_name: str, aggregation: str
+        ) -> None:
+            self.column_name = column_name
+            self.output_name = output_name
+            self.aggregation = aggregation
+
+        def __repr__(self) -> str:  # pragma: no cover
+            return f"{self.__class__.__name__}({self.column_name!r}, {self.output_name!r}, {self.aggregation!r})"
+
+        def _replace(self, **kwargs: str) -> AggregationT:
+            return self.__class__(
+                column_name=kwargs.get("column_name", self.column_name),
+                output_name=kwargs.get("output_name", self.output_name),
+                aggregation=kwargs.get("aggregation", self.aggregation),
+            )
+
+        def rename(self, name: str | ScalarT) -> AggregationT:
+            return self.__class__(self.column_name, name, self.aggregation)  # type: ignore[arg-type]
+
+        @classmethod
+        def any(
+            cls: AggregationT,
+            column: str,
+            *,
+            skip_nulls: bool | ScalarT = True,
+        ) -> AggregationT:
+            return Namespace.Aggregation(column, column, "any")
+
+        @classmethod
+        def all(
+            cls: AggregationT,
+            column: str,
+            *,
+            skip_nulls: bool | ScalarT = True,
+        ) -> AggregationT:
+            return Namespace.Aggregation(column, column, "all")
+
+        @classmethod
+        def min(
+            cls: AggregationT,
+            column: str,
+            *,
+            skip_nulls: bool | ScalarT = True,
+        ) -> AggregationT:
+            return Namespace.Aggregation(column, column, "min")
+
+        @classmethod
+        def max(
+            cls: AggregationT,
+            column: str,
+            *,
+            skip_nulls: bool | ScalarT = True,
+        ) -> AggregationT:
+            return Namespace.Aggregation(column, column, "max")
+
+        @classmethod
+        def sum(
+            cls: AggregationT,
+            column: str,
+            *,
+            skip_nulls: bool | ScalarT = True,
+        ) -> AggregationT:
+            return Namespace.Aggregation(column, column, "sum")
+
+        @classmethod
+        def prod(
+            cls: AggregationT,
+            column: str,
+            *,
+            skip_nulls: bool | ScalarT = True,
+        ) -> AggregationT:
+            return Namespace.Aggregation(column, column, "prod")
+
+        @classmethod
+        def median(
+            cls: AggregationT,
+            column: str,
+            *,
+            skip_nulls: bool | ScalarT = True,
+        ) -> AggregationT:
+            return Namespace.Aggregation(column, column, "median")
+
+        @classmethod
+        def mean(
+            cls: AggregationT,
+            column: str,
+            *,
+            skip_nulls: bool | ScalarT = True,
+        ) -> AggregationT:
+            return Namespace.Aggregation(column, column, "mean")
+
+        @classmethod
+        def std(
+            cls: AggregationT,
+            column: str,
+            *,
+            correction: float | ScalarT | NullTypeT = 1,
+            skip_nulls: bool | ScalarT = True,
+        ) -> AggregationT:
+            return Namespace.Aggregation(column, column, "std")
+
+        @classmethod
+        def var(
+            cls: AggregationT,
+            column: str,
+            *,
+            correction: float | ScalarT | NullTypeT = 1,
+            skip_nulls: bool | ScalarT = True,
+        ) -> AggregationT:
+            return Namespace.Aggregation(column, column, "var")
+
+        @classmethod
+        def size(
+            cls: AggregationT,
+        ) -> AggregationT:
+            return Namespace.Aggregation("__placeholder__", "size", "size")

--- a/modin/dataframe_api_standard/__init__.py
+++ b/modin/dataframe_api_standard/__init__.py
@@ -1,3 +1,17 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
 # MIT License
 
 # Copyright (c) 2023, Marco Gorelli

--- a/modin/dataframe_api_standard/column_object.py
+++ b/modin/dataframe_api_standard/column_object.py
@@ -1,0 +1,560 @@
+from __future__ import annotations
+
+import warnings
+from datetime import datetime
+from typing import TYPE_CHECKING, Any, Literal, NoReturn
+
+import numpy as np
+from pandas.api.types import is_extension_array_dtype
+
+import modin.dataframe_api_standard
+import modin.pandas as pd
+from modin.dataframe_api_standard.utils import validate_comparand
+
+if TYPE_CHECKING:
+    from dataframe_api import Column as ColumnT
+    from dataframe_api.typing import DType, NullType, Scalar
+
+    from modin.dataframe_api_standard.dataframe_object import DataFrame
+else:
+    ColumnT = object
+
+
+NUMPY_MAPPING = {
+    "Int64": "int64",
+    "Int32": "int32",
+    "Int16": "int16",
+    "Int8": "int8",
+    "UInt64": "uint64",
+    "UInt32": "uint32",
+    "UInt16": "uint16",
+    "UInt8": "uint8",
+    "boolean": "bool",
+    "Float64": "float64",
+    "Float32": "float32",
+}
+
+
+class Column(ColumnT):
+    def __init__(
+        self,
+        series: pd.Series[Any],
+        *,
+        df: DataFrame | None,
+        api_version: str,
+        is_persisted: bool = False,
+    ) -> None:
+        """Parameters
+        ----------
+        df
+            DataFrame this column originates from.
+        """
+
+        self._name = series.name
+        assert self._name is not None
+        self._series = series
+        self._api_version = api_version
+        self._df = df
+        self._is_persisted = is_persisted
+        assert is_persisted ^ (df is not None)
+
+    def _to_scalar(self, value: Any) -> Scalar:
+        from modin.dataframe_api_standard.scalar_object import Scalar
+
+        return Scalar(
+            value,
+            api_version=self._api_version,
+            df=self._df,
+            is_persisted=self._is_persisted,
+        )
+
+    def __repr__(self) -> str:  # pragma: no cover
+        header = f" Standard Column (api_version={self._api_version}) "
+        length = len(header)
+        return (
+            "┌"
+            + "─" * length
+            + "┐\n"
+            + f"|{header}|\n"
+            + "| Add `.column` to see native output         |\n"
+            + "└"
+            + "─" * length
+            + "┘\n"
+        )
+
+    def __iter__(self) -> NoReturn:
+        msg = ""
+        raise NotImplementedError(msg)
+
+    def _from_series(self, series: pd.Series) -> Column:
+        return Column(
+            series.reset_index(drop=True).rename(series.name),
+            api_version=self._api_version,
+            df=self._df,
+            is_persisted=self._is_persisted,
+        )
+
+    def _materialise(self) -> pd.Series:
+        if not self._is_persisted:
+            msg = "Column is not persisted, please call `.persist()` first.\nNote: `persist` forces computation, use it with care, only when you need to,\nand as late and little as possible."
+            raise RuntimeError(
+                msg,
+            )
+        return self.column
+
+    # In the standard
+    def __column_namespace__(
+        self,
+    ) -> modin.dataframe_api_standard.Namespace:
+        return modin.dataframe_api_standard.Namespace(
+            api_version=self._api_version,
+        )
+
+    def persist(self) -> Column:
+        if self._is_persisted:
+            warnings.warn(
+                "Calling `.persist` on Column that was already persisted",
+                UserWarning,
+                stacklevel=2,
+            )
+        return Column(
+            self.column,
+            df=None,
+            api_version=self._api_version,
+            is_persisted=True,
+        )
+
+    @property
+    def name(self) -> str:
+        return self._name  # type: ignore[no-any-return]
+
+    @property
+    def column(self) -> pd.Series[Any]:
+        return self._series
+
+    @property
+    def dtype(self) -> DType:
+        return modin.dataframe_api_standard.map_pandas_dtype_to_standard_dtype(
+            self._series.dtype,
+        )
+
+    @property
+    def parent_dataframe(self) -> DataFrame | None:
+        return self._df
+
+    def take(self, indices: Column) -> Column:
+        return self._from_series(self.column.iloc[indices.column])
+
+    def filter(self, mask: Column) -> Column:
+        ser = self.column
+        return self._from_series(ser.loc[mask.column])
+
+    def get_value(self, row_number: int) -> Any:
+        ser = self.column
+        return self._to_scalar(
+            ser.iloc[row_number],
+        )
+
+    def slice_rows(
+        self,
+        start: int | None,
+        stop: int | None,
+        step: int | None,
+    ) -> Column:
+        return self._from_series(self.column.iloc[start:stop:step])
+
+    # Binary comparisons
+
+    def __eq__(self, other: Column | Any) -> Column:  # type: ignore[override]
+        other = validate_comparand(self, other)
+        ser = self.column
+        return self._from_series((ser == other).rename(ser.name))
+
+    def __ne__(self, other: Column | Any) -> Column:  # type: ignore[override]
+        other = validate_comparand(self, other)
+        ser = self.column
+        return self._from_series((ser != other).rename(ser.name))
+
+    def __ge__(self, other: Column | Any) -> Column:
+        other = validate_comparand(self, other)
+        ser = self.column
+        return self._from_series((ser >= other).rename(ser.name))
+
+    def __gt__(self, other: Column | Any) -> Column:
+        other = validate_comparand(self, other)
+        ser = self.column
+        return self._from_series((ser > other).rename(ser.name))
+
+    def __le__(self, other: Column | Any) -> Column:
+        other = validate_comparand(self, other)
+        ser = self.column
+        return self._from_series((ser <= other).rename(ser.name))
+
+    def __lt__(self, other: Column | Any) -> Column:
+        other = validate_comparand(self, other)
+        ser = self.column
+        return self._from_series((ser < other).rename(ser.name))
+
+    def __and__(self, other: Column | bool | Scalar) -> Column:
+        ser = self.column
+        other = validate_comparand(self, other)
+        return self._from_series((ser & other).rename(ser.name))
+
+    def __rand__(self, other: Column | Any) -> Column:
+        return self.__and__(other)
+
+    def __or__(self, other: Column | bool | Scalar) -> Column:
+        ser = self.column
+        other = validate_comparand(self, other)
+        return self._from_series((ser | other).rename(ser.name))
+
+    def __ror__(self, other: Column | Any) -> Column:
+        return self.__or__(other)
+
+    def __add__(self, other: Column | Any) -> Column:
+        ser = self.column
+        other = validate_comparand(self, other)
+        return self._from_series((ser + other).rename(ser.name))
+
+    def __radd__(self, other: Column | Any) -> Column:
+        return self.__add__(other)
+
+    def __sub__(self, other: Column | Any) -> Column:
+        ser = self.column
+        other = validate_comparand(self, other)
+        return self._from_series((ser - other).rename(ser.name))
+
+    def __rsub__(self, other: Column | Any) -> Column:
+        return -1 * self.__sub__(other)
+
+    def __mul__(self, other: Column | Any) -> Column:
+        ser = self.column
+        other = validate_comparand(self, other)
+        return self._from_series((ser * other).rename(ser.name))
+
+    def __rmul__(self, other: Column | Any) -> Column:
+        return self.__mul__(other)
+
+    def __truediv__(self, other: Column | Any) -> Column:
+        ser = self.column
+        other = validate_comparand(self, other)
+        return self._from_series((ser / other).rename(ser.name))
+
+    def __rtruediv__(self, other: Column | Any) -> Column:
+        raise NotImplementedError
+
+    def __floordiv__(self, other: Column | Any) -> Column:
+        ser = self.column
+        other = validate_comparand(self, other)
+        return self._from_series((ser // other).rename(ser.name))
+
+    def __rfloordiv__(self, other: Column | Any) -> Column:
+        raise NotImplementedError
+
+    def __pow__(self, other: Column | Any) -> Column:
+        ser = self.column
+        other = validate_comparand(self, other)
+        return self._from_series((ser**other).rename(ser.name))
+
+    def __rpow__(self, other: Column | Any) -> Column:  # pragma: no cover
+        raise NotImplementedError
+
+    def __mod__(self, other: Column | Any) -> Column:
+        ser = self.column
+        other = validate_comparand(self, other)
+        return self._from_series((ser % other).rename(ser.name))
+
+    def __rmod__(self, other: Column | Any) -> Column:  # pragma: no cover
+        raise NotImplementedError
+
+    def __divmod__(self, other: Column | Any) -> tuple[Column, Column]:
+        quotient = self // other
+        remainder = self - quotient * other
+        return quotient, remainder
+
+    # Unary
+
+    def __invert__(self: Column) -> Column:
+        ser = self.column
+        return self._from_series(~ser)
+
+    # Reductions
+
+    def any(self, *, skip_nulls: bool | Scalar = True) -> Scalar:
+        ser = self.column
+        return self._to_scalar(ser.any())
+
+    def all(self, *, skip_nulls: bool | Scalar = True) -> Scalar:
+        ser = self.column
+        return self._to_scalar(ser.all())
+
+    def min(self, *, skip_nulls: bool | Scalar = True) -> Any:
+        ser = self.column
+        return self._to_scalar(ser.min())
+
+    def max(self, *, skip_nulls: bool | Scalar = True) -> Any:
+        ser = self.column
+        return self._to_scalar(ser.max())
+
+    def sum(self, *, skip_nulls: bool | Scalar = True) -> Any:
+        ser = self.column
+        return self._to_scalar(ser.sum())
+
+    def prod(self, *, skip_nulls: bool | Scalar = True) -> Any:
+        ser = self.column
+        return self._to_scalar(ser.prod())
+
+    def median(self, *, skip_nulls: bool | Scalar = True) -> Any:
+        ser = self.column
+        return self._to_scalar(ser.median())
+
+    def mean(self, *, skip_nulls: bool | Scalar = True) -> Any:
+        ser = self.column
+        return self._to_scalar(ser.mean())
+
+    def std(
+        self,
+        *,
+        correction: float | Scalar | NullType = 1.0,
+        skip_nulls: bool | Scalar = True,
+    ) -> Any:
+        ser = self.column
+        return self._to_scalar(
+            ser.std(ddof=correction),
+        )
+
+    def var(
+        self,
+        *,
+        correction: float | Scalar | NullType = 1.0,
+        skip_nulls: bool | Scalar = True,
+    ) -> Any:
+        ser = self.column
+        return self._to_scalar(
+            ser.var(ddof=correction),
+        )
+
+    def len(self) -> Scalar:
+        return self._to_scalar(len(self._series))
+
+    def n_unique(
+        self,
+        *,
+        skip_nulls: bool = True,
+    ) -> Scalar:
+        ser = self.column
+        return self._to_scalar(
+            ser.nunique(),
+        )
+
+    # Transformations
+
+    def is_null(self) -> Column:
+        ser = self.column
+        return self._from_series(ser.isna())
+
+    def is_nan(self) -> Column:
+        ser = self.column
+        if is_extension_array_dtype(ser.dtype):
+            return self._from_series((ser != ser).fillna(False))  # noqa: PLR0124
+        return self._from_series(ser.isna())
+
+    def sort(
+        self,
+        *,
+        ascending: bool = True,
+        nulls_position: Literal["first", "last"] = "last",
+    ) -> Column:
+        ser = self.column
+        if ascending:
+            return self._from_series(ser.sort_values().rename(self.name))
+        return self._from_series(ser.sort_values().rename(self.name)[::-1])
+
+    def is_in(self, values: Column) -> Column:
+        ser = self.column
+        return self._from_series(ser.isin(values.column))
+
+    def sorted_indices(
+        self,
+        *,
+        ascending: bool = True,
+        nulls_position: Literal["first", "last"] = "last",
+    ) -> Column:
+        ser = self.column
+        if ascending:
+            return self._from_series(ser.sort_values().index.to_series(name=self.name))
+        return self._from_series(
+            ser.sort_values().index.to_series(name=self.name)[::-1]
+        )
+
+    def unique_indices(
+        self,
+        *,
+        skip_nulls: bool | Scalar = True,
+    ) -> Column:  # pragma: no cover
+        msg = "not yet supported"
+        raise NotImplementedError(msg)
+
+    def fill_nan(self, value: float | NullType | Scalar) -> Column:
+        ser = self.column.copy()
+        if is_extension_array_dtype(ser.dtype):
+            if self.__column_namespace__().is_null(value):
+                ser[np.isnan(ser).fillna(False).to_numpy(bool)] = pd.NA
+            else:
+                ser[np.isnan(ser).fillna(False).to_numpy(bool)] = value
+        else:
+            if self.__column_namespace__().is_null(value):
+                ser[np.isnan(ser).fillna(False).to_numpy(bool)] = np.nan
+            else:
+                ser[np.isnan(ser).fillna(False).to_numpy(bool)] = value
+        return self._from_series(ser)
+
+    def fill_null(
+        self,
+        value: Any,
+    ) -> Column:
+        value = validate_comparand(self, value)
+        ser = self.column.copy()
+        if is_extension_array_dtype(ser.dtype):
+            # Mask should include NA values, but not NaN ones
+            mask = ser.isna() & (~(ser != ser).fillna(False))  # noqa: PLR0124
+            ser = ser.where(~mask, value)
+        else:
+            ser = ser.fillna(value)
+        return self._from_series(ser.rename(self.name))
+
+    def cumulative_sum(self, *, skip_nulls: bool | Scalar = True) -> Column:
+        ser = self.column
+        return self._from_series(ser.cumsum())
+
+    def cumulative_prod(self, *, skip_nulls: bool | Scalar = True) -> Column:
+        ser = self.column
+        return self._from_series(ser.cumprod())
+
+    def cumulative_max(self, *, skip_nulls: bool | Scalar = True) -> Column:
+        ser = self.column
+        return self._from_series(ser.cummax())
+
+    def cumulative_min(self, *, skip_nulls: bool | Scalar = True) -> Column:
+        ser = self.column
+        return self._from_series(ser.cummin())
+
+    def rename(self, name: str | Scalar) -> Column:
+        ser = self.column
+        return self._from_series(ser.rename(name))
+
+    def shift(self, offset: int | Scalar) -> Column:
+        ser = self.column
+        return self._from_series(ser.shift(offset))
+
+    # Conversions
+
+    def to_array(self) -> Any:
+        ser = self._materialise()
+        return ser.to_numpy(
+            dtype=NUMPY_MAPPING.get(self.column.dtype.name, self.column.dtype.name),
+        )
+
+    def cast(self, dtype: DType) -> Column:
+        ser = self.column
+        pandas_dtype = modin.dataframe_api_standard.map_standard_dtype_to_pandas_dtype(
+            dtype,
+        )
+        return self._from_series(ser.astype(pandas_dtype))
+
+    # --- temporal methods ---
+
+    def year(self) -> Column:
+        ser = self.column
+        return self._from_series(ser.dt.year)
+
+    def month(self) -> Column:
+        ser = self.column
+        return self._from_series(ser.dt.month)
+
+    def day(self) -> Column:
+        ser = self.column
+        return self._from_series(ser.dt.day)
+
+    def hour(self) -> Column:
+        ser = self.column
+        return self._from_series(ser.dt.hour)
+
+    def minute(self) -> Column:
+        ser = self.column
+        return self._from_series(ser.dt.minute)
+
+    def second(self) -> Column:
+        ser = self.column
+        return self._from_series(ser.dt.second)
+
+    def microsecond(self) -> Column:
+        ser = self.column
+        return self._from_series(ser.dt.microsecond)
+
+    def nanosecond(self) -> Column:
+        ser = self.column
+        return self._from_series(ser.dt.microsecond * 1000 + ser.dt.nanosecond)
+
+    def iso_weekday(self) -> Column:
+        ser = self.column
+        return self._from_series(ser.dt.weekday + 1)
+
+    def floor(self, frequency: str) -> Column:
+        frequency = (
+            frequency.replace("day", "D")
+            .replace("hour", "H")
+            .replace("minute", "T")
+            .replace("second", "S")
+            .replace("millisecond", "ms")
+            .replace("microsecond", "us")
+            .replace("nanosecond", "ns")
+        )
+        ser = self.column
+        return self._from_series(ser.dt.floor(frequency))
+
+    def unix_timestamp(
+        self,
+        *,
+        time_unit: str | Scalar = "s",
+    ) -> Column:
+        ser = self.column
+        if ser.dt.tz is None:
+            result = ser - datetime(1970, 1, 1)
+        else:  # pragma: no cover (todo: tz-awareness)
+            result = ser.dt.tz_convert("UTC").dt.tz_localize(None) - datetime(
+                1970, 1, 1
+            )
+        if time_unit == "s":
+            result = pd.Series(
+                np.floor(result.dt.total_seconds().astype("float64")),
+                name=ser.name,
+            )
+        elif time_unit == "ms":
+            result = pd.Series(
+                np.floor(
+                    np.floor(result.dt.total_seconds()) * 1000
+                    + result.dt.microseconds // 1000,
+                ),
+                name=ser.name,
+            )
+        elif time_unit == "us":
+            result = pd.Series(
+                np.floor(result.dt.total_seconds()) * 1_000_000
+                + result.dt.microseconds,
+                name=ser.name,
+            )
+        elif time_unit == "ns":
+            result = pd.Series(
+                (
+                    np.floor(result.dt.total_seconds()).astype("Int64") * 1_000_000
+                    + result.dt.microseconds.astype("Int64")
+                )
+                * 1000
+                + result.dt.nanoseconds.astype("Int64"),
+                name=ser.name,
+            )
+        else:  # pragma: no cover
+            msg = "Got invalid time_unit"
+            raise AssertionError(msg)
+        return self._from_series(result)

--- a/modin/dataframe_api_standard/column_object.py
+++ b/modin/dataframe_api_standard/column_object.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import warnings

--- a/modin/dataframe_api_standard/dataframe_object.py
+++ b/modin/dataframe_api_standard/dataframe_object.py
@@ -1,0 +1,540 @@
+from __future__ import annotations
+
+import collections
+import warnings
+from typing import TYPE_CHECKING, Any, Iterator, Literal, NoReturn
+
+import numpy as np
+from pandas.api.types import is_extension_array_dtype
+
+import modin.dataframe_api_standard
+import modin.pandas as pd
+from modin.dataframe_api_standard.utils import validate_comparand
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from dataframe_api import DataFrame as DataFrameT
+    from dataframe_api.typing import AnyScalar, Column, DType, NullType, Scalar
+
+    from modin.dataframe_api_standard.group_by_object import GroupBy
+else:
+    DataFrameT = object
+
+
+class DataFrame(DataFrameT):
+    """dataframe object"""
+
+    def __init__(
+        self,
+        dataframe: pd.DataFrame,
+        *,
+        api_version: str,
+        is_persisted: bool = False,
+    ) -> None:
+        self._is_persisted = is_persisted
+        self._validate_columns(dataframe.columns)
+        self._dataframe = dataframe.reset_index(drop=True)
+        self._api_version = api_version
+
+    # Validation helper methods
+
+    def _validate_is_persisted(self) -> pd.DataFrame:
+        if not self._is_persisted:
+            msg = "Method requires you to call `.persist` first.\n\nNote: `.persist` forces materialisation in lazy libraries and so should be called as late as possible in your pipeline. Use with care."
+            raise ValueError(
+                msg,
+            )
+        return self.dataframe
+
+    def __repr__(self) -> str:  # pragma: no cover
+        header = f" Standard DataFrame (api_version={self._api_version}) "
+        length = len(header)
+        return (
+            "┌"
+            + "─" * length
+            + "┐\n"
+            + f"|{header}|\n"
+            + "| Add `.dataframe` to see native output         |\n"
+            + "└"
+            + "─" * length
+            + "┘\n"
+        )
+
+    def _validate_columns(self, columns: Sequence[str]) -> None:
+        counter = collections.Counter(columns)
+        for col, count in counter.items():
+            if count > 1:
+                msg = f"Expected unique column names, got {col} {count} time(s)"
+                raise ValueError(
+                    msg,
+                )
+
+    def _validate_booleanness(self) -> None:
+        if not (
+            (self.dataframe.dtypes == "bool") | (self.dataframe.dtypes == "boolean")
+        ).all():
+            msg = "'any' can only be called on DataFrame where all dtypes are 'bool'"
+            raise TypeError(
+                msg,
+            )
+
+    def _from_dataframe(self, df: pd.DataFrame) -> DataFrame:
+        return DataFrame(
+            df,
+            api_version=self._api_version,
+            is_persisted=self._is_persisted,
+        )
+
+    # Properties
+    @property
+    def schema(self) -> dict[str, DType]:
+        return {
+            column_name: modin.dataframe_api_standard.map_pandas_dtype_to_standard_dtype(
+                dtype.name,
+            )
+            for column_name, dtype in self.dataframe.dtypes.items()
+        }
+
+    @property
+    def dataframe(self) -> pd.DataFrame:
+        return self._dataframe
+
+    @property
+    def column_names(self) -> list[str]:
+        return self.dataframe.columns.tolist()  # type: ignore[no-any-return]
+
+    # In the Standard
+
+    def __dataframe_namespace__(
+        self,
+    ) -> modin.dataframe_api_standard.Namespace:
+        return modin.dataframe_api_standard.Namespace(
+            api_version=self._api_version,
+        )
+
+    def iter_columns(self) -> Iterator[Column]:
+        return (self.col(col_name) for col_name in self.column_names)
+
+    def col(self, name: str) -> Column:
+        from modin.dataframe_api_standard.column_object import Column
+
+        return Column(
+            self.dataframe.loc[:, name],
+            df=None if self._is_persisted else self,
+            api_version=self._api_version,
+            is_persisted=self._is_persisted,
+        )
+
+    def shape(self) -> tuple[int, int]:
+        df = self._validate_is_persisted()
+        return df.shape  # type: ignore[no-any-return]
+
+    def group_by(self, *keys: str) -> GroupBy:
+        from modin.dataframe_api_standard.group_by_object import GroupBy
+
+        for key in keys:
+            if key not in self.column_names:
+                msg = f"key {key} not present in DataFrame's columns"
+                raise KeyError(msg)
+        return GroupBy(self, keys, api_version=self._api_version)
+
+    def select(self, *columns: str) -> DataFrame:
+        cols = list(columns)
+        if cols and isinstance(cols[0], (list, tuple)):
+            msg = f"Expected iterable of column names, but the first element is: {type(cols[0])}"
+            raise TypeError(msg)
+        return self._from_dataframe(
+            self.dataframe.loc[:, list(columns)],
+        )
+
+    def take(
+        self,
+        indices: Column,
+    ) -> DataFrame:
+        _indices = validate_comparand(self, indices)
+        return self._from_dataframe(
+            self.dataframe.iloc[_indices.to_list(), :],
+        )
+
+    def slice_rows(
+        self,
+        start: int | None,
+        stop: int | None,
+        step: int | None,
+    ) -> DataFrame:
+        return self._from_dataframe(self.dataframe.iloc[start:stop:step])
+
+    def filter(
+        self,
+        mask: Column,
+    ) -> DataFrame:
+        _mask = validate_comparand(self, mask)
+        df = self.dataframe
+        df = df.loc[_mask]
+        return self._from_dataframe(df)
+
+    def assign(
+        self,
+        *columns: Column,
+    ) -> DataFrame:
+        from modin.dataframe_api_standard.column_object import Column
+
+        df = self.dataframe.copy()  # TODO: remove defensive copy with CoW?
+        for column in columns:
+            if not isinstance(column, Column):
+                msg = f"Expected iterable of Column, but the first element is: {type(column)}"
+                raise TypeError(msg)
+            _series = validate_comparand(self, column)
+            df[_series.name] = _series
+        return self._from_dataframe(df)
+
+    def drop(self, *labels: str) -> DataFrame:
+        return self._from_dataframe(
+            self.dataframe.drop(list(labels), axis=1),
+        )
+
+    def rename(self, mapping: Mapping[str, str]) -> DataFrame:
+        if not isinstance(mapping, collections.abc.Mapping):
+            msg = f"Expected Mapping, got: {type(mapping)}"
+            raise TypeError(msg)
+        return self._from_dataframe(
+            self.dataframe.rename(columns=mapping),
+        )
+
+    def get_column_names(self) -> list[str]:
+        # DO NOT REMOVE
+        # This one is used in upstream tests - even if deprecated,
+        # just leave it in for backwards compatibility
+        return self.dataframe.columns.tolist()  # type: ignore[no-any-return]
+
+    def sort(
+        self,
+        *keys: str,
+        ascending: Sequence[bool] | bool = True,
+        nulls_position: Literal["first", "last"] = "last",
+    ) -> DataFrame:
+        if not keys:
+            keys = self.dataframe.columns.tolist()
+        df = self.dataframe
+        return self._from_dataframe(
+            df.sort_values(list(keys), ascending=ascending),
+        )
+
+    # Binary operations
+
+    def __eq__(self, other: AnyScalar) -> DataFrame:  # type: ignore[override]
+        return self._from_dataframe(self.dataframe.__eq__(other))
+
+    def __ne__(self, other: AnyScalar) -> DataFrame:  # type: ignore[override]
+        return self._from_dataframe(self.dataframe.__ne__(other))
+
+    def __ge__(self, other: AnyScalar) -> DataFrame:
+        return self._from_dataframe(self.dataframe.__ge__(other))
+
+    def __gt__(self, other: AnyScalar) -> DataFrame:
+        return self._from_dataframe(self.dataframe.__gt__(other))
+
+    def __le__(self, other: AnyScalar) -> DataFrame:
+        return self._from_dataframe(self.dataframe.__le__(other))
+
+    def __lt__(self, other: AnyScalar) -> DataFrame:
+        return self._from_dataframe(self.dataframe.__lt__(other))
+
+    def __and__(self, other: AnyScalar) -> DataFrame:
+        return self._from_dataframe(
+            self.dataframe.__and__(other),
+        )
+
+    def __rand__(self, other: Column | AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self.__and__(_other)
+
+    def __or__(self, other: AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self._from_dataframe(self.dataframe.__or__(_other))
+
+    def __ror__(self, other: Column | AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self.__or__(_other)
+
+    def __add__(self, other: AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self._from_dataframe(
+            self.dataframe.__add__(_other),
+        )
+
+    def __radd__(self, other: Column | AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self.__add__(_other)
+
+    def __sub__(self, other: AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self._from_dataframe(
+            self.dataframe.__sub__(_other),
+        )
+
+    def __rsub__(self, other: Column | AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return -1 * self.__sub__(_other)
+
+    def __mul__(self, other: AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self._from_dataframe(
+            self.dataframe.__mul__(_other),
+        )
+
+    def __rmul__(self, other: Column | AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self.__mul__(_other)
+
+    def __truediv__(self, other: AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self._from_dataframe(
+            self.dataframe.__truediv__(_other),
+        )
+
+    def __rtruediv__(self, other: Column | AnyScalar) -> DataFrame:  # pragma: no cover
+        _other = validate_comparand(self, other)  # noqa: F841
+        raise NotImplementedError
+
+    def __floordiv__(self, other: AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self._from_dataframe(
+            self.dataframe.__floordiv__(_other),
+        )
+
+    def __rfloordiv__(self, other: Column | AnyScalar) -> DataFrame:  # pragma: no cover
+        _other = validate_comparand(self, other)  # noqa: F841
+        raise NotImplementedError
+
+    def __pow__(self, other: AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)
+        return self._from_dataframe(
+            self.dataframe.__pow__(_other),
+        )
+
+    def __rpow__(self, other: Column | AnyScalar) -> DataFrame:  # pragma: no cover
+        _other = validate_comparand(self, other)  # noqa: F841
+        raise NotImplementedError
+
+    def __mod__(self, other: AnyScalar) -> DataFrame:
+        _other = validate_comparand(self, other)  # noqa: F841
+        return self._from_dataframe(
+            self.dataframe.__mod__(other),
+        )
+
+    def __rmod__(self, other: Column | AnyScalar) -> DataFrame:  # type: ignore[misc]  # pragma: no cover
+        _other = validate_comparand(self, other)  # noqa: F841
+        raise NotImplementedError
+
+    def __divmod__(
+        self,
+        other: DataFrame | AnyScalar,
+    ) -> tuple[DataFrame, DataFrame]:
+        _other = validate_comparand(self, other)
+        quotient, remainder = self.dataframe.__divmod__(_other)
+        return self._from_dataframe(quotient), self._from_dataframe(
+            remainder,
+        )
+
+    # Unary
+
+    def __invert__(self) -> DataFrame:
+        self._validate_booleanness()
+        return self._from_dataframe(self.dataframe.__invert__())
+
+    def __iter__(self) -> NoReturn:
+        raise NotImplementedError
+
+    # Reductions
+
+    def any(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        self._validate_booleanness()
+        return self._from_dataframe(
+            self.dataframe.any().to_frame().T,
+        )
+
+    def all(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        self._validate_booleanness()
+        return self._from_dataframe(
+            self.dataframe.all().to_frame().T,
+        )
+
+    def min(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        return self._from_dataframe(
+            self.dataframe.min().to_frame().T,
+        )
+
+    def max(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        return self._from_dataframe(
+            self.dataframe.max().to_frame().T,
+        )
+
+    def sum(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        return self._from_dataframe(
+            self.dataframe.sum().to_frame().T,
+        )
+
+    def prod(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        return self._from_dataframe(
+            self.dataframe.prod().to_frame().T,
+        )
+
+    def median(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        return self._from_dataframe(
+            self.dataframe.median().to_frame().T,
+        )
+
+    def mean(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        return self._from_dataframe(
+            self.dataframe.mean().to_frame().T,
+        )
+
+    def std(
+        self,
+        *,
+        correction: float | Scalar | NullType = 1.0,
+        skip_nulls: bool | Scalar = True,
+    ) -> DataFrame:
+        return self._from_dataframe(
+            self.dataframe.std().to_frame().T,
+        )
+
+    def var(
+        self,
+        *,
+        correction: float | Scalar | NullType = 1.0,
+        skip_nulls: bool | Scalar = True,
+    ) -> DataFrame:
+        return self._from_dataframe(
+            self.dataframe.var().to_frame().T,
+        )
+
+    # Transformations
+
+    def is_null(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        result: list[pd.Series] = []
+        for column in self.dataframe.columns:
+            result.append(self.dataframe[column].isna())
+        return self._from_dataframe(pd.concat(result, axis=1))
+
+    def is_nan(self) -> DataFrame:
+        return self.assign(*[col.is_nan() for col in self.iter_columns()])
+
+    def fill_nan(self, value: float | Scalar | NullType) -> DataFrame:
+        _value = validate_comparand(self, value)
+        new_cols = {}
+        df = self.dataframe
+        for col in df.columns:
+            ser = df[col].copy()
+            if is_extension_array_dtype(ser.dtype):
+                if self.__dataframe_namespace__().is_null(_value):
+                    ser[np.isnan(ser).fillna(False).to_numpy(bool)] = pd.NA
+                else:
+                    ser[np.isnan(ser).fillna(False).to_numpy(bool)] = _value
+            else:
+                if self.__dataframe_namespace__().is_null(_value):
+                    ser[np.isnan(ser).fillna(False).to_numpy(bool)] = np.nan
+                else:
+                    ser[np.isnan(ser).fillna(False).to_numpy(bool)] = _value
+            new_cols[col] = ser
+        df = pd.DataFrame(new_cols)
+        return self._from_dataframe(df)
+
+    def fill_null(
+        self,
+        value: AnyScalar,
+        *,
+        column_names: list[str] | None = None,
+    ) -> DataFrame:
+        if column_names is None:
+            column_names = self.dataframe.columns.tolist()
+        assert isinstance(column_names, list)  # help type checkers
+        return self.assign(
+            *[
+                col.fill_null(value)
+                for col in self.iter_columns()
+                if col.name in column_names
+            ],
+        )
+
+    def drop_nulls(
+        self,
+        *,
+        column_names: list[str] | None = None,
+    ) -> DataFrame:
+        namespace = self.__dataframe_namespace__()
+        mask = ~namespace.any_horizontal(
+            *[
+                self.col(col_name).is_null()
+                for col_name in column_names or self.column_names
+            ],
+        )
+        return self.filter(mask)
+
+    # Other
+
+    def join(
+        self,
+        other: DataFrame,
+        *,
+        how: Literal["left", "inner", "outer"],
+        left_on: str | list[str],
+        right_on: str | list[str],
+    ) -> DataFrame:
+        if how not in ["left", "inner", "outer"]:
+            msg = f"Expected 'left', 'inner', 'outer', got: {how}"
+            raise ValueError(msg)
+
+        if isinstance(left_on, str):
+            left_on = [left_on]
+        if isinstance(right_on, str):
+            right_on = [right_on]
+
+        if overlap := (set(self.column_names) - set(left_on)).intersection(
+            set(other.column_names) - set(right_on),
+        ):
+            msg = f"Found overlapping columns in join: {overlap}. Please rename columns to avoid this."
+            raise ValueError(msg)
+
+        return self._from_dataframe(
+            self.dataframe.merge(
+                other.dataframe,
+                left_on=left_on,
+                right_on=right_on,
+                how=how,
+            ),
+        )
+
+    def persist(self) -> DataFrame:
+        if self._is_persisted:
+            warnings.warn(
+                "Calling `.persist` on DataFrame that was already persisted",
+                UserWarning,
+                stacklevel=2,
+            )
+        return DataFrame(
+            self.dataframe,
+            api_version=self._api_version,
+            is_persisted=True,
+        )
+
+    # Conversion
+
+    def to_array(self, dtype: DType | None = None) -> Any:
+        self._validate_is_persisted()
+        return self.dataframe.to_numpy()
+
+    def cast(self, dtypes: Mapping[str, DType]) -> DataFrame:
+        from modin.dataframe_api_standard import map_standard_dtype_to_pandas_dtype
+
+        df = self._dataframe
+        return self._from_dataframe(
+            df.astype(
+                {
+                    col: map_standard_dtype_to_pandas_dtype(dtype)
+                    for col, dtype in dtypes.items()
+                },
+            ),
+        )

--- a/modin/dataframe_api_standard/dataframe_object.py
+++ b/modin/dataframe_api_standard/dataframe_object.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import collections

--- a/modin/dataframe_api_standard/group_by_object.py
+++ b/modin/dataframe_api_standard/group_by_object.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast

--- a/modin/dataframe_api_standard/group_by_object.py
+++ b/modin/dataframe_api_standard/group_by_object.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
+import modin.pandas as pd
+from modin.dataframe_api_standard import Namespace
+from modin.dataframe_api_standard.dataframe_object import DataFrame
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from dataframe_api import Aggregation as AggregationT
+    from dataframe_api import GroupBy as GroupByT
+    from dataframe_api.typing import NullType, Scalar
+
+
+else:
+    GroupByT = object
+
+
+class GroupBy(GroupByT):
+    def __init__(self, df: DataFrame, keys: Sequence[str], api_version: str) -> None:
+        self._df = df.dataframe
+        self._is_persisted = df._is_persisted
+        self._grouped = self._df.groupby(list(keys), sort=False, as_index=False)
+        self._keys = list(keys)
+        self._api_version = api_version
+
+    def _validate_result(self, result: pd.DataFrame) -> None:
+        failed_columns = self._df.columns.difference(result.columns)
+        if len(failed_columns) > 0:  # pragma: no cover
+            msg = "Groupby operation could not be performed on columns "
+            +f"{failed_columns}. Please drop them before calling group_by."
+            raise AssertionError(
+                msg,
+            )
+
+    def _validate_booleanness(self) -> None:
+        if not (
+            (self._df.drop(columns=self._keys).dtypes == "bool")
+            | (self._df.drop(columns=self._keys).dtypes == "boolean")
+        ).all():
+            msg = (
+                "'function' can only be called on DataFrame where all dtypes are 'bool'"
+            )
+            raise TypeError(
+                msg,
+            )
+
+    def _to_dataframe(self, result: pd.DataFrame) -> DataFrame:
+        return DataFrame(
+            result,
+            api_version=self._api_version,
+            is_persisted=self._is_persisted,
+        )
+
+    def size(self) -> DataFrame:
+        return self._to_dataframe(self._grouped.size())
+
+    def any(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        self._validate_booleanness()
+        result = self._grouped.any()
+        self._validate_result(result)
+        return self._to_dataframe(result)
+
+    def all(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        self._validate_booleanness()
+        result = self._grouped.all()
+        self._validate_result(result)
+        return self._to_dataframe(result)
+
+    def min(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        result = self._grouped.min()
+        self._validate_result(result)
+        return self._to_dataframe(result)
+
+    def max(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        result = self._grouped.max()
+        self._validate_result(result)
+        return self._to_dataframe(result)
+
+    def sum(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        result = self._grouped.sum()
+        self._validate_result(result)
+        return self._to_dataframe(result)
+
+    def prod(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        result = self._grouped.prod()
+        self._validate_result(result)
+        return self._to_dataframe(result)
+
+    def median(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        result = self._grouped.median()
+        self._validate_result(result)
+        return self._to_dataframe(result)
+
+    def mean(self, *, skip_nulls: bool | Scalar = True) -> DataFrame:
+        result = self._grouped.mean()
+        self._validate_result(result)
+        return self._to_dataframe(result)
+
+    def std(
+        self,
+        *,
+        correction: float | Scalar | NullType = 1.0,
+        skip_nulls: bool | Scalar = True,
+    ) -> DataFrame:
+        result = self._grouped.std()
+        self._validate_result(result)
+        return self._to_dataframe(result)
+
+    def var(
+        self,
+        *,
+        correction: float | Scalar | NullType = 1.0,
+        skip_nulls: bool | Scalar = True,
+    ) -> DataFrame:
+        result = self._grouped.var()
+        self._validate_result(result)
+        return self._to_dataframe(result)
+
+    def aggregate(
+        self,
+        *aggregations: AggregationT,
+    ) -> DataFrame:
+        aggregations = validate_aggregations(*aggregations, keys=self._keys)
+        df = self._grouped.agg(
+            **{
+                aggregation.output_name: resolve_aggregation(  # type: ignore[attr-defined]
+                    aggregation,
+                )
+                for aggregation in aggregations
+            },
+        )
+        return self._to_dataframe(
+            df,
+        )
+
+
+def validate_aggregations(
+    *aggregations: AggregationT,
+    keys: Sequence[str],
+) -> tuple[AggregationT, ...]:
+    return tuple(
+        (
+            aggregation
+            if aggregation.aggregation != "size"  # type: ignore[attr-defined]
+            else aggregation._replace(column_name=keys[0])  # type: ignore[attr-defined]
+        )
+        for aggregation in aggregations
+    )
+
+
+def resolve_aggregation(aggregation: AggregationT) -> pd.NamedAgg:
+    aggregation = cast(Namespace.Aggregation, aggregation)
+    return pd.NamedAgg(
+        column=aggregation.column_name,
+        aggfunc=aggregation.aggregation,
+    )

--- a/modin/dataframe_api_standard/scalar_object.py
+++ b/modin/dataframe_api_standard/scalar_object.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import warnings

--- a/modin/dataframe_api_standard/scalar_object.py
+++ b/modin/dataframe_api_standard/scalar_object.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+import warnings
+from typing import TYPE_CHECKING, Any
+
+from modin.dataframe_api_standard.utils import validate_comparand
+
+if TYPE_CHECKING:
+    from dataframe_api.typing import DType, Namespace
+    from dataframe_api.typing import Scalar as ScalarT
+
+    from modin.dataframe_api_standard.dataframe_object import DataFrame
+else:
+    ScalarT = object
+
+
+class Scalar(ScalarT):
+    def __init__(
+        self,
+        value: Any,
+        api_version: str,
+        df: DataFrame | None,
+        *,
+        is_persisted: bool = False,
+    ) -> None:
+        self._value = value
+        self._api_version = api_version
+        self._df = df
+        self._is_persisted = is_persisted
+        assert is_persisted ^ (df is not None)
+
+    def __scalar_namespace__(self) -> Namespace:
+        from modin.dataframe_api_standard import Namespace
+
+        return Namespace(api_version=self._api_version)
+
+    def _from_scalar(self, scalar: Scalar) -> Scalar:
+        return Scalar(
+            scalar,
+            df=self._df,
+            api_version=self._api_version,
+            is_persisted=self._is_persisted,
+        )
+
+    @property
+    def dtype(self) -> DType:  # pragma: no cover  # todo
+        msg = "dtype not yet implemented for Scalar"
+        raise NotImplementedError(msg)
+
+    @property
+    def scalar(self) -> Any:  # pragma: no cover  # todo
+        return self._value
+
+    @property
+    def parent_dataframe(self) -> Any:  # pragma: no cover  # todo
+        return self._df
+
+    def _materialise(self) -> Any:
+        if not self._is_persisted:
+            msg = "Can't call __bool__ on Scalar. Please use .persist() first."
+            raise RuntimeError(msg)
+        return self._value
+
+    def persist(self) -> Scalar:
+        if self._is_persisted:
+            warnings.warn(
+                "Calling `.persist` on Scalar that was already persisted",
+                UserWarning,
+                stacklevel=2,
+            )
+        return Scalar(
+            self._value,
+            df=None,
+            api_version=self._api_version,
+            is_persisted=True,
+        )
+
+    def __lt__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__lt__(other))
+
+    def __le__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__le__(other))
+
+    def __eq__(self, other: Any) -> Scalar:  # type: ignore[override]
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__eq__(other))
+
+    def __ne__(self, other: Any) -> Scalar:  # type: ignore[override]
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__ne__(other))
+
+    def __gt__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__gt__(other))
+
+    def __ge__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__ge__(other))
+
+    def __add__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__add__(other))
+
+    def __radd__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(other + self._value)
+
+    def __sub__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__sub__(other))
+
+    def __rsub__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(other - self._value)
+
+    def __mul__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__mul__(other))
+
+    def __rmul__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(other * self._value)
+
+    def __mod__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__mod__(other))
+
+    def __rmod__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(other % self._value)
+
+    def __pow__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__pow__(other))
+
+    def __rpow__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(other**self._value)
+
+    def __floordiv__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__floordiv__(other))
+
+    def __rfloordiv__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(other // self._value)
+
+    def __truediv__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(self._value.__truediv__(other))
+
+    def __rtruediv__(self, other: Any) -> Scalar:
+        other = validate_comparand(self, other)
+        if other is NotImplemented:
+            return NotImplemented
+        return self._from_scalar(other / self._value)
+
+    def __neg__(self) -> Scalar:
+        return self._from_scalar(self._value.__neg__())
+
+    def __abs__(self) -> Scalar:
+        return self._from_scalar(self._value.__abs__())
+
+    def __bool__(self) -> bool:
+        return self._materialise().__bool__()  # type: ignore[no-any-return]
+
+    def __int__(self) -> int:
+        return self._materialise().__int__()  # type: ignore[no-any-return]
+
+    def __float__(self) -> float:
+        return self._materialise().__float__()  # type: ignore[no-any-return]
+
+    def __repr__(self) -> str:  # pragma: no cover
+        header = f" Standard Scalar (api_version={self._api_version}) "
+        length = len(header)
+        return (
+            "┌"
+            + "─" * length
+            + "┐\n"
+            + f"|{header}|\n"
+            + "| Add `.scalar` to see native output         |\n"
+            + "└"
+            + "─" * length
+            + "┘\n"
+        )

--- a/modin/dataframe_api_standard/tests/__init__.py
+++ b/modin/dataframe_api_standard/tests/__init__.py
@@ -1,0 +1,1 @@
+from __future__ import annotations

--- a/modin/dataframe_api_standard/tests/__init__.py
+++ b/modin/dataframe_api_standard/tests/__init__.py
@@ -1,1 +1,38 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations

--- a/modin/dataframe_api_standard/tests/column/__init__.py
+++ b/modin/dataframe_api_standard/tests/column/__init__.py
@@ -1,0 +1,35 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/modin/dataframe_api_standard/tests/column/and_or_test.py
+++ b/modin/dataframe_api_standard/tests/column/and_or_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/and_or_test.py
+++ b/modin/dataframe_api_standard/tests/column/and_or_test.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    bool_dataframe_1,
+    compare_column_with_reference,
+)
+
+
+def test_column_and(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = df.col("b")
+    result = df.assign((ser & other).rename("result"))
+    expected = [True, True, False]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)
+
+
+def test_column_or(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = df.col("b")
+    result = df.assign((ser | other).rename("result"))
+    expected = [True, True, True]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)
+
+
+def test_column_and_with_scalar(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = True
+    result = df.assign((other & ser).rename("result"))
+    expected = [True, True, False]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)
+
+
+def test_column_or_with_scalar(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = True
+    result = df.assign((other | ser).rename("result"))
+    expected = [True, True, True]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)

--- a/modin/dataframe_api_standard/tests/column/any_all_test.py
+++ b/modin/dataframe_api_standard/tests/column/any_all_test.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, bool_dataframe_1
+
+
+def test_expr_any(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    with pytest.raises(RuntimeError):
+        bool(df.col("a").any())
+    df = df.persist()
+    result = df.col("a").any()
+    with pytest.warns(UserWarning):
+        assert bool(result.persist())
+
+
+def test_expr_all(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library).persist()
+    result = df.col("a").all()
+    assert not bool(result)

--- a/modin/dataframe_api_standard/tests/column/any_all_test.py
+++ b/modin/dataframe_api_standard/tests/column/any_all_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/column/cast_test.py
+++ b/modin/dataframe_api_standard/tests/column/cast_test.py
@@ -1,0 +1,14 @@
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_cast_integers(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.assign(df.col("a").cast(ns.Int32()))
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    expected_dtype = {"a": ns.Int32, "b": ns.Int64}
+    compare_dataframe_with_reference(result, expected, expected_dtype)

--- a/modin/dataframe_api_standard/tests/column/cast_test.py
+++ b/modin/dataframe_api_standard/tests/column/cast_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from modin.dataframe_api_standard.tests.utils import (
     BaseHandler,
     compare_dataframe_with_reference,

--- a/modin/dataframe_api_standard/tests/column/col_sorted_indices_test.py
+++ b/modin/dataframe_api_standard/tests/column/col_sorted_indices_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/col_sorted_indices_test.py
+++ b/modin/dataframe_api_standard/tests/column/col_sorted_indices_test.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_6,
+)
+
+
+def test_expression_sorted_indices_ascending(library: BaseHandler) -> None:
+    df = integer_dataframe_6(library)
+    ns = df.__dataframe_namespace__()
+    col = df.col
+    sorted_indices = col("b").sorted_indices()
+    result = df.take(sorted_indices)
+    expected = {"a": [2, 2, 1, 1, 1], "b": [1, 2, 3, 4, 4]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_expression_sorted_indices_descending(library: BaseHandler) -> None:
+    df = integer_dataframe_6(library)
+    ns = df.__dataframe_namespace__()
+    col = df.col
+    sorted_indices = col("b").sorted_indices(ascending=False)
+    result = df.take(sorted_indices)
+    expected = {"a": [1, 1, 1, 2, 2], "b": [4, 4, 3, 2, 1]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_column_sorted_indices_ascending(library: BaseHandler) -> None:
+    df = integer_dataframe_6(library)
+    ns = df.__dataframe_namespace__()
+    sorted_indices = df.col("b").sorted_indices()
+    result = df.take(sorted_indices)
+    expected = {"a": [2, 2, 1, 1, 1], "b": [1, 2, 3, 4, 4]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_column_sorted_indices_descending(library: BaseHandler) -> None:
+    df = integer_dataframe_6(library)
+    ns = df.__dataframe_namespace__()
+    sorted_indices = df.col("b").sorted_indices(ascending=False)
+    result = df.take(sorted_indices)
+    expected = {"a": [1, 1, 1, 2, 2], "b": [4, 4, 3, 2, 1]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/column/col_to_array_object_test.py
+++ b/modin/dataframe_api_standard/tests/column/col_to_array_object_test.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    bool_dataframe_1,
+    integer_dataframe_1,
+)
+
+
+@pytest.mark.parametrize(
+    "dtype",
+    [
+        "int8",
+        "int16",
+        "int32",
+        "int64",
+        "uint8",
+        "uint16",
+        "uint32",
+        "uint64",
+        "float32",
+        "float64",
+    ],
+)
+def test_column_to_array_object(
+    library: BaseHandler, dtype: str
+) -> None:  # noqa: ARG001
+    ser = integer_dataframe_1(library).col("a").persist()
+    result = np.asarray(ser.to_array())
+    expected = np.array([1, 2, 3], dtype=np.int64)
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_column_to_array_object_bool(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library).persist().col("a")
+    result = np.asarray(df.to_array())
+    expected = np.array([True, True, False], dtype="bool")
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_column_to_array_object_invalid(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library).col("a")
+    with pytest.raises(RuntimeError):
+        _ = np.asarray(df.to_array())

--- a/modin/dataframe_api_standard/tests/column/col_to_array_object_test.py
+++ b/modin/dataframe_api_standard/tests/column/col_to_array_object_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import numpy as np

--- a/modin/dataframe_api_standard/tests/column/comparisons_test.py
+++ b/modin/dataframe_api_standard/tests/column/comparisons_test.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    integer_dataframe_1,
+    integer_dataframe_7,
+)
+
+
+@pytest.mark.parametrize(
+    ("comparison", "expected_data", "expected_dtype"),
+    [
+        ("__eq__", [True, True, False], "Bool"),
+        ("__ne__", [False, False, True], "Bool"),
+        ("__ge__", [True, True, False], "Bool"),
+        ("__gt__", [False, False, False], "Bool"),
+        ("__le__", [True, True, True], "Bool"),
+        ("__lt__", [False, False, True], "Bool"),
+        ("__add__", [2, 4, 7], "Int64"),
+        ("__sub__", [0, 0, -1], "Int64"),
+        ("__mul__", [1, 4, 12], "Int64"),
+        ("__truediv__", [1, 1, 0.75], "Float64"),
+        ("__floordiv__", [1, 1, 0], "Int64"),
+        ("__pow__", [1, 4, 81], "Int64"),
+        ("__mod__", [0, 0, 3], "Int64"),
+    ],
+)
+def test_column_comparisons(
+    library: BaseHandler,
+    comparison: str,
+    expected_data: list[object],
+    expected_dtype: str,
+) -> None:
+    ser: Any
+    df = integer_dataframe_7(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = df.col("b")
+    result = df.assign(getattr(ser, comparison)(other).rename("result"))
+    expected_ns_dtype = getattr(ns, expected_dtype)
+    compare_column_with_reference(
+        result.col("result"), expected_data, expected_ns_dtype
+    )
+
+
+@pytest.mark.parametrize(
+    ("comparison", "expected_data", "expected_dtype"),
+    [
+        ("__eq__", [False, False, True], "Bool"),
+        ("__ne__", [True, True, False], "Bool"),
+        ("__ge__", [False, False, True], "Bool"),
+        ("__gt__", [False, False, False], "Bool"),
+        ("__le__", [True, True, True], "Bool"),
+        ("__lt__", [True, True, False], "Bool"),
+        ("__add__", [4, 5, 6], "Int64"),
+        ("__sub__", [-2, -1, 0], "Int64"),
+        ("__mul__", [3, 6, 9], "Int64"),
+        ("__truediv__", [1 / 3, 2 / 3, 1], "Float64"),
+        ("__floordiv__", [0, 0, 1], "Int64"),
+        ("__pow__", [1, 8, 27], "Int64"),
+        ("__mod__", [1, 2, 0], "Int64"),
+    ],
+)
+def test_column_comparisons_scalar(
+    library: BaseHandler,
+    comparison: str,
+    expected_data: list[object],
+    expected_dtype: str,
+) -> None:
+    ser: Any
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = 3
+    result = df.assign(getattr(ser, comparison)(other).rename("result"))
+    expected_ns_dtype = getattr(ns, expected_dtype)
+    compare_column_with_reference(
+        result.col("result"), expected_data, expected_ns_dtype
+    )
+
+
+@pytest.mark.parametrize(
+    ("comparison", "expected_data"),
+    [
+        ("__radd__", [3, 4, 5]),
+        ("__rsub__", [1, 0, -1]),
+        ("__rmul__", [2, 4, 6]),
+    ],
+)
+def test_right_column_comparisons(
+    library: BaseHandler,
+    comparison: str,
+    expected_data: list[object],
+) -> None:
+    # 1,2,3
+    ser: Any
+    df = integer_dataframe_7(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = 2
+    result = df.assign(getattr(ser, comparison)(other).rename("result"))
+    compare_column_with_reference(result.col("result"), expected_data, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/column/comparisons_test.py
+++ b/modin/dataframe_api_standard/tests/column/comparisons_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from typing import Any

--- a/modin/dataframe_api_standard/tests/column/conftest.py
+++ b/modin/dataframe_api_standard/tests/column/conftest.py
@@ -1,0 +1,35 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/modin/dataframe_api_standard/tests/column/cross_df_comparisons_test.py
+++ b/modin/dataframe_api_standard/tests/column/cross_df_comparisons_test.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    integer_dataframe_1,
+    integer_dataframe_2,
+)
+
+
+def test_invalid_comparisons(library: BaseHandler) -> None:
+    with pytest.raises(ValueError):
+        _ = integer_dataframe_1(library).col("a") > integer_dataframe_2(library).col(
+            "a"
+        )
+
+
+def test_invalid_comparisons_scalar(library: BaseHandler) -> None:
+    with pytest.raises(ValueError):
+        _ = (
+            integer_dataframe_1(library).col("a")
+            > integer_dataframe_2(library).col("a").mean()
+        )

--- a/modin/dataframe_api_standard/tests/column/cross_df_comparisons_test.py
+++ b/modin/dataframe_api_standard/tests/column/cross_df_comparisons_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/column/cumulative_test.py
+++ b/modin/dataframe_api_standard/tests/column/cumulative_test.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+import modin.pandas as pd
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    integer_dataframe_1,
+)
+
+
+@pytest.mark.parametrize(
+    ("func", "expected_data"),
+    [
+        ("cumulative_sum", [1, 3, 6]),
+        ("cumulative_prod", [1, 2, 6]),
+        ("cumulative_max", [1, 2, 3]),
+        ("cumulative_min", [1, 1, 1]),
+    ],
+)
+def test_cumulative_functions_column(
+    library: BaseHandler,
+    func: str,
+    expected_data: list[float],
+) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    expected = pd.Series(expected_data, name="result")
+    result = df.assign(getattr(ser, func)().rename("result"))
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/column/cumulative_test.py
+++ b/modin/dataframe_api_standard/tests/column/cumulative_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/column/divmod_test.py
+++ b/modin/dataframe_api_standard/tests/column/divmod_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/divmod_test.py
+++ b/modin/dataframe_api_standard/tests/column/divmod_test.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_expression_divmod(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = df.col("b")
+    result_quotient, result_remainder = ser.__divmod__(other)
+    # quotient
+    result = df.assign(result_quotient.rename("result"))
+    compare_column_with_reference(result.col("result"), [0, 0, 0], dtype=ns.Int64)
+    # remainder
+    result = df.assign(result_remainder.rename("result"))
+    compare_column_with_reference(result.col("result"), [1, 2, 3], dtype=ns.Int64)
+
+
+def test_expression_divmod_with_scalar(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    result_quotient, result_remainder = ser.__divmod__(2)
+    # quotient
+    result = df.assign(result_quotient.rename("result"))
+    compare_column_with_reference(result.col("result"), [0, 1, 1], dtype=ns.Int64)
+    # remainder
+    result = df.assign(result_remainder.rename("result"))
+    compare_column_with_reference(result.col("result"), [1, 0, 1], dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/column/fill_nan_test.py
+++ b/modin/dataframe_api_standard/tests/column/fill_nan_test.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    nan_dataframe_1,
+)
+from modin.pandas.test.utils import default_to_pandas_ignore_string
+
+pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+
+
+def test_column_fill_nan(library: BaseHandler) -> None:
+    # TODO: test with nullable pandas, check null isn't filled
+    df = nan_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    result = df.assign(ser.fill_nan(-1.0).rename("result"))
+    expected = [1.0, 2.0, -1.0]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Float64)
+
+
+def test_column_fill_nan_with_null(library: BaseHandler) -> None:
+    # TODO: test with nullable pandas, check null isn't filled
+    df = nan_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    result = df.assign(ser.fill_nan(ns.null).is_null().rename("result"))
+    expected = [False, False, True]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)

--- a/modin/dataframe_api_standard/tests/column/fill_nan_test.py
+++ b/modin/dataframe_api_standard/tests/column/fill_nan_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/column/fill_null_test.py
+++ b/modin/dataframe_api_standard/tests/column/fill_null_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/fill_null_test.py
+++ b/modin/dataframe_api_standard/tests/column/fill_null_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    nan_dataframe_1,
+    null_dataframe_2,
+)
+
+
+def test_fill_null_column(library: BaseHandler) -> None:
+    df = null_dataframe_2(library)
+    ser = df.col("a")
+    result = df.assign(ser.fill_null(0).rename("result")).col("result")
+    assert float(result.get_value(2).persist()) == 0.0  # type: ignore[arg-type]
+    assert float(result.get_value(1).persist()) != 0.0  # type: ignore[arg-type]
+    assert float(result.get_value(0).persist()) != 0.0  # type: ignore[arg-type]
+
+
+def test_fill_null_noop_column(library: BaseHandler) -> None:
+    df = nan_dataframe_1(library)
+    ser = df.col("a")
+    result = df.assign(ser.fill_null(0).rename("result")).persist().col("result")
+    # nan was filled with 0
+    assert float(result.get_value(2)) == 0  # type: ignore[arg-type]
+    assert float(result.get_value(1)) != 0.0  # type: ignore[arg-type]
+    assert float(result.get_value(0)) != 0.0  # type: ignore[arg-type]

--- a/modin/dataframe_api_standard/tests/column/get_rows_by_mask_test.py
+++ b/modin/dataframe_api_standard/tests/column/get_rows_by_mask_test.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import modin.pandas as pd
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    integer_dataframe_1,
+)
+from modin.pandas.test.utils import df_equals
+
+
+def test_column_filter(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ser = df.col("a")
+    mask = ser > 1
+    ser = ser.filter(mask).persist()
+    result_pd = pd.Series(ser.to_array(), name="result")
+    expected = pd.Series([2, 3], name="result")
+    df_equals(result_pd, expected)
+
+
+def test_column_take_by_mask_noop(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    mask = ser > 0
+    ser = ser.filter(mask)
+    result = df.assign(ser.rename("result"))
+    compare_column_with_reference(result.col("result"), [1, 2, 3], dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/column/get_rows_by_mask_test.py
+++ b/modin/dataframe_api_standard/tests/column/get_rows_by_mask_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import modin.pandas as pd

--- a/modin/dataframe_api_standard/tests/column/get_rows_test.py
+++ b/modin/dataframe_api_standard/tests/column/get_rows_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/get_rows_test.py
+++ b/modin/dataframe_api_standard/tests/column/get_rows_test.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_expression_take(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    indices = df.col("a") - 1
+    result = df.assign(ser.take(indices).rename("result")).select("result")
+    compare_column_with_reference(result.col("result"), [1, 2, 3], dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/column/get_value_test.py
+++ b/modin/dataframe_api_standard/tests/column/get_value_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1

--- a/modin/dataframe_api_standard/tests/column/get_value_test.py
+++ b/modin/dataframe_api_standard/tests/column/get_value_test.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_get_value(library: BaseHandler) -> None:
+    result = integer_dataframe_1(library).persist().col("a").get_value(0)
+    assert int(result) == 1  # type: ignore[call-overload]
+
+
+def test_mean_scalar(library: BaseHandler) -> None:
+    result = integer_dataframe_1(library).persist().col("a").max()
+    assert int(result) == 3  # type: ignore[call-overload]

--- a/modin/dataframe_api_standard/tests/column/invert_test.py
+++ b/modin/dataframe_api_standard/tests/column/invert_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/invert_test.py
+++ b/modin/dataframe_api_standard/tests/column/invert_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    bool_dataframe_1,
+    compare_column_with_reference,
+)
+
+
+def test_expression_invert(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    result = df.assign((~ser).rename("result"))
+    expected = [False, False, True]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)
+
+
+def test_column_invert(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    result = df.assign((~ser).rename("result"))
+    expected = [False, False, True]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)

--- a/modin/dataframe_api_standard/tests/column/is_in_test.py
+++ b/modin/dataframe_api_standard/tests/column/is_in_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any

--- a/modin/dataframe_api_standard/tests/column/is_in_test.py
+++ b/modin/dataframe_api_standard/tests/column/is_in_test.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    float_dataframe_1,
+    float_dataframe_2,
+    float_dataframe_3,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+
+@pytest.mark.parametrize(
+    ("df_factory", "expected_values"),
+    [
+        (float_dataframe_1, [False, True]),
+        (float_dataframe_2, [True, False]),
+        (float_dataframe_3, [True, False]),
+    ],
+)
+@pytest.mark.filterwarnings("ignore:np.find_common_type is deprecated")
+def test_is_in(
+    library: BaseHandler,
+    df_factory: Callable[[BaseHandler], Any],
+    expected_values: list[bool],
+) -> None:
+    df = df_factory(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = ser + 1
+    result = df.assign(ser.is_in(other).rename("result"))
+    compare_column_with_reference(result.col("result"), expected_values, dtype=ns.Bool)
+
+
+@pytest.mark.parametrize(
+    ("df_factory", "expected_values"),
+    [
+        (float_dataframe_1, [False, True]),
+        (float_dataframe_2, [True, False]),
+        (float_dataframe_3, [True, False]),
+    ],
+)
+@pytest.mark.filterwarnings("ignore:np.find_common_type is deprecated")
+def test_expr_is_in(
+    library: BaseHandler,
+    df_factory: Callable[[BaseHandler], Any],
+    expected_values: list[bool],
+) -> None:
+    df = df_factory(library)
+    ns = df.__dataframe_namespace__()
+    col = df.col
+    ser = col("a")
+    other = ser + 1
+    result = df.assign(ser.is_in(other).rename("result"))
+    compare_column_with_reference(result.col("result"), expected_values, dtype=ns.Bool)

--- a/modin/dataframe_api_standard/tests/column/is_nan_test.py
+++ b/modin/dataframe_api_standard/tests/column/is_nan_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/is_nan_test.py
+++ b/modin/dataframe_api_standard/tests/column/is_nan_test.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    nan_dataframe_1,
+)
+
+
+def test_column_is_nan(library: BaseHandler) -> None:
+    df = nan_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    result = df.assign(ser.is_nan().rename("result"))
+    expected = [False, False, True]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)

--- a/modin/dataframe_api_standard/tests/column/is_null_test.py
+++ b/modin/dataframe_api_standard/tests/column/is_null_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/is_null_test.py
+++ b/modin/dataframe_api_standard/tests/column/is_null_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    nan_dataframe_1,
+    null_dataframe_1,
+)
+
+
+def test_column_is_null_1(library: BaseHandler) -> None:
+    df = nan_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    result = df.assign(ser.is_null().rename("result"))
+    expected = [False, False, False]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)
+
+
+def test_column_is_null_2(library: BaseHandler) -> None:
+    df = null_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    result = df.assign(ser.is_null().rename("result"))
+    expected = [False, False, True]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)

--- a/modin/dataframe_api_standard/tests/column/len_test.py
+++ b/modin/dataframe_api_standard/tests/column/len_test.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_column_len(library: BaseHandler) -> None:
+    result = integer_dataframe_1(library).col("a").len().persist().scalar
+    assert result == 3

--- a/modin/dataframe_api_standard/tests/column/len_test.py
+++ b/modin/dataframe_api_standard/tests/column/len_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1

--- a/modin/dataframe_api_standard/tests/column/n_unique_test.py
+++ b/modin/dataframe_api_standard/tests/column/n_unique_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1

--- a/modin/dataframe_api_standard/tests/column/n_unique_test.py
+++ b/modin/dataframe_api_standard/tests/column/n_unique_test.py
@@ -1,0 +1,8 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_column_len(library: BaseHandler) -> None:
+    result = integer_dataframe_1(library).col("a").n_unique().persist().scalar
+    assert result == 3

--- a/modin/dataframe_api_standard/tests/column/name_test.py
+++ b/modin/dataframe_api_standard/tests/column/name_test.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_name(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library).persist()
+    name = df.col("a").name
+    assert name == "a"
+
+
+def test_pandas_name_if_0_named_column(library) -> None:
+    df = library.dataframe({0: [1, 2, 3]})
+    assert df.column_names == [0]  # type: ignore[comparison-overlap]
+    assert [col.name for col in df.iter_columns()] == [0]  # type: ignore[comparison-overlap]

--- a/modin/dataframe_api_standard/tests/column/name_test.py
+++ b/modin/dataframe_api_standard/tests/column/name_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1

--- a/modin/dataframe_api_standard/tests/column/parent_dataframe_test.py
+++ b/modin/dataframe_api_standard/tests/column/parent_dataframe_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
 
 

--- a/modin/dataframe_api_standard/tests/column/parent_dataframe_test.py
+++ b/modin/dataframe_api_standard/tests/column/parent_dataframe_test.py
@@ -1,0 +1,6 @@
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_parent_dataframe(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    assert df.col("a").parent_dataframe is df

--- a/modin/dataframe_api_standard/tests/column/pow_test.py
+++ b/modin/dataframe_api_standard/tests/column/pow_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/pow_test.py
+++ b/modin/dataframe_api_standard/tests/column/pow_test.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_float_powers_column(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = df.col("b") * 1.0
+    result = df.assign(ser.__pow__(other).rename("result"))
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6], "result": [1.0, 32.0, 729.0]}
+    expected_dtype = {"a": ns.Int64, "b": ns.Int64, "result": ns.Float64}
+    compare_dataframe_with_reference(result, expected, expected_dtype)  # type: ignore[arg-type]
+
+
+def test_float_powers_scalar_column(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = 1.0
+    result = df.assign(ser.__pow__(other).rename("result"))
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6], "result": [1.0, 2.0, 3.0]}
+    expected_dtype = {"a": ns.Int64, "b": ns.Int64, "result": ns.Float64}
+    compare_dataframe_with_reference(result, expected, expected_dtype)  # type: ignore[arg-type]
+
+
+def test_int_powers_column(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = df.col("b") * 1
+    result = df.assign(ser.__pow__(other).rename("result"))
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6], "result": [1, 32, 729]}
+    expected_dtype = {name: ns.Int64 for name in ("a", "b", "result")}
+    compare_dataframe_with_reference(result, expected, expected_dtype)
+
+
+def test_int_powers_scalar_column(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    other = 1
+    result = df.assign(ser.__pow__(other).rename("result"))
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6], "result": [1, 2, 3]}
+    expected_dtype = {name: ns.Int64 for name in ("a", "b", "result")}
+    compare_dataframe_with_reference(result, expected, expected_dtype)

--- a/modin/dataframe_api_standard/tests/column/reductions_test.py
+++ b/modin/dataframe_api_standard/tests/column/reductions_test.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    integer_dataframe_1,
+)
+
+
+@pytest.mark.parametrize(
+    ("reduction", "expected", "expected_dtype"),
+    [
+        ("min", 1, "Int64"),
+        ("max", 3, "Int64"),
+        ("sum", 6, "Int64"),
+        ("prod", 6, "Int64"),
+        ("median", 2.0, "Float64"),
+        ("mean", 2.0, "Float64"),
+        ("std", 1.0, "Float64"),
+        ("var", 1.0, "Float64"),
+    ],
+)
+def test_expression_reductions(
+    library: BaseHandler,
+    reduction: str,
+    expected: float,
+    expected_dtype: str,
+) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    ser = ser - getattr(ser, reduction)()
+    result = df.assign(ser.rename("result"))
+    reference = list((df.col("a") - expected).persist().to_array())
+    expected_ns_dtype = getattr(ns, expected_dtype)
+    compare_column_with_reference(result.col("result"), reference, expected_ns_dtype)

--- a/modin/dataframe_api_standard/tests/column/reductions_test.py
+++ b/modin/dataframe_api_standard/tests/column/reductions_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/column/rename_test.py
+++ b/modin/dataframe_api_standard/tests/column/rename_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1

--- a/modin/dataframe_api_standard/tests/column/rename_test.py
+++ b/modin/dataframe_api_standard/tests/column/rename_test.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_rename(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library).persist()
+    ser = df.col("a")
+    result = ser.rename("new_name")
+    assert result.name == "new_name"

--- a/modin/dataframe_api_standard/tests/column/schema_test.py
+++ b/modin/dataframe_api_standard/tests/column/schema_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import BaseHandler, mixed_dataframe_1

--- a/modin/dataframe_api_standard/tests/column/schema_test.py
+++ b/modin/dataframe_api_standard/tests/column/schema_test.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, mixed_dataframe_1
+
+
+def test_schema(library: BaseHandler) -> None:
+    df = mixed_dataframe_1(library)
+    namespace = df.__dataframe_namespace__()
+    result = df.col("a").dtype
+    assert isinstance(result, namespace.Int64)

--- a/modin/dataframe_api_standard/tests/column/shift_test.py
+++ b/modin/dataframe_api_standard/tests/column/shift_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 import pandas as pd
 import pytest
 

--- a/modin/dataframe_api_standard/tests/column/shift_test.py
+++ b/modin/dataframe_api_standard/tests/column/shift_test.py
@@ -1,0 +1,49 @@
+import pandas as pd
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    float_dataframe_1,
+    integer_dataframe_1,
+)
+from modin.pandas.test.utils import default_to_pandas_ignore_string
+
+pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+
+
+def test_shift_with_fill_value(library: BaseHandler) -> None:
+    if library.name == "modin":
+        pytest.skip("TODO: enable for modin")
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.assign(df.col("a").shift(1).fill_null(999))
+    expected = {"a": [999, 1, 2], "b": [4, 5, 6]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_shift_without_fill_value(library: BaseHandler) -> None:
+    if library.name == "modin":
+        pytest.skip("TODO: enable for modin")
+    df = float_dataframe_1(library)
+    result = df.assign(df.col("a").shift(-1))
+    if library.name == "pandas-numpy":
+        expected = pd.DataFrame({"a": [3.0, float("nan")]})
+        pd.testing.assert_frame_equal(result.dataframe, expected)
+    elif library.name == "pandas-nullable":
+        expected = pd.DataFrame({"a": [3.0, None]}, dtype="Float64")
+        pd.testing.assert_frame_equal(result.dataframe, expected)
+    else:  # pragma: no cover
+        msg = "unexpected library"
+        raise AssertionError(msg)
+
+
+def test_shift_with_fill_value_complicated(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.assign(df.col("a").shift(1).fill_null(df.col("a").mean()))
+    if library.name == "pandas-nullable":
+        result = result.cast({"a": ns.Float64()})
+    expected = {"a": [2.0, 1, 2], "b": [4, 5, 6]}
+    expected_dtype = {"a": ns.Float64, "b": ns.Int64}
+    compare_dataframe_with_reference(result, expected, expected_dtype)  # type: ignore[arg-type]

--- a/modin/dataframe_api_standard/tests/column/slice_rows_test.py
+++ b/modin/dataframe_api_standard/tests/column/slice_rows_test.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+import modin.pandas as pd
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_3
+from modin.pandas.test.utils import df_equals
+
+
+@pytest.mark.parametrize(
+    ("start", "stop", "step", "expected"),
+    [
+        (2, 7, 2, pd.Series([3, 5, 7], name="result")),
+        (None, 7, 2, pd.Series([1, 3, 5, 7], name="result")),
+        (2, None, 2, pd.Series([3, 5, 7], name="result")),
+        (2, None, None, pd.Series([3, 4, 5, 6, 7], name="result")),
+    ],
+)
+def test_column_slice_rows(
+    library: BaseHandler,
+    start: int | None,
+    stop: int | None,
+    step: int | None,
+    expected: pd.Series[Any],
+) -> None:
+    ser = integer_dataframe_3(library).col("a")
+    result = ser.slice_rows(start, stop, step).persist()
+    result_pd = pd.Series(result.to_array(), name="result")
+    df_equals(result_pd, expected)

--- a/modin/dataframe_api_standard/tests/column/slice_rows_test.py
+++ b/modin/dataframe_api_standard/tests/column/slice_rows_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from typing import Any

--- a/modin/dataframe_api_standard/tests/column/sort_test.py
+++ b/modin/dataframe_api_standard/tests/column/sort_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/sort_test.py
+++ b/modin/dataframe_api_standard/tests/column/sort_test.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_6,
+)
+
+
+def test_expression_sort_ascending(library: BaseHandler) -> None:
+    df = integer_dataframe_6(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    s_sorted = df.col("b").sort().rename("c")
+    result = df.assign(s_sorted)
+    expected = {
+        "a": [1, 1, 1, 2, 2],
+        "b": [4, 4, 3, 1, 2],
+        "c": [1, 2, 3, 4, 4],
+    }
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_expression_sort_descending(library: BaseHandler) -> None:
+    df = integer_dataframe_6(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    s_sorted = df.col("b").sort(ascending=False).rename("c")
+    result = df.assign(s_sorted)
+    expected = {
+        "a": [1, 1, 1, 2, 2],
+        "b": [4, 4, 3, 1, 2],
+        "c": [4, 4, 3, 2, 1],
+    }
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_column_sort_ascending(library: BaseHandler) -> None:
+    df = integer_dataframe_6(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    s_sorted = df.col("b").sort().rename("c")
+    result = df.assign(s_sorted)
+    expected = {
+        "a": [1, 1, 1, 2, 2],
+        "b": [4, 4, 3, 1, 2],
+        "c": [1, 2, 3, 4, 4],
+    }
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_column_sort_descending(library: BaseHandler) -> None:
+    df = integer_dataframe_6(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    s_sorted = df.col("b").sort(ascending=False).rename("c")
+    result = df.assign(s_sorted)
+    expected = {
+        "a": [1, 1, 1, 2, 2],
+        "b": [4, 4, 3, 1, 2],
+        "c": [4, 4, 3, 2, 1],
+    }
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/column/statistics_test.py
+++ b/modin/dataframe_api_standard/tests/column/statistics_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/column/statistics_test.py
+++ b/modin/dataframe_api_standard/tests/column/statistics_test.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_mean(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.assign((df.col("a") - df.col("a").mean()).rename("result"))
+    compare_column_with_reference(result.col("result"), [-1, 0, 1.0], dtype=ns.Float64)

--- a/modin/dataframe_api_standard/tests/column/temporal/__init__.py
+++ b/modin/dataframe_api_standard/tests/column/temporal/__init__.py
@@ -1,0 +1,35 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/modin/dataframe_api_standard/tests/column/temporal/components_test.py
+++ b/modin/dataframe_api_standard/tests/column/temporal/components_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from typing import Literal

--- a/modin/dataframe_api_standard/tests/column/temporal/components_test.py
+++ b/modin/dataframe_api_standard/tests/column/temporal/components_test.py
@@ -1,0 +1,117 @@
+from __future__ import annotations
+
+from typing import Literal
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    temporal_dataframe_1,
+)
+from modin.pandas.test.utils import default_to_pandas_ignore_string
+
+pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+
+
+@pytest.mark.parametrize(
+    ("attr", "expected"),
+    [
+        ("year", [2020, 2020, 2020]),
+        ("month", [1, 1, 1]),
+        ("day", [1, 2, 3]),
+        ("hour", [1, 3, 5]),
+        ("minute", [2, 1, 4]),
+        ("second", [1, 2, 9]),
+        ("iso_weekday", [3, 4, 5]),
+        ("unix_timestamp", [1577840521, 1577934062, 1578027849]),
+    ],
+)
+def test_col_components(library: BaseHandler, attr: str, expected: list[int]) -> None:
+    df = temporal_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    for col_name in ("a", "c", "e"):
+        result = (
+            df.assign(getattr(df.col(col_name), attr)().rename("result"))
+            .select(
+                "result",
+            )
+            .cast({"result": ns.Int64()})
+        )
+        compare_column_with_reference(result.col("result"), expected, dtype=ns.Int64)
+
+
+@pytest.mark.parametrize(
+    ("col_name", "expected"),
+    [
+        ("a", [123000, 321000, 987000]),
+        ("c", [123543, 321654, 987321]),
+        ("e", [123543, 321654, 987321]),
+    ],
+)
+def test_col_microsecond(
+    library: BaseHandler,
+    col_name: str,
+    expected: list[int],
+) -> None:
+    df = temporal_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = (
+        df.assign(df.col(col_name).microsecond().rename("result"))
+        .select(
+            "result",
+        )
+        .cast({"result": ns.Int64()})
+    )
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Int64)
+
+
+@pytest.mark.parametrize(
+    ("col_name", "expected"),
+    [
+        ("a", [123000000, 321000000, 987000000]),
+        ("c", [123543000, 321654000, 987321000]),
+        ("e", [123543000, 321654000, 987321000]),
+    ],
+)
+def test_col_nanosecond(
+    library: BaseHandler, col_name: str, expected: list[int]
+) -> None:
+    df = temporal_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = (
+        df.assign(df.col(col_name).nanosecond().rename("result"))  # type: ignore[attr-defined]
+        .select(
+            "result",
+        )
+        .cast({"result": ns.Int64()})
+    )
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Int64)
+
+
+@pytest.mark.parametrize(
+    ("time_unit", "expected"),
+    [
+        ("s", [1577840521, 1577934062, 1578027849]),
+        ("ms", [1577840521123, 1577934062321, 1578027849987]),
+        ("us", [1577840521123543, 1577934062321654, 1578027849987321]),
+        ("ns", [1577840521123543000, 1577934062321654000, 1578027849987321000]),
+    ],
+)
+def test_col_unix_timestamp_time_units(
+    library: BaseHandler,
+    time_unit: Literal["s", "ms", "us", "ns"],
+    expected: list[int],
+) -> None:
+    df = temporal_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = (
+        df.assign(
+            df.col("e").unix_timestamp(time_unit=time_unit).rename("result"),
+        )
+        .select(
+            "result",
+        )
+        .cast({"result": ns.Int64()})
+    )
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/column/temporal/filter_test.py
+++ b/modin/dataframe_api_standard/tests/column/temporal/filter_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from modin.dataframe_api_standard.tests.utils import (
     BaseHandler,
     compare_dataframe_with_reference,

--- a/modin/dataframe_api_standard/tests/column/temporal/filter_test.py
+++ b/modin/dataframe_api_standard/tests/column/temporal/filter_test.py
@@ -1,0 +1,12 @@
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    temporal_dataframe_1,
+)
+
+
+def test_filter_w_date(library: BaseHandler) -> None:
+    df = temporal_dataframe_1(library).select("a", "index")
+    ns = df.__dataframe_namespace__()
+    result = df.filter(df.col("a") > ns.date(2020, 1, 2)).select("index")
+    compare_dataframe_with_reference(result, {"index": [1, 2]}, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/column/temporal/floor_test.py
+++ b/modin/dataframe_api_standard/tests/column/temporal/floor_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    temporal_dataframe_1,
+)
+
+
+@pytest.mark.parametrize(
+    ("freq", "expected"),
+    [
+        ("1day", [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)]),
+    ],
+)
+def test_floor(library: BaseHandler, freq: str, expected: list[datetime]) -> None:
+    df = temporal_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    col = df.col
+    result = df.assign(col("a").floor(freq).rename("result")).select("result")  # type: ignore[attr-defined]
+    # TODO check the resolution
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Datetime)

--- a/modin/dataframe_api_standard/tests/column/temporal/floor_test.py
+++ b/modin/dataframe_api_standard/tests/column/temporal/floor_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from datetime import datetime

--- a/modin/dataframe_api_standard/tests/conftest.py
+++ b/modin/dataframe_api_standard/tests/conftest.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from typing import Any
+
+from modin.dataframe_api_standard.tests.utils import ModinHandler
+
+
+def pytest_generate_tests(metafunc: Any) -> None:
+    if "library" in metafunc.fixturenames:
+        libraries = ["modin"]
+        lib_handlers = [ModinHandler("modin")]
+
+        metafunc.parametrize("library", lib_handlers, ids=libraries)

--- a/modin/dataframe_api_standard/tests/conftest.py
+++ b/modin/dataframe_api_standard/tests/conftest.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from typing import Any

--- a/modin/dataframe_api_standard/tests/dataframe/__init__.py
+++ b/modin/dataframe_api_standard/tests/dataframe/__init__.py
@@ -1,0 +1,35 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/modin/dataframe_api_standard/tests/dataframe/all_rowwise_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/all_rowwise_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    bool_dataframe_1,
+    compare_dataframe_with_reference,
+)
+
+
+def test_all_horizontal(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    mask = ns.all_horizontal(*[df.col(col_name) for col_name in df.column_names])
+    result = df.filter(mask)
+    expected = {"a": [True, True], "b": [True, True]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Bool)
+
+
+def test_all_horizontal_invalid(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    namespace = df.__dataframe_namespace__()
+    with pytest.raises(ValueError):
+        _ = namespace.all_horizontal(df.col("a"), (df + 1).col("b"))

--- a/modin/dataframe_api_standard/tests/dataframe/all_rowwise_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/all_rowwise_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/and_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/and_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/dataframe/and_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/and_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    bool_dataframe_1,
+    compare_dataframe_with_reference,
+)
+
+
+def test_and_with_scalar(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    other = True
+    result = df & other
+    expected = {"a": [True, True, False], "b": [True, True, True]}
+    compare_dataframe_with_reference(result, expected, ns.Bool)
+
+
+def test_rand_with_scalar(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    other = True
+    result = other & df
+    expected = {"a": [True, True, False], "b": [True, True, True]}
+    compare_dataframe_with_reference(result, expected, ns.Bool)

--- a/modin/dataframe_api_standard/tests/dataframe/any_all_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/any_all_test.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    bool_dataframe_1,
+    bool_dataframe_3,
+    compare_dataframe_with_reference,
+)
+
+
+@pytest.mark.parametrize(
+    ("reduction", "expected_data"),
+    [
+        ("any", {"a": [True], "b": [True]}),
+        ("all", {"a": [False], "b": [True]}),
+    ],
+)
+def test_reductions(
+    library: BaseHandler,
+    reduction: str,
+    expected_data: dict[str, object],
+) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = getattr(df, reduction)()
+    compare_dataframe_with_reference(result, expected_data, dtype=ns.Bool)  # type: ignore[arg-type]
+
+
+def test_any(library: BaseHandler) -> None:
+    df = bool_dataframe_3(library)
+    ns = df.__dataframe_namespace__()
+    result = df.any()
+    expected = {"a": [False], "b": [True], "c": [True]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Bool)
+
+
+def test_all(library: BaseHandler) -> None:
+    df = bool_dataframe_3(library)
+    ns = df.__dataframe_namespace__()
+    result = df.all()
+    expected = {"a": [False], "b": [False], "c": [True]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Bool)

--- a/modin/dataframe_api_standard/tests/dataframe/any_all_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/any_all_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/any_rowwise_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/any_rowwise_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    bool_dataframe_1,
+    compare_dataframe_with_reference,
+)
+
+
+def test_any_horizontal(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    mask = ns.any_horizontal(*[df.col(col_name) for col_name in df.column_names])
+    result = df.filter(mask)
+    expected = {"a": [True, True, False], "b": [True, True, True]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Bool)
+
+
+def test_any_horizontal_invalid(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    namespace = df.__dataframe_namespace__()
+    with pytest.raises(ValueError):
+        _ = namespace.any_horizontal(df.col("a"), (df + 1).col("b"))

--- a/modin/dataframe_api_standard/tests/dataframe/any_rowwise_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/any_rowwise_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/assign_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/assign_test.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_insert_columns(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    new_col = (df.col("b") + 3).rename("result")
+    result = df.assign(new_col.rename("c"))
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+    # check original df didn't change
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    compare_dataframe_with_reference(df, expected, dtype=ns.Int64)
+
+
+def test_insert_multiple_columns(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    new_col = (df.col("b") + 3).rename("result")
+    result = df.assign(new_col.rename("c"), new_col.rename("d"))
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9], "d": [7, 8, 9]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+    # check original df didn't change
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    compare_dataframe_with_reference(df, expected, dtype=ns.Int64)
+
+
+def test_insert_multiple_columns_invalid(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library, api_version="2023.09-beta")
+    df.__dataframe_namespace__()
+    new_col = (df.col("b") + 3).rename("result")
+    with pytest.raises(TypeError):
+        _ = df.assign([new_col.rename("c"), new_col.rename("d")])  # type: ignore[arg-type]
+
+
+def test_insert_eager_columns(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    new_col = (df.col("b") + 3).rename("result")
+    result = df.assign(new_col.rename("c"), new_col.rename("d"))
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [7, 8, 9], "d": [7, 8, 9]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+    # check original df didn't change
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    compare_dataframe_with_reference(df, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/dataframe/assign_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/assign_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/cast_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/cast_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from modin.dataframe_api_standard.tests.utils import (
     BaseHandler,
     compare_dataframe_with_reference,

--- a/modin/dataframe_api_standard/tests/dataframe/cast_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/cast_test.py
@@ -1,0 +1,14 @@
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_cast_integers(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.cast({"a": ns.Int32()})
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    expected_dtype = {"a": ns.Int32, "b": ns.Int64}
+    compare_dataframe_with_reference(result, expected, dtype=expected_dtype)

--- a/modin/dataframe_api_standard/tests/dataframe/columns_iter_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/columns_iter_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from modin.dataframe_api_standard.tests.utils import (
     BaseHandler,
     compare_dataframe_with_reference,

--- a/modin/dataframe_api_standard/tests/dataframe/columns_iter_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/columns_iter_test.py
@@ -1,0 +1,18 @@
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_iter_columns(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.assign(
+        *[col / col.mean() for col in df.iter_columns()],
+    )
+    expected = {
+        "a": [0.5, 1.0, 1.5],
+        "b": [0.8, 1.0, 1.2],
+    }
+    compare_dataframe_with_reference(result, expected, dtype=ns.Float64)

--- a/modin/dataframe_api_standard/tests/dataframe/comparisons_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/comparisons_test.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+@pytest.mark.parametrize(
+    ("comparison", "expected_data", "expected_dtype"),
+    [
+        ("__eq__", {"a": [False, True, False], "b": [False, False, False]}, "Bool"),
+        ("__ne__", {"a": [True, False, True], "b": [True, True, True]}, "Bool"),
+        ("__ge__", {"a": [False, True, True], "b": [True, True, True]}, "Bool"),
+        ("__gt__", {"a": [False, False, True], "b": [True, True, True]}, "Bool"),
+        ("__le__", {"a": [True, True, False], "b": [False, False, False]}, "Bool"),
+        ("__lt__", {"a": [True, False, False], "b": [False, False, False]}, "Bool"),
+        ("__add__", {"a": [3, 4, 5], "b": [6, 7, 8]}, "Int64"),
+        ("__sub__", {"a": [-1, 0, 1], "b": [2, 3, 4]}, "Int64"),
+        ("__mul__", {"a": [2, 4, 6], "b": [8, 10, 12]}, "Int64"),
+        ("__truediv__", {"a": [0.5, 1, 1.5], "b": [2, 2.5, 3]}, "Float64"),
+        ("__floordiv__", {"a": [0, 1, 1], "b": [2, 2, 3]}, "Int64"),
+        ("__pow__", {"a": [1, 4, 9], "b": [16, 25, 36]}, "Int64"),
+        ("__mod__", {"a": [1, 0, 1], "b": [0, 1, 0]}, "Int64"),
+    ],
+)
+def test_comparisons_with_scalar(
+    library: BaseHandler,
+    comparison: str,
+    expected_data: dict[str, object],
+    expected_dtype: str,
+) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    other = 2
+    result = getattr(df, comparison)(other)
+    expected_ns_dtype = getattr(ns, expected_dtype)
+    compare_dataframe_with_reference(result, expected_data, dtype=expected_ns_dtype)  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize(
+    ("comparison", "expected_data"),
+    [
+        ("__radd__", {"a": [3, 4, 5], "b": [6, 7, 8]}),
+        ("__rsub__", {"a": [1, 0, -1], "b": [-2, -3, -4]}),
+        ("__rmul__", {"a": [2, 4, 6], "b": [8, 10, 12]}),
+    ],
+)
+def test_rcomparisons_with_scalar(
+    library: BaseHandler,
+    comparison: str,
+    expected_data: dict[str, object],
+) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    other = 2
+    result = getattr(df, comparison)(other)
+    compare_dataframe_with_reference(result, expected_data, dtype=ns.Int64)  # type: ignore[arg-type]

--- a/modin/dataframe_api_standard/tests/dataframe/comparisons_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/comparisons_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/cross_df_comparison_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/cross_df_comparison_test.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    integer_dataframe_1,
+    integer_dataframe_2,
+)
+
+
+def test_invalid_comparisons(library: BaseHandler) -> None:
+    df1 = integer_dataframe_1(library)
+    df2 = integer_dataframe_2(library)
+    mask = df2.col("a") > 1
+    with pytest.raises(ValueError):
+        _ = df1.filter(mask)

--- a/modin/dataframe_api_standard/tests/dataframe/cross_df_comparison_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/cross_df_comparison_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/divmod_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/divmod_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+from modin.pandas.test.utils import default_to_pandas_ignore_string
+
+pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+
+
+def test_divmod_with_scalar(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    other = 2
+    result_quotient, result_remainder = df.__divmod__(other)
+    expected_quotient = {"a": [0, 1, 1], "b": [2, 2, 3]}
+    expected_remainder = {"a": [1, 0, 1], "b": [0, 1, 0]}
+    compare_dataframe_with_reference(result_quotient, expected_quotient, dtype=ns.Int64)
+    compare_dataframe_with_reference(
+        result_remainder, expected_remainder, dtype=ns.Int64
+    )

--- a/modin/dataframe_api_standard/tests/dataframe/divmod_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/divmod_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/drop_column_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/drop_column_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/dataframe/drop_column_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/drop_column_test.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_drop_column(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.drop("a")
+    expected = {"b": [4, 5, 6]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/dataframe/drop_nulls_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/drop_nulls_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from modin.dataframe_api_standard.tests.utils import (
     BaseHandler,
     compare_dataframe_with_reference,

--- a/modin/dataframe_api_standard/tests/dataframe/drop_nulls_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/drop_nulls_test.py
@@ -1,0 +1,13 @@
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    null_dataframe_1,
+)
+
+
+def test_drop_nulls(library: BaseHandler) -> None:
+    df = null_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.drop_nulls()
+    expected = {"a": [1.0, 2.0]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Float64)

--- a/modin/dataframe_api_standard/tests/dataframe/fill_nan_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/fill_nan_test.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    nan_dataframe_1,
+)
+from modin.pandas.test.utils import default_to_pandas_ignore_string
+
+pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+
+
+def test_fill_nan(library: BaseHandler) -> None:
+    df = nan_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.fill_nan(-1)
+    result = result.cast({"a": ns.Float64()})
+    expected = {"a": [1.0, 2.0, -1.0]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Float64)
+
+
+def test_fill_nan_with_scalar(library: BaseHandler) -> None:
+    df = nan_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.fill_nan(df.col("a").get_value(0))
+    result = result.cast({"a": ns.Float64()})
+    expected = {"a": [1.0, 2.0, 1.0]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Float64)
+
+
+def test_fill_nan_with_scalar_invalid(library: BaseHandler) -> None:
+    df = nan_dataframe_1(library)
+    other = df + 1
+    with pytest.raises(ValueError):
+        _ = df.fill_nan(other.col("a").get_value(0))
+
+
+def test_fill_nan_with_null(library: BaseHandler) -> None:
+    df = nan_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.fill_nan(ns.null)
+    n_nans = result.is_nan().sum()
+    result = n_nans.col("a").persist().get_value(0).scalar
+    # null is nan for pandas-numpy
+    assert result == 1

--- a/modin/dataframe_api_standard/tests/dataframe/fill_nan_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/fill_nan_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/fill_null_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/fill_null_test.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    nan_dataframe_1,
+    null_dataframe_2,
+)
+from modin.pandas.test.utils import default_to_pandas_ignore_string
+
+pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+
+
+@pytest.mark.parametrize(
+    "column_names",
+    [
+        ["a", "b"],
+        None,
+        ["a"],
+        ["b"],
+    ],
+)
+def test_fill_null(library: BaseHandler, column_names: list[str] | None) -> None:
+    df = null_dataframe_2(library)
+    df.__dataframe_namespace__()
+    result = df.fill_null(0, column_names=column_names)
+
+    if column_names is None or "a" in column_names:
+        res1 = result.filter(result.col("a").is_null()).persist()
+        # check there no nulls left in the column
+        assert res1.shape()[0] == 0
+        # check the last element was filled with 0
+        assert result.col("a").persist().get_value(2).scalar == 0
+    if column_names is None or "b" in column_names:
+        res1 = result.filter(result.col("b").is_null()).persist()
+        assert res1.shape()[0] == 0
+        assert result.col("b").persist().get_value(2).scalar == 0
+
+
+def test_fill_null_noop(library: BaseHandler) -> None:
+    df = nan_dataframe_1(library)
+    result_raw = df.fill_null(0)
+    if hasattr(result_raw.dataframe, "collect"):
+        result = result_raw.dataframe.collect()
+    else:
+        result = result_raw.dataframe
+    # in pandas-numpy, null is nan, so it gets filled
+    assert result["a"][2] == 0

--- a/modin/dataframe_api_standard/tests/dataframe/fill_null_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/fill_null_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/get_column_by_name_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/get_column_by_name_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/dataframe/get_column_by_name_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/get_column_by_name_test.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_get_column(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    col = df.col
+    result = df.assign(col("a").rename("_tmp")).drop("a").rename({"_tmp": "a"})
+    expected = {"b": [4, 5, 6], "a": [1, 2, 3]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/dataframe/get_column_names_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/get_column_names_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1

--- a/modin/dataframe_api_standard/tests/dataframe/get_column_names_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/get_column_names_test.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_get_column_names(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    result = df.column_names
+    assert list(result) == ["a", "b"]

--- a/modin/dataframe_api_standard/tests/dataframe/get_rows_by_mask_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/get_rows_by_mask_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/dataframe/get_rows_by_mask_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/get_rows_by_mask_test.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_filter(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    mask = df.col("a") % 2 == 1
+    result = df.filter(mask)
+    expected = {"a": [1, 3], "b": [4, 6]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/dataframe/get_rows_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/get_rows_test.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+from modin.pandas.test.utils import default_to_pandas_ignore_string
+
+pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+
+
+def test_take(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    df = df.assign((df.col("a") - 1).sort(ascending=False).rename("result"))
+    result = df.take(df.col("result"))
+    expected = {"a": [3, 2, 1], "b": [6, 5, 4], "result": [0, 1, 2]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/dataframe/get_rows_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/get_rows_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/invert_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/invert_test.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    bool_dataframe_1,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_invert(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = ~df
+    expected = {"a": [False, False, True], "b": [False, False, False]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Bool)
+
+
+def test_invert_invalid(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    with pytest.raises(TypeError):
+        _ = ~df

--- a/modin/dataframe_api_standard/tests/dataframe/invert_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/invert_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/is_nan_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/is_nan_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/dataframe/is_nan_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/is_nan_test.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    nan_dataframe_1,
+)
+
+
+def test_dataframe_is_nan(library: BaseHandler) -> None:
+    df = nan_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.is_nan()
+    expected = {"a": [False, False, True]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Bool)

--- a/modin/dataframe_api_standard/tests/dataframe/is_null_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/is_null_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/dataframe/is_null_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/is_null_test.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    nan_dataframe_2,
+    null_dataframe_1,
+)
+
+
+def test_is_null_1(library: BaseHandler) -> None:
+    df = nan_dataframe_2(library)
+    ns = df.__dataframe_namespace__()
+    result = df.is_null()
+    expected = {"a": [False, False, False]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Bool)
+
+
+def test_is_null_2(library: BaseHandler) -> None:
+    df = null_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.is_null()
+    expected = {"a": [False, False, True]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Bool)

--- a/modin/dataframe_api_standard/tests/dataframe/join_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/join_test.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+    integer_dataframe_2,
+)
+from modin.pandas.test.utils import default_to_pandas_ignore_string
+
+pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+
+
+def test_join_left(library: BaseHandler) -> None:
+    if library.name == "modin":
+        pytest.skip("TODO: enable for modin")
+    left = integer_dataframe_1(library)
+    right = integer_dataframe_2(library).rename({"b": "c"})
+    result = left.join(right, left_on="a", right_on="a", how="left")
+    ns = result.__dataframe_namespace__()
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [4.0, 2.0, float("nan")]}
+    expected_dtype = {
+        "a": ns.Int64,
+        "b": ns.Int64,
+        "c": ns.Float64,
+    }
+    compare_dataframe_with_reference(result, expected, dtype=expected_dtype)  # type: ignore[arg-type]
+
+
+def test_join_overlapping_names(library: BaseHandler) -> None:
+    left = integer_dataframe_1(library)
+    right = integer_dataframe_2(library)
+    with pytest.raises(ValueError):
+        _ = left.join(right, left_on="a", right_on="a", how="left")
+
+
+def test_join_inner(library: BaseHandler) -> None:
+    left = integer_dataframe_1(library)
+    right = integer_dataframe_2(library).rename({"b": "c"})
+    result = left.join(right, left_on="a", right_on="a", how="inner")
+    ns = result.__dataframe_namespace__()
+    expected = {"a": [1, 2], "b": [4, 5], "c": [4, 2]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_join_outer(library: BaseHandler) -> None:  # pragma: no cover
+    left = integer_dataframe_1(library)
+    right = integer_dataframe_2(library).rename({"b": "c"})
+    result = left.join(right, left_on="a", right_on="a", how="outer").sort("a")
+    ns = result.__dataframe_namespace__()
+    expected = {
+        "a": [1, 2, 3, 4],
+        "b": [4, 5, 6, float("nan")],
+        "c": [4.0, 2.0, float("nan"), 6.0],
+    }
+    expected_dtype = {
+        "a": ns.Int64,
+        "b": ns.Float64,
+        "c": ns.Float64,
+    }
+    compare_dataframe_with_reference(result, expected, dtype=expected_dtype)  # type: ignore[arg-type]
+
+
+def test_join_two_keys(library: BaseHandler) -> None:
+    if library.name == "modin":
+        pytest.skip("TODO: enable for modin")
+    left = integer_dataframe_1(library)
+    right = integer_dataframe_2(library).rename({"b": "c"})
+    result = left.join(right, left_on=["a", "b"], right_on=["a", "c"], how="left")
+    ns = result.__dataframe_namespace__()
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6], "c": [4.0, float("nan"), float("nan")]}
+    expected_dtype = {
+        "a": ns.Int64,
+        "b": ns.Int64,
+        "c": ns.Float64,
+    }
+    compare_dataframe_with_reference(result, expected, dtype=expected_dtype)  # type: ignore[arg-type]
+
+
+def test_join_invalid(library: BaseHandler) -> None:
+    left = integer_dataframe_1(library)
+    right = integer_dataframe_2(library).rename({"b": "c"})
+    with pytest.raises(ValueError):
+        left.join(right, left_on=["a", "b"], right_on=["a", "c"], how="right")  # type: ignore  # noqa: PGH003

--- a/modin/dataframe_api_standard/tests/dataframe/join_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/join_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/or_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/or_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/dataframe/or_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/or_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    bool_dataframe_1,
+    compare_dataframe_with_reference,
+)
+
+
+def test_or_with_scalar(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    other = True
+    result = df | other
+    expected = {"a": [True, True, True], "b": [True, True, True]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Bool)
+
+
+def test_ror_with_scalar(library: BaseHandler) -> None:
+    df = bool_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    other = True
+    result = other | df
+    expected = {"a": [True, True, True], "b": [True, True, True]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Bool)

--- a/modin/dataframe_api_standard/tests/dataframe/pow_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/pow_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/dataframe/pow_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/pow_test.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_float_scalar_powers(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    other = 1.0
+    result = df.__pow__(other)
+    result = result.cast({"a": ns.Int64(), "b": ns.Int64()})
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/dataframe/reductions_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/reductions_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from typing import Any

--- a/modin/dataframe_api_standard/tests/dataframe/reductions_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/reductions_test.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+@pytest.mark.parametrize(
+    ("reduction", "expected", "expected_dtype"),
+    [
+        ("min", {"a": [1], "b": [4]}, "Int64"),
+        ("max", {"a": [3], "b": [6]}, "Int64"),
+        ("sum", {"a": [6], "b": [15]}, "Int64"),
+        ("prod", {"a": [6], "b": [120]}, "Int64"),
+        ("median", {"a": [2.0], "b": [5.0]}, "Float64"),
+        ("mean", {"a": [2.0], "b": [5.0]}, "Float64"),
+        ("std", {"a": [1.0], "b": [1.0]}, "Float64"),
+        ("var", {"a": [1.0], "b": [1.0]}, "Float64"),
+    ],
+)
+def test_dataframe_reductions(
+    library: BaseHandler,
+    reduction: str,
+    expected: dict[str, Any],
+    expected_dtype: str,
+) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = getattr(df, reduction)()
+    expected_ns_dtype = getattr(ns, expected_dtype)
+    compare_dataframe_with_reference(result, expected, dtype=expected_ns_dtype)

--- a/modin/dataframe_api_standard/tests/dataframe/rename_columns_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/rename_columns_test.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_rename(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.rename({"a": "c", "b": "e"})
+    expected = {"c": [1, 2, 3], "e": [4, 5, 6]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_rename_invalid(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    with pytest.raises(
+        TypeError,
+        match="Expected Mapping, got: <class 'function'>",
+    ):  # pragma: no cover
+        # why is this not covered? bug in coverage?
+        df.rename(lambda x: x.upper())  # type: ignore  # noqa: PGH003

--- a/modin/dataframe_api_standard/tests/dataframe/rename_columns_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/rename_columns_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/schema_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/schema_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import BaseHandler, mixed_dataframe_1

--- a/modin/dataframe_api_standard/tests/dataframe/schema_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/schema_test.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, mixed_dataframe_1
+
+
+def test_schema(library: BaseHandler) -> None:
+    df = mixed_dataframe_1(library)
+    namespace = df.__dataframe_namespace__()
+    result = df.schema
+    assert list(result.keys()) == [
+        "a",
+        "b",
+        "c",
+        "d",
+        "e",
+        "f",
+        "g",
+        "h",
+        "i",
+        "j",
+        "k",
+        "l",
+        "m",
+        "n",
+        "o",
+        "p",
+        "q",
+    ]
+    assert isinstance(result["a"], namespace.Int64)
+    assert isinstance(result["b"], namespace.Int32)
+    assert isinstance(result["c"], namespace.Int16)
+    assert isinstance(result["d"], namespace.Int8)
+    assert isinstance(result["e"], namespace.UInt64)
+    assert isinstance(result["f"], namespace.UInt32)
+    assert isinstance(result["g"], namespace.UInt16)
+    assert isinstance(result["h"], namespace.UInt8)
+    assert isinstance(result["i"], namespace.Float64)
+    assert isinstance(result["j"], namespace.Float32)
+    assert isinstance(result["k"], namespace.Bool)
+    assert isinstance(result["l"], namespace.String)
+    assert isinstance(result["m"], namespace.Datetime)
+    assert isinstance(result["n"], namespace.Datetime)
+    assert result["n"].time_unit == "ms"
+    assert result["n"].time_zone is None
+    assert isinstance(result["o"], namespace.Datetime)
+    assert result["o"].time_unit == "us"
+    assert result["o"].time_zone is None
+    # pandas non-nanosecond support only came in 2.0 - before that, these would be 'float'
+    assert isinstance(result["p"], namespace.Duration)
+    assert result["p"].time_unit == "ms"
+    assert isinstance(result["q"], namespace.Duration)
+    assert result["q"].time_unit == "us"

--- a/modin/dataframe_api_standard/tests/dataframe/select_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/select_test.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+from modin.pandas.test.utils import default_to_pandas_ignore_string
+
+pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+
+
+def test_select(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.select("b")
+    expected = {"b": [4, 5, 6]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_select_list_of_str(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = df.select("a", "b")
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_select_list_of_str_invalid(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    with pytest.raises(TypeError):
+        _ = df.select(["a", "b"])  # type: ignore[arg-type]
+
+
+@pytest.mark.filterwarnings("ignore:np.find_common_type is deprecated")
+def test_select_empty(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    result = df.select()
+    assert result.column_names == []

--- a/modin/dataframe_api_standard/tests/dataframe/select_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/select_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/shape_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/shape_test.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_shape(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library).persist()
+    assert df.shape() == (3, 2)
+
+    df = integer_dataframe_1(library)
+    with pytest.raises(ValueError):
+        df.shape()

--- a/modin/dataframe_api_standard/tests/dataframe/shape_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/shape_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/slice_rows_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/slice_rows_test.py
@@ -1,0 +1,33 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_3,
+)
+
+
+@pytest.mark.parametrize(
+    ("start", "stop", "step", "expected"),
+    [
+        (2, 7, 2, {"a": [3, 5, 7], "b": [5, 3, 1]}),
+        (None, 7, 2, {"a": [1, 3, 5, 7], "b": [7, 5, 3, 1]}),
+        (2, None, 2, {"a": [3, 5, 7], "b": [5, 3, 1]}),
+        (2, None, None, {"a": [3, 4, 5, 6, 7], "b": [5, 4, 3, 2, 1]}),
+    ],
+)
+def test_slice_rows(
+    library: BaseHandler,
+    start: int | None,
+    stop: int | None,
+    step: int | None,
+    expected: dict[str, Any],
+) -> None:
+    df = integer_dataframe_3(library)
+    ns = df.__dataframe_namespace__()
+    result = df.slice_rows(start, stop, step)
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/dataframe/slice_rows_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/slice_rows_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from typing import Any

--- a/modin/dataframe_api_standard/tests/dataframe/sort_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/sort_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/dataframe/sort_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/sort_test.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_5,
+)
+
+
+@pytest.mark.parametrize("keys", [["a", "b"], []])
+def test_sort(library: BaseHandler, keys: list[str]) -> None:
+    df = integer_dataframe_5(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    result = df.sort(*keys)
+    expected = {"a": [1, 1], "b": [3, 4]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+@pytest.mark.parametrize("keys", [["a", "b"], []])
+def test_sort_descending(
+    library: BaseHandler,
+    keys: list[str],
+) -> None:
+    df = integer_dataframe_5(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    result = df.sort(*keys, ascending=False)
+    expected = {"a": [1, 1], "b": [4, 3]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/dataframe/to_array_object_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/to_array_object_test.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import numpy as np
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_to_array_object(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library).persist()
+    result = np.asarray(df.to_array(dtype="int64"))  # type: ignore[call-arg]
+    expected = np.array([[1, 4], [2, 5], [3, 6]], dtype=np.int64)
+    np.testing.assert_array_equal(result, expected)

--- a/modin/dataframe_api_standard/tests/dataframe/to_array_object_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/to_array_object_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import numpy as np

--- a/modin/dataframe_api_standard/tests/dataframe/update_columns_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/update_columns_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/dataframe/update_columns_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/update_columns_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_update_columns(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    col = df.col
+    result = df.assign(col("a") + 1)
+    expected = {"a": [2, 3, 4], "b": [4, 5, 6]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_update_multiple_columns(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    col = df.col
+    result = df.assign(col("a") + 1, col("b") + 2)
+    expected = {"a": [2, 3, 4], "b": [6, 7, 8]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/dataframe/update_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/update_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/dataframe/update_test.py
+++ b/modin/dataframe_api_standard/tests/dataframe/update_test.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_update_column(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    new_col = df.col("b") + 3
+    result = df.assign(new_col)
+    expected = {"a": [1, 2, 3], "b": [7, 8, 9]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+    # check original df didn't change
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    compare_dataframe_with_reference(df, expected, dtype=ns.Int64)
+
+
+def test_update_columns(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library, api_version="2023.09-beta")
+    ns = df.__dataframe_namespace__()
+    new_col_a = df.col("a") + 1
+    new_col_b = df.col("b") + 3
+    result = df.assign(new_col_a, new_col_b)
+    expected = {"a": [2, 3, 4], "b": [7, 8, 9]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+    # check original df didn't change
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    compare_dataframe_with_reference(df, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/groupby/__init__.py
+++ b/modin/dataframe_api_standard/tests/groupby/__init__.py
@@ -1,0 +1,35 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/modin/dataframe_api_standard/tests/groupby/aggregate_test.py
+++ b/modin/dataframe_api_standard/tests/groupby/aggregate_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 import pytest
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/groupby/aggregate_test.py
+++ b/modin/dataframe_api_standard/tests/groupby/aggregate_test.py
@@ -1,0 +1,116 @@
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_4,
+)
+
+
+def test_aggregate(library: BaseHandler) -> None:
+    if library.name == "modin":
+        pytest.skip("https://github.com/modin-project/modin/issues/3602")
+    df = integer_dataframe_4(library)
+    df = df.assign((df.col("b") > 0).rename("d"))
+    ns = df.__dataframe_namespace__()
+    result = (
+        df.group_by("key")
+        .aggregate(
+            ns.Aggregation.sum("b").rename("b_sum"),
+            ns.Aggregation.prod("b").rename("b_prod"),
+            ns.Aggregation.mean("b").rename("b_mean"),
+            ns.Aggregation.median("b").rename("b_median"),
+            ns.Aggregation.min("b").rename("b_min"),
+            ns.Aggregation.max("b").rename("b_max"),
+            ns.Aggregation.std("b").rename("b_std"),
+            ns.Aggregation.var("b").rename("b_var"),
+            ns.Aggregation.size().rename("b_count"),
+            ns.Aggregation.any("d").rename("d_any"),
+            ns.Aggregation.all("d").rename("d_all"),
+        )
+        .sort("key")
+    )
+    expected = {
+        "key": [1, 2],
+        "b_sum": [3, 7],
+        "b_prod": [2, 12],
+        "b_mean": [1.5, 3.5],
+        "b_median": [1.5, 3.5],
+        "b_min": [1, 3],
+        "b_max": [2, 4],
+        "b_std": [0.707107, 0.707107],
+        "b_var": [0.5, 0.5],
+        "b_count": [2, 2],
+        "d_any": [True, True],
+        "d_all": [True, True],
+    }
+    expected_dtype = {
+        "key": ns.Int64,
+        "b_sum": ns.Int64,
+        "b_prod": ns.Int64,
+        "b_mean": ns.Float64,
+        "b_median": ns.Float64,
+        "b_min": ns.Int64,
+        "b_max": ns.Int64,
+        "b_std": ns.Float64,
+        "b_var": ns.Float64,
+        "b_count": ns.Int64,
+        "d_any": ns.Bool,
+        "d_all": ns.Bool,
+    }
+    compare_dataframe_with_reference(result, expected, dtype=expected_dtype)  # type: ignore[arg-type]
+
+
+def test_aggregate_only_size(library: BaseHandler) -> None:
+    if library.name == "modin":
+        pytest.skip("https://github.com/modin-project/modin/issues/3602")
+    df = integer_dataframe_4(library)
+    ns = df.__dataframe_namespace__()
+    result = (
+        df.group_by("key")
+        .aggregate(
+            ns.Aggregation.size().rename("b_count"),
+        )
+        .sort("key")
+    )
+    expected = {
+        "key": [1, 2],
+        "b_count": [2, 2],
+    }
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_aggregate_no_size(library: BaseHandler) -> None:
+    df = integer_dataframe_4(library)
+    ns = df.__dataframe_namespace__()
+    result = (
+        df.group_by("key")
+        .aggregate(
+            ns.Aggregation.sum("b").rename("b_sum"),
+            ns.Aggregation.mean("b").rename("b_mean"),
+            ns.Aggregation.min("b").rename("b_min"),
+            ns.Aggregation.max("b").rename("b_max"),
+            ns.Aggregation.std("b").rename("b_std"),
+            ns.Aggregation.var("b").rename("b_var"),
+        )
+        .sort("key")
+    )
+    expected = {
+        "key": [1, 2],
+        "b_sum": [3, 7],
+        "b_mean": [1.5, 3.5],
+        "b_min": [1, 3],
+        "b_max": [2, 4],
+        "b_std": [0.707107, 0.707107],
+        "b_var": [0.5, 0.5],
+    }
+    expected_dtype = {
+        "key": ns.Int64,
+        "b_sum": ns.Int64,
+        "b_mean": ns.Float64,
+        "b_min": ns.Int64,
+        "b_max": ns.Int64,
+        "b_std": ns.Float64,
+        "b_var": ns.Float64,
+    }
+    compare_dataframe_with_reference(result, expected, dtype=expected_dtype)  # type: ignore[arg-type]

--- a/modin/dataframe_api_standard/tests/groupby/groupby_any_all_test.py
+++ b/modin/dataframe_api_standard/tests/groupby/groupby_any_all_test.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    bool_dataframe_2,
+    compare_dataframe_with_reference,
+)
+
+
+@pytest.mark.parametrize(
+    ("aggregation", "expected_b", "expected_c"),
+    [
+        ("any", [True, True], [True, False]),
+        ("all", [False, True], [False, False]),
+    ],
+)
+def test_groupby_boolean(
+    library: BaseHandler,
+    aggregation: str,
+    expected_b: list[bool],
+    expected_c: list[bool],
+) -> None:
+    df = bool_dataframe_2(library)
+    ns = df.__dataframe_namespace__()
+    result = getattr(df.group_by("key"), aggregation)()
+    # need to sort
+    result = result.sort("key")
+    expected = {"key": [1, 2], "b": expected_b, "c": expected_c}
+    expected_dtype = {"key": ns.Int64, "b": ns.Bool, "c": ns.Bool}
+    compare_dataframe_with_reference(result, expected, dtype=expected_dtype)  # type: ignore[arg-type]

--- a/modin/dataframe_api_standard/tests/groupby/groupby_any_all_test.py
+++ b/modin/dataframe_api_standard/tests/groupby/groupby_any_all_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/groupby/invalid_test.py
+++ b/modin/dataframe_api_standard/tests/groupby/invalid_test.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_groupby_invalid(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library).select("a")
+    with pytest.raises((KeyError, TypeError)):
+        df.group_by(0)  # type: ignore[arg-type]
+    with pytest.raises((KeyError, TypeError)):
+        df.group_by("0")
+    with pytest.raises((KeyError, TypeError)):
+        df.group_by("b")

--- a/modin/dataframe_api_standard/tests/groupby/invalid_test.py
+++ b/modin/dataframe_api_standard/tests/groupby/invalid_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/groupby/numeric_test.py
+++ b/modin/dataframe_api_standard/tests/groupby/numeric_test.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_4,
+)
+
+
+@pytest.mark.parametrize(
+    ("aggregation", "expected_b", "expected_c", "expected_dtype"),
+    [
+        ("min", [1, 3], [4, 6], "Int64"),
+        ("max", [2, 4], [5, 7], "Int64"),
+        ("sum", [3, 7], [9, 13], "Int64"),
+        ("prod", [2, 12], [20, 42], "Int64"),
+        ("median", [1.5, 3.5], [4.5, 6.5], "Float64"),
+        ("mean", [1.5, 3.5], [4.5, 6.5], "Float64"),
+        (
+            "std",
+            [0.7071067811865476, 0.7071067811865476],
+            [0.7071067811865476, 0.7071067811865476],
+            "Float64",
+        ),
+        ("var", [0.5, 0.5], [0.5, 0.5], "Float64"),
+    ],
+)
+def test_group_by_numeric(
+    library: BaseHandler,
+    aggregation: str,
+    expected_b: list[float],
+    expected_c: list[float],
+    expected_dtype: str,
+) -> None:
+    df = integer_dataframe_4(library)
+    ns = df.__dataframe_namespace__()
+    result = getattr(df.group_by("key"), aggregation)()
+    result = result.sort("key")
+    expected = {"key": [1, 2], "b": expected_b, "c": expected_c}
+    dtype = getattr(ns, expected_dtype)
+    expected_ns_dtype = {"key": ns.Int64, "b": dtype, "c": dtype}
+    compare_dataframe_with_reference(result, expected, dtype=expected_ns_dtype)  # type: ignore[arg-type]

--- a/modin/dataframe_api_standard/tests/groupby/numeric_test.py
+++ b/modin/dataframe_api_standard/tests/groupby/numeric_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/groupby/size_test.py
+++ b/modin/dataframe_api_standard/tests/groupby/size_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/groupby/size_test.py
+++ b/modin/dataframe_api_standard/tests/groupby/size_test.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_4,
+)
+
+
+def test_group_by_size(library: BaseHandler) -> None:
+    df = integer_dataframe_4(library)
+    ns = df.__dataframe_namespace__()
+    result = df.group_by("key").size()
+    result = result.sort("key")
+    expected = {"key": [1, 2], "size": [2, 2]}
+    result = result.cast({"size": ns.Int64()})
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/integration/__init__.py
+++ b/modin/dataframe_api_standard/tests/integration/__init__.py
@@ -1,0 +1,35 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/modin/dataframe_api_standard/tests/integration/free_vs_w_parent_test.py
+++ b/modin/dataframe_api_standard/tests/integration/free_vs_w_parent_test.py
@@ -1,0 +1,19 @@
+import numpy as np
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_free_vs_w_parent(library: BaseHandler) -> None:
+    df1 = integer_dataframe_1(library)
+    namespace = df1.__dataframe_namespace__()
+    free_ser1 = namespace.column_from_1d_array(  # type: ignore[call-arg]
+        np.array([1, 2, 3], dtype="int64"),
+        name="preds",
+    )
+    free_ser2 = namespace.column_from_1d_array(  # type: ignore[call-arg]
+        np.array([4, 5, 6], dtype="int64"),
+        name="preds",
+    )
+
+    result = free_ser1 + free_ser2
+    assert namespace.is_dtype(result.dtype, "integral")

--- a/modin/dataframe_api_standard/tests/integration/free_vs_w_parent_test.py
+++ b/modin/dataframe_api_standard/tests/integration/free_vs_w_parent_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 import numpy as np
 
 from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1

--- a/modin/dataframe_api_standard/tests/integration/persistedness_test.py
+++ b/modin/dataframe_api_standard/tests/integration/persistedness_test.py
@@ -1,0 +1,121 @@
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+    integer_dataframe_2,
+)
+
+
+def test_within_df_propagation(library: BaseHandler) -> None:
+    df1 = integer_dataframe_1(library)
+    df1 = df1 + 1
+    with pytest.raises(RuntimeError):
+        _ = int(df1.col("a").get_value(0))  # type: ignore[call-overload]
+
+    df1 = integer_dataframe_1(library)
+    df1 = df1.persist()
+    df1 = df1 + 1
+    # the call below would recompute `df1 + 1` multiple times
+    assert int(df1.col("a").get_value(0)) == 2  # type: ignore[call-overload]
+
+    # this is the correct way
+    df1 = integer_dataframe_1(library)
+    df1 = df1 + 1
+    df1 = df1.persist()
+    assert int(df1.col("a").get_value(0)) == 2  # type: ignore[call-overload]
+
+    # persisting the column works too
+    df1 = integer_dataframe_1(library)
+    df1 = df1 + 1
+    assert int(df1.col("a").persist().get_value(0)) == 2  # type: ignore[call-overload]
+
+    # ...but not if the column was modified
+    df1 = integer_dataframe_1(library)
+    df1 = df1 + 1
+    col = df1.col("a").persist()
+    assert int((col + 1).get_value(0)) == 3  # type: ignore[call-overload]
+
+    # persisting the scalar works too
+    df1 = integer_dataframe_1(library)
+    df1 = df1 + 1
+    assert int(df1.col("a").get_value(0).persist()) == 2  # type: ignore[call-overload]
+
+    # ...but not if you modify the scalar
+    df1 = integer_dataframe_1(library)
+    df1 = df1 + 1
+    scalar = df1.col("a").get_value(0).persist()
+    assert int(scalar + 1) == 3  # type: ignore[call-overload]
+
+
+def test_within_df_within_col_propagation(library: BaseHandler) -> None:
+    df1 = integer_dataframe_1(library)
+    df1 = df1 + 1
+    df1 = df1.persist()
+    assert int((df1.col("a") + 1).mean()) == 4  # type: ignore[call-overload]
+
+
+def test_cross_df_propagation(library: BaseHandler) -> None:
+    if library.name == "modin":
+        pytest.skip("TODO: enable for modin")
+    df1 = integer_dataframe_1(library)
+    df2 = integer_dataframe_2(library)
+    ns = df1.__dataframe_namespace__()
+    df1 = df1 + 1
+    df2 = df2.rename({"b": "c"})
+    result = df1.join(df2, how="left", left_on="a", right_on="a")
+    ns = result.__dataframe_namespace__()
+    expected = {
+        "a": [2, 3, 4],
+        "b": [5, 6, 7],
+        "c": [2.0, float("nan"), 6.0],
+    }
+    expected_dtype = {
+        "a": ns.Int64,
+        "b": ns.Int64,
+        "c": ns.Float64,
+    }
+    compare_dataframe_with_reference(result, expected, dtype=expected_dtype)  # type: ignore[arg-type]
+
+
+def test_multiple_propagations(library: BaseHandler) -> None:
+    # This is a bit "ugly", as the user is "required" to call `persist`
+    # multiple times to do things optimally
+    df = integer_dataframe_1(library)
+    df = df.persist()
+    with pytest.warns(UserWarning):
+        df1 = df.filter(df.col("a") > 1).persist()
+        df2 = df.filter(df.col("a") <= 1).persist()
+    assert int(df1.col("a").mean()) == 2  # type: ignore[call-overload]
+    assert int(df2.col("a").mean()) == 1  # type: ignore[call-overload]
+
+    # But what if I want to do this
+    df = integer_dataframe_1(library)
+    df = df.persist()
+    df1 = df.filter(df.col("a") > 1)
+    df2 = df.filter(df.col("a") <= 1)
+
+    df1 = df1 + 1
+    # without this persist, `df1 + 1` will be computed twice
+    int(df1.col("a").mean())  # type: ignore[call-overload]
+    int(df1.col("a").mean())  # type: ignore[call-overload]
+
+
+def test_parent_propagations(library: BaseHandler) -> None:
+    # Set up something like this:
+    #
+    #         df
+    #     df1    df2
+    #
+    # If I persist df1, then that triggers df.
+    # If I then want call some scalar on df2, that will have to trigger
+    # df again. If df2 wasn't persisted, then df would be recomputed.
+    # So, we need to persist df2 as well.
+    df = integer_dataframe_1(library)
+    df1 = df.filter(df.col("a") > 1)
+    df2 = df.filter(df.col("a") <= 1)
+
+    df1 = df1.persist()
+    with pytest.raises(RuntimeError):
+        int(df2.col("a").mean())  # type: ignore[call-overload]

--- a/modin/dataframe_api_standard/tests/integration/persistedness_test.py
+++ b/modin/dataframe_api_standard/tests/integration/persistedness_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 import pytest
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/integration/scale_column_test.py
+++ b/modin/dataframe_api_standard/tests/integration/scale_column_test.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+import modin.pandas as pd
+from modin.pandas.test.utils import df_equals
+
+
+def test_scale_column_modin() -> None:
+    s = pd.Series([1, 2, 3], name="a")
+    ser = s.__column_consortium_standard__()
+    ser = ser - ser.mean()
+    result = ser.column
+    df_equals(result, pd.Series([-1, 0, 1.0], name="a"))

--- a/modin/dataframe_api_standard/tests/integration/scale_column_test.py
+++ b/modin/dataframe_api_standard/tests/integration/scale_column_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import modin.pandas as pd

--- a/modin/dataframe_api_standard/tests/integration/upstream_test.py
+++ b/modin/dataframe_api_standard/tests/integration/upstream_test.py
@@ -1,10 +1,44 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 class TestModin:
     def test_modin(self) -> None:
         """
         Test some basic methods of the dataframe consortium standard.
-
-        Full testing is done at https://github.com/data-apis/dataframe-api-compat,
-        this is just to check that the entry point works as expected.
         """
         import modin.pandas as pd
 

--- a/modin/dataframe_api_standard/tests/integration/upstream_test.py
+++ b/modin/dataframe_api_standard/tests/integration/upstream_test.py
@@ -1,0 +1,18 @@
+class TestModin:
+    def test_modin(self) -> None:
+        """
+        Test some basic methods of the dataframe consortium standard.
+
+        Full testing is done at https://github.com/data-apis/dataframe-api-compat,
+        this is just to check that the entry point works as expected.
+        """
+        import modin.pandas as pd
+
+        df_pd = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        df = df_pd.__dataframe_consortium_standard__()
+        result_1 = df.get_column_names()
+        expected_1 = ["a", "b"]
+        assert result_1 == expected_1
+
+        ser = pd.Series([1, 2, 3], name="a")
+        assert ser.name == "a"

--- a/modin/dataframe_api_standard/tests/namespace/__init__.py
+++ b/modin/dataframe_api_standard/tests/namespace/__init__.py
@@ -1,0 +1,35 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/modin/dataframe_api_standard/tests/namespace/column_from_1d_array_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/column_from_1d_array_test.py
@@ -1,0 +1,109 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timedelta
+
+import numpy as np
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    integer_dataframe_1,
+)
+
+
+@pytest.mark.parametrize(
+    ("pandas_dtype", "column_dtype"),
+    [
+        ("float64", "Float64"),
+        ("float32", "Float32"),
+        ("int64", "Int64"),
+        ("int32", "Int32"),
+        ("int16", "Int16"),
+        ("int8", "Int8"),
+        ("uint64", "UInt64"),
+        ("uint32", "UInt32"),
+        ("uint16", "UInt16"),
+        ("uint8", "UInt8"),
+    ],
+)
+def test_column_from_1d_array(
+    library: BaseHandler,
+    pandas_dtype: str,
+    column_dtype: str,
+) -> None:
+    ser = integer_dataframe_1(library).col("a").persist()
+    ns = ser.__column_namespace__()
+    arr = np.array([1, 2, 3], dtype=pandas_dtype)
+    result = ns.dataframe_from_columns(
+        ns.column_from_1d_array(  # type: ignore[call-arg]
+            arr,
+            name="result",
+        ),
+    )
+    expected = [1, 2, 3]
+    compare_column_with_reference(
+        result.col("result"),
+        expected,
+        dtype=getattr(ns, column_dtype),
+    )
+
+
+def test_column_from_1d_array_string(
+    library: BaseHandler,
+) -> None:
+    ser = integer_dataframe_1(library).persist().col("a")
+    ns = ser.__column_namespace__()
+    arr = np.array(["a", "b", "c"])
+    result = ns.dataframe_from_columns(
+        ns.column_from_1d_array(  # type: ignore[call-arg]
+            arr,
+            name="result",
+        ),
+    )
+    expected = ["a", "b", "c"]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.String)
+
+
+def test_column_from_1d_array_bool(
+    library: BaseHandler,
+) -> None:
+    ser = integer_dataframe_1(library).persist().col("a")
+    ns = ser.__column_namespace__()
+    arr = np.array([True, False, True])
+    result = ns.dataframe_from_columns(
+        ns.column_from_1d_array(  # type: ignore[call-arg]
+            arr,
+            name="result",
+        ),
+    )
+    expected = [True, False, True]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Bool)
+
+
+def test_datetime_from_1d_array(library: BaseHandler) -> None:
+    ser = integer_dataframe_1(library).persist().col("a")
+    ns = ser.__column_namespace__()
+    arr = np.array([date(2020, 1, 1), date(2020, 1, 2)], dtype="datetime64[ms]")
+    result = ns.dataframe_from_columns(
+        ns.column_from_1d_array(  # type: ignore[call-arg]
+            arr,
+            name="result",
+        ),
+    )
+    expected = [datetime(2020, 1, 1), datetime(2020, 1, 2)]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Datetime)
+
+
+def test_duration_from_1d_array(library: BaseHandler) -> None:
+    ser = integer_dataframe_1(library).persist().col("a")
+    ns = ser.__column_namespace__()
+    arr = np.array([timedelta(1), timedelta(2)], dtype="timedelta64[ms]")
+    result = ns.dataframe_from_columns(
+        ns.column_from_1d_array(  # type: ignore[call-arg]
+            arr,
+            name="result",
+        ),
+    )
+    expected = [timedelta(1), timedelta(2)]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Duration)

--- a/modin/dataframe_api_standard/tests/namespace/column_from_1d_array_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/column_from_1d_array_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from datetime import date, datetime, timedelta

--- a/modin/dataframe_api_standard/tests/namespace/column_from_sequence_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/column_from_sequence_test.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_column_with_reference,
+    integer_dataframe_1,
+)
+
+
+@pytest.mark.parametrize(
+    ("values", "dtype", "kwargs"),
+    [
+        ([1, 2, 3], "Int64", {}),
+        ([1, 2, 3], "Int32", {}),
+        ([1, 2, 3], "Int16", {}),
+        ([1, 2, 3], "Int8", {}),
+        ([1, 2, 3], "UInt64", {}),
+        ([1, 2, 3], "UInt32", {}),
+        ([1, 2, 3], "UInt16", {}),
+        ([1, 2, 3], "UInt8", {}),
+        ([1.0, 2.0, 3.0], "Float64", {}),
+        ([1.0, 2.0, 3.0], "Float32", {}),
+        ([True, False, True], "Bool", {}),
+        (["express", "yourself"], "String", {}),
+        ([datetime(2020, 1, 1), datetime(2020, 1, 2)], "Datetime", {"time_unit": "us"}),
+        ([timedelta(1), timedelta(2)], "Duration", {"time_unit": "us"}),
+    ],
+)
+def test_column_from_sequence(
+    library: BaseHandler,
+    values: list[Any],
+    dtype: str,
+    kwargs: dict[str, Any],
+) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    ser = df.col("a")
+    ns = ser.__column_namespace__()
+    expected_dtype = getattr(ns, dtype)
+    result = ns.dataframe_from_columns(
+        ns.column_from_sequence(
+            values,
+            dtype=expected_dtype(**kwargs),
+            name="result",
+        ),
+    )
+    compare_column_with_reference(result.col("result"), values, dtype=expected_dtype)
+
+
+def test_column_from_sequence_no_dtype(
+    library: BaseHandler,
+) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    result = ns.dataframe_from_columns(ns.column_from_sequence([1, 2, 3], name="result"))  # type: ignore[call-arg]
+    expected = [1, 2, 3]
+    compare_column_with_reference(result.col("result"), expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/namespace/column_from_sequence_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/column_from_sequence_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from datetime import datetime, timedelta

--- a/modin/dataframe_api_standard/tests/namespace/concat_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/concat_test.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+    integer_dataframe_2,
+    integer_dataframe_4,
+)
+
+
+def test_concat(library: BaseHandler) -> None:
+    df1 = integer_dataframe_1(library)
+    df2 = integer_dataframe_2(library)
+    ns = df1.__dataframe_namespace__()
+    result = ns.concat([df1, df2])
+    expected = {"a": [1, 2, 3, 1, 2, 4], "b": [4, 5, 6, 4, 2, 6]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)
+
+
+def test_concat_mismatch(library: BaseHandler) -> None:
+    df1 = integer_dataframe_1(library).persist()
+    df2 = integer_dataframe_4(library).persist()
+    ns = df1.__dataframe_namespace__()
+    # TODO check the error
+    with pytest.raises(ValueError):
+        _ = ns.concat([df1, df2]).persist()

--- a/modin/dataframe_api_standard/tests/namespace/concat_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/concat_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/namespace/convert_to_standard_column_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/convert_to_standard_column_test.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import modin.pandas as pd
+
+
+def test_convert_to_std_column() -> None:
+    s = pd.Series([1, 2, 3]).__column_consortium_standard__()
+    assert float(s.mean()) == 2
+    s = pd.Series([1, 2, 3], name="alice").__column_consortium_standard__()
+    assert float(s.mean()) == 2

--- a/modin/dataframe_api_standard/tests/namespace/convert_to_standard_column_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/convert_to_standard_column_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import modin.pandas as pd

--- a/modin/dataframe_api_standard/tests/namespace/dataframe_from_2d_array_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/dataframe_from_2d_array_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import numpy as np

--- a/modin/dataframe_api_standard/tests/namespace/dataframe_from_2d_array_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/dataframe_from_2d_array_test.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+import numpy as np
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+)
+
+
+def test_dataframe_from_2d_array(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    arr = np.array([[1, 4], [2, 5], [3, 6]])
+    result = ns.dataframe_from_2d_array(
+        arr,
+        names=["a", "b"],
+    )
+    # TODO: consistent return type, for windows compat?
+    result = result.cast({"a": ns.Int64(), "b": ns.Int64()})
+    expected = {"a": [1, 2, 3], "b": [4, 5, 6]}
+    compare_dataframe_with_reference(result, expected, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/namespace/is_dtype_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/is_dtype_test.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, mixed_dataframe_1
+
+
+@pytest.mark.parametrize(
+    ("dtype", "expected"),
+    [
+        ("integral", ["a", "b", "c", "d", "e", "f", "g", "h"]),
+        ("signed integer", ["a", "b", "c", "d"]),
+        ("unsigned integer", ["e", "f", "g", "h"]),
+        ("floating", ["i", "j"]),
+        ("bool", ["k"]),
+        ("string", ["l"]),
+        (("string", "integral"), ["a", "b", "c", "d", "e", "f", "g", "h", "l"]),
+        (("string", "unsigned integer"), ["e", "f", "g", "h", "l"]),
+    ],
+)
+def test_is_dtype(library: BaseHandler, dtype: str, expected: list[str]) -> None:
+    df = mixed_dataframe_1(library).persist()
+    namespace = df.__dataframe_namespace__()
+    result = [i for i in df.column_names if namespace.is_dtype(df.schema[i], dtype)]
+    assert result == expected

--- a/modin/dataframe_api_standard/tests/namespace/is_dtype_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/is_dtype_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import pytest

--- a/modin/dataframe_api_standard/tests/namespace/namespace_is_null_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/namespace_is_null_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/namespace/namespace_is_null_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/namespace_is_null_test.py
@@ -1,0 +1,19 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    integer_dataframe_1,
+    integer_dataframe_2,
+)
+
+
+def test_is_null(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    other = integer_dataframe_2(library)
+    # use scalar namespace just for coverage purposes
+    namespace = df.col("a").get_value(0).__scalar_namespace__()
+    namespace_other = other.__dataframe_namespace__()
+    null = namespace.null
+    assert namespace_other.is_null(null)
+    assert not namespace_other.is_null(float("nan"))
+    assert not namespace_other.is_null(0)

--- a/modin/dataframe_api_standard/tests/namespace/sorted_indices_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/sorted_indices_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 from modin.dataframe_api_standard.tests.utils import (

--- a/modin/dataframe_api_standard/tests/namespace/sorted_indices_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/sorted_indices_test.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_6,
+)
+
+
+def test_column_sorted_indices_ascending(library: BaseHandler) -> None:
+    df = integer_dataframe_6(library)
+    ns = df.__dataframe_namespace__()
+    sorted_indices = df.col("b").sorted_indices()
+    result = df.assign(sorted_indices.rename("result"))
+    expected_1 = {
+        "a": [1, 1, 1, 2, 2],
+        "b": [4, 4, 3, 1, 2],
+        "result": [3, 4, 2, 0, 1],
+    }
+    expected_2 = {
+        "a": [1, 1, 1, 2, 2],
+        "b": [4, 4, 3, 1, 2],
+        "result": [3, 4, 2, 1, 0],
+    }
+    try:
+        compare_dataframe_with_reference(result, expected_1, dtype=ns.Int64)
+    except AssertionError:  # pragma: no cover
+        # order isn't determinist, so try both
+        compare_dataframe_with_reference(result, expected_2, dtype=ns.Int64)
+
+
+def test_column_sorted_indices_descending(library: BaseHandler) -> None:
+    df = integer_dataframe_6(library)
+    ns = df.__dataframe_namespace__()
+    sorted_indices = df.col("b").sorted_indices(ascending=False)
+    result = df.assign(sorted_indices.rename("result"))
+    expected_1 = {
+        "a": [1, 1, 1, 2, 2],
+        "b": [4, 4, 3, 1, 2],
+        "result": [1, 0, 2, 4, 3],
+    }
+    expected_2 = {
+        "a": [1, 1, 1, 2, 2],
+        "b": [4, 4, 3, 1, 2],
+        "result": [0, 1, 2, 4, 3],
+    }
+    try:
+        compare_dataframe_with_reference(result, expected_1, dtype=ns.Int64)
+    except AssertionError:
+        # order isn't determinist, so try both
+        compare_dataframe_with_reference(result, expected_2, dtype=ns.Int64)

--- a/modin/dataframe_api_standard/tests/namespace/to_array_object_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/to_array_object_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import numpy as np

--- a/modin/dataframe_api_standard/tests/namespace/to_array_object_test.py
+++ b/modin/dataframe_api_standard/tests/namespace/to_array_object_test.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+import numpy as np
+
+from modin.dataframe_api_standard.tests.utils import BaseHandler, integer_dataframe_1
+
+
+def test_to_array_object(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library).persist()
+    result = np.asarray(df.to_array(dtype="int64"))  # type: ignore  # noqa: PGH003
+    expected = np.array([[1, 4], [2, 5], [3, 6]], dtype=np.int64)
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_column_to_array_object(library: BaseHandler) -> None:
+    col = integer_dataframe_1(library).col("a")
+    result = np.asarray(col.persist().to_array())
+    result = np.asarray(col.persist().to_array())
+    expected = np.array([1, 2, 3], dtype=np.int64)
+    np.testing.assert_array_equal(result, expected)

--- a/modin/dataframe_api_standard/tests/scalars/__init__.py
+++ b/modin/dataframe_api_standard/tests/scalars/__init__.py
@@ -1,0 +1,35 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/modin/dataframe_api_standard/tests/scalars/float_test.py
+++ b/modin/dataframe_api_standard/tests/scalars/float_test.py
@@ -1,0 +1,113 @@
+import numpy as np
+import pytest
+
+from modin.dataframe_api_standard.tests.utils import (
+    BaseHandler,
+    compare_dataframe_with_reference,
+    integer_dataframe_1,
+    integer_dataframe_2,
+)
+
+
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "__lt__",
+        "__le__",
+        "__eq__",
+        "__ne__",
+        "__gt__",
+        "__ge__",
+        "__add__",
+        "__radd__",
+        "__sub__",
+        "__rsub__",
+        "__mul__",
+        "__rmul__",
+        "__mod__",
+        "__rmod__",
+        "__pow__",
+        "__rpow__",
+        "__floordiv__",
+        "__rfloordiv__",
+        "__truediv__",
+        "__rtruediv__",
+    ],
+)
+def test_float_binary(library: BaseHandler, attr: str) -> None:
+    other = 0.5
+    df = integer_dataframe_2(library).persist()
+    scalar = df.col("a").mean()
+    float_scalar = float(scalar)  # type: ignore[arg-type]
+    assert getattr(scalar, attr)(other) == getattr(float_scalar, attr)(other)
+
+
+def test_float_binary_invalid(library: BaseHandler) -> None:
+    lhs = integer_dataframe_2(library).col("a").mean()
+    rhs = integer_dataframe_1(library).col("b").mean()
+    with pytest.raises(ValueError):
+        _ = lhs > rhs
+
+
+def test_float_binary_lazy_valid(library: BaseHandler) -> None:
+    df = integer_dataframe_2(library).persist()
+    lhs = df.col("a").mean()
+    rhs = df.col("b").mean()
+    result = lhs > rhs
+    assert not bool(result)
+
+
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "__abs__",
+        "__neg__",
+    ],
+)
+def test_float_unary(library: BaseHandler, attr: str) -> None:
+    df = integer_dataframe_2(library).persist()
+    with pytest.warns(UserWarning):
+        scalar = df.col("a").persist().mean()
+    float_scalar = float(scalar)  # type: ignore[arg-type]
+    assert getattr(scalar, attr)() == getattr(float_scalar, attr)()
+
+
+@pytest.mark.parametrize(
+    "attr",
+    [
+        "__int__",
+        "__float__",
+        "__bool__",
+    ],
+)
+def test_float_unary_invalid(library: BaseHandler, attr: str) -> None:
+    df = integer_dataframe_2(library)
+    scalar = df.col("a").mean()
+    float_scalar = float(scalar.persist())  # type: ignore[arg-type]
+    with pytest.raises(RuntimeError):
+        assert getattr(scalar, attr)() == getattr(float_scalar, attr)()
+
+
+def test_free_standing(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    namespace = df.__dataframe_namespace__()
+    ser = namespace.column_from_1d_array(  # type: ignore[call-arg]
+        np.array([1, 2, 3]),
+        name="a",
+    )
+    result = float(ser.mean() + 1)  # type: ignore[arg-type]
+    assert result == 3.0
+
+
+def test_right_comparand(library: BaseHandler) -> None:
+    df = integer_dataframe_1(library)
+    ns = df.__dataframe_namespace__()
+    col = df.col("a")  # [1, 2, 3]
+    scalar = df.col("b").get_value(0)  # 4
+    result = df.assign((scalar - col).rename("c"))
+    expected = {
+        "a": [1, 2, 3],
+        "b": [4, 5, 6],
+        "c": [3, 2, 1],
+    }
+    compare_dataframe_with_reference(result, expected, ns.Int64)

--- a/modin/dataframe_api_standard/tests/scalars/float_test.py
+++ b/modin/dataframe_api_standard/tests/scalars/float_test.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 import numpy as np
 import pytest
 

--- a/modin/dataframe_api_standard/tests/utils.py
+++ b/modin/dataframe_api_standard/tests/utils.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from __future__ import annotations
 
 import math

--- a/modin/dataframe_api_standard/tests/utils.py
+++ b/modin/dataframe_api_standard/tests/utils.py
@@ -1,0 +1,305 @@
+from __future__ import annotations
+
+import math
+from abc import abstractmethod
+from datetime import datetime, timedelta
+from typing import TYPE_CHECKING, Any, Mapping
+
+if TYPE_CHECKING:
+    from dataframe_api import Column, DataFrame
+
+
+class BaseHandler:
+    @property
+    @abstractmethod
+    def name(self) -> str:
+        pass
+
+    @abstractmethod
+    def dataframe(
+        self,
+        data: Any,
+        api_version: str | None = None,
+        **kwargs: Any,
+    ) -> DataFrame:
+        pass
+
+
+class ModinHandler(BaseHandler):
+    def __init__(self, name: str) -> None:
+        assert name == "modin"
+        self._name = name
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def __str__(self) -> str:
+        return self.name
+
+    def dataframe(
+        self,
+        data: Any,
+        api_version: str | None = None,
+        **kwargs: str,
+    ) -> DataFrame:
+        import modin.dataframe_api_standard
+        import modin.pandas as pd
+
+        cast_dtypes = None
+        if "dtype" in kwargs and isinstance(kwargs["dtype"], dict):
+            cast_dtypes = kwargs.pop("dtype")
+
+        df = pd.DataFrame(data, **kwargs)
+
+        if cast_dtypes:
+            df = df.astype(cast_dtypes)
+
+        return modin.dataframe_api_standard.convert_to_standard_compliant_dataframe(
+            df,
+            api_version=api_version or "2023.11-beta",
+        )
+
+
+def integer_dataframe_1(
+    library: BaseHandler,
+    api_version: str | None = None,
+) -> DataFrame:
+    return library.dataframe(
+        {"a": [1, 2, 3], "b": [4, 5, 6]},
+        dtype="int64",
+        api_version=api_version,
+    )
+
+
+def integer_dataframe_2(library: BaseHandler) -> DataFrame:
+    return library.dataframe(
+        {"a": [1, 2, 4], "b": [4, 2, 6]},
+        dtype="int64",
+    )
+
+
+def integer_dataframe_3(library: BaseHandler) -> DataFrame:
+    return library.dataframe(
+        {"a": [1, 2, 3, 4, 5, 6, 7], "b": [7, 6, 5, 4, 3, 2, 1]},
+        dtype="int64",
+    )
+
+
+def integer_dataframe_4(library: BaseHandler) -> DataFrame:
+    return library.dataframe(
+        {"key": [1, 1, 2, 2], "b": [1, 2, 3, 4], "c": [4, 5, 6, 7]},
+        dtype="int64",
+    )
+
+
+def integer_dataframe_5(
+    library: BaseHandler,
+    api_version: str | None = None,
+) -> DataFrame:
+    return library.dataframe(
+        {"a": [1, 1], "b": [4, 3]},
+        dtype="int64",
+        api_version=api_version,
+    )
+
+
+def integer_dataframe_6(
+    library: BaseHandler,
+    api_version: str | None = None,
+) -> DataFrame:
+    return library.dataframe(
+        {"a": [1, 1, 1, 2, 2], "b": [4, 4, 3, 1, 2]},
+        dtype="int64",
+        api_version=api_version,
+    )
+
+
+def integer_dataframe_7(library: BaseHandler) -> DataFrame:
+    return library.dataframe({"a": [1, 2, 3], "b": [1, 2, 4]}, dtype="int64")
+
+
+def nan_dataframe_1(library: BaseHandler) -> DataFrame:
+    return library.dataframe({"a": [1.0, 2.0, float("nan")]}, dtype="float64")
+
+
+def nan_dataframe_2(library: BaseHandler) -> DataFrame:
+    return library.dataframe({"a": [0.0, 1.0, float("nan")]}, dtype="float64")
+
+
+def null_dataframe_1(library: BaseHandler) -> DataFrame:
+    return library.dataframe({"a": [1.0, 2.0, float("nan")]}, dtype="float64")
+
+
+def null_dataframe_2(library: BaseHandler) -> DataFrame:
+    return library.dataframe(
+        {"a": [1.0, -1.0, float("nan")], "b": [1.0, -1.0, float("nan")]},
+        dtype="float64",
+    )
+
+
+def bool_dataframe_1(
+    library: BaseHandler,
+    api_version: str = "2023.09-beta",
+) -> DataFrame:
+    return library.dataframe(
+        {"a": [True, True, False], "b": [True, True, True]},
+        dtype="bool",
+        api_version=api_version,
+    )
+
+
+def bool_dataframe_2(library: BaseHandler) -> DataFrame:
+    return library.dataframe(
+        {
+            "key": [1, 1, 2, 2],
+            "b": [False, True, True, True],
+            "c": [True, False, False, False],
+        },
+    )
+
+
+def bool_dataframe_3(library: BaseHandler) -> DataFrame:
+    return library.dataframe(
+        {"a": [False, False], "b": [False, True], "c": [True, True]},
+        dtype="bool",
+    )
+
+
+def float_dataframe_1(library: BaseHandler) -> DataFrame:
+    return library.dataframe({"a": [2.0, 3.0]}, dtype="float64")
+
+
+def float_dataframe_2(library: BaseHandler) -> DataFrame:
+    return library.dataframe({"a": [2.0, 1.0]}, dtype="float64")
+
+
+def float_dataframe_3(library: BaseHandler) -> DataFrame:
+    return library.dataframe({"a": [float("nan"), 2.0]}, dtype="float64")
+
+
+def temporal_dataframe_1(library: BaseHandler) -> DataFrame:
+    return library.dataframe(
+        {
+            "a": [
+                datetime(2020, 1, 1, 1, 2, 1, 123000),
+                datetime(2020, 1, 2, 3, 1, 2, 321000),
+                datetime(2020, 1, 3, 5, 4, 9, 987000),
+            ],
+            "b": [
+                timedelta(1, milliseconds=1),
+                timedelta(2, milliseconds=3),
+                timedelta(3, milliseconds=5),
+            ],
+            "c": [
+                datetime(2020, 1, 1, 1, 2, 1, 123543),
+                datetime(2020, 1, 2, 3, 1, 2, 321654),
+                datetime(2020, 1, 3, 5, 4, 9, 987321),
+            ],
+            "d": [
+                timedelta(1, milliseconds=1),
+                timedelta(2, milliseconds=3),
+                timedelta(3, milliseconds=5),
+            ],
+            "e": [
+                datetime(2020, 1, 1, 1, 2, 1, 123543),
+                datetime(2020, 1, 2, 3, 1, 2, 321654),
+                datetime(2020, 1, 3, 5, 4, 9, 987321),
+            ],
+            "f": [
+                timedelta(1, milliseconds=1),
+                timedelta(2, milliseconds=3),
+                timedelta(3, milliseconds=5),
+            ],
+            "index": [0, 1, 2],
+        },
+    )
+
+
+def compare_column_with_reference(
+    column: Column,
+    reference: list[Any],
+    dtype: Any,
+) -> None:
+    column = column.persist()
+    col_len = column.len().scalar
+    assert col_len == len(reference), f"column length: {col_len} != {len(reference)}"
+    assert isinstance(
+        column.dtype,
+        dtype,
+    ), f"column dtype: {column.dtype} isn't a instance of {dtype}"
+    for idx in range(col_len):
+        a, b = reference[idx], column.get_value(idx).scalar
+        if a == b:
+            return
+
+        # copied from pandas
+        rtol, atol = 1e-5, 1e-8
+        assert math.isclose(
+            a,
+            b,
+            rel_tol=rtol,
+            abs_tol=atol,
+        ), f"expected {a:.5f} but got {b:.5f}, with rtol={rtol}, atol={atol}"
+
+
+def compare_dataframe_with_reference(
+    dataframe: DataFrame,
+    reference: Mapping[str, list[Any]],
+    dtype: Any | Mapping[str, Any],
+) -> None:
+    assert dataframe.column_names == list(
+        reference.keys(),
+    ), f"dataframe column names: '{dataframe.column_names}' != '{list(reference.keys())}'"
+    for col_name in dataframe.column_names:
+        col_dtype = dtype[col_name] if isinstance(dtype, dict) else dtype
+        compare_column_with_reference(
+            dataframe.col(col_name),
+            reference[col_name],
+            dtype=col_dtype,
+        )
+
+
+def mixed_dataframe_1(library: BaseHandler) -> DataFrame:
+    data = {
+        "a": [1, 2, 3],
+        "b": [1, 2, 3],
+        "c": [1, 2, 3],
+        "d": [1, 2, 3],
+        "e": [1, 2, 3],
+        "f": [1, 2, 3],
+        "g": [1, 2, 3],
+        "h": [1, 2, 3],
+        "i": [1.0, 2.0, 3.0],
+        "j": [1.0, 2.0, 3.0],
+        "k": [True, False, True],
+        "l": ["a", "b", "c"],
+        "m": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
+        "n": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
+        "o": [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
+        "p": [timedelta(days=1), timedelta(days=2), timedelta(days=3)],
+        "q": [timedelta(days=1), timedelta(days=2), timedelta(days=3)],
+    }
+    # TODO: use standard cast function for that
+    return library.dataframe(
+        data,
+        dtype={
+            "a": "int64",
+            "b": "int32",
+            "c": "int16",
+            "d": "int8",
+            "e": "uint64",
+            "f": "uint32",
+            "g": "uint16",
+            "h": "uint8",
+            "i": "float64",
+            "j": "float32",
+            "k": "bool",
+            "l": "object",
+            "m": "datetime64[s]",
+            "n": "datetime64[ms]",
+            "o": "datetime64[us]",
+            "p": "timedelta64[ms]",
+            "q": "timedelta64[us]",
+        },
+    )

--- a/modin/dataframe_api_standard/utils.py
+++ b/modin/dataframe_api_standard/utils.py
@@ -1,0 +1,78 @@
+from typing import Any
+
+
+# Technically, it would be possible to correctly type hint this function
+# with a tonne of overloads, but for now, it' not worth it, just use Any
+def validate_comparand(left: Any, right: Any) -> Any:
+    """Validate comparand, raising if it can't be compared with `left`.
+
+    If `left` and `right` are derived from the same dataframe, then return
+    the underlying object of `right`.
+
+    If the comparison isn't supported, return `NotImplemented` so that the
+    "right-hand-side" operation (e.g. `__radd__`) can be tried.
+    """
+    if hasattr(left, "__dataframe_namespace__") and hasattr(
+        right,
+        "__dataframe_namespace__",
+    ):  # pragma: no cover
+        # Technically, currently unreachable - but, keeping this in case it
+        # becomes reachable in the future.
+        msg = "Cannot compare different dataframe objects - please join them first"
+        raise ValueError(msg)
+    if hasattr(left, "__dataframe_namespace__") and hasattr(
+        right,
+        "__column_namespace__",
+    ):
+        if right.parent_dataframe is not None and right.parent_dataframe is not left:
+            msg = "Cannot compare Column with DataFrame it was not derived from."
+            raise ValueError(msg)
+        return right.column
+    if hasattr(left, "__dataframe_namespace__") and hasattr(
+        right,
+        "__scalar_namespace__",
+    ):
+        if right.parent_dataframe is not None and right.parent_dataframe is not left:
+            msg = "Cannot compare Scalar with DataFrame it was not derived from."
+            raise ValueError(msg)
+        return right.scalar
+
+    if hasattr(left, "__column_namespace__") and hasattr(
+        right,
+        "__dataframe_namespace__",
+    ):
+        return NotImplemented
+    if hasattr(left, "__column_namespace__") and hasattr(right, "__column_namespace__"):
+        if (
+            right.parent_dataframe is not None
+            and right.parent_dataframe is not left.parent_dataframe
+        ):
+            msg = "Cannot compare Columns from different dataframes"
+            raise ValueError(msg)
+        return right.column
+    if hasattr(left, "__column_namespace__") and hasattr(right, "__scalar_namespace__"):
+        if (
+            right.parent_dataframe is not None
+            and right.parent_dataframe is not left.parent_dataframe
+        ):
+            msg = "Cannot compare Column and Scalar if they don't share the same parent dataframe"
+            raise ValueError(msg)
+        return right.scalar
+
+    if hasattr(left, "__scalar_namespace__") and hasattr(
+        right,
+        "__dataframe_namespace__",
+    ):
+        return NotImplemented
+    if hasattr(left, "__scalar_namespace__") and hasattr(right, "__column_namespace__"):
+        return NotImplemented
+    if hasattr(left, "__scalar_namespace__") and hasattr(right, "__scalar_namespace__"):
+        if (
+            right.parent_dataframe is not None
+            and right.parent_dataframe is not left.parent_dataframe
+        ):
+            msg = "Cannot combine Scalars from different dataframes"
+            raise ValueError(msg)
+        return right.scalar
+
+    return right

--- a/modin/dataframe_api_standard/utils.py
+++ b/modin/dataframe_api_standard/utils.py
@@ -1,3 +1,40 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+# MIT License
+
+# Copyright (c) 2023, Marco Gorelli
+
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+
 from typing import Any
 
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2811,9 +2811,7 @@ class DataFrame(BasePandasDataset):
     def __dataframe_consortium_standard__(
         self, *, api_version: str | None = None
     ):  # noqa: PR01, RT01
-        """
-        Provide entry point to the Consortium DataFrame Standard API.
-        """
+        """Provide entry point to the Consortium DataFrame Standard API."""
         import modin.dataframe_api_standard as dataframe_api_standard
 
         convert_to_standard_compliant_dataframe = (

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -50,7 +50,6 @@ from modin.utils import (
     _inherit_docstrings,
     expanduser_path_arg,
     hashable,
-    import_optional_dependency,
     try_cast_to_pandas,
 )
 
@@ -2818,11 +2817,10 @@ class DataFrame(BasePandasDataset):
         This is developed and maintained outside of Modin.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        dataframe_api_compat = import_optional_dependency(
-            "dataframe_api_compat", "implementation"
-        )
+        import modin.dataframe_api_standard as dataframe_api_standard
+
         convert_to_standard_compliant_dataframe = (
-            dataframe_api_compat.modin_standard.convert_to_standard_compliant_dataframe
+            dataframe_api_standard.convert_to_standard_compliant_dataframe
         )
         return convert_to_standard_compliant_dataframe(self, api_version=api_version)
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2818,7 +2818,9 @@ class DataFrame(BasePandasDataset):
         This is developed and maintained outside of Modin.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        dataframe_api_compat = import_optional_dependency("dataframe_api_compat")
+        dataframe_api_compat = import_optional_dependency(
+            "dataframe_api_compat", "implementation"
+        )
         convert_to_standard_compliant_dataframe = (
             dataframe_api_compat.modin_standard.convert_to_standard_compliant_dataframe
         )

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2813,9 +2813,6 @@ class DataFrame(BasePandasDataset):
     ):  # noqa: PR01, RT01
         """
         Provide entry point to the Consortium DataFrame Standard API.
-
-        This is developed and maintained outside of Modin.
-        Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
         import modin.dataframe_api_standard as dataframe_api_standard
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -50,6 +50,7 @@ from modin.utils import (
     _inherit_docstrings,
     expanduser_path_arg,
     hashable,
+    import_optional_dependency,
     try_cast_to_pandas,
 )
 
@@ -2807,6 +2808,21 @@ class DataFrame(BasePandasDataset):
         return self._query_compiler.to_dataframe(
             nan_as_null=nan_as_null, allow_copy=allow_copy
         )
+
+    def __dataframe_consortium_standard__(
+        self, *, api_version: str | None = None
+    ):  # noqa: PR01, RT01
+        """
+        Provide entry point to the Consortium DataFrame Standard API.
+
+        This is developed and maintained outside of Modin.
+        Please report any issues to https://github.com/data-apis/dataframe-api-compat.
+        """
+        dataframe_api_compat = import_optional_dependency("dataframe_api_compat")
+        convert_to_standard_compliant_dataframe = (
+            dataframe_api_compat.modin_standard.convert_to_standard_compliant_dataframe
+        )
+        return convert_to_standard_compliant_dataframe(self, api_version=api_version)
 
     @property
     def attrs(self):  # noqa: RT01, D200

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -33,7 +33,11 @@ from pandas.util._validators import validate_bool_kwarg
 from modin.config import PersistentPickle
 from modin.logging import disable_logging
 from modin.pandas.io import from_pandas, to_pandas
-from modin.utils import MODIN_UNNAMED_SERIES_LABEL, _inherit_docstrings
+from modin.utils import (
+    MODIN_UNNAMED_SERIES_LABEL,
+    _inherit_docstrings,
+    import_optional_dependency,
+)
 
 from .accessor import CachedAccessor, SparseAccessor
 from .base import _ATTRS_NO_LOOKUP, BasePandasDataset
@@ -213,6 +217,20 @@ class Series(BasePandasDataset):
         Return the values as a NumPy array.
         """
         return super(Series, self).__array__(dtype).flatten()
+
+    def __column_consortium_standard__(
+        self, *, api_version: str | None = None
+    ):  # noqa: PR01, RT01
+        """
+        Provide entry point to the Consortium DataFrame Standard API.
+
+        This is developed and maintained outside of Modin.
+        Please report any issues to https://github.com/data-apis/dataframe-api-compat.
+        """
+        dataframe_api_compat = import_optional_dependency("dataframe_api_compat")
+        return dataframe_api_compat.modin_standard.convert_to_standard_compliant_column(
+            self, api_version=api_version
+        )
 
     def __contains__(self, key):
         """

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -217,9 +217,7 @@ class Series(BasePandasDataset):
     def __column_consortium_standard__(
         self, *, api_version: str | None = None
     ):  # noqa: PR01, RT01
-        """
-        Provide entry point to the Consortium DataFrame Standard API.
-        """
+        """Provide entry point to the Consortium DataFrame Standard API."""
         import modin.dataframe_api_standard as dataframe_api_standard
 
         return dataframe_api_standard.convert_to_standard_compliant_column(

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -33,11 +33,7 @@ from pandas.util._validators import validate_bool_kwarg
 from modin.config import PersistentPickle
 from modin.logging import disable_logging
 from modin.pandas.io import from_pandas, to_pandas
-from modin.utils import (
-    MODIN_UNNAMED_SERIES_LABEL,
-    _inherit_docstrings,
-    import_optional_dependency,
-)
+from modin.utils import MODIN_UNNAMED_SERIES_LABEL, _inherit_docstrings
 
 from .accessor import CachedAccessor, SparseAccessor
 from .base import _ATTRS_NO_LOOKUP, BasePandasDataset
@@ -227,10 +223,9 @@ class Series(BasePandasDataset):
         This is developed and maintained outside of Modin.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        dataframe_api_compat = import_optional_dependency(
-            "dataframe_api_compat", "implementation"
-        )
-        return dataframe_api_compat.modin_standard.convert_to_standard_compliant_column(
+        import modin.dataframe_api_standard as dataframe_api_standard
+
+        return dataframe_api_standard.convert_to_standard_compliant_column(
             self, api_version=api_version
         )
 

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -227,7 +227,9 @@ class Series(BasePandasDataset):
         This is developed and maintained outside of Modin.
         Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
-        dataframe_api_compat = import_optional_dependency("dataframe_api_compat")
+        dataframe_api_compat = import_optional_dependency(
+            "dataframe_api_compat", "implementation"
+        )
         return dataframe_api_compat.modin_standard.convert_to_standard_compliant_column(
             self, api_version=api_version
         )

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -219,9 +219,6 @@ class Series(BasePandasDataset):
     ):  # noqa: PR01, RT01
         """
         Provide entry point to the Consortium DataFrame Standard API.
-
-        This is developed and maintained outside of Modin.
-        Please report any issues to https://github.com/data-apis/dataframe-api-compat.
         """
         import modin.dataframe_api_standard as dataframe_api_standard
 

--- a/modin/test/test_dataframe_api_standard.py
+++ b/modin/test/test_dataframe_api_standard.py
@@ -11,8 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-import pytest
-
 import modin.pandas
 
 
@@ -23,7 +21,6 @@ def test_dataframe_consortium() -> None:
     Full testing is done at https://github.com/data-apis/dataframe-api-compat,
     this is just to check that the entry point works as expected.
     """
-    pytest.importorskip("dataframe_api_compat")
     df_pd = modin.pandas.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     df = df_pd.__dataframe_consortium_standard__()
     result_1 = df.get_column_names()

--- a/modin/test/test_dataframe_api_standard.py
+++ b/modin/test/test_dataframe_api_standard.py
@@ -1,0 +1,37 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+import pytest
+
+import modin.pandas
+
+
+def test_dataframe_consortium() -> None:
+    """
+    Test some basic methods of the dataframe consortium standard.
+
+    Full testing is done at https://github.com/data-apis/dataframe-api-compat,
+    this is just to check that the entry point works as expected.
+    """
+    pytest.importorskip("dataframe_api_compat")
+    df_pd = modin.pandas.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+    df = df_pd.__dataframe_consortium_standard__()
+    result_1 = df.get_column_names()
+    expected_1 = ["a", "b"]
+    assert result_1 == expected_1
+
+    ser = modin.pandas.Series([1, 2, 3])
+    col = ser.__column_consortium_standard__()
+    result_2 = col.get_value(1)
+    expected_2 = 2
+    assert result_2 == expected_2

--- a/modin/test/test_dataframe_api_standard.py
+++ b/modin/test/test_dataframe_api_standard.py
@@ -17,9 +17,6 @@ import modin.pandas
 def test_dataframe_consortium() -> None:
     """
     Test some basic methods of the dataframe consortium standard.
-
-    Full testing is done at https://github.com/data-apis/dataframe-api-compat,
-    this is just to check that the entry point works as expected.
     """
     df_pd = modin.pandas.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
     df = df_pd.__dataframe_consortium_standard__()

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,6 +35,7 @@ tqdm>=4.60.0
 numexpr<2.8.5
 # Latest modin-spreadsheet with widget fix
 git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
+dataframe-api-compat>=0.2.6
 
 ## dependencies for making release
 PyGithub>=1.58.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -35,7 +35,6 @@ tqdm>=4.60.0
 numexpr<2.8.5
 # Latest modin-spreadsheet with widget fix
 git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
-dataframe-api-compat>=0.2.6
 
 ## dependencies for making release
 PyGithub>=1.58.0

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -43,5 +43,6 @@ dependencies:
   - mypy>=1.0.0
 
   - pip:
+      - dataframe-api-compat>=0.2.6
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -43,6 +43,5 @@ dependencies:
   - mypy>=1.0.0
 
   - pip:
-      - dataframe-api-compat>=0.2.6
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
       - numpydoc==1.1.0

--- a/requirements/env_unidist_win.yml
+++ b/requirements/env_unidist_win.yml
@@ -54,7 +54,6 @@ dependencies:
   - pandas-stubs>=2.0.0
 
   - pip:
-      - dataframe-api-compat>=0.2.6
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - connectorx>=0.2.6a4

--- a/requirements/env_unidist_win.yml
+++ b/requirements/env_unidist_win.yml
@@ -54,6 +54,7 @@ dependencies:
   - pandas-stubs>=2.0.0
 
   - pip:
+      - dataframe-api-compat>=0.2.6
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - connectorx>=0.2.6a4

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -45,7 +45,6 @@ dependencies:
   - flake8-print>=5.0.0
 
   - pip:
-      - dataframe-api-compat>=0.2.6
       - asv==0.5.1
       # no conda package for windows
       - connectorx>=0.2.6a4

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -45,6 +45,7 @@ dependencies:
   - flake8-print>=5.0.0
 
   - pip:
+      - dataframe-api-compat>=0.2.6
       - asv==0.5.1
       # no conda package for windows
       - connectorx>=0.2.6a4

--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,12 @@ dask_deps = ["dask>=2.22.0", "distributed>=2.22.0"]
 # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
 ray_deps = ["ray[default]>=1.13.0,!=2.5.0", "pyarrow>=7.0.0"]
 mpi_deps = ["unidist[mpi]>=0.2.1"]
-consortium_standard_deps = ['dataframe-api-compat>=0.2.6']
 spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]
 # Currently, Modin does not include `mpi` option in `all`.
 # Otherwise, installation of modin[all] would fail because
 # users need to have a working MPI implementation and
 # certain software installed beforehand.
-all_deps = dask_deps + ray_deps + spreadsheet_deps + consortium_standard_deps
+all_deps = dask_deps + ray_deps + spreadsheet_deps
 
 # Distribute 'modin-autoimport-pandas.pth' along with binary and source distributions.
 # This file provides the "import pandas before Ray init" feature if specific
@@ -63,7 +62,6 @@ setup(
         "dask": dask_deps,
         "ray": ray_deps,
         "mpi": mpi_deps,
-        "consortium-standard": consortium_standard_deps,
         "spreadsheet": spreadsheet_deps,
         "all": all_deps,
     },

--- a/setup.py
+++ b/setup.py
@@ -9,12 +9,13 @@ dask_deps = ["dask>=2.22.0", "distributed>=2.22.0"]
 # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
 ray_deps = ["ray[default]>=1.13.0,!=2.5.0", "pyarrow>=7.0.0"]
 mpi_deps = ["unidist[mpi]>=0.2.1"]
+consortium_standard_deps = ['dataframe-api-compat>=0.2.6']
 spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]
 # Currently, Modin does not include `mpi` option in `all`.
 # Otherwise, installation of modin[all] would fail because
 # users need to have a working MPI implementation and
 # certain software installed beforehand.
-all_deps = dask_deps + ray_deps + spreadsheet_deps
+all_deps = dask_deps + ray_deps + spreadsheet_deps + consortium_standard_deps
 
 # Distribute 'modin-autoimport-pandas.pth' along with binary and source distributions.
 # This file provides the "import pandas before Ray init" feature if specific
@@ -62,6 +63,7 @@ setup(
         "dask": dask_deps,
         "ray": ray_deps,
         "mpi": mpi_deps,
+        "consortium-standard": consortium_standard_deps,
         "spreadsheet": spreadsheet_deps,
         "all": all_deps,
     },


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This is an example of how DataFrame API protocol implementation might look like if it will be added directly to Modin, instead of https://github.com/data-apis/dataframe-api-compat.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
