### PR TITLE
TEST-#6932: don't use deprecated `pandas._testing.makeStringIndex`

### DIFF
--- a/asv_bench/benchmarks/benchmarks.py
+++ b/asv_bench/benchmarks/benchmarks.py
@@ -22,7 +22,6 @@
 import math
 
 import numpy as np
-import pandas._testing as tm
 
 from .utils import (
     GROUPBY_NGROUPS,
@@ -139,8 +138,10 @@ class TimeJoinStringIndex:
 
     def setup(self, shapes, sort):
         assert shapes[0] % 100 == 0, "implementation restriction"
-        level1 = tm.makeStringIndex(10).values
-        level2 = tm.makeStringIndex(shapes[0] // 100).values
+        level1 = IMPL.Index([f"i-{i}" for i in range(10)], dtype=object).values
+        level2 = IMPL.Index(
+            [f"i-{i}" for i in range(shapes[0] // 100)], dtype=object
+        ).values
         codes1 = np.arange(10).repeat(shapes[0] // 100)
         codes2 = np.tile(np.arange(shapes[0] // 100), 10)
         index2 = IMPL.MultiIndex(levels=[level1, level2], codes=[codes1, codes2])
@@ -897,8 +898,12 @@ class TimeReindex:
         self.df2 = IMPL.DataFrame(
             index=range(rows), data=np.random.rand(rows, cols), columns=range(cols)
         )
-        level1 = tm.makeStringIndex(rows // 10).values.repeat(10)
-        level2 = np.tile(tm.makeStringIndex(10).values, rows // 10)
+        level1 = IMPL.Index(
+            [f"i-{i}" for i in range(rows // 10)], dtype=object
+        ).values.repeat(10)
+        level2 = np.tile(
+            IMPL.Index([f"i-{i}" for i in range(10)], dtype=object).values, rows // 10
+        )
         index = IMPL.MultiIndex.from_arrays([level1, level2])
         self.s = IMPL.Series(np.random.randn(rows), index=index)
         self.s_subset = self.s[::2]
@@ -1033,7 +1038,9 @@ class TimeDropDuplicatesDataframe:
         temp_df = DataFrame()
         # dataframe would  have cols-1 keys(strings) and one value(int) column
         for col in range(cols - 1):
-            temp_df["key" + str(col + 1)] = tm.makeStringIndex(N).values.repeat(K)
+            temp_df["key" + str(col + 1)] = IMPL.Index(
+                [f"i-{i}" for i in range(N)], dtype=object
+            ).values.repeat(K)
         self.df = IMPL.DataFrame(temp_df)
         self.df["value"] = np.random.randn(N * K)
         execute(self.df)
@@ -1052,7 +1059,12 @@ class TimeDropDuplicatesSeries:
 
     def setup(self, shape):
         rows = shape[0]
-        self.series = IMPL.Series(np.tile(tm.makeStringIndex(rows // 10).values, 10))
+        self.series = IMPL.Series(
+            np.tile(
+                IMPL.Index([f"i-{i}" for i in range(rows // 10)], dtype=object).values,
+                10,
+            )
+        )
         execute(self.series)
 
     def time_drop_dups(self, shape):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Same as in https://github.com/pandas-dev/pandas/pull/56155/files.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6932 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
