### PR TITLE
FEAT-#7118: Add range-partitioning impl for 'df.resample()'

### DIFF
--- a/.github/actions/run-core-tests/group_3/action.yml
+++ b/.github/actions/run-core-tests/group_3/action.yml
@@ -20,9 +20,10 @@ runs:
       - run: |
           echo "::group::Running range-partitioning tests (group 3)..."
           MODIN_RANGE_PARTITIONING_GROUPBY=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_groupby.py
-          MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_series.py -k "test_unique or test_nunique or drop_duplicates"
+          MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_series.py -k "test_unique or test_nunique or drop_duplicates or test_resample"
           MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/test_general.py -k "test_unique"
           MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/dataframe/test_map_metadata.py -k "drop_duplicates"
           MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/dataframe/test_join_sort.py -k "merge"
+          MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/pandas/test/dataframe/test_default.py -k "resample"
           echo "::endgroup::"
         shell: bash -l {0}

--- a/docs/flow/modin/experimental/range_partitioning_groupby.rst
+++ b/docs/flow/modin/experimental/range_partitioning_groupby.rst
@@ -95,3 +95,13 @@ Range-partitioning implementation of '.unique()'/'.drop_duplicates()' works best
 
 Range-partitioning implementation of '.nunique()'' works best when the input data size is big (more than
 5_000_000 rows) and when the output size is also expected to be big (no more than 80% values are duplicates).
+
+Resample
+""""""""
+
+.. note::
+
+    Range-partitioning approach doesn't support transform-like functions (like `.interpolate()`, `.ffill()`, `.bfill()`, ...)
+
+It is recommended to use range-partitioning for resampling if you're dealing with a dataframe that has more than
+5_000_000 rows and the expected output is also expected to be big (more than 500_000 rows).

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2438,6 +2438,7 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
             dtypes=new_dtypes,
         )
 
+    @lazy_metadata_decorator(apply_axis="both")
     def _apply_func_to_range_partitioning(
         self,
         key_columns,
@@ -2447,6 +2448,7 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
         data=None,
         data_key_columns=None,
         level=None,
+        shuffle_func_cls=ShuffleSortFunctions,
         **kwargs,
     ):
         """
@@ -2470,6 +2472,9 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
             Additional key columns from `data`. Will be combined with `key_columns`.
         level : list of ints or labels, optional
             Index level(s) to build the range partitioning for. Can't be specified along with `key_columns`.
+        shuffle_func_cls : cls, default: ShuffleSortFunctions
+            A class implementing ``modin.core.dataframe.pandas.utils.ShuffleFunctions`` to be used
+            as a shuffle function.
         **kwargs : dict
             Additional arguments to forward to the range builder function.
 
@@ -2573,7 +2578,7 @@ class PandasDataframe(ClassLogger, modin_layer="CORE-DATAFRAME"):
         else:
             new_partitions = grouper._partitions
 
-        shuffling_functions = ShuffleSortFunctions(
+        shuffling_functions = shuffle_func_cls(
             grouper,
             key_columns,
             ascending[0] if is_list_like(ascending) else ascending,

--- a/modin/core/dataframe/pandas/dataframe/utils.py
+++ b/modin/core/dataframe/pandas/dataframe/utils.py
@@ -19,7 +19,9 @@ from typing import TYPE_CHECKING, Callable, Optional, Union
 
 import numpy as np
 import pandas
+from pandas._libs.tslibs import to_offset
 from pandas.core.dtypes.common import is_list_like, is_numeric_dtype
+from pandas.core.resample import _get_timestamp_range_edges
 
 from modin.error_message import ErrorMessage
 from modin.utils import _inherit_docstrings
@@ -122,6 +124,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
         The ideal number of new partitions.
     level : list of strings or ints, or None
         Index level(s) to use as a key. Can't be specified along with `columns`.
+    closed_on_right : bool, default: True
     **kwargs : dict
         Additional keyword arguments.
     """
@@ -133,6 +136,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
         ascending: Union[list, bool],
         ideal_num_new_partitions: int,
         level: Optional[list[Union[str, int]]] = None,
+        closed_on_right: bool = True,
         **kwargs: dict,
     ):
         self.frame_len = len(modin_frame)
@@ -142,6 +146,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
         self.kwargs = kwargs.copy()
         self.level = level
         self.columns_info = None
