### PR TITLE
REFACTOR-#7017: Align `to_hdf` and `hist` signatures to pandas

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import pickle as pkl
 import re
 import warnings
-from typing import Any, Hashable, Optional, Sequence, Union
+from typing import Any, Hashable, Literal, Optional, Sequence, Union
 
 import numpy as np
 import pandas
@@ -3238,13 +3238,41 @@ class BasePandasDataset(ClassLogger):
 
     @expanduser_path_arg("path_or_buf")
     def to_hdf(
-        self, path_or_buf, key, format="table", **kwargs
-    ):  # pragma: no cover  # noqa: PR01, RT01, D200
+        self,
+        path_or_buf,
+        key: str,
+        mode: Literal["a", "w", "r+"] = "a",
+        complevel: int | None = None,
+        complib: Literal["zlib", "lzo", "bzip2", "blosc"] | None = None,
+        append: bool = False,
+        format: Literal["fixed", "table"] | None = None,
+        index: bool = True,
+        min_itemsize: int | dict[str, int] | None = None,
+        nan_rep=None,
+        dropna: bool | None = None,
+        data_columns: Literal[True] | list[str] | None = None,
+        errors: str = "strict",
+        encoding: str = "UTF-8",
+    ) -> None:  # pragma: no cover  # noqa: PR01, RT01, D200
         """
         Write the contained data to an HDF5 file using HDFStore.
         """
         return self._default_to_pandas(
-            "to_hdf", path_or_buf, key, format=format, **kwargs
+            "to_hdf",
+            path_or_buf,
+            key=key,
+            mode=mode,
+            complevel=complevel,
+            complib=complib,
+            append=append,
+            format=format,
+            index=index,
+            min_itemsize=min_itemsize,
+            nan_rep=nan_rep,
+            dropna=dropna,
+            data_columns=data_columns,
+            errors=errors,
+            encoding=encoding,
         )
 
     @expanduser_path_arg("path_or_buf")

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -27,7 +27,13 @@ from typing import IO, Hashable, Iterator, Optional, Sequence, Union
 import numpy as np
 import pandas
 from pandas._libs import lib
-from pandas._typing import CompressionOptions, FilePath, StorageOptions, WriteBuffer
+from pandas._typing import (
+    CompressionOptions,
+    FilePath,
+    IndexLabel,
+    StorageOptions,
+    WriteBuffer,
+)
 from pandas.core.common import apply_if_callable, get_cython_func
 from pandas.core.computation.eval import _check_engine
 from pandas.core.dtypes.common import (
@@ -966,26 +972,28 @@ class DataFrame(BasePandasDataset):
         )
 
     def hist(
-        self,
-        column=None,
+        data,
+        column: IndexLabel | None = None,
         by=None,
-        grid=True,
-        xlabelsize=None,
-        xrot=None,
-        ylabelsize=None,
-        yrot=None,
+        grid: bool = True,
+        xlabelsize: int | None = None,
+        xrot: float | None = None,
+        ylabelsize: int | None = None,
+        yrot: float | None = None,
         ax=None,
-        sharex=False,
-        sharey=False,
-        figsize=None,
-        layout=None,
-        bins=10,
-        **kwds,
+        sharex: bool = False,
+        sharey: bool = False,
+        figsize: tuple[int, int] | None = None,
+        layout: tuple[int, int] | None = None,
+        bins: int | Sequence[int] = 10,
+        backend: str | None = None,
+        legend: bool = False,
+        **kwargs,
     ):  # pragma: no cover # noqa: PR01, RT01, D200
         """
         Make a histogram of the ``DataFrame``.
         """
-        return self._default_to_pandas(
+        return data._default_to_pandas(
             pandas.DataFrame.hist,
             column=column,
             by=by,
@@ -1000,7 +1008,9 @@ class DataFrame(BasePandasDataset):
             figsize=figsize,
             layout=layout,
             bins=bins,
-            **kwds,
+            backend=backend,
+            legend=legend,
+            **kwargs,
         )
 
     def info(

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -22,7 +22,7 @@ from typing import IO, TYPE_CHECKING, Hashable, Optional, Union
 import numpy as np
 import pandas
 from pandas._libs import lib
-from pandas._typing import Axis, IndexKeyFunc
+from pandas._typing import Axis, IndexKeyFunc, Sequence
 from pandas.api.types import is_integer
 from pandas.core.common import apply_if_callable, is_bool_indexer
 from pandas.core.dtypes.common import is_dict_like, is_list_like
@@ -1123,14 +1123,16 @@ class Series(BasePandasDataset):
         self,
         by=None,
         ax=None,
-        grid=True,
-        xlabelsize=None,
-        xrot=None,
-        ylabelsize=None,
-        yrot=None,
-        figsize=None,
-        bins=10,
-        **kwds,
+        grid: bool = True,
+        xlabelsize: int | None = None,
+        xrot: float | None = None,
+        ylabelsize: int | None = None,
+        yrot: float | None = None,
+        figsize: tuple[int, int] | None = None,
+        bins: int | Sequence[int] = 10,
+        backend: str | None = None,
+        legend: bool = False,
+        **kwargs,
     ):  # noqa: PR01, RT01, D200
         """
         Draw histogram of the input series using matplotlib.
@@ -1146,7 +1148,9 @@ class Series(BasePandasDataset):
             yrot=yrot,
             figsize=figsize,
             bins=bins,
-            **kwds,
+            backend=backend,
+            legend=legend,
+            **kwargs,
         )
 
     def idxmax(self, axis=0, skipna=True, *args, **kwargs):  # noqa: PR01, RT01, D200

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -164,7 +164,7 @@ def test_dataframe_api_equality():
     ), "Differences found in API: {}".format(set(modin_dir) - set(pandas_dir))
 
     # These have to be checked manually
-    allowed_different = ["to_hdf", "hist", "modin", "to_pandas", "to_ray_dataset"]
+    allowed_different = ["modin", "to_pandas", "to_ray_dataset"]
 
     assert_parameters_eq((pandas.DataFrame, pd.DataFrame), modin_dir, allowed_different)
 
@@ -274,7 +274,7 @@ def test_series_api_equality():
     )
 
     # These have to be checked manually
-    allowed_different = ["to_hdf", "hist", "to_pandas", "to_ray_dataset"]
+    allowed_different = ["to_pandas", "to_ray_dataset"]
 
     assert_parameters_eq((pandas.Series, pd.Series), modin_dir, allowed_different)
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7017 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
