### PR TITLE
FEAT-#7117: Support building range-partitioning from an index level

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2587,8 +2587,11 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
             partition_indices = np.unique(
                 np.digitize(key_indices, np.cumsum(grouper.column_widths))
             )
-        else:
+        elif level is not None:
+            # each partition contains an index, so taking the first one
             partition_indices = [0]
+        else:
+            raise ValueError("Must specify either 'level' or 'key_columns'")
 
         new_partitions = grouper._partition_mgr_cls.shuffle_partitions(
             new_partitions,

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2445,6 +2445,7 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
         preserve_columns=False,
         data=None,
         data_key_columns=None,
+        level=None,
         **kwargs,
     ):
         """
@@ -2453,7 +2454,7 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
         Parameters
         ----------
         key_columns : list of hashables
-            Columns to build the range partitioning for.
+            Columns to build the range partitioning for. Can't be specified along with `level`.
         func : callable(pandas.DataFrame) -> pandas.DataFrame
             Function to apply against partitions.
         ascending : bool, default: True
@@ -2466,6 +2467,8 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
             ``df["grouper"] # self`` and ``df["data"] # data``.
         data_key_columns : list of hashables, optional
             Additional key columns from `data`. Will be combined with `key_columns`.
+        level : list of ints or labels, optional
+            Index level(s) to build the range partitioning for. Can't be specified along with `key_columns`.
         **kwargs : dict
             Additional arguments to forward to the range builder function.
 
@@ -2574,14 +2577,18 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
             key_columns,
             ascending[0] if is_list_like(ascending) else ascending,
             ideal_num_new_partitions,
+            level=level,
             **kwargs,
         )
 
-        # here we want to get indices of those partitions that hold the key columns
-        key_indices = grouper.columns.get_indexer_for(key_columns)
-        partition_indices = np.unique(
-            np.digitize(key_indices, np.cumsum(grouper.column_widths))
-        )
+        if key_columns:
+            # here we want to get indices of those partitions that hold the key columns
+            key_indices = grouper.columns.get_indexer_for(key_columns)
+            partition_indices = np.unique(
+                np.digitize(key_indices, np.cumsum(grouper.column_widths))
+            )
+        else:
+            partition_indices = [0]
 
         new_partitions = grouper._partition_mgr_cls.shuffle_partitions(
             new_partitions,
@@ -4031,6 +4038,10 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
         duplicated_suffix = "__duplicated_suffix__"
         duplicated_pattern = r"_[\d]*__duplicated_suffix__"
         kwargs["observed"] = True
+        level = kwargs.get("level")
+
+        if level is not None and not isinstance(level, list):
+            level = [level]
 
         def apply_func(df):  # pragma: no cover
             if has_external_grouper:
@@ -4074,6 +4085,12 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
 
             if series_groupby:
                 df = df.squeeze(axis=1)
+
+            if kwargs.get("level") is not None:
+                assert len(by) == 0
+                # passing an empty list triggers an error
+                by = None
+
             result = operator(df.groupby(by, **kwargs))
 
             if align_result_columns and df.empty and result.empty:
@@ -4128,6 +4145,7 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
             func=apply_func,
             data=data,
             data_key_columns=data_key_columns,
+            level=level,
         )
         # no need aligning columns if there's only one row partition
         if add_missing_cats or align_result_columns and result._partitions.shape[0] > 1:
@@ -4286,7 +4304,11 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
                 row_lengths=result._row_lengths_cache,
             )
 
-        if not result.has_materialized_index and not has_external_grouper:
+        if (
+            not result.has_materialized_index
+            and not has_external_grouper
+            and level is None
+        ):
             by_dtypes = ModinDtypes(self._dtypes).lazy_get(internal_by)
             if by_dtypes.is_materialized:
                 new_index = ModinIndex(value=result, axis=0, dtypes=by_dtypes)

--- a/modin/core/dataframe/pandas/dataframe/utils.py
+++ b/modin/core/dataframe/pandas/dataframe/utils.py
@@ -132,7 +132,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
         columns: Optional[Union[str, list]],
         ascending: Union[list, bool],
         ideal_num_new_partitions: int,
-        level: Optional[list[Union[str, int]]],
+        level: Optional[list[Union[str, int]]] = None,
         **kwargs: dict,
     ):
         self.frame_len = len(modin_frame)
@@ -321,7 +321,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
         df: pandas.DataFrame,
         columns_info: "list[ColumnInfo]",
         ascending: bool,
-        keys_are_index_levels: bool,
+        keys_are_index_levels: bool = False,
         **kwargs: dict,
     ) -> "tuple[pandas.DataFrame, ...]":
         """
@@ -340,7 +340,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
             Information regarding keys and pivots for range partitioning.
         ascending : bool
             The ascending flag.
