### PR TITLE
FIX-#6974: Always use actual pandas version in 'test_all_urls_exist'

### DIFF
--- a/modin/test/test_docstring_urls.py
+++ b/modin/test/test_docstring_urls.py
@@ -20,6 +20,7 @@ from urllib.request import urlopen
 import pytest
 
 import modin.pandas
+from modin.utils import PANDAS_API_URL_TEMPLATE
 
 
 @pytest.fixture
@@ -37,18 +38,18 @@ def doc_urls(get_generated_doc_urls):
 def test_all_urls_exist(doc_urls):
     broken = []
     # TODO: remove the hack after pandas fixes it
-    broken_urls = (
-        "https://pandas.pydata.org/pandas-docs/version/2.2.0/reference/api/pandas.DataFrame.flags.html",
-        "https://pandas.pydata.org/pandas-docs/version/2.2.0/reference/api/pandas.Series.info.html",
-        "https://pandas.pydata.org/pandas-docs/version/2.2.0/reference/api/pandas.DataFrame.isetitem.html",
-        "https://pandas.pydata.org/pandas-docs/version/2.2.0/reference/api/pandas.Series.swapaxes.html",
-        "https://pandas.pydata.org/pandas-docs/version/2.2.0/reference/api/pandas.DataFrame.to_numpy.html",
-        "https://pandas.pydata.org/pandas-docs/version/2.2.0/reference/api/pandas.Series.axes.html",
-        "https://pandas.pydata.org/pandas-docs/version/2.2.0/reference/api/pandas.Series.divmod.html",
-        "https://pandas.pydata.org/pandas-docs/version/2.2.0/reference/api/pandas.Series.rdivmod.html",
+    methods_with_broken_urls = (
+        "pandas.DataFrame.flags",
+        "pandas.Series.info",
+        "pandas.DataFrame.isetitem",
+        "pandas.Series.swapaxes",
+        "pandas.DataFrame.to_numpy",
+        "pandas.Series.axes",
+        "pandas.Series.divmod",
+        "pandas.Series.rdivmod",
     )
-    for broken_url in broken_urls:
-        doc_urls.remove(broken_url)
+    for broken_method in methods_with_broken_urls:
+        doc_urls.remove(PANDAS_API_URL_TEMPLATE.format(broken_method))
 
     def _test_url(url):
         try:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

The PR starts using [`PANDAS_API_URL_TEMPLATE`](https://github.com/modin-project/modin/blob/271d98b260f03b345ae2384001f2df83b98322bf/modin/utils.py#L89) that always contains an actual pandas version instead of raw urls (if the pandas version in the url doesn't match with the installed one, the test fails)

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6974 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
