### PR TITLE
FIX-#7060: Fix `pivot` unexpected exception when index or columns are of Index type

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1462,9 +1462,9 @@ class DataFrame(BasePandasDataset):
         # index or columns
         if values is None:
             values = list(self.columns)
-            if index:
+            if index is not None:
                 values = [v for v in values if v not in index]
-            if columns:
+            if columns is not None:
                 values = [v for v in values if v not in columns]
 
         return self.__constructor__(

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -603,6 +603,7 @@ def test_pivot(data, index, columns, values, request):
     if (
         "one_column_values-one_column-default-float_nan_data"
         in request.node.callspec.id
+        or "default-one_column-several_columns_index" in request.node.callspec.id
         or (
             current_execution in ("BaseOnPython", "HdkOnNative")
             and index is lib.no_default


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7060 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
