### PR TITLE
FEAT-#7100: Add range-partitioning impl for 'nunique()'

### DIFF
--- a/.github/actions/run-core-tests/group_3/action.yml
+++ b/.github/actions/run-core-tests/group_3/action.yml
@@ -18,7 +18,8 @@ runs:
           echo "::endgroup::"
         shell: bash -l {0}
       - run: |
-          echo "::group::Running experimental groupby tests (group 3)..."
+          echo "::group::Running range-partitioning tests (group 3)..."
           MODIN_RANGE_PARTITIONING_GROUPBY=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_groupby.py
+          MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_series.py -k "test_nunique"
           echo "::endgroup::"
         shell: bash -l {0}

--- a/docs/flow/modin/experimental/range_partitioning_groupby.rst
+++ b/docs/flow/modin/experimental/range_partitioning_groupby.rst
@@ -85,7 +85,7 @@ the left dataframe. In this case, range-partitioning implementation works faster
 .. note::
 
     Range-partitioning approach is implemented only for 'pd.Series.nunique()' and 1-column dataframes.
-    For multi-column dataframes '.nunique()' can only use full-column implementation.
+    For multi-column dataframes '.nunique()' can only use full-axis reduce implementation.
 
 Range-partitioning implementation of '.nunique()'' works best when the input data size is big (more than
 5_000_000 rows) and when the output size is also expected to be big (no more than 80% values are duplicates).

--- a/docs/flow/modin/experimental/range_partitioning_groupby.rst
+++ b/docs/flow/modin/experimental/range_partitioning_groupby.rst
@@ -78,3 +78,14 @@ Range-partitioning Merge
 
 It is recommended to use this implementation if the right dataframe in merge is as big as
 the left dataframe. In this case, range-partitioning implementation works faster and consumes less RAM.
+
+'.nunique()'
+""""""""""""""""""""""""""""""""""""
+
+.. note::
+
+    Range-partitioning approach is implemented only for 'pd.Series.nunique()' and 1-column dataframes.
+    For multi-column dataframes '.nunique()' can only use full-column implementation.
+
+Range-partitioning implementation of '.nunique()'' works best when the input data size is big (more than
+5_000_000 rows) and when the output size is also expected to be big (no more than 80% values are duplicates).

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -980,10 +980,12 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 self, axis=axis, dropna=dropna
             )
 
+        # compute '.nunique()' for each row partitions
         new_modin_frame = self._modin_frame._apply_func_to_range_partitioning(
             key_columns=self.columns.tolist(),
             func=lambda df: df.nunique(dropna=dropna).to_frame(),
         )
+        # sum the results of each row part to get the final value
         new_modin_frame = new_modin_frame.reduce(axis=0, function=lambda df: df.sum())
         return self.__constructor__(new_modin_frame, shape_hint="column")
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -972,7 +972,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         if len(unsupported_message) > 0:
             message = (
                 f"Can't use range-partitioning implementation for 'nunique' because:\n{unsupported_message}"
-                + "Falling back to a full-axis implementation."
+                + "Falling back to a full-axis reduce implementation."
             )
             get_logger().info(message)
             ErrorMessage.warn(message)

--- a/modin/pandas/test/dataframe/test_reduce.py
+++ b/modin/pandas/test/dataframe/test_reduce.py
@@ -87,6 +87,16 @@ def test_count(data, axis):
     )
 
 
+@pytest.mark.parametrize("axis", axis_values, ids=axis_keys)
+@pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
+@pytest.mark.parametrize("dropna", [True, False])
+def test_nunique(data, axis, dropna):
+    eval_general(
+        *create_test_dfs(data),
+        lambda df: df.nunique(axis=axis, dropna=dropna),
+    )
+
+
 @pytest.mark.parametrize("numeric_only", [False, True])
 def test_count_specific(numeric_only):
     eval_general(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Adds range-partitioning implementation for `.nunique()` method. Unfortunately, range-partitioning in `.nunique()` can be used only for 1D data (`pd.Series` and 1-column DataFrames). The reason is that we need each column to be the 'key' in range-partitioning, which is not possible even if we use several columns to build bins:
```
initial df:        building bins for range-parts           splitting in range-parts           reduction phase
   a  b       ---> bins: {                          ---->     a   b                           a 1                    
0  0  1                    0: [a<=0 and b<=10],            0  0   1    bin0.nunique()         b 2 
1  0  10                   1: [a<=0 and b>10]              1  0   10                  ---->   -----  sum(bin0, bin1)  ---->  a 2 (incorrect)
2  0  20                  }                                ----------                         a 1                            b 3
                                                              a   b    bin1.nunique()         b 1                              
                                                           2  0   20                           
```
This is not a problem for other methods, since there we want to extract <b>unique rows</b> rather than <b>unique values</b> in each column independently.

<details><summary>perf measurements</summary>

![image](https://github.com/modin-project/modin/assets/62142979/619d410e-d0b5-44b4-a190-590d9e8a7c85)

<details><summary>script to measure</summary>

```python
import modin.pandas as pd
import numpy as np
import modin.config as cfg

from modin.utils import execute
from timeit import default_timer as timer
import pandas

cfg.CpuCount.put(16)

def get_data(nrows, dtype):
    if dtype == int:
        return np.arange(nrows)
    elif dtype == float:
        return np.arange(nrows).astype(float)
    elif dtype == str:
        return np.array([f"value{i}" for i in range(nrows)])
    else:
        raise NotImplementedError(dtype)

pd.DataFrame(np.arange(cfg.NPartitions.get() * cfg.MinPartitionSize.get())).to_numpy()

nrows = [1_000_000, 5_000_000, 10_000_000, 25_000_000, 50_000_000, 100_000_000]
duplicate_rate = [0, 0.1, 0.5, 0.95]
dtypes = [int, str]
use_range_part = [True, False]

columns = pandas.MultiIndex.from_product([dtypes, duplicate_rate, use_range_part], names=["dtype", "duplicate rate", "use range-part"])
result = pandas.DataFrame(index=nrows, columns=columns)

i = 0
total_its = len(nrows) * len(duplicate_rate) * len(dtypes) * len(use_range_part)

for dt in dtypes:
    for nrow in nrows:
        data = get_data(nrow, dt)
        np.random.shuffle(data)
        for dpr in duplicate_rate:
            data_c = data.copy()
            dupl_val = data_c[0]

            num_duplicates = int(dpr * nrow)
            dupl_indices = np.random.choice(np.arange(nrow), num_duplicates, replace=False)
            data_c[dupl_indices] = dupl_val

            for impl in use_range_part:
                print(f"{round((i / total_its) * 100, 2)}%")
                i += 1
                cfg.RangePartitioning.put(impl)

                sr = pd.Series(data_c)
                execute(sr)

                t1 = timer()
                # returns a scalar, so no need for materialization
                res = sr.nunique()
                tm = timer() - t1
                print(nrow, dpr, dt, impl, tm)
                result.loc[nrow, (dt, dpr, impl)] = tm
                result.to_excel("nunique.xlsx")
```

</details>

</details>

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7100 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
