### PR TITLE
FEAT-#7090: Add range-partitioning implementation for '.unique()' and '.drop_duplicates()'

### DIFF
--- a/.github/actions/run-core-tests/group_2/action.yml
+++ b/.github/actions/run-core-tests/group_2/action.yml
@@ -20,5 +20,3 @@ runs:
                                                       modin/pandas/test/dataframe/test_pickle.py
           echo "::endgroup::"
         shell: bash -l {0}
-      - run: MODIN_RANGE_PARTITIONING=1 python -m pytest modin/pandas/test/dataframe/test_join_sort.py -k "merge"
-        shell: bash -l {0}

--- a/.github/actions/run-core-tests/group_3/action.yml
+++ b/.github/actions/run-core-tests/group_3/action.yml
@@ -18,7 +18,15 @@ runs:
           echo "::endgroup::"
         shell: bash -l {0}
       - run: |
-          echo "::group::Running experimental groupby tests (group 3)..."
+          echo "::group::Running range-partitioning groupby tests (group 3)..."
           MODIN_RANGE_PARTITIONING_GROUPBY=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_groupby.py
+          echo "::endgroup::"
+        shell: bash -l {0}
+      - run: |
+          echo "::group::Running range-partitioning tests (group 3)..."
+          MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_series.py -k "test_unique or drop_duplicates"
+          MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_general.py -k "test_unique"
+          MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/dataframe/test_map_metadata.py -k "drop_duplicates"
+          MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/dataframe/test_join_sort.py -k "merge"
           echo "::endgroup::"
         shell: bash -l {0}

--- a/.github/actions/run-core-tests/group_3/action.yml
+++ b/.github/actions/run-core-tests/group_3/action.yml
@@ -18,12 +18,8 @@ runs:
           echo "::endgroup::"
         shell: bash -l {0}
       - run: |
-          echo "::group::Running range-partitioning groupby tests (group 3)..."
-          MODIN_RANGE_PARTITIONING_GROUPBY=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_groupby.py
-          echo "::endgroup::"
-        shell: bash -l {0}
-      - run: |
           echo "::group::Running range-partitioning tests (group 3)..."
+          MODIN_RANGE_PARTITIONING_GROUPBY=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_groupby.py
           MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_series.py -k "test_unique or drop_duplicates"
           MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_general.py -k "test_unique"
           MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/dataframe/test_map_metadata.py -k "drop_duplicates"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,7 +188,6 @@ jobs:
       - run: python -m pytest modin/pandas/test/dataframe/test_binary.py
       - run: python -m pytest modin/pandas/test/dataframe/test_reduce.py
       - run: python -m pytest modin/pandas/test/dataframe/test_join_sort.py
-      - run: MODIN_RANGE_PARTITIONING=1 python -m pytest modin/pandas/test/dataframe/test_join_sort.py -k "merge"
       - run: python -m pytest modin/pandas/test/test_general.py
       - run: python -m pytest modin/pandas/test/dataframe/test_indexing.py
       - run: python -m pytest modin/pandas/test/test_series.py

--- a/.github/workflows/push-to-master.yml
+++ b/.github/workflows/push-to-master.yml
@@ -46,7 +46,6 @@ jobs:
           python -m pytest modin/pandas/test/dataframe/test_indexing.py
           python -m pytest modin/pandas/test/dataframe/test_iter.py
           python -m pytest modin/pandas/test/dataframe/test_join_sort.py
-          MODIN_RANGE_PARTITIONING=1 python -m pytest modin/pandas/test/dataframe/test_join_sort.py -k "merge"
           python -m pytest modin/pandas/test/dataframe/test_map_metadata.py
           python -m pytest modin/pandas/test/dataframe/test_reduce.py
           python -m pytest modin/pandas/test/dataframe/test_udf.py

