### PR TITLE
REFACTOR-#6958: Remove DataFrame.to_pickle_distributed in favour of DataFrame.modin.to_pickle_distributed

### DIFF
--- a/modin/experimental/pandas/__init__.py
+++ b/modin/experimental/pandas/__init__.py
@@ -32,9 +32,6 @@ Examples
 >>> df = pd.read_csv_glob("data*.csv")
 """
 
-import functools
-import warnings
-
 from modin.pandas import *  # noqa F401, F403
 
 from .io import (  # noqa F401
@@ -45,20 +42,4 @@ from .io import (  # noqa F401
     read_pickle_distributed,
     read_sql,
     read_xml_glob,
-    to_pickle_distributed,
 )
-
-old_to_pickle_distributed = to_pickle_distributed
-
-
-@functools.wraps(to_pickle_distributed)
-def to_pickle_distributed(*args, **kwargs):
-    warnings.warn(
-        "`DataFrame.to_pickle_distributed` is deprecated and will be removed in a future version. "
-        + "Please use `DataFrame.modin.to_pickle_distributed` instead.",
-        category=FutureWarning,
-    )
-    return old_to_pickle_distributed(*args, **kwargs)
-
-
-setattr(DataFrame, "to_pickle_distributed", to_pickle_distributed)  # noqa: F405


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6958 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