+        self.closed_on_right = closed_on_right
 
     def sample_fn(self, partition: pandas.DataFrame) -> pandas.DataFrame:
         if self.level is not None:
@@ -159,11 +164,11 @@ class ShuffleSortFunctions(ShuffleFunctions):
         columns_info: "list[ColumnInfo]" = []
         number_of_groups = 1
         cols = []
-        for col in samples.columns:
+        for i, col in enumerate(samples.columns):
             num_pivots = int(self.ideal_num_new_partitions / number_of_groups)
             if num_pivots < 2 and len(columns_info):
                 break
-            column_val = samples[col].to_numpy()
+            column_val = samples[col]
             cols.append(col)
             is_numeric = is_numeric_dtype(column_val.dtype)
 
@@ -172,7 +177,13 @@ class ShuffleSortFunctions(ShuffleFunctions):
             pivots = self.pick_pivots_from_samples_for_sort(
                 column_val, num_pivots, method, key
             )
-            columns_info.append(ColumnInfo(col, pivots, is_numeric))
+            columns_info.append(
+                ColumnInfo(
+                    self.level[i] if col is None and self.level is not None else col,
+                    pivots,
+                    is_numeric,
+                )
+            )
             number_of_groups *= len(pivots) + 1
         self.columns_info = columns_info
         return number_of_groups
@@ -190,6 +201,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
             self.columns_info,
             self.ascending,
             keys_are_index_levels=self.level is not None,
+            closed_on_right=self.closed_on_right,
             **self.kwargs,
         )
 
@@ -270,10 +282,9 @@ class ShuffleSortFunctions(ShuffleFunctions):
         probability = (1 / m) * np.log(num_partitions * length)
         return df.sample(frac=probability)
 
-    @classmethod
     def pick_pivots_from_samples_for_sort(
-        cls,
-        samples: np.ndarray,
+        self,
+        samples: pandas.Series,
         ideal_num_new_partitions: int,
         method: str = "linear",
         key: Optional[Callable] = None,
@@ -288,7 +299,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
 
         Parameters
         ----------
-        samples : np.ndarray
+        samples : pandas.Series
             The samples computed by ``get_partition_quantiles_for_sort``.
         ideal_num_new_partitions : int
             The ideal number of new partitions.
@@ -302,6 +313,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
         np.ndarray
             A list of overall quantiles.
         """
+        samples = samples.to_numpy()
         # We don't call `np.unique` on the samples, since if a quantile shows up in multiple
         # partition's samples, this is probably an indicator of skew in the dataset, and we
         # want our final partitions to take this into account.
@@ -313,7 +325,7 @@ class ShuffleSortFunctions(ShuffleFunctions):
         # If we only desire 1 partition, we need to ensure that we're not trying to find quantiles
         # from an empty list of pivots.
         if len(quantiles) > 0:
-            return cls._find_quantiles(samples, quantiles, method)
+            return self._find_quantiles(samples, quantiles, method)
         return np.array([])
 
     @staticmethod
@@ -322,8 +334,9 @@ class ShuffleSortFunctions(ShuffleFunctions):
         columns_info: "list[ColumnInfo]",
         ascending: bool,
         keys_are_index_levels: bool = False,
+        closed_on_right: bool = True,
         **kwargs: dict,
-    ) -> "tuple[pandas.DataFrame, ...]":
+    ) -> "tuple[pandas.DataFrame, ...]":  # noqa
         """
         Split the given dataframe into the partitions specified by `pivots` in `columns_info`.
 
@@ -402,7 +415,9 @@ class ShuffleSortFunctions(ShuffleFunctions):
                 cols_to_digitize = cols_to_digitize.squeeze()
 
             if col_info.is_numeric:
-                groupby_col = np.digitize(cols_to_digitize, pivots)
+                groupby_col = np.digitize(
+                    cols_to_digitize, pivots, right=not closed_on_right
+                )
                 # `np.digitize` returns results based off of the sort order of the pivots it is passed.
                 # When we only have one unique value in our pivots, `np.digitize` assumes that the pivots
                 # are sorted in ascending order, and gives us results based off of that assumption - so if
@@ -410,7 +425,11 @@ class ShuffleSortFunctions(ShuffleFunctions):
                 if not ascending and len(np.unique(pivots)) == 1:
                     groupby_col = len(pivots) - groupby_col
             else:
-                groupby_col = np.searchsorted(pivots, cols_to_digitize, side="right")
+                groupby_col = np.searchsorted(
+                    pivots,
+                    cols_to_digitize,
+                    side="right" if closed_on_right else "left",
+                )
                 # Since np.searchsorted requires the pivots to be in ascending order, if we want to sort
                 # in descending order, we need to swap the new indices.
                 if not ascending:
@@ -477,6 +496,154 @@ class ShuffleSortFunctions(ShuffleFunctions):
         }
         index_data = pandas.DataFrame(data, index=df.index, copy=False)
         return index_data
