### PR TITLE
FIX-#6935: Fix Merge failed when right operand is an empty dataframe

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3354,10 +3354,9 @@ class PandasDataframe(ClassLogger):
             if df._partitions.size > 0:
                 return df._partitions
             else:
-                empty_partition = self._partition_mgr_cls.create_partition_from_data(
+                return np.array([[self._partition_mgr_cls._partition_class.put(
                     pandas.DataFrame(index=df.index, columns=df.columns)
-                )
-                return empty_partition
+                ]])
 
         if other is not None:
             if not isinstance(other, list):

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3348,10 +3348,21 @@ class PandasDataframe(ClassLogger):
         PandasDataframe
             New Modin DataFrame.
         """
+
+        def get_partitions(df):
+            """Deal with the corner case if the "other" dataframe has no partitions."""
+            if df._partitions.size > 0:
+                return df._partitions
+            else:
+                empty_partition = self._partition_mgr_cls.create_partition_from_data(
+                    pandas.DataFrame(index=df.index, columns=df.columns)
+                )
+                return empty_partition
+
         if other is not None:
             if not isinstance(other, list):
                 other = [other]
-            other = [o._partitions for o in other] if len(other) else None
+            other = [get_partitions(o) for o in other] if len(other) else None
 
         if apply_indices is not None:
             numeric_indices = self.get_axis(axis ^ 1).get_indexer_for(apply_indices)

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3354,9 +3354,15 @@ class PandasDataframe(ClassLogger):
             if df._partitions.size > 0:
                 return df._partitions
             else:
-                return np.array([[self._partition_mgr_cls._partition_class.put(
-                    pandas.DataFrame(index=df.index, columns=df.columns)
-                ]])
+                return np.array(
+                    [
+                        [
+                            self._partition_mgr_cls._partition_class.put(
+                                pandas.DataFrame(index=df.index, columns=df.columns)
+                            )
+                        ]
+                    ]
+                )
 
         if other is not None:
             if not isinstance(other, list):

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -176,6 +176,23 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
     # END Abstract Methods
 
     @classmethod
+    def create_partition_from_data(cls, data):
+        """
+        Create NumPy array of partitions that wrapps the given data.
+
+        Parameters
+        ----------
+        data : pandas.DataFrame or pandas.Series
+            Data that has to be wrapped in partition.
+
+        Returns
+        -------
+        np.ndarray
+            A NumPy 2D array of a single partition which contains the data.
+        """
+        return np.array([[cls._partition_class.put(data)]])
+
+    @classmethod
     def column_partitions(cls, partitions, full_axis=True):
         """
         Get the list of `BaseDataframeAxisPartition` objects representing column-wise partitions.
@@ -1120,8 +1137,8 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 (df,) + dfs, partition_shape, called_from_remote=True
             )
 
-        if partitions.size == 0:
-            return np.array([[]])
+        if partitions.size <= 1:
+            return partitions
 
         preprocessed_func = cls.preprocess_func(to_pandas_remote)
         partition_shape = partitions.shape

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1120,6 +1120,9 @@ class PandasDataframePartitionManager(ClassLogger, ABC):
                 (df,) + dfs, partition_shape, called_from_remote=True
             )
 
+        if partitions.size == 0:
+            return np.array([[]])
+
         preprocessed_func = cls.preprocess_func(to_pandas_remote)
         partition_shape = partitions.shape
         partitions_flattened = partitions.flatten()

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -383,6 +383,20 @@ def test_merge(test_data, test_data2):
         modin_df.merge("Non-valid type")
 
 
+def test_merge_empty():
+    data = np.random.uniform(0, 100, size=(2**6, 2**6))
+    pandas_df = pandas.DataFrame(data)
+    pandas_df2 = pandas_df.iloc[:0]
+    modin_df = pd.DataFrame(data)
+    modin_df_2 = modin_df.iloc[:0]
+    modin_result = pd.merge(
+        modin_df,
+        modin_df_2,
+    )
+    pandas_result = pandas.merge(pandas_df, pandas_df2)
+    df_equals(modin_result, pandas_result)
+
+
 def test_merge_with_mi_columns():
     modin_df1, pandas_df1 = create_test_dfs(
         {

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -386,15 +386,8 @@ def test_merge(test_data, test_data2):
 def test_merge_empty():
     data = np.random.uniform(0, 100, size=(2**6, 2**6))
     pandas_df = pandas.DataFrame(data)
-    pandas_df2 = pandas_df.iloc[:0]
     modin_df = pd.DataFrame(data)
-    modin_df_2 = modin_df.iloc[:0]
-    modin_result = pd.merge(
-        modin_df,
-        modin_df_2,
-    )
-    pandas_result = pandas.merge(pandas_df, pandas_df2)
-    df_equals(modin_result, pandas_result)
+    eval_general(modin_df, pandas_df, lambda df: df.merge(df.iloc[:0]))
 
 
 def test_merge_with_mi_columns():


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?
Fixing corner case when partitions are empty for merge.
<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6935 ? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
