### PR TITLE
TEST-#7049: Add some sanity tests with pyarrow-backed pandas dataframes

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -250,6 +250,7 @@ def try_compute_new_dtypes(
 
     try:
         if infer_dtypes == "bool" or is_bool_dtype(result_dtype):
+            # can be `pandas.api.types.pandas_dtype("bool[pyarrow]")` depending on the data
             dtypes = maybe_build_dtypes_series(
                 first, second, dtype=pandas.api.types.pandas_dtype(bool)
             )

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1411,7 +1411,6 @@ def test_pyarrow_array_retrieve():
         modin_series,
         pandas_series,
         lambda ser: pa.array(ser),
-        raising_exceptions=(Exception,),
     )
 
 
@@ -1432,7 +1431,6 @@ def test_pyarrow_functions():
         lambda ser: ser
         + (modin_series if isinstance(ser, pd.Series) else pandas_series),
         comparator=comparator,
-        raising_exceptions=(Exception,),
     )
 
     eval_general(
@@ -1440,7 +1438,6 @@ def test_pyarrow_functions():
         pandas_series,
         lambda ser: ser > (ser + 1),
         comparator=comparator,
-        raising_exceptions=(Exception,),
     )
 
     eval_general(
@@ -1448,7 +1445,6 @@ def test_pyarrow_functions():
         pandas_series,
         lambda ser: ser.dropna(),
         comparator=comparator,
-        raising_exceptions=(Exception,),
     )
 
     eval_general(
@@ -1456,7 +1452,6 @@ def test_pyarrow_functions():
         pandas_series,
         lambda ser: ser.isna(),
         comparator=comparator,
-        raising_exceptions=(Exception,),
     )
 
     eval_general(
@@ -1464,7 +1459,6 @@ def test_pyarrow_functions():
         pandas_series,
         lambda ser: ser.fillna(0),
         comparator=comparator,
-        raising_exceptions=(Exception,),
     )
 
 

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1380,6 +1380,94 @@ def test_constructor_arrow_extension_array():
     df_equals(md_ser.dtypes, pd_ser.dtypes)
 
 
+def test_pyarrow_constructor():
+    pa = pytest.importorskip("pyarrow")
+    data = list("abcd")
+    _ = pd.Series(data, dtype="string[pyarrow]")
+    _ = pd.Series(data, dtype=pd.ArrowDtype(pa.string()))
+
+    list_str_type = pa.list_(pa.string())
+    _ = pd.Series([["hello"], ["there"]], dtype=pd.ArrowDtype(list_str_type))
+
+    from datetime import time
+
+    _ = pd.Index([time(12, 30), None], dtype=pd.ArrowDtype(pa.time64("us")))
+
+    from decimal import Decimal
+
+    decimal_type = pd.ArrowDtype(pa.decimal128(3, scale=2))
+
+    data = [[Decimal("3.19"), None], [None, Decimal("-1.23")]]
+
+    _ = pd.DataFrame(data, dtype=decimal_type)
+
+
+def test_pyarrow_array_retrieve():
+    pa = pytest.importorskip("pyarrow")
+    modin_series, pandas_series = create_test_series(
+        [1, 2, None], dtype="uint8[pyarrow]"
+    )
+    eval_general(
+        modin_series,
+        pandas_series,
+        lambda ser: pa.array(ser),
+        raising_exceptions=(Exception,),
+    )
+
+
+def test_pyarrow_functions():
+    pytest.importorskip("pyarrow")
+    modin_series, pandas_series = create_test_series(
+        [-1.545, 0.211, None], dtype="float32[pyarrow]"
+    )
+    df_equals(modin_series.mean(), pandas_series.mean())
+
+    def comparator(df1, df2):
+        df_equals(df1, df2)
+        df_equals(df1.dtypes, df2.dtypes)
+
+    eval_general(
+        modin_series,
+        pandas_series,
+        lambda ser: ser
+        + (modin_series if isinstance(ser, pd.Series) else pandas_series),
+        comparator=comparator,
+        raising_exceptions=(Exception,),
+    )
+
+    eval_general(
+        modin_series,
+        pandas_series,
+        lambda ser: ser > (ser + 1),
+        comparator=comparator,
+        raising_exceptions=(Exception,),
+    )
+
+    eval_general(
+        modin_series,
+        pandas_series,
+        lambda ser: ser.dropna(),
+        comparator=comparator,
+        raising_exceptions=(Exception,),
+    )
+
+    eval_general(
+        modin_series,
+        pandas_series,
+        lambda ser: ser.isna(),
+        comparator=comparator,
+        raising_exceptions=(Exception,),
+    )
+
+    eval_general(
+        modin_series,
+        pandas_series,
+        lambda ser: ser.fillna(0),
+        comparator=comparator,
+        raising_exceptions=(Exception,),
+    )
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_copy(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7049 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
