### PR TITLE
REFACTOR-#7105: Deprecate 'cfg.RangePartitioningGroupby'

### DIFF
--- a/.github/actions/run-core-tests/group_3/action.yml
+++ b/.github/actions/run-core-tests/group_3/action.yml
@@ -19,7 +19,7 @@ runs:
         shell: bash -l {0}
       - run: |
           echo "::group::Running range-partitioning tests (group 3)..."
-          MODIN_RANGE_PARTITIONING_GROUPBY=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/tests/pandas/test_groupby.py
+          MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/tests/pandas/test_groupby.py
           MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/tests/pandas/test_series.py -k "test_unique or test_nunique or drop_duplicates or test_resample"
           MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/tests/pandas/test_general.py -k "test_unique"
           MODIN_RANGE_PARTITIONING=1 ${{ inputs.runner }} ${{ inputs.parallel }} modin/tests/pandas/dataframe/test_map_metadata.py -k "drop_duplicates"

--- a/docs/flow/modin/experimental/range_partitioning_groupby.rst
+++ b/docs/flow/modin/experimental/range_partitioning_groupby.rst
@@ -4,16 +4,16 @@ Range-partitioning GroupBy
 The range-partitioning GroupBy implementation utilizes Modin's reshuffling mechanism that gives an
 ability to build range partitioning over a Modin DataFrame.
 
-In order to enable/disable the range-partitiong implementation you have to specify ``cfg.RangePartitioningGroupby``
+In order to enable/disable the range-partitiong implementation you have to specify ``cfg.RangePartitioning``
 :doc:`configuration variable: </flow/modin/config>`
 
 .. code-block:: ipython
 
-    In [4]: import modin.config as cfg; cfg.RangePartitioningGroupby.put(True)
+    In [4]: import modin.config as cfg; cfg.RangePartitioning.put(True)
 
     In [5]: # past this point, Modin will always use the range-partitiong groupby implementation
 
-    In [6]: cfg.RangePartitioningGroupby.put(False)
+    In [6]: cfg.RangePartitioning.put(False)
 
     In [7]: # past this point, Modin won't use range-partitiong groupby implementation anymore
 
@@ -32,7 +32,7 @@ The range-partitiong implementation appears to be quite efficient when compared 
     In [6]: %timeit df.groupby("col0").nunique() # full-axis implementation
     Out[6]: # 2.73 s ± 28.8 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
 
-    In [7]: import modin.config as cfg; cfg.RangePartitioningGroupby.put(True)
+    In [7]: import modin.config as cfg; cfg.RangePartitioning.put(True)
 
     In [8]: %timeit df.groupby("col0").nunique() # range-partitiong implementation
     Out[8]: # 595 ms ± 61.3 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
@@ -51,7 +51,7 @@ have too few unique values (and thus fewer units of parallelization):
     In [6]: %timeit df.groupby("col0").sum() # TreeReduce implementation
     Out[6]: # 155 ms ± 5.02 ms per loop (mean ± std. dev. of 7 runs, 10 loops each)
 
-    In [7]: import modin.config as cfg; cfg.RangePartitioningGroupby.put(True)
+    In [7]: import modin.config as cfg; cfg.RangePartitioning.put(True)
 
     In [8]: %timeit df.groupby("col0").sum() # range-partitiong implementation
     Out[8]: # 230 ms ± 22.2 ms per loop (mean ± std. dev. of 7 runs, 1 loop each)
@@ -65,7 +65,7 @@ implementation with the respective warning if it meets an unsupported case:
 
 .. code-block:: python
 
-    In [14]: import modin.config as cfg; cfg.RangePartitioningGroupby.put(True)
+    In [14]: import modin.config as cfg; cfg.RangePartitioning.put(True)
 
     In [15]: df.groupby(level=0).sum()
     Out[15]: # UserWarning: Can't use range-partitiong groupby implementation because of:

--- a/modin/config/__init__.py
+++ b/modin/config/__init__.py
@@ -55,6 +55,7 @@ from modin.config.envvars import (
     TestReadFromPostgres,
     TestReadFromSqlServer,
     TrackFileLeaks,
+    use_range_partitioning_groupby,
 )
 from modin.config.pubsub import Parameter, ValueSource, context
 
