### PR TITLE
FIX-#7072: Replace MaterializationHook with the materialized object on serialization.

### DIFF
--- a/modin/core/execution/ray/common/engine_wrapper.py
+++ b/modin/core/execution/ray/common/engine_wrapper.py
@@ -307,6 +307,31 @@ class MaterializationHook:
         """
         raise NotImplementedError()
 
+    def __reduce__(self):
+        """
+        Replace this hook with the materialized object on serialization.
+
+        Returns
+        -------
+        tuple
+        """
+        return _hook_deserializer, (RayWrapper.materialize(self),)
+
+
+def _hook_deserializer(obj):
+    """
+    Simply returns the object. Used for the MaterializationHook serialization.
+
+    Parameters
+    ----------
+    obj : object
+
+    Returns
+    -------
+    object
+    """
+    return obj
+
 
 RayObjectRefTypes = (ray.ObjectRef, ClientObjectRef)
 ObjectRefTypes = (*RayObjectRefTypes, MaterializationHook)

--- a/modin/core/execution/ray/common/engine_wrapper.py
+++ b/modin/core/execution/ray/common/engine_wrapper.py
@@ -316,22 +316,9 @@ class MaterializationHook:
         tuple
         """
         data = RayWrapper.materialize(self)
-        return int if isinstance(data, int) else self._get, (data,)
-
-    @staticmethod
-    def _get(obj):
-        """
-        Simply returns the object. Used for the serialization only.
-
-        Parameters
-        ----------
-        obj : object
-
-        Returns
-        -------
-        object
-        """
-        return obj
+        if not isinstance(data, int):
+            raise NotImplementedError("Only integers are currently supported")
+        return int, (data,)
 
 
 RayObjectRefTypes = (ray.ObjectRef, ClientObjectRef)

--- a/modin/core/execution/ray/common/engine_wrapper.py
+++ b/modin/core/execution/ray/common/engine_wrapper.py
@@ -315,22 +315,23 @@ class MaterializationHook:
         -------
         tuple
         """
-        return _hook_deserializer, (RayWrapper.materialize(self),)
+        data = RayWrapper.materialize(self)
+        return int if isinstance(data, int) else self._get, (data,)
 
+    @staticmethod
+    def _get(obj):
+        """
+        Simply returns the object. Used for the serialization only.
 
-def _hook_deserializer(obj):
-    """
-    Simply returns the object. Used for the MaterializationHook serialization.
+        Parameters
+        ----------
+        obj : object
 
-    Parameters
-    ----------
-    obj : object
-
-    Returns
-    -------
-    object
-    """
-    return obj
+        Returns
+        -------
+        object
+        """
+        return obj
 
 
 RayObjectRefTypes = (ray.ObjectRef, ClientObjectRef)

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -41,7 +41,10 @@ from modin.utils import try_cast_to_pandas
 NPartitions.put(4)
 
 if Engine.get() == "Ray":
+    import ray
+
     from modin.core.execution.ray.common import RayWrapper
+    from modin.core.execution.ray.common.deferred_execution import MetaList
     from modin.core.execution.ray.implementations.pandas_on_ray.partitioning import (
         PandasOnRayDataframeColumnPartition,
         PandasOnRayDataframePartition,
@@ -2494,10 +2497,6 @@ def test_ray_lazy_exec_mode(mode):
 
 @pytest.mark.skipif(Engine.get() != "Ray", reason="Ray specific")
 def test_materialization_hook_serialization():
-    import ray
-
-    from modin.core.execution.ray.common.deferred_execution import MetaList
-
     @ray.remote(num_returns=1)
     def f1():
         return [1, 2, 3]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7072 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