--- a/docs/flow/modin/experimental/range_partitioning_groupby.rst
+++ b/docs/flow/modin/experimental/range_partitioning_groupby.rst
@@ -78,3 +78,9 @@ Range-partitioning Merge
 
 It is recommended to use this implementation if the right dataframe in merge is as big as
 the left dataframe. In this case, range-partitioning implementation works faster and consumes less RAM.
+
+'.unique()' and '.drop_duplicates()'
+""""""""""""""""""""""""""""""""""""
+
+Range-partitioning implementation of '.unique()'/'.drop_duplicates()' works best when the input data size is big (more than
+5_000_000 rows) and when the output size is also expected to be big (no more than 80% values are duplicates).

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1770,7 +1770,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         )
 
     @doc_utils.add_refer_to("Series.drop_duplicates")
-    def unique(self, keep="first", ignore_index=False, subset=None):
+    def unique(self, keep="first", ignore_index=True, subset=None):
         """
         Get unique rows of `self`.
 
@@ -1778,7 +1778,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
         ----------
         keep : {"first", "last", False}, default: "first"
             Which duplicates to keep.
-        ignore_index : bool, default: False
+        ignore_index : bool, default: True
             If ``True``, the resulting axis will be labeled ``0, 1, …, n - 1``.
         subset : list, optional
             Only consider certain columns for identifying duplicates, if `None`, use all of the columns.

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1768,7 +1768,8 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             self, unit=unit, errors=errors
         )
 
-    @doc_utils.add_refer_to("Series.drop_duplicates")
+    # 'qc.unique()' is uses most of the arguments from 'df.drop_duplicates()', so refering to this method
+    @doc_utils.add_refer_to("DataFrame.drop_duplicates")
     def unique(self, keep="first", ignore_index=True, subset=None):
         """
         Get unique rows of `self`.

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1768,7 +1768,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             self, unit=unit, errors=errors
         )
 
-    # 'qc.unique()' is uses most of the arguments from 'df.drop_duplicates()', so refering to this method
+    # 'qc.unique()' uses most of the arguments from 'df.drop_duplicates()', so refering to this method
     @doc_utils.add_refer_to("DataFrame.drop_duplicates")
     def unique(self, keep="first", ignore_index=True, subset=None):
         """

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1772,13 +1772,16 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
     @doc_utils.add_refer_to("Series.drop_duplicates")
     def unique(self, keep="first", ignore_index=False, subset=None):
         """
-        Get unique values of `self`.
+        Get unique rows of `self`.
 
         Parameters
         ----------
         keep : {"first", "last", False}, default: "first"
+            Which duplicates to keep.
         ignore_index : bool, default: False
+            If ``True``, the resulting axis will be labeled ``0, 1, …, n - 1``.
         subset : list, optional
+            Only consider certain columns for identifying duplicates, if `None`, use all of the columns.
 
         Returns
         -------

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -1794,7 +1794,7 @@ class BaseQueryCompiler(ClassLogger, abc.ABC):
             mask = self
         without_duplicates = self.getitem_array(mask.duplicated(keep=keep).invert())
         if ignore_index:
-            without_duplicates.index = pandas.RangeIndex(len(without_duplicates.index))
+            without_duplicates = without_duplicates.reset_index(drop=True)
         return without_duplicates
 
     @doc_utils.add_one_column_warning

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1899,10 +1899,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # END String map partitions operations
 
-    def unique(self, keep="first", ignore_index=False, subset=None):
+    def unique(self, keep="first", ignore_index=True, subset=None):
         # kernels with 'pandas.Series.unique()' work faster
         can_use_unique_kernel = (
-            subset is None and ignore_index and len(self.columns) == 1 and not keep
+            subset is None and ignore_index and len(self.columns) == 1 and keep
         )
 
         if not can_use_unique_kernel and not RangePartitioning.get():

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1900,6 +1900,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # END String map partitions operations
 
     def unique(self, keep="first", ignore_index=False, subset=None):
+        # kernels with 'pandas.Series.unique()' work faster
         can_use_unique_kernel = (
             subset is None and ignore_index and len(self.columns) == 1 and not keep
         )
