### PR TITLE
FEAT-#4622: Unify data type of log_level in logging module

### DIFF
--- a/modin/logging/class_logger.py
+++ b/modin/logging/class_logger.py
@@ -19,6 +19,7 @@ Module contains ``ClassLogger`` class.
 
 from typing import Dict, Optional
 
+from .config import LogLevel
 from .logger_decorator import enable_logging
 
 
@@ -38,7 +39,7 @@ class ClassLogger:
         cls,
         modin_layer: Optional[str] = None,
         class_name: Optional[str] = None,
-        log_level: str = "info",
+        log_level: LogLevel = LogLevel.INFO,
         **kwargs: Dict,
     ) -> None:
         """
@@ -51,8 +52,8 @@ class ClassLogger:
         class_name : str, optional
             The name of the class the decorator is being applied to.
             Composed from the decorated class name if not specified.
-        log_level : str, default: "info"
-            The log level (INFO, DEBUG, WARNING, etc.).
+        log_level : LogLevel, default: LogLevel.INFO
+            The log level (LogLevel.INFO, LogLevel.DEBUG, LogLevel.WARNING, etc.).
         **kwargs : dict
         """
         modin_layer = modin_layer or cls._modin_logging_layer

--- a/modin/logging/config.py
+++ b/modin/logging/config.py
@@ -38,7 +38,7 @@ __LOGGER_CONFIGURED__: bool = False
 
 
 class LogLevel(IntEnum):  # noqa: PR01
-    """Enumerator to Specify the valid values of LogLevel accepted by Logger.setLevel()."""
+    """Enumerator to specify the valid values of LogLevel accepted by Logger.setLevel()."""
 
     DEBUG = 10
     INFO = 20

--- a/modin/logging/config.py
+++ b/modin/logging/config.py
@@ -23,6 +23,7 @@ import platform
 import threading
 import time
 import uuid
+from enum import IntEnum
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
 from typing import Optional
@@ -34,6 +35,16 @@ import modin
 from modin.config import LogFileSize, LogMemoryInterval, LogMode
 
 __LOGGER_CONFIGURED__: bool = False
+
+
+class LogLevel(IntEnum):  # noqa: PR01
+    """Enumerator to Specify the valid values of LogLevel accepted by Logger.setLevel()."""
+
+    DEBUG = 10
+    INFO = 20
+    WARNING = 30
+    ERROR = 40
+    CRITICAL = 50
 
 
 class ModinFormatter(logging.Formatter):  # noqa: PR01
@@ -97,7 +108,7 @@ def bytes_int_to_str(num_bytes: int, suffix: str = "B") -> str:
 
 
 def _create_logger(
-    namespace: str, job_id: str, log_name: str, log_level: int
+    namespace: str, job_id: str, log_name: str, log_level: LogLevel
 ) -> logging.Logger:
     """
     Create and configure logger as Modin expects it to be.
@@ -110,8 +121,7 @@ def _create_logger(
         Part of path to where logs are stored.
     log_name : str
         Name of the log file to create.
-    log_level : int
-        Log level as accepted by `Logger.setLevel()`.
+    log_level : LogLevel
 
     Returns
     -------
@@ -159,7 +169,7 @@ def configure_logging() -> None:
         "modin.logger.default",
         job_id,
         "trace",
-        logging.INFO if LogMode.get() == "enable_api_only" else logging.DEBUG,
+        LogLevel.INFO if LogMode.get() == "enable_api_only" else LogLevel.DEBUG,
     )
 
     logger.info(f"OS Version: {platform.platform()}")
@@ -174,7 +184,7 @@ def configure_logging() -> None:
     if LogMode.get() != "enable_api_only":
         mem_sleep = LogMemoryInterval.get()
         mem_logger = _create_logger(
-            "modin_memory.logger", job_id, "memory", logging.DEBUG
+            "modin_memory.logger", job_id, "memory", LogLevel.DEBUG
         )
 
         svmem = psutil.virtual_memory()
@@ -186,7 +196,7 @@ def configure_logging() -> None:
         )
         mem.start()
 
-    _create_logger("modin.logger.errors", job_id, "error", logging.INFO)
+    _create_logger("modin.logger.errors", job_id, "error", LogLevel.INFO)
 
     __LOGGER_CONFIGURED__ = True
 

--- a/modin/test/test_logging.py
+++ b/modin/test/test_logging.py
@@ -27,8 +27,8 @@ class _FakeLogger:
         self.messages = collections.defaultdict(list)
         self.namespace = namespace
 
-    def info(self, message, *args, **kw):
-        self.messages["info"].append(message.format(*args, **kw))
+    def log(self, log_level, message, *args, **kw):
+        self.messages[log_level].append(message.format(*args, **kw))
 
     def exception(self, message, *args, **kw):
         self.messages["exception"].append(message.format(*args, **kw))
@@ -81,8 +81,8 @@ def test_function_decorator(monkeypatch, get_log_messages):
         with pytest.raises(ValueError):
             func(do_raise=True)
 
-    assert "func" in get_log_messages()["info"][0]
-    assert "START" in get_log_messages()["info"][0]
+    assert "func" in get_log_messages()[logging.INFO][0]
+    assert "START" in get_log_messages()[logging.INFO][0]
     assert get_log_messages("modin.logger.errors")["exception"] == [
         "STOP::PANDAS-API::func"
     ]
@@ -137,7 +137,7 @@ def test_class_decorator(monkeypatch, get_log_messages):
         Bar().method1()
         Bar().method4()
 
-    assert get_log_messages()["info"] == [
+    assert get_log_messages()[logging.INFO] == [
         "START::CUSTOM::Foo.method1",
         "STOP::CUSTOM::Foo.method1",
         "START::CUSTOM::Foo.method2",
@@ -164,7 +164,7 @@ def test_class_inheritance(monkeypatch, get_log_messages):
         Bar().method1()
         Bar().method2()
 
-    assert get_log_messages()["info"] == [
+    assert get_log_messages()[logging.INFO] == [
         "START::CUSTOM::Foo.method1",
         "STOP::CUSTOM::Foo.method1",
         "START::CUSTOM::Foo.method1",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #4622? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