+
+
+class ShuffleResample(ShuffleSortFunctions):  # noqa
+    def __init__(
+        self,
+        modin_frame: "PandasDataframe",
+        columns: Union[str, list],
+        ascending: Union[list, bool],
+        ideal_num_new_partitions: int,
+        resample_kwargs: dict,
+        **kwargs: dict,
+    ):
+        super().__init__(
+            modin_frame,
+            columns,
+            ascending,
+            ideal_num_new_partitions,
+            closed_on_right=False,
+            **kwargs,
+        )
+
+        resample_kwargs = resample_kwargs.copy()
+        rule = resample_kwargs.pop("rule")
+
+        if resample_kwargs["closed"] is None:
+            if rule in ("ME", "YE", "QE", "BME", "BA", "BQE", "W"):
+                resample_kwargs["closed"] = "right"
+            else:
+                resample_kwargs["closed"] = "left"
+
+        self.closed_on_right = resample_kwargs["closed"] != "right"
+
+        resample_kwargs["freq"] = to_offset(rule)
+        self.resample_kwargs = resample_kwargs
+
+    @staticmethod
+    def pick_samples_for_quantiles(
+        df: pandas.DataFrame,
+        num_partitions: int,
+        length: int,
+    ) -> pandas.DataFrame:  # noqa
+        return pandas.concat([df.min().to_frame().T, df.max().to_frame().T])
+
+    def pick_pivots_from_samples_for_sort(
+        self,
+        samples: np.ndarray,
+        ideal_num_new_partitions: int,
+        method: str = "linear",
+        key: Optional[Callable] = None,
+    ) -> np.ndarray:  # noqa
+        if key is not None:
+            raise NotImplementedError(key)
+
+        max_value = samples.max()
+
+        first, last = _get_timestamp_range_edges(
+            samples.min(),
+            max_value,
+            self.resample_kwargs["freq"],
+            unit=samples.dt.unit,
+            closed=self.resample_kwargs["closed"],
+            origin=self.resample_kwargs["origin"],
+            offset=self.resample_kwargs["offset"],
+        )
+
+        all_bins = pandas.date_range(
+            start=first,
+            end=last,
+            freq=self.resample_kwargs["freq"],
+            ambiguous=True,
+            nonexistent="shift_forward",
+            unit=samples.dt.unit,
+        )
+
+        all_bins = self._adjust_bin_edges(
+            all_bins,
+            max_value,
+            freq=self.resample_kwargs["freq"],
+            closed=self.resample_kwargs["closed"],
+        )
+
+        step = 1 / ideal_num_new_partitions
+        bins = [
+            all_bins[int(len(all_bins) * i * step)]
+            for i in range(1, ideal_num_new_partitions)
+        ]
+        return bins
+
+    def _adjust_bin_edges(
+        self,
+        binner: pandas.DatetimeIndex,
+        end_timestamp,
+        freq,
+        closed,
+    ) -> tuple[pandas.DatetimeIndex, np.ndarray[np.int64]]:  # noqa
+        # Some hacks for > daily data, see #1471, #1458, #1483
+
+        if freq.name not in ("BME", "ME", "W") and freq.name.split("-")[0] not in (
+            "BQE",
+            "BYE",
+            "QE",
+            "YE",
+            "W",
+        ):
+            return binner
+
+        # If the right end-point is on the last day of the month, roll forwards
+        # until the last moment of that day. Note that we only do this for offsets
+        # which correspond to the end of a super-daily period - "month start", for
+        # example, is excluded.
+        if closed == "right":
+            # GH 21459, GH 9119: Adjust the bins relative to the wall time
+            edges_dti = binner.tz_localize(None)
+            edges_dti = (
+                edges_dti
+                + pandas.Timedelta(days=1, unit=edges_dti.unit).as_unit(edges_dti.unit)
+                - pandas.Timedelta(1, unit=edges_dti.unit).as_unit(edges_dti.unit)
+            )
+            binner = edges_dti.tz_localize(binner.tz)
+
+        # intraday values on last day
+        if binner[-2] > end_timestamp:
+            binner = binner[:-1]
+        return binner
+
+    @staticmethod
+    def split_partitions_using_pivots_for_sort(
+        df: pandas.DataFrame,
+        columns_info: "list[ColumnInfo]",
+        ascending: bool,
+        closed_on_right: bool = True,
+        **kwargs: dict,
+    ) -> "tuple[pandas.DataFrame, ...]":  # noqa
+        def add_attr(df, timestamp):
+            if "bin_bounds" in df.attrs:
+                df.attrs["bin_bounds"] = (*df.attrs["bin_bounds"], timestamp)
+            else:
+                df.attrs["bin_bounds"] = (timestamp,)
+            return df
+
+        result = ShuffleSortFunctions.split_partitions_using_pivots_for_sort(
+            df, columns_info, ascending, **kwargs
+        )
+        for i, pivot in enumerate(columns_info[0].pivots):
+            add_attr(result[i], pivot - pandas.Timedelta(1, unit="ns"))
+            if i + 1 <= len(result):
+                add_attr(result[i + 1], pivot + pandas.Timedelta(1, unit="ns"))
+        return result
 
 
 def lazy_metadata_decorator(apply_axis=None, axis_arg=-1, transpose=False):

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1023,7 +1023,14 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # END Reduce operations
 
     def _resample_func(
-        self, resample_kwargs, func_name, new_columns=None, df_op=None, *args, **kwargs
+        self,
+        resample_kwargs,
+        func_name,
+        new_columns=None,
+        df_op=None,
+        use_range_impl=True,
+        *args,
+        **kwargs,
     ):
         """
         Resample underlying time-series data and apply aggregation on it.
@@ -1039,6 +1046,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
             Modin frame. If not specified will be computed automaticly.
         df_op : callable(pandas.DataFrame) -> [pandas.DataFrame, pandas.Series], optional
             Preprocessor function to apply to the passed frame before resampling.
+        use_range_impl : bool, default: True
+            Whether to use range-partitioning or full-column implementation.
         *args : args
             Arguments to pass to the aggregation function.
         **kwargs : kwargs
@@ -1049,9 +1058,33 @@ class PandasQueryCompiler(BaseQueryCompiler):
         PandasQueryCompiler
             New QueryCompiler containing the result of resample aggregation.
         """