-        keys_are_index_levels : bool
+        keys_are_index_levels : bool, default: False
             Whether `columns_info` describes index levels or actual columns from `df`.
         **kwargs : dict
             Additional keyword arguments.

--- a/modin/core/dataframe/pandas/dataframe/utils.py
+++ b/modin/core/dataframe/pandas/dataframe/utils.py
@@ -114,12 +114,14 @@ class ShuffleSortFunctions(ShuffleFunctions):
     ----------
     modin_frame : PandasDataframe
         The frame to build the range-partitioning for.
-    columns : str or list of strings
-        The column/columns to use as a key.
+    columns : str, list of strings or None
+        The column/columns to use as a key. Can't be specified along with `level`.
     ascending : bool
         Whether the ranges should be in ascending or descending order.
     ideal_num_new_partitions : int
         The ideal number of new partitions.
+    level : list of strings or ints, or None
+        Index level(s) to use as a key. Can't be specified along with `columns`.
     **kwargs : dict
         Additional keyword arguments.
     """
@@ -127,9 +129,10 @@ class ShuffleSortFunctions(ShuffleFunctions):
     def __init__(
         self,
         modin_frame: "PandasDataframe",
-        columns: Union[str, list],
+        columns: Optional[Union[str, list]],
         ascending: Union[list, bool],
         ideal_num_new_partitions: int,
+        level: Optional[list[Union[str, int]]],
         **kwargs: dict,
     ):
         self.frame_len = len(modin_frame)
@@ -137,11 +140,16 @@ class ShuffleSortFunctions(ShuffleFunctions):
         self.columns = columns if is_list_like(columns) else [columns]
         self.ascending = ascending
         self.kwargs = kwargs.copy()
+        self.level = level
         self.columns_info = None
 
     def sample_fn(self, partition: pandas.DataFrame) -> pandas.DataFrame:
+        if self.level is not None:
+            partition = self._index_to_df_zero_copy(partition, self.level)
+        else:
+            partition = partition[self.columns]
         return self.pick_samples_for_quantiles(
-            partition[self.columns], self.ideal_num_new_partitions, self.frame_len
+            partition, self.ideal_num_new_partitions, self.frame_len
         )
 
     def pivot_fn(self, samples: "list[pandas.DataFrame]") -> int:
@@ -181,6 +189,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
             partition,
             self.columns_info,
             self.ascending,
+            keys_are_index_levels=self.level is not None,
             **self.kwargs,
         )
 
@@ -312,6 +321,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
         df: pandas.DataFrame,
         columns_info: "list[ColumnInfo]",
         ascending: bool,
+        keys_are_index_levels: bool,
         **kwargs: dict,
     ) -> "tuple[pandas.DataFrame, ...]":
         """
@@ -330,6 +340,8 @@ class ShuffleSortFunctions(ShuffleFunctions):
             Information regarding keys and pivots for range partitioning.
         ascending : bool
             The ascending flag.
+        keys_are_index_levels : bool
+            Whether `columns_info` describes index levels or actual columns from `df`.
         **kwargs : dict
             Additional keyword arguments.
 
@@ -342,9 +354,14 @@ class ShuffleSortFunctions(ShuffleFunctions):
             # We can return the dataframe with zero changes if there were no pivots passed
             return (df,)
 
-        na_index = (
-            df[[col_info.name for col_info in columns_info]].isna().squeeze(axis=1)
+        key_data = (
+            ShuffleSortFunctions._index_to_df_zero_copy(
+                df, [col_info.name for col_info in columns_info]
+            )
+            if keys_are_index_levels
+            else df[[col_info.name for col_info in columns_info]]
         )
+        na_index = key_data.isna().squeeze(axis=1)
         if na_index.ndim == 2:
             na_index = na_index.any(axis=1)
         na_rows = df[na_index]
@@ -373,12 +390,19 @@ class ShuffleSortFunctions(ShuffleFunctions):
                 pivots = pivots[::-1]
             group_keys.append(range(len(pivots) + 1))
             key = kwargs.pop("key", None)
-            cols_to_digitize = non_na_rows[col_info.name]
+            cols_to_digitize = (
+                non_na_rows.index.get_level_values(col_info.name)
+                if keys_are_index_levels
+                else non_na_rows[col_info.name]
+            )
             if key is not None:
                 cols_to_digitize = key(cols_to_digitize)
 
+            if cols_to_digitize.ndim == 2:
+                cols_to_digitize = cols_to_digitize.squeeze()
+
             if col_info.is_numeric:
-                groupby_col = np.digitize(cols_to_digitize.squeeze(), pivots)
+                groupby_col = np.digitize(cols_to_digitize, pivots)
                 # `np.digitize` returns results based off of the sort order of the pivots it is passed.
                 # When we only have one unique value in our pivots, `np.digitize` assumes that the pivots
                 # are sorted in ascending order, and gives us results based off of that assumption - so if
@@ -386,9 +410,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
                 if not ascending and len(np.unique(pivots)) == 1:
                     groupby_col = len(pivots) - groupby_col
             else:
-                groupby_col = np.searchsorted(
-                    pivots, cols_to_digitize.squeeze(), side="right"
-                )
+                groupby_col = np.searchsorted(pivots, cols_to_digitize, side="right")
                 # Since np.searchsorted requires the pivots to be in ascending order, if we want to sort
                 # in descending order, we need to swap the new indices.
                 if not ascending:
@@ -425,6 +447,36 @@ class ShuffleSortFunctions(ShuffleFunctions):
             [groups[index_to_insert_na_vals], na_rows]
         ).astype(df.dtypes)
         return tuple(groups)
