### PR TITLE
FEAT-#7070: Add `modin.pandas.arrays` module

### DIFF
--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -171,7 +171,7 @@ def _update_engine(publisher: Parameter):
     _is_first_update[publisher.get()] = False
 
 
-from modin.pandas import errors
+from modin.pandas import arrays, errors
 from modin.utils import show_versions
 
 from .. import __version__

--- a/modin/pandas/arrays/__init__.py
+++ b/modin/pandas/arrays/__init__.py
@@ -1,0 +1,18 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+
+"""The module is needed to allow the following import `import modin.pandas.arrays`."""
+
+from pandas.arrays import *  # noqa: F403, F401
+from pandas.arrays import __all__  # noqa: F401

--- a/modin/pandas/test/test_api.py
+++ b/modin/pandas/test/test_api.py
@@ -35,7 +35,6 @@ def test_top_level_api_equality():
         "util",
         "offsets",
         "datetime",
-        "arrays",
         "api",
         "tseries",
         "to_msgpack",  # This one is experimental, and doesn't look finished

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -1271,6 +1271,20 @@ def test_constructor_columns_and_index():
         pd.Series(modin_series, index=[1, 2, 99999])
 
 
+def test_constructor_arrow_extension_array():
+    # example from pandas docs
+    pa = pytest.importorskip("pyarrow")
+    array = pd.arrays.ArrowExtensionArray(
+        pa.array(
+            [{"1": "2"}, {"10": "20"}, None],
+            type=pa.map_(pa.string(), pa.string()),
+        )
+    )
+    md_ser, pd_ser = create_test_series(array)
+    df_equals(md_ser, pd_ser)
+    df_equals(md_ser.dtypes, pd_ser.dtypes)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_copy(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This module is part of the public interface of Pandas.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7070 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
