### PR TITLE
FIX-#7153: Fix `Series.corr` with `method != pearson`

### DIFF
--- a/modin/core/dataframe/algebra/default2pandas/default.py
+++ b/modin/core/dataframe/algebra/default2pandas/default.py
@@ -127,6 +127,7 @@ class DefaultMethod(Operator):
                 and func not in ("divmod", pandas.Series.divmod)
                 and func not in ("rdivmod", pandas.Series.rdivmod)
                 and func not in ("to_list", pandas.Series.to_list)
+                and func not in ("corr", pandas.Series.corr)
                 and func not in ("to_dict", pandas.Series.to_dict)
                 and func not in ("mean", pandas.DataFrame.mean)
                 and func not in ("median", pandas.DataFrame.median)

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -698,6 +698,21 @@ class BaseQueryCompiler(ClassLogger, abc.ABC, modin_layer="QUERY-COMPILER"):
         """
         return DataFrameDefault.register(pandas.DataFrame.corr)(self, **kwargs)
 
+    @doc_utils.add_refer_to("Series.corr")
+    def series_corr(self, **kwargs):  # noqa: PR01
+        """
+        Compute correlation with `other` Series, excluding missing values.
+
+        The two `Series` objects are not required to be the same length and will be
+        aligned internally before the correlation function is applied.
+
+        Returns
+        -------
+        float
+            Correlation with other.
+        """
+        return SeriesDefault.register(pandas.Series.corr)(self, **kwargs)
+
     @doc_utils.add_refer_to("DataFrame.corrwith")
     def corrwith(self, **kwargs):  # noqa: PR01
         """

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -823,8 +823,8 @@ class Series(BasePandasDataset):
                 np.clip(result.imag, -1, 1, out=result.imag)
             return result[0]
 
-        return self.__constructor__(
-            query_compiler=self._query_compiler.series_corr(other, method, min_periods)
+        return self._query_compiler.series_corr(
+            other=other, method=method, min_periods=min_periods
         )
 
     def count(self):  # noqa: PR01, RT01, D200

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -1400,11 +1400,12 @@ def test_copy_empty_series():
     assert res.dtype == ser.dtype
 
 
+@pytest.mark.parametrize("method", ["pearson", "kendall"])
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test_corr(data):
+def test_corr(data, method):
     modin_series, pandas_series = create_test_series(data)
-    modin_result = modin_series.corr(modin_series)
-    pandas_result = pandas_series.corr(pandas_series)
+    modin_result = modin_series.corr(modin_series, method=method)
+    pandas_result = pandas_series.corr(pandas_series, method=method)
     df_equals(modin_result, pandas_result)
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7153 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
