### PR TITLE
PERF-#6979: Do not trigger '._copartition()' for identical indices on binary operations

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -196,7 +196,7 @@ class PandasDataframe(ClassLogger):
     @classmethod
     def _get_lengths(cls, parts, axis):
         """
-        Get list of  dimensions for all the provided parts.
+        Get list of dimensions for all the provided parts.
 
         Parameters
         ----------
@@ -3548,13 +3548,23 @@ class PandasDataframe(ClassLogger):
             Tuple containing:
                 1) 2-d NumPy array of aligned left partitions
                 2) list of 2-d NumPy arrays of aligned right partitions
-                3) joined index along ``axis``
-                4) List with sizes of partitions along axis that partitioning
-                   was done on. This list will be empty if and only if all
+                3) joined index along ``axis``, may be ``ModinIndex`` if not materialized
+                4) If materialized, list with sizes of partitions along axis that partitioning
+                   was done on, otherwise ``None``. This list will be empty if and only if all
                    the frames are empty.
         """
         if isinstance(other, type(self)):
             other = [other]
+
+        if not force_repartition and all(
+            o._check_if_axes_identical(self, axis) for o in other
+        ):
+            return (
+                self._partitions,
+                [o._partitions for o in other],
+                self.copy_axis_cache(axis, copy_lengths=True),
+                self._get_axis_lengths_cache(axis),
+            )
 
         self_index = self.get_axis(axis)
         others_index = [o.get_axis(axis) for o in other]
@@ -3684,15 +3694,19 @@ class PandasDataframe(ClassLogger):
         )
         if copartition_along_columns:
             new_left_frame = self.__constructor__(
-                left_parts, joined_index, self.columns, row_lengths, self.column_widths
+                left_parts,
+                joined_index,
+                self.copy_columns_cache(copy_lengths=True),
+                row_lengths,
+                self._column_widths_cache,
             )
             new_right_frames = [
                 self.__constructor__(
                     right_parts,
                     joined_index,
-                    right_frame.columns,
+                    right_frame.copy_columns_cache(copy_lengths=True),
                     row_lengths,
-                    right_frame.column_widths,
+                    right_frame._column_widths_cache,
                 )
                 for right_parts, right_frame in zip(list_of_right_parts, right_frames)
             ]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Check axes equality at the beginning of [`._copartition()`](https://github.com/modin-project/modin/blob/f601f8a9d602c70333548df3ef5e3c953df04f37/modin/core/dataframe/pandas/dataframe/dataframe.py#L3523) method using [`._check_if_axes_identical()`](https://github.com/modin-project/modin/blob/f601f8a9d602c70333548df3ef5e3c953df04f37/modin/core/dataframe/pandas/dataframe/dataframe.py#L3492), that supports computation-free comparison for sibling frames.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6979 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