@@ -1927,7 +1928,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 lambda x: x.squeeze(axis=1).unique(),
                 new_columns=self.columns,
             )
-        return self.__constructor__(new_modin_frame, shape_hint="column")
+        return self.__constructor__(new_modin_frame, shape_hint=self._shape_hint)
 
     def searchsorted(self, **kwargs):
         def searchsorted(df):

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1899,13 +1899,35 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # END String map partitions operations
 
-    def unique(self):
-        new_modin_frame = self._modin_frame.apply_full_axis(
-            0,
-            lambda x: x.squeeze(axis=1).unique(),
-            new_columns=self.columns,
+    def unique(self, keep="first", ignore_index=False, subset=None):
+        can_use_unique_kernel = (
+            subset is None and ignore_index and len(self.columns) == 1 and not keep
         )
-        return self.__constructor__(new_modin_frame)
+
+        if not can_use_unique_kernel and not RangePartitioning.get():
+            return super().unique(keep=keep, ignore_index=ignore_index, subset=subset)
+
+        if RangePartitioning.get():
+            new_modin_frame = self._modin_frame._apply_func_to_range_partitioning(
+                key_columns=self.columns.tolist() if subset is None else subset,
+                func=(
+                    (lambda df: pandas.DataFrame(df.squeeze(axis=1).unique()))
+                    if can_use_unique_kernel
+                    else (
+                        lambda df: df.drop_duplicates(
+                            keep=keep, ignore_index=ignore_index, subset=subset
+                        )
+                    )
+                ),
+                preserve_columns=True,
+            )
+        else:
+            new_modin_frame = self._modin_frame.apply_full_axis(
+                0,
+                lambda x: x.squeeze(axis=1).unique(),
+                new_columns=self.columns,
+            )
+        return self.__constructor__(new_modin_frame, shape_hint="column")
 
     def searchsorted(self, **kwargs):
         def searchsorted(df):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1511,13 +1511,12 @@ class BasePandasDataset(ClassLogger):
                     subset = list(subset)
             else:
                 subset = [subset]
-            df = self[subset]
-        else:
-            df = self
-        duplicated = df.duplicated(keep=keep)
-        result = self[~duplicated]
-        if ignore_index:
-            result.index = pandas.RangeIndex(stop=len(result))
+            if len(diff := pandas.Index(subset).difference(self.columns)) > 0:
+                raise KeyError(diff)
+        result_qc = self._query_compiler.unique(
+            keep=keep, ignore_index=ignore_index, subset=subset
+        )
+        result = self.__constructor__(query_compiler=result_qc)
         if inplace:
             self._update_inplace(result._query_compiler)
         else:

--- a/modin/pandas/test/dataframe/test_join_sort.py
+++ b/modin/pandas/test/dataframe/test_join_sort.py
@@ -34,6 +34,7 @@ from modin.pandas.test.utils import (
     generate_multiindex,
     random_state,
     rotate_decimal_digits_or_symbols,
+    sort_if_range_partitioning,
     test_data,
     test_data_keys,
     test_data_values,
@@ -247,10 +248,6 @@ def test_join_6602():
     ],
 )
 def test_merge(test_data, test_data2):