+        from modin.core.dataframe.pandas.dataframe.utils import ShuffleResample
 
         def map_func(df, resample_kwargs=resample_kwargs):  # pragma: no cover
             """Resample time-series data of the passed frame and apply aggregation function on it."""
+            if len(df) == 0:
+                if resample_kwargs["on"] is not None:
+                    df = df.set_index(resample_kwargs["on"])
+                return df
+            if "bin_bounds" in df.attrs:
+                timestamps = df.attrs["bin_bounds"]
+                if isinstance(df.index, pandas.MultiIndex):
+                    level_to_keep = resample_kwargs["level"]
+                    if isinstance(level_to_keep, int):
+                        to_drop = [
+                            lvl
+                            for lvl in range(df.index.nlevels)
+                            if lvl != level_to_keep
+                        ]
+                    else:
+                        to_drop = [
+                            lvl for lvl in df.index.names if lvl != level_to_keep
+                        ]
+                    df.index = df.index.droplevel(to_drop)
+                    resample_kwargs = resample_kwargs.copy()
+                    resample_kwargs["level"] = None
+                for ts in timestamps:
+                    df.loc[ts] = np.NaN
             if df_op is not None:
                 df = df_op(df)
             resampled_val = df.resample(**resample_kwargs)
@@ -1072,13 +1105,33 @@ class PandasQueryCompiler(BaseQueryCompiler):
             else:
                 return val
 