+
+    @staticmethod
+    def _index_to_df_zero_copy(
+        df: pandas.DataFrame, levels: list[Union[str, int]]
+    ) -> pandas.DataFrame:
+        """
+        Convert index `level` of `df` to a ``pandas.DataFrame``.
+
+        Parameters
+        ----------
+        df : pandas.DataFrame
+        levels : list of labels or ints
+            Index level to convert to a dataframe.
+
+        Returns
+        -------
+        pandas.DataFrame
+            The columns in the resulting dataframe use the same data arrays as the index levels
+            in the original `df`, so no copies.
+        """
+        # calling 'df.index.to_frame()' creates a copy of the index, so doing the conversion manually
+        # to avoid the copy
+        data = {
+            (
+                df.index.names[lvl] if isinstance(lvl, int) else lvl
+            ): df.index.get_level_values(lvl)
+            for lvl in levels
+        }
+        index_data = pandas.DataFrame(data, index=df.index, copy=False)
+        return index_data
 
 
 def lazy_metadata_decorator(apply_axis=None, axis_arg=-1, transpose=False):

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3700,12 +3700,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 by, agg_func, axis, groupby_kwargs, agg_args, agg_kwargs, how, drop
             )
 
-        if groupby_kwargs.get("level") is not None:
-            raise NotImplementedError(
-                "Grouping on an index level is not yet supported by range-partitioning groupby implementation: "
-                + "https://github.com/modin-project/modin/issues/5926"
-            )
-
+        grouping_on_level = groupby_kwargs.get("level") is not None
         if any(
             isinstance(obj, pandas.Grouper)
             for obj in (by if isinstance(by, list) else [by])
@@ -3715,7 +3710,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
                 + "https://github.com/modin-project/modin/issues/5926"
             )
 
-        external_by, internal_by, by_positions = self._groupby_separate_by(by, drop)
+        if grouping_on_level:
+            external_by, internal_by, by_positions = [], [], []
+        else:
+            external_by, internal_by, by_positions = self._groupby_separate_by(by, drop)
 
         all_external_are_qcs = all(isinstance(obj, type(self)) for obj in external_by)
         if not all_external_are_qcs:

--- a/modin/pandas/test/test_groupby.py
+++ b/modin/pandas/test/test_groupby.py
@@ -1342,6 +1342,7 @@ def sort_if_experimental_groupby(*dfs):
     the experimental implementation changes the order of rows for that:
     https://github.com/modin-project/modin/issues/5924
     """
+    result = dfs
     if RangePartitioningGroupby.get():
         dfs = try_cast_to_pandas(dfs)
         result = []

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -665,6 +665,23 @@ def assert_dtypes_equal(df1, df2):
                 break
 
 
+def assert_set_of_rows_identical(df1, df2):
+    """
+    Assert that the set of rows for the passed dataframes is identical.
+
+    Works much slower than ``df1.equals(df2)``, so it's recommended to use this
+    function only in exceptional cases.
+    """
+    # replacing NaN with None to pass the comparison: 'NaN == NaN -> false; None == None -> True'
+    df1, df2 = map(
+        lambda df: (df.to_frame() if df.ndim == 1 else df).replace({np.nan: None}),
+        (df1, df2),
+    )
+    rows1 = set((idx, *row.tolist()) for idx, row in df1.iterrows())
+    rows2 = set((idx, *row.tolist()) for idx, row in df2.iterrows())
+    assert rows1 == rows2
+
+
 def sort_data(data):
     """Sort the passed sequence."""
     if isinstance(data, (pandas.DataFrame, pd.DataFrame)):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Adds support for building range-partitioning based on an index level(s) and enables range-partitioning support for `df.groupby(level=...)` cases.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7117 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
