### PR TITLE
FEAT-#7111: Implemented `@remote_function` decorator with cache

### DIFF
--- a/modin/core/execution/utils.py
+++ b/modin/core/execution/utils.py
@@ -16,6 +16,8 @@
 import contextlib
 import os
 
+from modin.error_message import ErrorMessage
+
 
 @contextlib.contextmanager
 def set_env(**environ):
@@ -59,6 +61,12 @@ if "remote_function" not in dir():
         _remote_function_cache = {}
 
         def remote_function(func):  # noqa: F811
+            if func.__closure__:
+                ErrorMessage.warn(
+                    f"The remote function {func} can not be cached, because "
+                    + "it captures objects from the outer scope."
+                )
+                return func
             func_id = id(func.__code__)
             ref = _remote_function_cache.get(func_id, None)
             if ref is None:

--- a/modin/core/execution/utils.py
+++ b/modin/core/execution/utils.py
@@ -81,7 +81,8 @@ elif "remote_function" not in dir():
                         + "default values. Use `ignore_defaults` to forcibly enable caching."
                     )
                     return func
-                # For the nested functions, use __code__ as the key
+                # For the nested functions, use __code__ as the key, because it's the same
+                # object for each instance of the function.
                 key = id(func.__code__)
             else:
                 key = func

--- a/modin/core/execution/utils.py
+++ b/modin/core/execution/utils.py
@@ -33,43 +33,60 @@ def set_env(**environ):
         os.environ.update(old_environ)
 
 
+if "_MODIN_DOC_CHECKER_" in os.environ:
+
+    # The doc checker should get the non-processed functions
+    def remote_function(func, ignore_defaults=False):
+        return func
+
+
 # Check if the function already exists to avoid circular imports
-if "remote_function" not in dir():
+elif "remote_function" not in dir():
     from modin.config import Engine
 
     if Engine.get() == "Ray":
         from modin.core.execution.ray.common import RayWrapper
 
-        _remote_function_wrapper = RayWrapper.put
+        _preprocess_func = RayWrapper.put
     elif Engine.get() == "Unidist":
         from modin.core.execution.unidist.common import UnidistWrapper
 
-        _remote_function_wrapper = UnidistWrapper.put
+        _preprocess_func = UnidistWrapper.put
     elif Engine.get() == "Dask":
         from modin.core.execution.dask.common import DaskWrapper
 
         # The function cache is not supported for Dask
-        def remote_function(func):
+        def remote_function(func, ignore_defaults=False):
             return DaskWrapper.put(func)
 
     else:
 
-        def remote_function(func):
+        def remote_function(func, ignore_defaults=False):
             return func
 
     if "remote_function" not in dir():
         _remote_function_cache = {}
 
-        def remote_function(func):  # noqa: F811
-            if func.__closure__:
-                ErrorMessage.warn(
-                    f"The remote function {func} can not be cached, because "
-                    + "it captures objects from the outer scope."
-                )
-                return func
-            func_id = id(func.__code__)
-            ref = _remote_function_cache.get(func_id, None)
+        def remote_function(func, ignore_defaults=False):  # noqa: F811
+            if "<locals>" in func.__qualname__:  # Nested function
+                if func.__closure__:
+                    ErrorMessage.single_warning(
+                        f"The nested function {func} can not be cached, because "
+                        + "it captures objects from the outer scope."
+                    )
+                    return func
+                if not ignore_defaults and func.__defaults__:
+                    ErrorMessage.single_warning(
+                        f"The nested function {func} can not be cached, because it has "
+                        + "default values. Use `ignore_defaults` to forcibly enable caching."
+                    )
+                    return func
+                # For the nested functions, use __code__ as the key
+                key = id(func.__code__)
+            else:
+                key = func
+            ref = _remote_function_cache.get(key, None)
             if ref is None:
-                ref = _remote_function_wrapper(func)
-                _remote_function_cache[func_id] = ref
+                ref = _preprocess_func(func)
+                _remote_function_cache[key] = ref
             return ref

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -28,6 +28,7 @@ from modin.core.dataframe.pandas.metadata import (
     LazyProxyCategoricalDtype,
     ModinDtypes,
 )
+from modin.core.execution.utils import remote_function
 from modin.core.storage_formats.pandas.utils import split_result_of_axis_func_pandas
 from modin.distributed.dataframe.pandas import from_partitions
 from modin.pandas.test.utils import (
@@ -55,6 +56,8 @@ if Engine.get() == "Ray":
     virtual_column_partition_class = PandasOnRayDataframeColumnPartition
     virtual_row_partition_class = PandasOnRayDataframeRowPartition
     put = RayWrapper.put
+    deploy = RayWrapper.deploy
+    materialize = RayWrapper.materialize
 elif Engine.get() == "Dask":
     from modin.core.execution.dask.common import DaskWrapper
     from modin.core.execution.dask.implementations.pandas_on_dask.partitioning import (
@@ -72,6 +75,8 @@ elif Engine.get() == "Dask":
     block_partition_class = PandasOnDaskDataframePartition
     virtual_column_partition_class = PandasOnDaskDataframeColumnPartition
     virtual_row_partition_class = PandasOnDaskDataframeRowPartition
+    deploy = DaskWrapper.deploy
+    materialize = DaskWrapper.materialize
 elif Engine.get() == "Python":
     from modin.core.execution.python.common import PythonWrapper
     from modin.core.execution.python.implementations.pandas_on_python.partitioning import (
@@ -82,6 +87,12 @@ elif Engine.get() == "Python":
 
     def put(x):
         return PythonWrapper.put(x, hash=False)
+
+    def deploy(func, args):
+        return func(*args)
+
+    def materialize(arg):
+        return arg
 
     block_partition_class = PandasOnPythonDataframePartition
     virtual_column_partition_class = PandasOnPythonDataframeColumnPartition
@@ -2507,3 +2518,22 @@ def test_materialization_hook_serialization():
 
     hook = MetaList(f1.remote())[2]
     assert ray.get(f2.remote(hook)) == 3
+
+
+def test_remote_function():
+    def get_func():
+        @remote_function
+        def remote_func(arg):
+            return arg
+
+        return remote_func
+
+    if Engine.get() in ("Ray", "Unidist"):
+        from modin.core.execution.utils import _remote_function_cache
+
+        cache_len = len(_remote_function_cache)
+        assert get_func() is get_func()
+        assert get_func() in _remote_function_cache.values()
+        assert len(_remote_function_cache) == cache_len + 1
+
+    assert materialize(deploy(get_func(), [123])) == 123

--- a/modin/test/storage_formats/pandas/test_internals.py
+++ b/modin/test/storage_formats/pandas/test_internals.py
@@ -88,7 +88,7 @@ elif Engine.get() == "Python":
     def put(x):
         return PythonWrapper.put(x, hash=False)
 
-    def deploy(func, args=[]):
+    def deploy(func, args=tuple()):
         return func(*args)
 
     def materialize(arg):

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -35,6 +35,9 @@ from typing import List
 from numpydoc.docscrape import NumpyDocString
 from numpydoc.validate import Docstring
 
+# Let the other modules to know that the doc checker is running.
+os.environ["_MODIN_DOC_CHECKER_"] = "1"
+
 # fake cuDF-related modules if they're missing
 for mod_name in ("cudf", "cupy"):
     try:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7111 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
