### PR TITLE
FEAT-#6934: Support 'include_groups=False' parameter in 'groupby.apply()'

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3971,7 +3971,10 @@ class PandasDataframe(ClassLogger):
                 align_result_columns
                 and df.empty
                 and result.empty
-                and df.columns.equals(result.columns)
+                and (
+                    df.columns.equals(result.columns)
+                    or not kwargs.get("as_index", True)
+                )
             ):
                 # We want to align columns only of those frames that actually performed
                 # some groupby aggregation, if an empty frame was originally passed

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3967,15 +3967,7 @@ class PandasDataframe(ClassLogger):
                 df = df.squeeze(axis=1)
             result = operator(df.groupby(by, **kwargs))
 
-            if (
-                align_result_columns
-                and df.empty
-                and result.empty
-                and (
-                    df.columns.equals(result.columns)
-                    or not kwargs.get("as_index", True)
-                )
-            ):
+            if align_result_columns and df.empty and result.empty:
                 # We want to align columns only of those frames that actually performed
                 # some groupby aggregation, if an empty frame was originally passed
                 # (an empty bin on reshuffling was created) then there were no groupby

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -646,16 +646,6 @@ class DataFrameGroupBy(ClassLogger):
         )
 
     def apply(self, func, *args, include_groups=True, **kwargs):
-        if not include_groups:
-            return self._default_to_pandas(
-                lambda df: df.apply(
-                    func,
-                    *args,
-                    include_groups=include_groups,
-                    **kwargs,
-                )
-            )
-
         func = cast_function_modin2pandas(func)
         if not isinstance(func, BuiltinFunctionType):
             func = wrap_udf_function(func)
@@ -665,7 +655,7 @@ class DataFrameGroupBy(ClassLogger):
             numeric_only=False,
             agg_func=func,
             agg_args=args,
-            agg_kwargs=kwargs,
+            agg_kwargs={**kwargs, "include_groups": include_groups},
             how="group_wise",
         )
         reduced_index = pandas.Index([MODIN_UNNAMED_SERIES_LABEL])

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -3358,3 +3358,24 @@ def test_range_groupby_categories_external_grouper(columns, cat_cols):
     pd_df, pd_by = get_external_groupers(pd_df, columns, drop_from_original_df=True)
 
     eval_general(md_df.groupby(md_by), pd_df.groupby(pd_by), lambda grp: grp.count())
+
+
+@pytest.mark.parametrize("by", [["a"], ["a", "b"]])
+@pytest.mark.parametrize("as_index", [True, False])
+def test_include_groups_False(by, as_index):
+    data = {
+        "a": [1, 1, 2, 2] * 64,
+        "b": [11, 11, 22, 22] * 64,
+        "c": [111, 111, 222, 222] * 64,
+        "data": [1, 2, 3, 4] * 64,
+    }
+
+    def func(df):
+        assert len(df.columns.intersection(by)) == 0
+        return df.sum()
+
+    md_df, pd_df = create_test_dfs(data)
+
+    md_res = md_df.groupby(by, as_index=as_index).apply(func, include_groups=False)
+    pd_res = pd_df.groupby(by, as_index=as_index).apply(func, include_groups=False)
+    df_equals(md_res, pd_res)

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -3362,7 +3362,8 @@ def test_range_groupby_categories_external_grouper(columns, cat_cols):
 
 @pytest.mark.parametrize("by", [["a"], ["a", "b"]])
 @pytest.mark.parametrize("as_index", [True, False])
-def test_include_groups_False(by, as_index):
+@pytest.mark.parametrize("include_groups", [True, False])
+def test_include_groups(by, as_index, include_groups):
     data = {
         "a": [1, 1, 2, 2] * 64,
         "b": [11, 11, 22, 22] * 64,
@@ -3371,11 +3372,17 @@ def test_include_groups_False(by, as_index):
     }
 
     def func(df):
-        assert len(df.columns.intersection(by)) == 0
+        if include_groups:
+            assert len(df.columns.intersection(by)) == len(by)
+        else:
+            assert len(df.columns.intersection(by)) == 0
         return df.sum()
 
     md_df, pd_df = create_test_dfs(data)
-
-    md_res = md_df.groupby(by, as_index=as_index).apply(func, include_groups=False)
-    pd_res = pd_df.groupby(by, as_index=as_index).apply(func, include_groups=False)
-    df_equals(md_res, pd_res)
+    eval_general(
+        md_df,
+        pd_df,
+        lambda df: df.groupby(by, as_index=as_index).apply(
+            func, include_groups=include_groups
+        ),
+    )


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Supporting this parameter is as simple as forwarding it to `groupby.apply()` call inside of the kernel

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6934 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