-        new_modin_frame = self._modin_frame.apply_full_axis(
-            axis=0, func=map_func, new_columns=new_columns
-        )
+        if resample_kwargs["on"] is None:
+            level = [
+                0 if resample_kwargs["level"] is None else resample_kwargs["level"]
+            ]
+            key_columns = []
+        else:
+            level = None
+            key_columns = [resample_kwargs["on"]]
+
+        if not use_range_impl or resample_kwargs["axis"] not in (0, "index"):
+            new_modin_frame = self._modin_frame.apply_full_axis(
+                axis=0, func=map_func, new_columns=new_columns
+            )
+        else:
+            new_modin_frame = self._modin_frame._apply_func_to_range_partitioning(
+                key_columns=key_columns,
+                level=level,
+                func=map_func,
+                shuffle_func_cls=ShuffleResample,
+                resample_kwargs=resample_kwargs,
+            )
         return self.__constructor__(new_modin_frame)
 
     def resample_get_group(self, resample_kwargs, name, obj):
-        return self._resample_func(resample_kwargs, "get_group", name=name, obj=obj)
+        return self._resample_func(
+            resample_kwargs, "get_group", name=name, use_range_impl=False, obj=obj
+        )
 
     def resample_app_ser(self, resample_kwargs, func, *args, **kwargs):
         return self._resample_func(
@@ -1110,24 +1163,34 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     def resample_transform(self, resample_kwargs, arg, *args, **kwargs):
         return self._resample_func(
-            resample_kwargs, "transform", arg=arg, *args, **kwargs
+            resample_kwargs, "transform", arg=arg, use_range_impl=False, *args, **kwargs
         )
 
     def resample_pipe(self, resample_kwargs, func, *args, **kwargs):
         return self._resample_func(resample_kwargs, "pipe", func=func, *args, **kwargs)
 
     def resample_ffill(self, resample_kwargs, limit):
-        return self._resample_func(resample_kwargs, "ffill", limit=limit)
+        return self._resample_func(
+            resample_kwargs, "ffill", limit=limit, use_range_impl=False
+        )
 
     def resample_bfill(self, resample_kwargs, limit):
-        return self._resample_func(resample_kwargs, "bfill", limit=limit)
+        return self._resample_func(
+            resample_kwargs, "bfill", limit=limit, use_range_impl=False
+        )
 
     def resample_nearest(self, resample_kwargs, limit):
-        return self._resample_func(resample_kwargs, "nearest", limit=limit)
+        return self._resample_func(
+            resample_kwargs, "nearest", limit=limit, use_range_impl=False
+        )
 
     def resample_fillna(self, resample_kwargs, method, limit):
         return self._resample_func(
-            resample_kwargs, "fillna", method=method, limit=limit
+            resample_kwargs,
+            "fillna",
+            method=method,
+            limit=limit,
+            use_range_impl=method is None,
         )
 
     def resample_asfreq(self, resample_kwargs, fill_value):
@@ -1154,6 +1217,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
             limit_direction=limit_direction,
             limit_area=limit_area,
             downcast=downcast,
+            use_range_impl=False,
             **kwargs,
         )
 
@@ -1164,16 +1228,20 @@ class PandasQueryCompiler(BaseQueryCompiler):
         return self._resample_func(resample_kwargs, "nunique", *args, **kwargs)
 
     def resample_first(self, resample_kwargs, *args, **kwargs):
-        return self._resample_func(resample_kwargs, "first", *args, **kwargs)
+        return self._resample_func(
+            resample_kwargs, "first", use_range_impl=False, *args, **kwargs
+        )
 
     def resample_last(self, resample_kwargs, *args, **kwargs):
-        return self._resample_func(resample_kwargs, "last", *args, **kwargs)
+        return self._resample_func(
+            resample_kwargs, "last", use_range_impl=False, *args, **kwargs
+        )
 
     def resample_max(self, resample_kwargs, *args, **kwargs):
         return self._resample_func(resample_kwargs, "max", *args, **kwargs)
 
     def resample_mean(self, resample_kwargs, *args, **kwargs):
-        return self._resample_func(resample_kwargs, "median", *args, **kwargs)
+        return self._resample_func(resample_kwargs, "mean", *args, **kwargs)
 
     def resample_median(self, resample_kwargs, *args, **kwargs):
         return self._resample_func(resample_kwargs, "median", *args, **kwargs)
@@ -1204,7 +1272,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     def resample_size(self, resample_kwargs):
         return self._resample_func(
-            resample_kwargs, "size", new_columns=[MODIN_UNNAMED_SERIES_LABEL]
+            resample_kwargs,
+            "size",
+            new_columns=[MODIN_UNNAMED_SERIES_LABEL],
+            use_range_impl=False,
         )
 
     def resample_sem(self, resample_kwargs, *args, **kwargs):

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -1083,8 +1083,10 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     df.index = df.index.droplevel(to_drop)
                     resample_kwargs = resample_kwargs.copy()
                     resample_kwargs["level"] = None
