### PR TITLE
FIX-#6946: Remove 'needs: [lint-black-isort, ...]'

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
       - uses: ./.github/actions/upload-coverage
 
   test-clean-install:
-    needs: [lint-flake8, lint-black-isort]
+    needs: [lint-flake8]
     strategy:
       matrix:
         os:
@@ -94,7 +94,7 @@ jobs:
         if: matrix.os == 'ubuntu'
 
   test-internals:
-    needs: [lint-flake8, lint-black-isort]
+    needs: [lint-flake8]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -119,7 +119,7 @@ jobs:
       - uses: ./.github/actions/upload-coverage
 
   test-defaults:
-    needs: [lint-flake8, lint-black-isort]
+    needs: [lint-flake8]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -150,7 +150,7 @@ jobs:
       - uses: ./.github/actions/upload-coverage
 
   test-hdk:
-    needs: [lint-flake8, lint-black-isort]
+    needs: [lint-flake8]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -207,7 +207,7 @@ jobs:
 
   test-asv-benchmarks:
     if: github.event_name == 'pull_request'
-    needs: [lint-flake8, lint-black-isort]
+    needs: [lint-flake8]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -312,7 +312,7 @@ jobs:
               "${{ steps.filter.outputs.ray }}" "${{ steps.filter.outputs.dask }}" >> $GITHUB_OUTPUT
 
   test-all-unidist:
-    needs: [lint-flake8, lint-black-isort, execution-filter]
+    needs: [lint-flake8, execution-filter]
     if: github.event_name == 'push' || needs.execution-filter.outputs.unidist == 'true'
     runs-on: ubuntu-latest
     defaults:
@@ -387,7 +387,7 @@ jobs:
       - uses: ./.github/actions/upload-coverage
 
   test-all:
-    needs: [lint-flake8, lint-black-isort, execution-filter]
+    needs: [lint-flake8, execution-filter]
     strategy:
       matrix:
         os:
@@ -521,7 +521,7 @@ jobs:
         if: matrix.os == 'windows'
 
   test-sanity:
-    needs: [lint-flake8, lint-black-isort, execution-filter]
+    needs: [lint-flake8, execution-filter]
     if: github.event_name == 'pull_request'
     strategy:
       matrix:
@@ -653,7 +653,7 @@ jobs:
       - uses: ./.github/actions/upload-coverage
 
   test-experimental:
-    needs: [lint-flake8, lint-black-isort]
+    needs: [lint-flake8]
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -682,7 +682,7 @@ jobs:
       - uses: ./.github/actions/upload-coverage
 
   test-spreadsheet:
-    needs: [lint-flake8, lint-black-isort]
+    needs: [lint-flake8]
     runs-on: ubuntu-latest
     defaults:
       run:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The `lint-black-isort` was moved to another file (#6945), so referencing it is no longer valid
<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #6946 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
