### PR TITLE
FIX-#7088: Make sure `rank` raises `No axis named None...` exception

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2362,6 +2362,10 @@ class BasePandasDataset(ClassLogger):
         ascending: bool = True,
         pct: bool = False,
     ):
+        if axis is None:
+            raise ValueError(
+                f"No axis named None for object type {type(self).__name__}"
+            )
         axis = self._get_axis_number(axis)
         return self.__constructor__(
             query_compiler=self._query_compiler.rank(

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -337,20 +337,16 @@ def test_sum_single_column(data):
 
 
 @pytest.mark.parametrize(
-    "fn", ["max", "min", "median", "mean", "skew", "kurt", "sem", "std", "var", "rank"]
+    "fn", ["max", "min", "median", "mean", "skew", "kurt", "sem", "std", "var"]
 )
 @pytest.mark.parametrize("axis", [0, 1, None])
 @pytest.mark.parametrize(
     "numeric_only", bool_arg_values, ids=arg_keys("numeric_only", bool_arg_keys)
 )
 def test_reduce_specific(fn, numeric_only, axis):
-    raising_exceptions = None
-    if numeric_only and axis is None and fn == "rank":
-        raising_exceptions = ValueError("No axis named None for object type DataFrame")
     eval_general(
         *create_test_dfs(test_data_diff_dtype),
         lambda df: getattr(df, fn)(numeric_only=numeric_only, axis=axis),
-        raising_exceptions=raising_exceptions,
     )
 
 

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -337,16 +337,20 @@ def test_sum_single_column(data):
 
 
 @pytest.mark.parametrize(
-    "fn", ["max", "min", "median", "mean", "skew", "kurt", "sem", "std", "var"]
+    "fn", ["max", "min", "median", "mean", "skew", "kurt", "sem", "std", "var", "rank"]
 )
 @pytest.mark.parametrize("axis", [0, 1, None])
 @pytest.mark.parametrize(
     "numeric_only", bool_arg_values, ids=arg_keys("numeric_only", bool_arg_keys)
 )
 def test_reduce_specific(fn, numeric_only, axis):
+    raising_exceptions = None
+    if numeric_only and axis is None and fn == "rank":
+        raising_exceptions = ValueError("No axis named None for object type DataFrame")
     eval_general(
         *create_test_dfs(test_data_diff_dtype),
         lambda df: getattr(df, fn)(numeric_only=numeric_only, axis=axis),
+        raising_exceptions=raising_exceptions,
     )
 
 

--- a/modin/pandas/test/dataframe/test_window.py
+++ b/modin/pandas/test/dataframe/test_window.py
@@ -728,6 +728,14 @@ def test_std_var_rank(axis, skipna, method):
     )
 
 
+def test_rank_except():
+    eval_general(
+        *create_test_dfs(test_data["float_nan_data"]),
+        lambda df: df.rank(axis=None),
+        raising_exceptions=ValueError("No axis named None for object type DataFrame"),
+    )
+
+
 @pytest.mark.parametrize("axis", ["rows", "columns"])
 @pytest.mark.parametrize("ddof", int_arg_values, ids=arg_keys("ddof", int_arg_keys))
 @pytest.mark.parametrize("method", ["std", "var"])


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7088 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
