### PR TITLE
REFACTOR-#7002: get more information about exceptions from `eval_general` utility

### DIFF
--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -863,7 +863,7 @@ def check_df_columns_have_nans(df, cols):
     )
 
 
-class TestError(Exception):
+class NoModinException(Exception):
     pass
 
 
@@ -912,7 +912,7 @@ def eval_general(
                             md_e, tuple(raising_exceptions)
                         ), f"not acceptable exception type: {md_e}"
             else:
-                raise TestError(
+                raise NoModinException(
                     f"Modin doesn't throw an exception, while pandas does: [{repr(pd_e)}]"
                 )
         else:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7002 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
