### PR TITLE
PERF-#7132: Preserve partition lengths in apply_full_axis with keep_partitioning=False

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3450,7 +3450,7 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
                 kw["column_widths"] = [len(new_columns)]
         elif axis == 1:
             if is_index_materialized and new_partitions.shape[0] == 1:
-                kw["row_lengths"] = [len(new_columns)]
+                kw["row_lengths"] = [len(new_index)]
         if not keep_partitioning:
             if kw["row_lengths"] is None and is_index_materialized:
                 if axis == 0:

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3448,13 +3448,20 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
                     kw["row_lengths"] = get_length_list(
                         axis_len=len(new_index), num_splits=new_partitions.shape[0]
                     )
+                    if (
+                        kw["column_widths"] is None
+                        and ModinIndex.is_materialized_index(new_columns)
+                        and len(new_partitions.shape) > 1
+                        and new_partitions.shape[1] == 1
+                    ):
+                        kw["column_widths"] = [len(new_columns)]
                 elif axis == 1:
                     if self._row_lengths_cache is not None and len(new_index) == sum(
                         self._row_lengths_cache
                     ):
                         kw["row_lengths"] = self._row_lengths_cache
-                    elif len(new_index) == 1 and new_partitions.shape[0] == 1:
-                        kw["row_lengths"] = [1]
+                    elif new_partitions.shape[0] == 1:
+                        kw["row_lengths"] = [len(new_index)]
             if kw["column_widths"] is None and ModinIndex.is_materialized_index(
                 new_columns
             ):
@@ -3463,13 +3470,19 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
                         axis_len=len(new_columns),
                         num_splits=new_partitions.shape[1],
                     )
+                    if (
+                        kw["row_lengths"] is None
+                        and ModinIndex.is_materialized_index(new_index)
+                        and new_partitions.shape[0] == 1
+                    ):
+                        kw["row_lengths"] = [len(new_index)]
                 elif axis == 0:
                     if self._column_widths_cache is not None and len(
                         new_columns
                     ) == sum(self._column_widths_cache):
                         kw["column_widths"] = self._column_widths_cache
-                    elif len(new_columns) == 1 and new_partitions.shape[1] == 1:
-                        kw["column_widths"] = [1]
+                    elif new_partitions.shape[1] == 1:
+                        kw["column_widths"] = [len(new_columns)]
         else:
             if axis == 0:
                 if (

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3439,84 +3439,61 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
                             index=new_columns,
                         )
                     )
-
-        if not keep_partitioning:
-            if kw["row_lengths"] is None and ModinIndex.is_materialized_index(
-                new_index
+        is_index_materialized = ModinIndex.is_materialized_index(new_index)
+        is_columns_materialized = ModinIndex.is_materialized_index(new_columns)
+        if axis == 0:
+            if (
+                is_columns_materialized
+                and len(new_partitions.shape) > 1
+                and new_partitions.shape[1] == 1
             ):
+                kw["column_widths"] = [len(new_columns)]
+        elif axis == 1:
+            if is_index_materialized and new_partitions.shape[0] == 1:
+                kw["row_lengths"] = [len(new_columns)]
+        if not keep_partitioning:
+            if kw["row_lengths"] is None and is_index_materialized:
                 if axis == 0:
                     kw["row_lengths"] = get_length_list(
                         axis_len=len(new_index), num_splits=new_partitions.shape[0]
                     )
-                    if (
-                        kw["column_widths"] is None
-                        and ModinIndex.is_materialized_index(new_columns)
-                        and len(new_partitions.shape) > 1
-                        and new_partitions.shape[1] == 1
-                    ):
-                        kw["column_widths"] = [len(new_columns)]
                 elif axis == 1:
                     if self._row_lengths_cache is not None and len(new_index) == sum(
                         self._row_lengths_cache
                     ):
                         kw["row_lengths"] = self._row_lengths_cache
-                    elif new_partitions.shape[0] == 1:
-                        kw["row_lengths"] = [len(new_index)]
-            if kw["column_widths"] is None and ModinIndex.is_materialized_index(
-                new_columns
-            ):
+            if kw["column_widths"] is None and is_columns_materialized:
                 if axis == 1:
                     kw["column_widths"] = get_length_list(
                         axis_len=len(new_columns),
                         num_splits=new_partitions.shape[1],
                     )
-                    if (
-                        kw["row_lengths"] is None
-                        and ModinIndex.is_materialized_index(new_index)
-                        and new_partitions.shape[0] == 1
-                    ):
-                        kw["row_lengths"] = [len(new_index)]
                 elif axis == 0:
                     if self._column_widths_cache is not None and len(
                         new_columns
                     ) == sum(self._column_widths_cache):
                         kw["column_widths"] = self._column_widths_cache
-                    elif new_partitions.shape[1] == 1:
-                        kw["column_widths"] = [len(new_columns)]
         else:
             if axis == 0:
                 if (
                     kw["row_lengths"] is None
                     and self._row_lengths_cache is not None
-                    and ModinIndex.is_materialized_index(new_index)
+                    and is_index_materialized
                     and len(new_index) == sum(self._row_lengths_cache)
                     # to avoid problems that may arise when filtering empty dataframes
                     and all(r != 0 for r in self._row_lengths_cache)
                 ):
                     kw["row_lengths"] = self._row_lengths_cache
-                if (
-                    kw["column_widths"] is None
-                    and ModinIndex.is_materialized_index(new_columns)
-                    and len(new_partitions.shape) > 1
-                    and new_partitions.shape[1] == 1
-                ):
-                    kw["column_widths"] = [len(new_columns)]
-            if axis == 1:
+            elif axis == 1:
                 if (
                     kw["column_widths"] is None
                     and self._column_widths_cache is not None
-                    and ModinIndex.is_materialized_index(new_columns)
+                    and is_columns_materialized
                     and len(new_columns) == sum(self._column_widths_cache)
                     # to avoid problems that may arise when filtering empty dataframes
                     and all(w != 0 for w in self._column_widths_cache)
                 ):
                     kw["column_widths"] = self._column_widths_cache
-                if (
-                    kw["row_lengths"] is None
-                    and ModinIndex.is_materialized_index(new_index)
-                    and new_partitions.shape[0] == 1
-                ):
-                    kw["row_lengths"] = [len(new_index)]
 
         result = self.__constructor__(
             new_partitions, index=new_index, columns=new_columns, **kw


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7132  <!-- issue must be created for each patch -->
- [x] tests passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
