### PR TITLE
FEAT-#6983: Add Pluggable Documentation Module Support

### DIFF
--- a/modin/config/__init__.py
+++ b/modin/config/__init__.py
@@ -22,6 +22,7 @@ from modin.config.envvars import (
     CIAWSSecretAccessKey,
     CpuCount,
     DaskThreadsPerWorker,
+    DocumentationPluginModuleName,
     DoUseCalcite,
     Engine,
     EnvironmentVariable,
@@ -107,4 +108,6 @@ __all__ = [
     "LogMode",
     "LogMemoryInterval",
     "LogFileSize",
+    # Plugin settings
+    "DocumentationPluginModuleName",
 ]

--- a/modin/config/__init__.py
+++ b/modin/config/__init__.py
@@ -22,7 +22,7 @@ from modin.config.envvars import (
     CIAWSSecretAccessKey,
     CpuCount,
     DaskThreadsPerWorker,
-    DocumentationPluginModuleName,
+    DocModule,
     DoUseCalcite,
     Engine,
     EnvironmentVariable,
@@ -109,5 +109,5 @@ __all__ = [
     "LogMemoryInterval",
     "LogFileSize",
     # Plugin settings
-    "DocumentationPluginModuleName",
+    "DocModule",
 ]

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -831,6 +831,18 @@ class LazyExecution(EnvironmentVariable, type=str):
     default = "Auto"
 
 
+class DocumentationPluginModuleName(EnvironmentVariable, type=str):
+    """
+    The module to use that will be used for docstrings.
+
+    The value set here must be a valid, importable module. It should have
+    a `DataFrame`, `Series`, and/or several APIs directly (e.g. `read_csv`).
+    """
+
+    varname = "MODIN_DOC_MODULE"
+    default = "pandas"
+
+
 class DaskThreadsPerWorker(EnvironmentVariable, type=int):
     """Number of threads per Dask worker."""
 

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -13,6 +13,7 @@
 
 """Module houses Modin configs originated from environment variables."""
 
+import importlib
 import os
 import secrets
 import sys
@@ -841,6 +842,29 @@ class DocumentationPluginModuleName(EnvironmentVariable, type=str):
 
     varname = "MODIN_DOC_MODULE"
     default = "pandas"
+
+    @classmethod
+    def put(cls, value: Any) -> None:
+        super().put(value)
+        # Reload everything to apply the documentation. This is required since the
+        # docs might already have been created and the implementation will assume
+        # that the new docs are applied when the config is set. This set of operations
+        # does this.
+        import modin.pandas as pd
+
+        importlib.reload(pd.accessor)
+        importlib.reload(pd.base)
+        importlib.reload(pd.dataframe)
+        importlib.reload(pd.general)
+        importlib.reload(pd.groupby)
+        importlib.reload(pd.indexing)
+        importlib.reload(pd.io)
+        importlib.reload(pd.iterator)
+        importlib.reload(pd.series)
+        importlib.reload(pd.series_utils)
+        importlib.reload(pd.utils)
+        importlib.reload(pd.window)
+        importlib.reload(pd)
 
 
 class DaskThreadsPerWorker(EnvironmentVariable, type=int):

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -845,6 +845,14 @@ class DocModule(EnvironmentVariable, type=ExactStr):
 
     @classmethod
     def put(cls, value: str) -> None:
+        """
+        Assign a value to the DocModule config.
+
+        Parameters
+        ----------
+        value : str
+            Config value to set.
+        """
         super().put(value)
         # Reload everything to apply the documentation. This is required since the
         # docs might already have been created and the implementation will assume
@@ -857,7 +865,6 @@ class DocModule(EnvironmentVariable, type=ExactStr):
         importlib.reload(pd.dataframe)
         importlib.reload(pd.general)
         importlib.reload(pd.groupby)
-        importlib.reload(pd.indexing)
         importlib.reload(pd.io)
         importlib.reload(pd.iterator)
         importlib.reload(pd.series)

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -832,7 +832,7 @@ class LazyExecution(EnvironmentVariable, type=str):
     default = "Auto"
 
 
-class DocumentationPluginModuleName(EnvironmentVariable, type=str):
+class DocModule(EnvironmentVariable, type=ExactStr):
     """
     The module to use that will be used for docstrings.
 
@@ -844,7 +844,7 @@ class DocumentationPluginModuleName(EnvironmentVariable, type=str):
     default = "pandas"
 
     @classmethod
-    def put(cls, value: Any) -> None:
+    def put(cls, value: str) -> None:
         super().put(value)
         # Reload everything to apply the documentation. This is required since the
         # docs might already have been created and the implementation will assume

--- a/modin/config/test/docs_module/__init__.py
+++ b/modin/config/test/docs_module/__init__.py
@@ -14,5 +14,4 @@
 from .classes import DataFrame, Series
 from .functions import read_csv
 
-
 __all__ = ["DataFrame", "Series", "read_csv"]

--- a/modin/config/test/docs_module/__init__.py
+++ b/modin/config/test/docs_module/__init__.py
@@ -1,0 +1,8 @@
+from .classes import DataFrame, Series
+
+
+def read_csv():
+    """Test override for functions on the module."""
+
+
+__all__ = ["DataFrame", "Series", "read_csv"]

--- a/modin/config/test/docs_module/classes.py
+++ b/modin/config/test/docs_module/classes.py
@@ -1,3 +1,16 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 class DataFrame:
     def apply(self):
         """This is a test of the documentation module for DataFrame."""

--- a/modin/config/test/docs_module/classes.py
+++ b/modin/config/test/docs_module/classes.py
@@ -1,0 +1,10 @@
+class DataFrame:
+    def apply(self):
+        """This is a test of the documentation module for DataFrame."""
+        return
+
+
+class Series:
+    def isna(self):
+        """This is a test of the documentation module for Series."""
+        return

--- a/modin/config/test/docs_module/classes.py
+++ b/modin/config/test/docs_module/classes.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+
 class DataFrame:
     def apply(self):
         """This is a test of the documentation module for DataFrame."""

--- a/modin/config/test/docs_module/functions.py
+++ b/modin/config/test/docs_module/functions.py
@@ -11,8 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from .classes import DataFrame, Series
-from .functions import read_csv
-
-
-__all__ = ["DataFrame", "Series", "read_csv"]
+def read_csv():
+    """Test override for functions on the module."""
+    return

--- a/modin/config/test/docs_module/functions.py
+++ b/modin/config/test/docs_module/functions.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+
 def read_csv():
     """Test override for functions on the module."""
     return

--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -85,9 +85,9 @@ def test_doc_module():
     import pandas
 
     import modin.pandas as pd
-    from modin.config import DocumentationPluginModuleName
+    from modin.config import DocModule
 
-    DocumentationPluginModuleName.put("modin.config.test.docs_module")
+    DocModule.put("modin.config.test.docs_module")
 
     # Test for override
     assert (

--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -16,7 +16,6 @@ import os
 import unittest.mock
 import warnings
 
-import jellyfish
 import pytest
 from packaging import version
 

--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -84,8 +84,9 @@ def test_custom_help(make_custom_envvar):
 
 
 def test_doc_module():
-    from modin.config import DocumentationPluginModuleName
     import pandas as default_pd
+
+    from modin.config import DocumentationPluginModuleName
 
     DocumentationPluginModuleName.put("modin.config.test.docs_module")
 
@@ -99,12 +100,18 @@ def test_doc_module():
     importlib.reload(pd)
 
     # Test for override
-    assert pd.DataFrame.apply.__doc__ == "This is a test of the documentation module for DataFrame."
+    assert (
+        pd.DataFrame.apply.__doc__
+        == "This is a test of the documentation module for DataFrame."
+    )
     # Test for pandas doc when method is not defined on the plugin module
     assert default_pd.DataFrame.isna.__doc__ in pd.DataFrame.isna.__doc__
     assert default_pd.DataFrame.isnull.__doc__ in pd.DataFrame.isnull.__doc__
     # Test for override
-    assert pd.Series.isna.__doc__ == "This is a test of the documentation module for Series."
+    assert (
+        pd.Series.isna.__doc__
+        == "This is a test of the documentation module for Series."
+    )
     # Test for pandas doc when method is not defined on the plugin module
     assert default_pd.Series.isnull.__doc__ in pd.Series.isnull.__doc__
     assert default_pd.Series.apply.__doc__ in pd.Series.apply.__doc__

--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -82,7 +82,7 @@ def test_custom_help(make_custom_envvar):
 
 
 def test_doc_module():
-    import pandas as default_pd
+    import pandas
 
     import modin.pandas as pd
     from modin.config import DocumentationPluginModuleName
@@ -95,20 +95,20 @@ def test_doc_module():
         == "This is a test of the documentation module for DataFrame."
     )
     # Test for pandas doc when method is not defined on the plugin module
-    assert default_pd.DataFrame.isna.__doc__ in pd.DataFrame.isna.__doc__
-    assert default_pd.DataFrame.isnull.__doc__ in pd.DataFrame.isnull.__doc__
+    assert pandas.DataFrame.isna.__doc__ in pd.DataFrame.isna.__doc__
+    assert pandas.DataFrame.isnull.__doc__ in pd.DataFrame.isnull.__doc__
     # Test for override
     assert (
         pd.Series.isna.__doc__
         == "This is a test of the documentation module for Series."
     )
     # Test for pandas doc when method is not defined on the plugin module
-    assert default_pd.Series.isnull.__doc__ in pd.Series.isnull.__doc__
-    assert default_pd.Series.apply.__doc__ in pd.Series.apply.__doc__
+    assert pandas.Series.isnull.__doc__ in pd.Series.isnull.__doc__
+    assert pandas.Series.apply.__doc__ in pd.Series.apply.__doc__
     # Test for override
     assert pd.read_csv.__doc__ == "Test override for functions on the module."
     # Test for pandas doc when function is not defined on module.
-    assert default_pd.read_table.__doc__ in pd.read_table.__doc__
+    assert pandas.read_table.__doc__ in pd.read_table.__doc__
 
 
 def test_hdk_envvar():

--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -11,7 +11,6 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-import importlib
 import os
 import unittest.mock
 import warnings

--- a/modin/config/test/test_envvars.py
+++ b/modin/config/test/test_envvars.py
@@ -85,18 +85,10 @@ def test_custom_help(make_custom_envvar):
 def test_doc_module():
     import pandas as default_pd
 
+    import modin.pandas as pd
     from modin.config import DocumentationPluginModuleName
 
     DocumentationPluginModuleName.put("modin.config.test.docs_module")
-
-    import modin.pandas as pd
-
-    importlib.invalidate_caches()
-    importlib.reload(pd.dataframe)
-    importlib.reload(pd.series)
-    importlib.reload(pd.base)
-    importlib.reload(pd.io)
-    importlib.reload(pd)
 
     # Test for override
     assert (

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1094,11 +1094,23 @@ class DataFrame(BasePandasDataset):
         return super(DataFrame, self).isin(values)
 
     def isna(self):
-        """Detect missing values."""
+        """
+        Detect missing values.
+
+        Returns
+        -------
+        The result of detecting missing values.
+        """
         return super(DataFrame, self).isna()
 
     def isnull(self):
-        """Detect missing values."""
+        """
+        Detect missing values.
+
+        Returns
+        -------
+        The result of detecting missing values.
+        """
         return super(DataFrame, self).isnull()
 
     def iterrows(self):  # noqa: D200

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1094,15 +1094,11 @@ class DataFrame(BasePandasDataset):
         return super(DataFrame, self).isin(values)
 
     def isna(self):
-        """
-        Detect missing values.
-        """
+        """Detect missing values."""
         return super(DataFrame, self).isna()
 
     def isnull(self):
-        """
-        Detect missing values.
-        """
+        """Detect missing values."""
         return super(DataFrame, self).isnull()
 
     def iterrows(self):  # noqa: D200

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1093,6 +1093,18 @@ class DataFrame(BasePandasDataset):
         """
         return super(DataFrame, self).isin(values)
 
+    def isna(self):
+        """
+        Detect missing values.
+        """
+        return super(DataFrame, self).isna()
+
+    def isnull(self):
+        """
+        Detect missing values.
+        """
+        return super(DataFrame, self).isnull()
+
     def iterrows(self):  # noqa: D200
         """
         Iterate over ``DataFrame`` rows as (index, ``Series``) pairs.

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1183,6 +1183,18 @@ class Series(BasePandasDataset):
         """
         return super(Series, self).isin(values, shape_hint="column")
 
+    def isna(self):
+        """
+        Detect missing values.
+        """
+        return super(Series, self).isna()
+
+    def isnull(self):
+        """
+        Detect missing values.
+        """
+        return super(Series, self).isnull
+
     def item(self):  # noqa: RT01, D200
         """
         Return the first element of the underlying data as a Python scalar.

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1184,11 +1184,23 @@ class Series(BasePandasDataset):
         return super(Series, self).isin(values, shape_hint="column")
 
     def isna(self):
-        """Detect missing values."""
+        """
+        Detect missing values.
+
+        Returns
+        -------
+        The result of detecting missing values.
+        """
         return super(Series, self).isna()
 
     def isnull(self):
-        """Detect missing values."""
+        """
+        Detect missing values.
+
+        Returns
+        -------
+        The result of detecting missing values.
+        """
         return super(Series, self).isnull()
 
     def item(self):  # noqa: RT01, D200

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1184,16 +1184,12 @@ class Series(BasePandasDataset):
         return super(Series, self).isin(values, shape_hint="column")
 
     def isna(self):
-        """
-        Detect missing values.
-        """
+        """Detect missing values."""
         return super(Series, self).isna()
 
     def isnull(self):
-        """
-        Detect missing values.
-        """
-        return super(Series, self).isnull
+        """Detect missing values."""
+        return super(Series, self).isnull()
 
     def item(self):  # noqa: RT01, D200
         """

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -49,7 +49,7 @@ from pandas.util._print_versions import (  # type: ignore[attr-defined]
 )
 
 from modin._version import get_versions
-from modin.config import Engine, StorageFormat
+from modin.config import Engine, StorageFormat, DocumentationPluginModuleName
 
 T = TypeVar("T")
 """Generic type parameter"""
@@ -399,6 +399,20 @@ def _inherit_docstrings(
     are not defined in target class (but are defined in the ancestor class),
     which means that ancestor class attribute docstrings could also change.
     """
+    # Import the docs module and get the class (e.g. `DataFrame`).
+    imported_doc_module = importlib.import_module(
+        DocumentationPluginModuleName.get().lower()
+    )
+    # Set the default parent so we can use it in case some docs are missing from
+    # parent module.
+    default_parent = parent
+    # Try to get the parent object from the doc module, and if it isn't there,
+    # get it from parent instead.
+    parent = getattr(imported_doc_module, parent.__name__, parent)
+    if parent != default_parent:
+        # Reset API link in case the docs are overridden.
+        apilink = None
+        overwrite_existing = True
 
     def _documentable_obj(obj: object) -> bool:
         """Check if `obj` docstring could be patched."""
@@ -421,7 +435,10 @@ def _inherit_docstrings(
                     if attr in seen:
                         continue
                     seen.add(attr)
-                    parent_obj = getattr(parent, attr, None)
+                    # Try to get the attribute from the docs class first, then
+                    # from the default parent (pandas), and if it's not in either,
+                    # set `parent_obj` to `None`.
+                    parent_obj = getattr(parent, attr, getattr(default_parent, attr, None))
                     if (
                         parent_obj in excluded
                         or not _documentable_obj(parent_obj)

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -405,8 +405,10 @@ def _inherit_docstrings(
     # parent module.
     default_parent = parent
     # Try to get the parent object from the doc module, and if it isn't there,
-    # get it from parent instead.
-    parent = getattr(imported_doc_module, getattr(parent, "__name__", ""), parent)
+    # get it from parent instead. We only do this if we are overriding pandas
+    # documentation. We don't touch other docs.
+    if "pandas" in str(parent.__module__):
+        parent = getattr(imported_doc_module, getattr(parent, "__name__", ""), parent)
     if parent != default_parent:
         # Reset API link in case the docs are overridden.
         apilink = None

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -407,7 +407,7 @@ def _inherit_docstrings(
     # Try to get the parent object from the doc module, and if it isn't there,
     # get it from parent instead. We only do this if we are overriding pandas
     # documentation. We don't touch other docs.
-    if "pandas" in str(parent.__module__):
+    if "pandas" in str(getattr(parent, "__module__", "")):
         parent = getattr(imported_doc_module, getattr(parent, "__name__", ""), parent)
     if parent != default_parent:
         # Reset API link in case the docs are overridden.

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -49,7 +49,7 @@ from pandas.util._print_versions import (  # type: ignore[attr-defined]
 )
 
 from modin._version import get_versions
-from modin.config import Engine, StorageFormat, DocumentationPluginModuleName
+from modin.config import DocumentationPluginModuleName, Engine, StorageFormat
 
 T = TypeVar("T")
 """Generic type parameter"""
@@ -438,7 +438,9 @@ def _inherit_docstrings(
                     # Try to get the attribute from the docs class first, then
                     # from the default parent (pandas), and if it's not in either,
                     # set `parent_obj` to `None`.
-                    parent_obj = getattr(parent, attr, getattr(default_parent, attr, None))
+                    parent_obj = getattr(
+                        parent, attr, getattr(default_parent, attr, None)
+                    )
                     if (
                         parent_obj in excluded
                         or not _documentable_obj(parent_obj)

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -408,7 +408,7 @@ def _inherit_docstrings(
     default_parent = parent
     # Try to get the parent object from the doc module, and if it isn't there,
     # get it from parent instead.
-    parent = getattr(imported_doc_module, parent.__name__, parent)
+    parent = getattr(imported_doc_module, getattr(parent, "__name__", ""), parent)
     if parent != default_parent:
         # Reset API link in case the docs are overridden.
         apilink = None

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -407,7 +407,9 @@ def _inherit_docstrings(
     # Try to get the parent object from the doc module, and if it isn't there,
     # get it from parent instead. We only do this if we are overriding pandas
     # documentation. We don't touch other docs.
-    if "pandas" in str(getattr(parent, "__module__", "")):
+    if DocModule.get() != DocModule.default and "pandas" in str(
+        getattr(parent, "__module__", "")
+    ):
         parent = getattr(imported_doc_module, getattr(parent, "__name__", ""), parent)
     if parent != default_parent:
         # Reset API link in case the docs are overridden.

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -49,7 +49,7 @@ from pandas.util._print_versions import (  # type: ignore[attr-defined]
 )
 
 from modin._version import get_versions
-from modin.config import DocumentationPluginModuleName, Engine, StorageFormat
+from modin.config import DocModule, Engine, StorageFormat
 
 T = TypeVar("T")
 """Generic type parameter"""
@@ -400,9 +400,7 @@ def _inherit_docstrings(
     which means that ancestor class attribute docstrings could also change.
     """
     # Import the docs module and get the class (e.g. `DataFrame`).
-    imported_doc_module = importlib.import_module(
-        DocumentationPluginModuleName.get().lower()
-    )
+    imported_doc_module = importlib.import_module(DocModule.get())
     # Set the default parent so we can use it in case some docs are missing from
     # parent module.
     default_parent = parent


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Add support for custom documentation defined at runtime.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6983 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
