### PR TITLE
FIX-#6952: use `render_as_string` to get sqlalchemy engine url

### DIFF
--- a/modin/core/io/sql/sql_dispatcher.py
+++ b/modin/core/io/sql/sql_dispatcher.py
@@ -149,7 +149,9 @@ class SQLDispatcher(FileDispatcher):
         # are not pickleable. We have to convert it to the URL string and connect from
         # each of the workers.
         if cls._is_supported_sqlalchemy_object(kwargs["con"]):
-            kwargs["con"] = str(kwargs["con"].engine.url)
+            kwargs["con"] = kwargs["con"].engine.url.render_as_string(
+                hide_password=False
+            )
 
         empty_df = qc.getitem_row_array([0]).to_pandas().head(0)
         empty_df.to_sql(**kwargs)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Instead of calling `url.__str__()`, call `url.render_as_string()` directly.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6952 
- [x]  tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