-    # RangePartitioning merge always produces sorted result, so we have to sort
-    # pandas' result as well in order them to match
-    comparator = df_equals_and_sort if RangePartitioning.get() else df_equals
-
     modin_df = pd.DataFrame(
         test_data,
         columns=["col{}".format(i) for i in range(test_data.shape[1])],
@@ -283,7 +280,7 @@ def test_merge(test_data, test_data2):
             pandas_result = pandas_df.merge(
                 pandas_df2, how=hows[i], on=ons[j], sort=sorts[j]
             )
-            comparator(modin_result, pandas_result)
+            sort_if_range_partitioning(modin_result, pandas_result)
 
             modin_result = modin_df.merge(
                 modin_df2,
@@ -299,7 +296,7 @@ def test_merge(test_data, test_data2):
                 right_on="key",
                 sort=sorts[j],
             )
-            comparator(modin_result, pandas_result)
+            sort_if_range_partitioning(modin_result, pandas_result)
 
     # Test for issue #1771
     modin_df = pd.DataFrame({"name": np.arange(40)})
@@ -308,7 +305,7 @@ def test_merge(test_data, test_data2):
     pandas_df2 = pandas.DataFrame({"name": [39], "position": [0]})
     modin_result = modin_df.merge(modin_df2, on="name", how="inner")
     pandas_result = pandas_df.merge(pandas_df2, on="name", how="inner")
-    comparator(modin_result, pandas_result)
+    sort_if_range_partitioning(modin_result, pandas_result)
 
     frame_data = {
         "col1": [0, 1, 2, 3],
@@ -329,7 +326,7 @@ def test_merge(test_data, test_data2):
         # Defaults
         modin_result = modin_df.merge(modin_df2, how=how)
         pandas_result = pandas_df.merge(pandas_df2, how=how)
-        comparator(modin_result, pandas_result)
+        sort_if_range_partitioning(modin_result, pandas_result)
 
         # left_on and right_index
         modin_result = modin_df.merge(
@@ -338,7 +335,7 @@ def test_merge(test_data, test_data2):
         pandas_result = pandas_df.merge(
             pandas_df2, how=how, left_on="col1", right_index=True
         )
-        comparator(modin_result, pandas_result)
+        sort_if_range_partitioning(modin_result, pandas_result)
 
         # left_index and right_on
         modin_result = modin_df.merge(
@@ -347,7 +344,7 @@ def test_merge(test_data, test_data2):
         pandas_result = pandas_df.merge(
             pandas_df2, how=how, left_index=True, right_on="col1"
         )
-        comparator(modin_result, pandas_result)
+        sort_if_range_partitioning(modin_result, pandas_result)
 
         # left_on and right_on col1
         modin_result = modin_df.merge(
@@ -356,7 +353,7 @@ def test_merge(test_data, test_data2):
         pandas_result = pandas_df.merge(
             pandas_df2, how=how, left_on="col1", right_on="col1"
         )
-        comparator(modin_result, pandas_result)
+        sort_if_range_partitioning(modin_result, pandas_result)
 
         # left_on and right_on col2
         modin_result = modin_df.merge(
@@ -365,7 +362,7 @@ def test_merge(test_data, test_data2):
         pandas_result = pandas_df.merge(
             pandas_df2, how=how, left_on="col2", right_on="col2"
         )
-        comparator(modin_result, pandas_result)
+        sort_if_range_partitioning(modin_result, pandas_result)
 
         # left_index and right_index
         modin_result = modin_df.merge(
@@ -374,7 +371,7 @@ def test_merge(test_data, test_data2):
         pandas_result = pandas_df.merge(
             pandas_df2, how=how, left_index=True, right_index=True
         )
-        comparator(modin_result, pandas_result)
+        sort_if_range_partitioning(modin_result, pandas_result)
 
     # Cannot merge a Series without a name
     ps = pandas.Series(frame_data2.get("col1"))
@@ -383,7 +380,7 @@ def test_merge(test_data, test_data2):
         modin_df,
         pandas_df,
         lambda df: df.merge(ms if isinstance(df, pd.DataFrame) else ps),
-        comparator=comparator,
+        comparator=sort_if_range_partitioning,
     )
 
     # merge a Series with a name
@@ -393,7 +390,7 @@ def test_merge(test_data, test_data2):
         modin_df,
         pandas_df,
         lambda df: df.merge(ms if isinstance(df, pd.DataFrame) else ps),
-        comparator=comparator,
+        comparator=sort_if_range_partitioning,
     )
 
     with pytest.raises(TypeError):

--- a/modin/pandas/test/dataframe/test_map_metadata.py
+++ b/modin/pandas/test/dataframe/test_map_metadata.py
@@ -17,7 +17,7 @@ import pandas
 import pytest
 
 import modin.pandas as pd
-from modin.config import NPartitions, StorageFormat
+from modin.config import NPartitions, RangePartitioning, StorageFormat
 from modin.core.dataframe.pandas.metadata import LazyProxyCategoricalDtype
 from modin.core.storage_formats.pandas.utils import split_result_of_axis_func_pandas
 from modin.pandas.test.utils import (
@@ -61,6 +61,13 @@ matplotlib.use("Agg")
 # instances of defaulting to pandas, but some test modules, like this one,
 # have too many such instances.
 pytestmark = pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+
+
+def sort_and_compare(df1, df2):
+    df_equals(
+        df1.sort_values(df1.columns.tolist(), ignore_index=True),
+        df2.sort_values(df2.columns.tolist(), ignore_index=True),
+    )
 
 
 def eval_insert(modin_df, pandas_df, **kwargs):
@@ -1055,6 +1062,8 @@ def test_droplevel():
 @pytest.mark.parametrize("ignore_index", [True, False], ids=["True", "False"])
 @pytest.mark.exclude_in_sanity
 def test_drop_duplicates(data, keep, subset, ignore_index):
+    comparator = sort_and_compare if RangePartitioning.get() else df_equals
+
     modin_df = pd.DataFrame(data)
     pandas_df = pandas.DataFrame(data)
 
@@ -1068,7 +1077,7 @@ def test_drop_duplicates(data, keep, subset, ignore_index):
                 keep=keep, inplace=False, subset=subset, ignore_index=ignore_index
             )
     else:
-        df_equals(
+        comparator(
             pandas_df.drop_duplicates(
                 keep=keep, inplace=False, subset=subset, ignore_index=ignore_index
             ),
@@ -1078,7 +1087,7 @@ def test_drop_duplicates(data, keep, subset, ignore_index):
         )
 
     try:
-        pandas_results = pandas_df.drop_duplicates(
+        pandas_df.drop_duplicates(
             keep=keep, inplace=True, subset=subset, ignore_index=ignore_index
         )
     except Exception as err:
@@ -1087,13 +1096,15 @@ def test_drop_duplicates(data, keep, subset, ignore_index):
                 keep=keep, inplace=True, subset=subset, ignore_index=ignore_index
             )
     else:
-        modin_results = modin_df.drop_duplicates(
+        modin_df.drop_duplicates(
             keep=keep, inplace=True, subset=subset, ignore_index=ignore_index
         )
-        df_equals(modin_results, pandas_results)
+        comparator(modin_df, pandas_df)
 
 
 def test_drop_duplicates_with_missing_index_values():
+    comparator = sort_and_compare if RangePartitioning.get() else df_equals
+
     data = {
         "columns": ["value", "time", "id"],
         "index": [
@@ -1168,10 +1179,12 @@ def test_drop_duplicates_with_missing_index_values():
     modin_df = pd.DataFrame(data["data"], index=data["index"], columns=data["columns"])
     modin_result = modin_df.sort_values(["id", "time"]).drop_duplicates(["id"])
     pandas_result = pandas_df.sort_values(["id", "time"]).drop_duplicates(["id"])
-    df_equals(modin_result, pandas_result)
+    comparator(modin_result, pandas_result)
 
 
 def test_drop_duplicates_after_sort():
+    comparator = sort_and_compare if RangePartitioning.get() else df_equals
+
     data = [
         {"value": 1, "time": 2},
         {"value": 1, "time": 1},
@@ -1183,15 +1196,19 @@ def test_drop_duplicates_after_sort():
 
     modin_result = modin_df.sort_values(["value", "time"]).drop_duplicates(["value"])
     pandas_result = pandas_df.sort_values(["value", "time"]).drop_duplicates(["value"])
-    df_equals(modin_result, pandas_result)
+    comparator(modin_result, pandas_result)
 
 
 def test_drop_duplicates_with_repeated_index_values():
+    comparator = sort_and_compare if RangePartitioning.get() else df_equals
+
     # This tests for issue #4467: https://github.com/modin-project/modin/issues/4467
     data = [[0], [1], [0]]
     index = [0, 0, 0]
     modin_df, pandas_df = create_test_dfs(data, index=index)
-    eval_general(modin_df, pandas_df, lambda df: df.drop_duplicates())
+    eval_general(
+        modin_df, pandas_df, lambda df: df.drop_duplicates(), comparator=comparator
+    )
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -19,7 +19,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import modin.pandas as pd
-from modin.config import StorageFormat
+from modin.config import RangePartitioning, StorageFormat
 from modin.pandas.io import to_pandas
 from modin.pandas.testing import assert_frame_equal
 from modin.test.test_utils import warns_that_defaulting_to_pandas
@@ -565,15 +565,21 @@ def test_pivot_table():
         )
 
 
+def sort_arr(arr1, arr2):
+    assert_array_equal(np.sort(arr1), np.sort(arr2))
+
+
 def test_unique():
+    comparator = sort_arr if RangePartitioning.get() else assert_array_equal
+
     modin_result = pd.unique([2, 1, 3, 3])
     pandas_result = pandas.unique([2, 1, 3, 3])
-    assert_array_equal(modin_result, pandas_result)
+    comparator(modin_result, pandas_result)
     assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.unique(pd.Series([2] + [1] * 5))
     pandas_result = pandas.unique(pandas.Series([2] + [1] * 5))
-    assert_array_equal(modin_result, pandas_result)
+    comparator(modin_result, pandas_result)
     assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.unique(
@@ -582,7 +588,7 @@ def test_unique():
     pandas_result = pandas.unique(
         pandas.Series([pandas.Timestamp("20160101"), pandas.Timestamp("20160101")])
     )
-    assert_array_equal(modin_result, pandas_result)
+    comparator(modin_result, pandas_result)
     assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.unique(
@@ -601,7 +607,7 @@ def test_unique():
             ]
         )
     )
-    assert_array_equal(modin_result, pandas_result)
+    comparator(modin_result, pandas_result)
     assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.unique(
@@ -620,12 +626,12 @@ def test_unique():
             ]
         )
     )
-    assert_array_equal(modin_result, pandas_result)
+    comparator(modin_result, pandas_result)
     assert modin_result.shape == pandas_result.shape
 
     modin_result = pd.unique(pd.Series(pd.Categorical(list("baabc"))))
     pandas_result = pandas.unique(pandas.Series(pandas.Categorical(list("baabc"))))
-    assert_array_equal(modin_result, pandas_result)
+    comparator(modin_result, pandas_result)
     assert modin_result.shape == pandas_result.shape
 
 

--- a/modin/pandas/test/test_general.py
+++ b/modin/pandas/test/test_general.py
@@ -19,7 +19,7 @@ import pytest
 from numpy.testing import assert_array_equal
 
 import modin.pandas as pd
-from modin.config import RangePartitioning, StorageFormat
+from modin.config import StorageFormat
 from modin.pandas.io import to_pandas
 from modin.pandas.testing import assert_frame_equal
 from modin.test.test_utils import warns_that_defaulting_to_pandas
@@ -32,6 +32,7 @@ from .utils import (
     default_to_pandas_ignore_string,
     df_equals,
     eval_general,
+    sort_if_range_partitioning,
     sort_index_for_equal_values,
     test_data_keys,
     test_data_values,
@@ -565,12 +566,10 @@ def test_pivot_table():
         )
 
 
-def sort_arr(arr1, arr2):
-    assert_array_equal(np.sort(arr1), np.sort(arr2))
-
-
 def test_unique():
-    comparator = sort_arr if RangePartitioning.get() else assert_array_equal
+    comparator = lambda *args: sort_if_range_partitioning(  # noqa: E731
+        *args, comparator=assert_array_equal
+    )
 
     modin_result = pd.unique([2, 1, 3, 3])
     pandas_result = pandas.unique([2, 1, 3, 3])

--- a/modin/pandas/test/test_series.py
+++ b/modin/pandas/test/test_series.py
@@ -86,11 +86,6 @@ from .utils import (
     test_string_list_data_values,
 )
 
-
-def sort_and_compare(sr1, sr2):
-    df_equals(sr1.sort_values(), sr2.sort_values())
-
-
 # Our configuration in pytest.ini requires that we explicitly catch all
 # instances of defaulting to pandas, but some test modules, like this one,
 # have too many such instances.

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -37,7 +37,14 @@ from pandas.core.dtypes.common import (
 )
 
 import modin.pandas as pd
-from modin.config import MinPartitionSize, NPartitions, TestDatasetSize, TrackFileLeaks
+from modin.config import (
+    MinPartitionSize,
+    NPartitions,
+    RangePartitioning,
+    RangePartitioningGroupby,
+    TestDatasetSize,
+    TrackFileLeaks,
+)
 from modin.pandas.io import to_pandas
 from modin.pandas.testing import (
     assert_extension_array_equal,
@@ -660,6 +667,27 @@ def assert_dtypes_equal(df1, df2):
                 # We met a dtype that both types satisfy, so we can stop iterating
                 # over comparators and compare next dtypes
                 break
+
+
+def sort_data(data):
+    """Sort the passed sequence."""
+    if isinstance(data, (pandas.DataFrame, pd.DataFrame)):
+        return data.sort_values(data.columns.to_list(), ignore_index=True)
+    elif isinstance(data, (pandas.Series, pd.Series)):
+        return data.sort_values()
+    else:
+        return np.sort(data)
+
+
+def sort_if_range_partitioning(df1, df2, comparator=None):
+    """Sort the passed objects if 'RangePartitioning' is enabled and compare the sorted results."""
+    if comparator is None:
+        comparator = df_equals
+
+    if RangePartitioning.get() or RangePartitioningGroupby.get():
+        df1, df2 = sort_data(df1), sort_data(df2)
+
+    comparator(df1, df2)
 
 
 def df_equals(df1, df2, check_dtypes=True):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR merges implementations of `.unique()`/`.drop_duplicates()` into a single query compiler method called `unique()`. Some parts of `DataFrame.drop_duplicates()` implementation were moved to `BaseQueryCompiler.unique()`.

The performance highly depends on the number of duplicated values in the input data, so it's almost impossible to figure out a solid working heuristic:

<details><summary>perf for '.unique()'</summary>

MODIN_CPUS=16
![image](https://github.com/modin-project/modin/assets/62142979/b81e8e82-0eff-4267-8f95-017585852a32)

MODIN_CPUS=44
![image](https://github.com/modin-project/modin/assets/62142979/6572407b-d16d-43e4-84db-72bd2292d307)

<details><summary>script to measure</summary>

```python
import modin.pandas as pd
import numpy as np
import modin.config as cfg

from modin.utils import execute
from timeit import default_timer as timer
import pandas

cfg.CpuCount.put(16)

def get_data(nrows, dtype):
    if dtype == int:
        return np.arange(nrows)
    elif dtype == float:
        return np.arange(nrows).astype(float)
    elif dtype == str:
        return np.array([f"value{i}" for i in range(nrows)])
    else:
        raise NotImplementedError(dtype)

pd.DataFrame(np.arange(cfg.NPartitions.get() * cfg.MinPartitionSize.get())).to_numpy()

nrows = [1_000_000, 5_000_000, 10_000_000, 25_000_000, 50_000_000, 100_000_000]
duplicate_rate = [0, 0.1, 0.5, 0.95]
dtypes = [int, str]
use_range_part = [True, False]

columns = pandas.MultiIndex.from_product([dtypes, duplicate_rate, use_range_part], names=["dtype", "duplicate rate", "use range-part"])
result = pandas.DataFrame(index=nrows, columns=columns)

i = 0
total_its = len(nrows) * len(duplicate_rate) * len(dtypes) * len(use_range_part)

for dt in dtypes:
    for nrow in nrows:
        data = get_data(nrow, dt)
        np.random.shuffle(data)
        for dpr in duplicate_rate:
            data_c = data.copy()
            dupl_val = data_c[0]

            num_duplicates = int(dpr * nrow)
            dupl_indices = np.random.choice(np.arange(nrow), num_duplicates, replace=False)
            data_c[dupl_indices] = dupl_val

            for impl in use_range_part:
                print(f"{round((i / total_its) * 100, 2)}%")
                i += 1
                cfg.RangePartitioning.put(impl)

                sr = pd.Series(data_c)
                execute(sr)

                t1 = timer()
                # returns a list, so no need for materialization
                sr.unique()
                tm = timer() - t1
                print(nrow, dpr, dt, impl, tm)
                result.loc[nrow, (dt, dpr, impl)] = tm
                result.to_excel("unique.xlsx")
```

</details>

</details>

<details><summary>perf for '.drop_duplicates()'</summary>

MODIN_CPUS=16
![image](https://github.com/modin-project/modin/assets/62142979/45ac092c-8aaa-4e60-b5b9-79a78455aca1)

MODIN_CPUS=44
![image](https://github.com/modin-project/modin/assets/62142979/d161e11c-822e-4537-aaf6-31373920e70d)

<details><summary>script to measure</summary>

```python
import modin.pandas as pd
import numpy as np
import modin.config as cfg

from modin.utils import execute
from timeit import default_timer as timer
import pandas

cfg.CpuCount.put(16)

pd.DataFrame(np.arange(cfg.NPartitions.get() * cfg.MinPartitionSize.get())).to_numpy()

nrows = [1_000_000, 5_000_000, 10_000_000, 25_000_000]
duplicate_rate = [0, 0.1, 0.5, 0.95]
subset = [["col0"], ["col1", "col2", "col3", "col4"], None]
ncols = 15
use_range_part = [True, False]

columns = pandas.MultiIndex.from_product(
    [
        [len(sbs) if sbs is not None else ncols for sbs in subset],
        duplicate_rate,
        use_range_part
    ],
    names=["subset size", "duplicate rate", "use range-part"]
)
result = pandas.DataFrame(index=nrows, columns=columns)

i = 0
total_its = len(nrows) * len(duplicate_rate) * len(subset) * len(use_range_part)

for sbs in subset:
    for nrow in nrows:
        data = {f"col{i}": np.arange(nrow) for i in range(ncols)}
        pandas_df = pandas.DataFrame(data)

        for dpr in duplicate_rate:
            pandas_df_c = pandas_df.copy()
            dupl_val = pandas_df_c.iloc[0]

            num_duplicates = int(dpr * nrow)
            dupl_indices = np.random.choice(np.arange(nrow), num_duplicates, replace=False)
            pandas_df_c.iloc[dupl_indices] = dupl_val

            for impl in use_range_part:
                print(f"{round((i / total_its) * 100, 2)}%")
                i += 1
                cfg.RangePartitioning.put(impl)

                md_df = pd.DataFrame(pandas_df_c)
                execute(md_df)

                t1 = timer()
                res = md_df.drop_duplicates(subset=sbs)
                execute(res)
                tm = timer() - t1

                sbs_s = len(sbs) if sbs is not None else ncols
                print("len()", res.shape, nrow, dpr, sbs_s, impl, tm)
                result.loc[nrow, (sbs_s, dpr, impl)] = tm
                result.to_excel("drop_dupl.xlsx")
```

</details>

</details>

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7090 <!-- issue must be created for each patch -->
- [x] tests <s>added and</s> are passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
