### PR TITLE
Revert "TEST-#7166: Fix HDF tests in CI (#7167)"

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -31,7 +31,6 @@ dependencies:
   - sqlalchemy>=2.0.0
   - pandas-gbq>=0.19.0
   - pytables>=3.8.0
-  - c-blosc2<=2.14.1
   # pymssql==2.2.8 broken: https://github.com/modin-project/modin/issues/6429
   - pymssql>=2.1.5,!=2.2.8
   - psycopg2>=2.9.6

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -21,7 +21,6 @@ dependencies:
   - matplotlib>=3.6.3
   - xarray>=2022.12.0
   - pytables>=3.8.0
-  - c-blosc2<=2.14.1
   - fastparquet>=2022.12.0
   # pandas isn't compatible with numexpr=2.8.5: https://github.com/modin-project/modin/issues/6469
   - numexpr<2.8.5

--- a/requirements/env_unidist_linux.yml
+++ b/requirements/env_unidist_linux.yml
@@ -26,7 +26,6 @@ dependencies:
   - sqlalchemy>=2.0.0
   - pandas-gbq>=0.19.0
   - pytables>=3.8.0
-  - c-blosc2<=2.14.1
   # pymssql==2.2.8 broken: https://github.com/modin-project/modin/issues/6429
   - pymssql>=2.1.5,!=2.2.8
   - psycopg2>=2.9.6

--- a/requirements/env_unidist_win.yml
+++ b/requirements/env_unidist_win.yml
@@ -26,7 +26,6 @@ dependencies:
   - sqlalchemy>=2.0.0
   - pandas-gbq>=0.19.0
   - pytables>=3.8.0
-  - c-blosc2<=2.14.1
   # pymssql==2.2.8 broken: https://github.com/modin-project/modin/issues/6429
   - pymssql>=2.1.5,!=2.2.8
   - psycopg2>=2.9.6

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -23,7 +23,6 @@ dependencies:
   - sqlalchemy>=2.0.0
   - pandas-gbq>=0.19.0
   - pytables>=3.8.0
-  - c-blosc2<=2.14.1
   - tqdm>=4.60.0
   # pandas isn't compatible with numexpr=2.8.5: https://github.com/modin-project/modin/issues/6469
   - numexpr<2.8.5


### PR DESCRIPTION
This reverts commit 975b32ce16f076c449c0e22ad7236448da6ebc6b.

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Should already be fixed in https://github.com/conda-forge/pytables-feedstock/issues/97

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