@@ -96,6 +97,7 @@ __all__ = [
     "ExperimentalNumPyAPI",
     "RangePartitioningGroupby",
     "RangePartitioning",
+    "use_range_partitioning_groupby",
     "ExperimentalGroupbyImpl",
     "AsyncReadMode",
     "ReadSqlEngine",

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -733,7 +733,7 @@ ExperimentalNumPyAPI._deprecation_descriptor = DeprecationDescriptor(
 )
 
 
-class RangePartitioning(EnvWithSibilings, type=bool):
+class RangePartitioning(EnvironmentVariable, type=bool):
     """
     Set to true to use Modin's range-partitioning implementation where possible.
 
@@ -743,11 +743,6 @@ class RangePartitioning(EnvWithSibilings, type=bool):
 
     varname = "MODIN_RANGE_PARTITIONING"
     default = False
-
-    @classmethod
-    def _sibling(cls) -> type[EnvWithSibilings]:
-        """Get a parameter sibling."""
-        return RangePartitioningGroupby
 
 
 class RangePartitioningGroupby(EnvWithSibilings, type=bool):
@@ -794,6 +789,26 @@ class ExperimentalGroupbyImpl(EnvWithSibilings, type=bool):
 ExperimentalGroupbyImpl._deprecation_descriptor = DeprecationDescriptor(
     ExperimentalGroupbyImpl, RangePartitioningGroupby
 )
+
+
+def use_range_partitioning_groupby() -> bool:
+    """
+    Determine whether range-partitioning implementation for groupby was enabled by a user.
+
+    This is a temporary helper function that queries ``RangePartitioning`` and deprecated
+    ``RangePartitioningGroupby`` config variables in order to determine whether to range-part
+    impl for groupby is enabled. Eventially this function should be removed together with
+    ``RangePartitioningGroupby`` variable.
+
+    Returns
+    -------
+    bool
+    """
+    with warnings.catch_warnings():
+        # filter deprecation warning, it was already showed when a user set the variable
+        warnings.filterwarnings("ignore", category=FutureWarning)
+        old_range_part_var = RangePartitioningGroupby.get()
+    return RangePartitioning.get() or old_range_part_var
 
 
 class CIAWSSecretAccessKey(EnvironmentVariable, type=str):

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -733,14 +733,28 @@ ExperimentalNumPyAPI._deprecation_descriptor = DeprecationDescriptor(
 )
 
 
+class RangePartitioning(EnvWithSibilings, type=bool):
+    """
+    Set to true to use Modin's range-partitioning implementation where possible.
+
+    Please refer to documentation for cases where enabling this options would be beneficial:
+    https://modin.readthedocs.io/en/stable/flow/modin/experimental/range_partitioning_groupby.html
+    """
+
+    varname = "MODIN_RANGE_PARTITIONING"
+    default = False
+
+    @classmethod
+    def _sibling(cls) -> type[EnvWithSibilings]:
+        """Get a parameter sibling."""
+        return RangePartitioningGroupby
+
+
 class RangePartitioningGroupby(EnvWithSibilings, type=bool):
     """
     Set to true to use Modin's range-partitioning group by implementation.
 
-    Experimental groupby is implemented using a range-partitioning technique,
-    note that it may not always work better than the original Modin's TreeReduce
-    and FullAxis implementations. For more information visit the according section
-    of Modin's documentation: TODO: add a link to the section once it's written.
+    This parameter is deprecated. Use ``RangePartitioning`` instead.
     """
 
     varname = "MODIN_RANGE_PARTITIONING_GROUPBY"
@@ -752,11 +766,18 @@ class RangePartitioningGroupby(EnvWithSibilings, type=bool):
         return ExperimentalGroupbyImpl
 
 
+# Let the parameter's handling logic know that this variable is deprecated and that
+# we should raise respective warnings
+RangePartitioningGroupby._deprecation_descriptor = DeprecationDescriptor(
+    RangePartitioningGroupby, RangePartitioning
+)
+
+
 class ExperimentalGroupbyImpl(EnvWithSibilings, type=bool):
     """
     Set to true to use Modin's range-partitioning group by implementation.
 
-    This parameter is deprecated. Use ``RangePartitioningGroupby`` instead.
+    This parameter is deprecated. Use ``RangePartitioning`` instead.
     """
 
     varname = "MODIN_EXPERIMENTAL_GROUPBY"
@@ -773,18 +794,6 @@ class ExperimentalGroupbyImpl(EnvWithSibilings, type=bool):
 ExperimentalGroupbyImpl._deprecation_descriptor = DeprecationDescriptor(
     ExperimentalGroupbyImpl, RangePartitioningGroupby
 )
-
-
-class RangePartitioning(EnvironmentVariable, type=bool):
-    """
-    Set to true to use Modin's range-partitioning implementation where possible.
-
-    Please refer to documentation for cases where enabling this options would be beneficial:
-    https://modin.readthedocs.io/en/stable/flow/modin/experimental/range_partitioning_groupby.html
-    """
-
-    varname = "MODIN_RANGE_PARTITIONING"
-    default = False
 
 
 class CIAWSSecretAccessKey(EnvironmentVariable, type=str):

--- a/modin/core/storage_formats/pandas/groupby.py
+++ b/modin/core/storage_formats/pandas/groupby.py
@@ -13,10 +13,12 @@
 
 """Contains implementations for GroupbyReduce functions."""
 
+import warnings
+
 import numpy as np
 import pandas
 
-from modin.config import RangePartitioningGroupby
+from modin.config import RangePartitioning, RangePartitioningGroupby
 from modin.core.dataframe.algebra import GroupByReduce
 from modin.error_message import ErrorMessage
 from modin.utils import hashable
@@ -93,7 +95,11 @@ class GroupbyReduceImpl:
         )
 
         def method(query_compiler, *args, **kwargs):
-            if RangePartitioningGroupby.get():
+            with warnings.catch_warnings():
+                # filter deprecation warning, it was already showed when a user set the variable
+                warnings.filterwarnings("ignore", category=FutureWarning)
+                old_range_part_var = RangePartitioningGroupby.get()
+            if RangePartitioning.get() or old_range_part_var:
                 try:
                     if finalizer_fn is not None:
                         raise NotImplementedError(

--- a/modin/core/storage_formats/pandas/groupby.py
+++ b/modin/core/storage_formats/pandas/groupby.py
@@ -13,12 +13,10 @@
 
 """Contains implementations for GroupbyReduce functions."""
 
-import warnings
-
 import numpy as np
 import pandas
 
-from modin.config import RangePartitioning, RangePartitioningGroupby
+from modin.config import use_range_partitioning_groupby
 from modin.core.dataframe.algebra import GroupByReduce
 from modin.error_message import ErrorMessage
 from modin.utils import hashable
@@ -95,11 +93,7 @@ class GroupbyReduceImpl:
         )
 
         def method(query_compiler, *args, **kwargs):
-            with warnings.catch_warnings():
-                # filter deprecation warning, it was already showed when a user set the variable
-                warnings.filterwarnings("ignore", category=FutureWarning)
-                old_range_part_var = RangePartitioningGroupby.get()
-            if RangePartitioning.get() or old_range_part_var:
+            if use_range_partitioning_groupby():
                 try:
                     if finalizer_fn is not None:
                         raise NotImplementedError(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3537,7 +3537,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
         return result
 
     def groupby_mean(self, by, axis, groupby_kwargs, agg_args, agg_kwargs, drop=False):
-        if RangePartitioningGroupby.get():
+        with warnings.catch_warnings():
+            # filter deprecation warning, it was already showed when a user set the variable
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            old_range_part_var = RangePartitioningGroupby.get()
+        if RangePartitioning.get() or old_range_part_var:
             try:
                 return self._groupby_shuffle(
                     by=by,
@@ -3608,7 +3612,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
         agg_kwargs,
         drop=False,
     ):
-        if RangePartitioningGroupby.get():
+        with warnings.catch_warnings():
+            # filter deprecation warning, it was already showed when a user set the variable
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            old_range_part_var = RangePartitioningGroupby.get()
+        if RangePartitioning.get() or old_range_part_var:
             try:
                 return self._groupby_shuffle(
                     by=by,
@@ -4027,9 +4035,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
             )
 
         # 'group_wise' means 'groupby.apply()'. We're certain that range-partitioning groupby
-        # always works better for '.apply()', so we're using it regardless of the 'RangePartitioningGroupby'
+        # always works better for '.apply()', so we're using it regardless of the 'RangePartitioning'
         # value
-        if how == "group_wise" or RangePartitioningGroupby.get():
+        with warnings.catch_warnings():
+            # filter deprecation warning, it was already showed when a user set the variable
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            old_range_part_var = RangePartitioningGroupby.get()
+        if how == "group_wise" or RangePartitioning.get() or old_range_part_var:
             try:
                 return self._groupby_shuffle(
                     by=by,
@@ -4050,7 +4062,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
                     + "\nFalling back to a full-axis implementation."
                 )
                 get_logger().info(message)
-                if RangePartitioningGroupby.get():
+                if RangePartitioning.get() or old_range_part_var:
                     ErrorMessage.warn(message)
 
         if isinstance(agg_func, dict) and GroupbyReduceImpl.has_impl_for(agg_func):

--- a/modin/tests/config/test_envvars.py
+++ b/modin/tests/config/test_envvars.py
@@ -156,8 +156,9 @@ def test_hdk_envvar():
 @pytest.mark.parametrize(
     "deprecated_var, new_var",
     [
-        (cfg.ExperimentalGroupbyImpl, cfg.RangePartitioningGroupby),
+        (cfg.ExperimentalGroupbyImpl, cfg.RangePartitioning),
         (cfg.ExperimentalNumPyAPI, cfg.ModinNumpy),
+        (cfg.RangePartitioningGroupby, cfg.RangePartitioning),
     ],
 )
 def test_deprecated_bool_vars_warnings(deprecated_var, new_var):

--- a/modin/tests/core/storage_formats/pandas/test_internals.py
+++ b/modin/tests/core/storage_formats/pandas/test_internals.py
@@ -20,7 +20,7 @@ import pandas
 import pytest
 
 import modin.pandas as pd
-from modin.config import Engine, MinPartitionSize, NPartitions, RangePartitioningGroupby
+from modin.config import Engine, MinPartitionSize, NPartitions, RangePartitioning
 from modin.core.dataframe.pandas.dataframe.dataframe import PandasDataframe
 from modin.core.dataframe.pandas.dataframe.utils import ColumnInfo, ShuffleSortFunctions
 from modin.core.dataframe.pandas.metadata import (
@@ -1174,9 +1174,7 @@ def test_setitem_unhashable_preserve_dtypes():
     assert df._query_compiler._modin_frame.has_materialized_dtypes
 
 
-@pytest.mark.parametrize(
-    "modify_config", [{RangePartitioningGroupby: True}], indirect=True
-)
+@pytest.mark.parametrize("modify_config", [{RangePartitioning: True}], indirect=True)
 def test_groupby_size_shuffling(modify_config):
     # verifies that 'groupby.size()' works with reshuffling implementation
     # https://github.com/modin-project/modin/issues/6367
@@ -2447,7 +2445,7 @@ class TestZeroComputationDtypes:
             assert res_dtypes._known_dtypes["a"] == np.dtype("int64")
 
             # case 2: ExperimentalImpl impl, Series as an output of groupby
-            RangePartitioningGroupby.put(True)
+            RangePartitioning.put(True)
             try:
                 df = pd.DataFrame({"a": [1, 2, 2], "b": [3, 4, 5]})
                 res = df.groupby("a").size().reset_index(name="new_name")
@@ -2455,7 +2453,7 @@ class TestZeroComputationDtypes:
                 assert "a" in res_dtypes._known_dtypes
                 assert res_dtypes._known_dtypes["a"] == np.dtype("int64")
             finally:
-                RangePartitioningGroupby.put(False)
+                RangePartitioning.put(False)
 
             # case 3: MapReduce impl, DataFrame as an output of groupby
             df = pd.DataFrame({"a": [1, 2, 2], "b": [3, 4, 5]})
@@ -2465,7 +2463,7 @@ class TestZeroComputationDtypes:
             assert res_dtypes._known_dtypes["a"] == np.dtype("int64")
 
             # case 4: ExperimentalImpl impl, DataFrame as an output of groupby
-            RangePartitioningGroupby.put(True)
+            RangePartitioning.put(True)
             try:
                 df = pd.DataFrame({"a": [1, 2, 2], "b": [3, 4, 5]})
                 res = df.groupby("a").sum().reset_index()
@@ -2473,7 +2471,7 @@ class TestZeroComputationDtypes:
                 assert "a" in res_dtypes._known_dtypes
                 assert res_dtypes._known_dtypes["a"] == np.dtype("int64")
             finally:
-                RangePartitioningGroupby.put(False)
+                RangePartitioning.put(False)
 
             # case 5: FullAxis impl, DataFrame as an output of groupby
             df = pd.DataFrame({"a": [1, 2, 2], "b": [3, 4, 5]})

--- a/modin/tests/pandas/utils.py
+++ b/modin/tests/pandas/utils.py
@@ -42,7 +42,6 @@ from modin.config import (
     MinPartitionSize,
     NPartitions,
     RangePartitioning,
-    RangePartitioningGroupby,
     TestDatasetSize,
     TrackFileLeaks,
 )
@@ -700,7 +699,7 @@ def sort_if_range_partitioning(df1, df2, comparator=None):
     if comparator is None:
         comparator = df_equals
 
-    if RangePartitioning.get() or RangePartitioningGroupby.get():
+    if RangePartitioning.get() or RangePartitioning.get():
         df1, df2 = sort_data(df1), sort_data(df2)
 
     comparator(df1, df2)

--- a/modin/tests/pandas/utils.py
+++ b/modin/tests/pandas/utils.py
@@ -44,6 +44,7 @@ from modin.config import (
     RangePartitioning,
     TestDatasetSize,
     TrackFileLeaks,
+    use_range_partitioning_groupby,
 )
 from modin.pandas.io import to_pandas
 from modin.pandas.testing import (
@@ -699,7 +700,7 @@ def sort_if_range_partitioning(df1, df2, comparator=None):
     if comparator is None:
         comparator = df_equals
 
-    if RangePartitioning.get() or RangePartitioning.get():
+    if RangePartitioning.get() or use_range_partitioning_groupby():
         df1, df2 = sort_data(df1), sort_data(df2)
 
     comparator(df1, df2)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Deprecate `cfg.RangePartitioningGroupby` in favor of `cfg.RangePartitioning`

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7105 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
