### PR TITLE
FIX-#7157: Make sure `quantile` function works with `numeric_only=True`

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -2588,7 +2588,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
         axis = kwargs.get("axis", 0)
         q = kwargs.get("q")
         numeric_only = kwargs.get("numeric_only", True)
-        assert isinstance(q, (pandas.Series, np.ndarray, pandas.Index, list))
+        assert isinstance(q, (pandas.Series, np.ndarray, pandas.Index, list, tuple))
 
         if numeric_only:
             new_columns = self._modin_frame.numeric_columns()

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -2337,6 +2337,7 @@ class BasePandasDataset(ClassLogger):
                 query_compiler=numeric_only_df._query_compiler.quantile_for_list_of_values(
                     q=q,
                     axis=axis,
+                    # `numeric_only=True` has already been processed by using `self.drop` function
                     numeric_only=False,
                     interpolation=interpolation,
                     method=method,
@@ -2347,6 +2348,7 @@ class BasePandasDataset(ClassLogger):
                 numeric_only_df._query_compiler.quantile_for_single_value(
                     q=q,
                     axis=axis,
+                    # `numeric_only=True` has already been processed by using `self.drop` function
                     numeric_only=False,
                     interpolation=interpolation,
                     method=method,

--- a/modin/tests/pandas/dataframe/test_window.py
+++ b/modin/tests/pandas/dataframe/test_window.py
@@ -676,7 +676,8 @@ def test_quantile_7157():
     n_mcols = 5
 
     df1_md, df1_pd = create_test_dfs(
-        random_state.rand(n_rows, n_fcols), columns=[f"feat_{i}" for i in range(n_fcols)]
+        random_state.rand(n_rows, n_fcols),
+        columns=[f"feat_{i}" for i in range(n_fcols)],
     )
     df2_md, df2_pd = create_test_dfs(
         {

--- a/modin/tests/pandas/dataframe/test_window.py
+++ b/modin/tests/pandas/dataframe/test_window.py
@@ -669,6 +669,31 @@ def test_quantile(request, data, q):
             modin_df.T.quantile(q)
 
 
+def test_quantile_7157():
+    # for details: https://github.com/modin-project/modin/issues/7157
+    n_rows = 100
+    n_fcols = 10
+    n_mcols = 5
+
+    df1_md, df1_pd = create_test_dfs(
+        random_state.rand(n_rows, n_fcols), columns=[f"feat_{i}" for i in range(10)]
+    )
+    df2_md, df2_pd = create_test_dfs(
+        {
+            "test_string1": ["test_string2" for _ in range(n_rows)]
+            for _ in range(n_mcols)
+        }
+    )
+    df3_md = pd.concat([df2_md, df1_md], axis=1)
+    df3_pd = pandas.concat([df2_pd, df1_pd], axis=1)
+
+    eval_general(df3_md, df3_pd, lambda df: df.quantile(0.25, numeric_only=True))
+    eval_general(df3_md, df3_pd, lambda df: df.quantile((0.25,), numeric_only=True))
+    eval_general(
+        df3_md, df3_pd, lambda df: df.quantile((0.25, 0.75), numeric_only=True)
+    )
+
+
 @pytest.mark.parametrize("axis", ["rows", "columns"])
 @pytest.mark.parametrize(
     "na_option", ["keep", "top", "bottom"], ids=["keep", "top", "bottom"]

--- a/modin/tests/pandas/dataframe/test_window.py
+++ b/modin/tests/pandas/dataframe/test_window.py
@@ -676,7 +676,7 @@ def test_quantile_7157():
     n_mcols = 5
 
     df1_md, df1_pd = create_test_dfs(
-        random_state.rand(n_rows, n_fcols), columns=[f"feat_{i}" for i in range(10)]
+        random_state.rand(n_rows, n_fcols), columns=[f"feat_{i}" for i in range(n_fcols)]
     )
     df2_md, df2_pd = create_test_dfs(
         {


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7157 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
