### PR TITLE
PERF-#7150: Reduce peak memory consumption

### DIFF
--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -453,6 +453,8 @@ class PandasDataframePartitionManager(
             other = (
                 pandas.concat(others, axis=axis ^ 1) if len(others) > 1 else others[0]
             )
+            # to reduce peak memory consumption
+            del others
             return apply_func(df, other)
 
         map_func = cls.preprocess_func(map_func)

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -800,8 +800,9 @@ class PandasDataframePartitionManager(
         pandas.DataFrame
             A pandas DataFrame
         """
-        retrieved_objects = cls.get_objects_from_partitions(partitions.flatten())
-        return create_pandas_df_from_partitions(retrieved_objects, partitions.shape)
+        return create_pandas_df_from_partitions(
+            cls.get_objects_from_partitions(partitions.flatten()), partitions.shape
+        )
 
     @classmethod
     def to_numpy(cls, partitions, **kwargs):

--- a/modin/core/dataframe/pandas/utils.py
+++ b/modin/core/dataframe/pandas/utils.py
@@ -122,8 +122,11 @@ def create_pandas_df_from_partitions(
         for row in partition_data
         if not all(is_part_empty(part) for part in row)
     ]
-    copy = not called_from_remote
+
+    # to reduce peak memory consumption
+    del partition_data
+
     if len(df_rows) == 0:
         return pandas.DataFrame()
     else:
-        return concatenate(df_rows, copy)
+        return concatenate(df_rows, copy=not called_from_remote)

--- a/modin/core/storage_formats/pandas/groupby.py
+++ b/modin/core/storage_formats/pandas/groupby.py
@@ -341,11 +341,14 @@ class PivotTableImpl:
                 Pivot table for this particular partition.
             """
             concated = pandas.concat([df, other], axis=1, copy=False)
+            # to reduce peak memory consumption
+            del df, other
             result = pandas.pivot_table(
                 concated,
                 **pivot_kwargs,
             )
-
+            # to reduce peak memory consumption
+            del concated
             # if only one value is specified, removing level that maps
             # columns from `values` to the actual values
             if drop_column_level is not None:

--- a/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
+++ b/modin/experimental/core/execution/native/implementations/hdk_on_native/dataframe/utils.py
@@ -289,6 +289,8 @@ def build_categorical_from_at(table, column_name):
     """
     chunks = table.column(column_name).chunks
     cat = pandas.concat([chunk.dictionary.to_pandas() for chunk in chunks])
+    # to reduce peak memory consumption
+    del chunks
     return pandas.CategoricalDtype(cat.unique())
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Keeping large objects (in our case, dataframes) in local variables when they are no longer needed is extremely memory-intensive. I propose to review all such places and try to free up memory as early as possible.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7150 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