-                for ts in timestamps:
-                    df.loc[ts] = np.NaN
+                filler = pandas.DataFrame(
+                    np.NaN, index=pandas.Index(timestamps), columns=df.columns
+                )
+                df = pandas.concat([df, filler], copy=False)
             if df_op is not None:
                 df = df_op(df)
             resampled_val = df.resample(**resample_kwargs)

--- a/modin/pandas/test/dataframe/test_default.py
+++ b/modin/pandas/test/dataframe/test_default.py
@@ -1003,7 +1003,10 @@ def test_resample_specific(rule, closed, label, on, level):
 
     if on is None and level is not None:
         index = pandas.MultiIndex.from_product(
-            [["a", "b", "c"], pandas.date_range("31/12/2000", periods=4, freq="h")]
+            [
+                ["a", "b", "c", "d"],
+                pandas.date_range("31/12/2000", periods=len(pandas_df) // 4, freq="h"),
+            ]
         )
         pandas_df.index = index
         modin_df.index = index
@@ -1011,8 +1014,12 @@ def test_resample_specific(rule, closed, label, on, level):
         level = None
 
     if on is not None:
-        pandas_df[on] = pandas.date_range("22/06/1941", periods=12, freq="min")
-        modin_df[on] = pandas.date_range("22/06/1941", periods=12, freq="min")
+        pandas_df[on] = pandas.date_range(
+            "22/06/1941", periods=len(pandas_df), freq="min"
+        )
+        modin_df[on] = pandas.date_range(
+            "22/06/1941", periods=len(modin_df), freq="min"
+        )
 
     pandas_resampler = pandas_df.resample(
         rule,

--- a/modin/pandas/test/utils.py
+++ b/modin/pandas/test/utils.py
@@ -175,8 +175,11 @@ test_bool_data = {
 test_groupby_data = {f"col{i}": np.arange(NCOLS) % NGROUPS for i in range(NROWS)}
 
 test_data_resample = {
-    "data": {"A": range(12), "B": range(12)},
-    "index": pandas.date_range("31/12/2000", periods=12, freq="h"),
+    "data": {
+        f"col{i}": random_state.randint(RAND_LOW, RAND_HIGH, size=NROWS)
+        for i in range(10)
+    },
+    "index": pandas.date_range("31/12/2000", periods=NROWS, freq="h"),
 }
 
 test_data_with_duplicates = {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Adds range-partitioning impl for `df.resample()`. The new implementation doesn't always work better, so enabling it only when the flag is specified.

![image](https://github.com/modin-project/modin/assets/62142979/ac622ebe-9ffd-403a-830b-1baee79a8916)

<details><summary>script to measure</summary>

```python
import pandas
import numpy as np
import modin.pandas as pd
import modin.config as cfg

from timeit import default_timer as timer

from modin.utils import execute

cfg.CpuCount.put(16)

nrows = [1_000_000, 5_000_000, 10_000_000]
ncols = [5, 33]
rules = [
    "500ms", # doubles nrows
    "30s", # decreases nrows in 30 times
    "5min", # decreases nrows in 300
]
use_rparts = [True, False]

cols = pandas.MultiIndex.from_product([rules, ncols, use_rparts], names=["rule", "ncols", "USE RANGE PART"])
rres = pandas.DataFrame(index=nrows, columns=cols)

total_nits = len(nrows) * len(ncols) * len(rules) * len(use_rparts)
i = 0

for nrow in nrows:
    for ncol in ncols:
        index = pandas.date_range("31/12/2000", periods=nrow, freq="s")
        data = {f"col{i}": np.arange(nrow) for i in range(ncol)}
        pd_df = pandas.DataFrame(data, index=index)
        for rule in rules:
            for rparts in use_rparts:
                print(f"{round((i / total_nits) * 100, 2)}%")
                i += 1
                cfg.RangePartitioning.put(rparts)

                df = pd.DataFrame(data, index=index)
                execute(df)

                t1 = timer()
                res = df.resample(rule).sum()
                execute(res)
                ts = timer() - t1
                print(nrow, ncol, rule, rparts, ts)

                rres.loc[nrow, (rule, ncol, rparts)] = ts
                rres.to_excel("resample.xlsx")
```

</details>

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7118 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
