### PR TITLE
FIX-#7170: Don't use `MinPartitionSize` configuration variable in remote context

### DIFF
--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -18,6 +18,7 @@ import warnings
 import numpy as np
 import pandas
 
+from modin.config import MinPartitionSize
 from modin.core.dataframe.base.partitioning.axis_partition import (
     BaseDataframeAxisPartition,
 )
@@ -392,6 +393,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         maintain_partitioning,
         *partitions,
         lengths=None,
+        min_block_size=None,
         manual_partition=False,
         return_generator=False,
     ):
@@ -473,10 +475,16 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
                     lengths = None
         if return_generator:
             return generate_result_of_axis_func_pandas(
-                axis, num_splits, result, lengths
+                axis,
+                num_splits,
+                result,
+                lengths,
+                min_block_size=min_block_size,
             )
         else:
-            return split_result_of_axis_func_pandas(axis, num_splits, result, lengths)
+            return split_result_of_axis_func_pandas(
+                axis, num_splits, result, lengths, min_block_size=min_block_size
+            )
 
     @classmethod
     def deploy_func_between_two_axis_partitions(

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -18,7 +18,6 @@ import warnings
 import numpy as np
 import pandas
 
-from modin.config import MinPartitionSize
 from modin.core.dataframe.base.partitioning.axis_partition import (
     BaseDataframeAxisPartition,
 )

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -391,8 +391,8 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         num_splits,
         maintain_partitioning,
         *partitions,
+        min_block_size,
         lengths=None,
-        min_block_size=None,
         manual_partition=False,
         return_generator=False,
     ):
@@ -416,6 +416,8 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
             If False, create a new partition layout.
         *partitions : iterable
             All partitions that make up the full axis (row or column).
+        min_block_size : int
+            Minimum number of rows/columns in a single split.
         lengths : list, optional
             The list of lengths to shuffle the object.
         manual_partition : bool, default: False
@@ -477,12 +479,12 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
                 axis,
                 num_splits,
                 result,
+                min_block_size,
                 lengths,
-                min_block_size=min_block_size,
             )
         else:
             return split_result_of_axis_func_pandas(
-                axis, num_splits, result, lengths, min_block_size=min_block_size
+                axis, num_splits, result, min_block_size, lengths
             )
 
     @classmethod
@@ -496,6 +498,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
         len_of_left,
         other_shape,
         *partitions,
+        min_block_size,
         return_generator=False,
     ):
         """
@@ -520,6 +523,8 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
             (other_shape[i-1], other_shape[i]) will indicate slice to restore i-1 axis partition.
         *partitions : iterable
             All partitions that make up the full axis (row or column) for both data sets.
+        min_block_size : int
+            Minimum number of rows/columns in a single split.
         return_generator : bool, default: False
             Return a generator from the function, set to `True` for Ray backend
             as Ray remote functions can return Generators.
@@ -566,12 +571,14 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
                 axis,
                 num_splits,
                 result,
+                min_block_size,
             )
         else:
             return split_result_of_axis_func_pandas(
                 axis,
                 num_splits,
                 result,
+                min_block_size,
             )
 
     @classmethod

--- a/modin/core/dataframe/pandas/partitioning/axis_partition.py
+++ b/modin/core/dataframe/pandas/partitioning/axis_partition.py
@@ -18,6 +18,7 @@ import warnings
 import numpy as np
 import pandas
 
+from modin.config import MinPartitionSize
 from modin.core.dataframe.base.partitioning.axis_partition import (
     BaseDataframeAxisPartition,
 )
@@ -276,6 +277,7 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
                             for part in axis_partition.list_of_blocks
                         ]
                     ),
+                    min_block_size=MinPartitionSize.get(),
                 )
             )
         result = self._wrap_partitions(
@@ -287,8 +289,9 @@ class PandasDataframeAxisPartition(BaseDataframeAxisPartition):
                 num_splits,
                 maintain_partitioning,
                 *self.list_of_blocks,
-                manual_partition=manual_partition,
+                min_block_size=MinPartitionSize.get(),
                 lengths=lengths,
+                manual_partition=manual_partition,
             )
         )
         if self.full_axis:

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -30,6 +30,7 @@ from pandas._libs.lib import no_default
 from modin.config import (
     BenchmarkMode,
     Engine,
+    MinPartitionSize,
     NPartitions,
     PersistentPickle,
     ProgressBar,
@@ -890,8 +891,9 @@ class PandasDataframePartitionManager(
             A NumPy array with partitions (with dimensions or not).
         """
         num_splits = NPartitions.get()
-        row_chunksize = compute_chunksize(df.shape[0], num_splits)
-        col_chunksize = compute_chunksize(df.shape[1], num_splits)
+        min_block_size = MinPartitionSize.get()
+        row_chunksize = compute_chunksize(df.shape[0], num_splits, min_block_size)
+        col_chunksize = compute_chunksize(df.shape[1], num_splits, min_block_size)
 
         bar_format = (
             "{l_bar}{bar}{r_bar}"

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -17,6 +17,7 @@ import pandas
 from distributed import Future
 from distributed.utils import get_ip
 
+from modin.config import MinPartitionSize
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
@@ -161,6 +162,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
             f_kwargs={
                 "lengths": lengths,
                 "manual_partition": manual_partition,
+                "min_block_size": MinPartitionSize.get(),
             },
             num_returns=result_num_splits * (1 + cls._PARTITIONS_METADATA_LEN),
             pure=False,

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -17,7 +17,6 @@ import pandas
 from distributed import Future
 from distributed.utils import get_ip
 
-from modin.config import MinPartitionSize
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
@@ -113,6 +112,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         num_splits,
         maintain_partitioning,
         *partitions,
+        min_block_size,
         lengths=None,
         manual_partition=False,
     ):
@@ -136,6 +136,8 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
             If False, create a new partition layout.
         *partitions : iterable
             All partitions that make up the full axis (row or column).
+        min_block_size : int
+            Minimum number of rows/columns in a single split.
         lengths : iterable, default: None
             The list of lengths to shuffle the partition into.
         manual_partition : bool, default: False
@@ -160,7 +162,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
                 *partitions,
             ),
             f_kwargs={
-                "min_block_size": MinPartitionSize.get(),
+                "min_block_size": min_block_size,
                 "lengths": lengths,
                 "manual_partition": manual_partition,
             },
@@ -179,6 +181,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
         len_of_left,
         other_shape,
         *partitions,
+        min_block_size,
     ):
         """
         Deploy a function along a full axis between two data sets.
@@ -202,6 +205,8 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
             (other_shape[i-1], other_shape[i]) will indicate slice to restore i-1 axis partition.
         *partitions : iterable
             All partitions that make up the full axis (row or column) for both data sets.
+        min_block_size : int
+            Minimum number of rows/columns in a single split.
 
         Returns
         -------
@@ -220,7 +225,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
                 len_of_left,
                 other_shape,
                 *partitions,
-                MinPartitionSize.get(),
+                min_block_size,
             ),
             num_returns=num_splits * (1 + cls._PARTITIONS_METADATA_LEN),
             pure=False,

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -225,8 +225,10 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
                 len_of_left,
                 other_shape,
                 *partitions,
-                min_block_size,
             ),
+            f_kwargs={
+                "min_block_size": min_block_size,
+            },
             num_returns=num_splits * (1 + cls._PARTITIONS_METADATA_LEN),
             pure=False,
         )

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -160,9 +160,9 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
                 *partitions,
             ),
             f_kwargs={
+                "min_block_size": MinPartitionSize.get(),
                 "lengths": lengths,
                 "manual_partition": manual_partition,
-                "min_block_size": MinPartitionSize.get(),
             },
             num_returns=result_num_splits * (1 + cls._PARTITIONS_METADATA_LEN),
             pure=False,

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -220,6 +220,7 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
                 len_of_left,
                 other_shape,
                 *partitions,
+                MinPartitionSize.get(),
             ),
             num_returns=num_splits * (1 + cls._PARTITIONS_METADATA_LEN),
             pure=False,

--- a/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition_manager.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/partition_manager.py
@@ -16,7 +16,7 @@
 import numpy as np
 import ray
 
-from modin.config import GpuCount
+from modin.config import GpuCount, MinPartitionSize
 from modin.core.execution.ray.common import RayWrapper
 from modin.core.execution.ray.generic.partitioning import (
     GenericRayDataframePartitionManager,
@@ -125,7 +125,9 @@ class cuDFOnRayDataframePartitionManager(GenericRayDataframePartitionManager):
         num_splits = GpuCount.get()
         put_func = cls._partition_class.put
         # For now, we default to row partitioning
-        pandas_dfs = split_result_of_axis_func_pandas(0, num_splits, df)
+        pandas_dfs = split_result_of_axis_func_pandas(
+            0, num_splits, df, min_block_size=MinPartitionSize.get()
+        )
         keys = [
             put_func(cls._get_gpu_managers()[i], pandas_dfs[i])
             for i in range(num_splits)

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -17,6 +17,7 @@ import pandas
 import ray
 from ray.util import get_node_ip_address
 
+from modin.config import MinPartitionSize
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
@@ -189,6 +190,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             f_kwargs=f_kwargs,
             manual_partition=manual_partition,
             lengths=lengths,
+            min_block_size=MinPartitionSize.get(),
             return_generator=True,
         )
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -189,8 +189,8 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             f_len_args=len(f_args),
             f_kwargs=f_kwargs,
             manual_partition=manual_partition,
-            lengths=lengths,
             min_block_size=MinPartitionSize.get(),
+            lengths=lengths,
             return_generator=True,
         )
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -17,7 +17,6 @@ import pandas
 import ray
 from ray.util import get_node_ip_address
 
-from modin.config import MinPartitionSize
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
@@ -138,6 +137,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         num_splits,
         maintain_partitioning,
         *partitions,
+        min_block_size,
         lengths=None,
         manual_partition=False,
         max_retries=None,
@@ -162,6 +162,8 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             If False, create a new partition layout.
         *partitions : iterable
             All partitions that make up the full axis (row or column).
+        min_block_size : int
+            Minimum number of rows/columns in a single split.
         lengths : list, optional
             The list of lengths to shuffle the object.
         manual_partition : bool, default: False
@@ -189,7 +191,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             f_len_args=len(f_args),
             f_kwargs=f_kwargs,
             manual_partition=manual_partition,
-            min_block_size=MinPartitionSize.get(),
+            min_block_size=min_block_size,
             lengths=lengths,
             return_generator=True,
         )
@@ -205,6 +207,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
         len_of_left,
         other_shape,
         *partitions,
+        min_block_size,
     ):
         """
         Deploy a function along a full axis between two data sets.
@@ -228,6 +231,8 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             (other_shape[i-1], other_shape[i]) will indicate slice to restore i-1 axis partition.
         *partitions : iterable
             All partitions that make up the full axis (row or column) for both data sets.
+        min_block_size : int
+            Minimum number of rows/columns in a single split.
 
         Returns
         -------
@@ -247,7 +252,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             f_to_deploy=func,
             f_len_args=len(f_args),
             f_kwargs=f_kwargs,
-            min_block_size=MinPartitionSize.get(),
+            min_block_size=min_block_size,
             return_generator=True,
         )
 

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -247,6 +247,7 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
             f_to_deploy=func,
             f_len_args=len(f_args),
             f_kwargs=f_kwargs,
+            min_block_size=MinPartitionSize.get(),
             return_generator=True,
         )
 

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -18,6 +18,7 @@ import warnings
 import pandas
 import unidist
 
+from modin.config import MinPartitionSize
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
@@ -189,6 +190,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
             *partitions,
             manual_partition=manual_partition,
             lengths=lengths,
+            min_block_size=MinPartitionSize.get(),
         )
 
     @classmethod

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -18,7 +18,6 @@ import warnings
 import pandas
 import unidist
 
-from modin.config import MinPartitionSize
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
@@ -139,6 +138,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         num_splits,
         maintain_partitioning,
         *partitions,
+        min_block_size,
         lengths=None,
         manual_partition=False,
         max_retries=None,
@@ -163,6 +163,8 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
             If False, create a new partition layout.
         *partitions : iterable
             All partitions that make up the full axis (row or column).
+        min_block_size : int
+            Minimum number of rows/columns in a single split.
         lengths : list, optional
             The list of lengths to shuffle the object.
         manual_partition : bool, default: False
@@ -189,7 +191,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
             maintain_partitioning,
             *partitions,
             manual_partition=manual_partition,
-            min_block_size=MinPartitionSize.get(),
+            min_block_size=min_block_size,
             lengths=lengths,
         )
 
@@ -204,6 +206,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
         len_of_left,
         other_shape,
         *partitions,
+        min_block_size,
     ):
         """
         Deploy a function along a full axis between two data sets.
@@ -227,6 +230,8 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
             (other_shape[i-1], other_shape[i]) will indicate slice to restore i-1 axis partition.
         *partitions : iterable
             All partitions that make up the full axis (row or column) for both data sets.
+        min_block_size : int
+            Minimum number of rows/columns in a single split.
 
         Returns
         -------
@@ -245,7 +250,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
             len_of_left,
             other_shape,
             *partitions,
-            MinPartitionSize.get(),
+            min_block_size,
         )
 
     def wait(self):

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -245,6 +245,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
             len_of_left,
             other_shape,
             *partitions,
+            MinPartitionSize.get(),
         )
 
     def wait(self):

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -189,8 +189,8 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
             maintain_partitioning,
             *partitions,
             manual_partition=manual_partition,
-            lengths=lengths,
             min_block_size=MinPartitionSize.get(),
+            lengths=lengths,
         )
 
     @classmethod

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -250,7 +250,7 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
             len_of_left,
             other_shape,
             *partitions,
-            min_block_size,
+            min_block_size=min_block_size,
         )
 
     def wait(self):

--- a/modin/core/io/column_stores/column_store_dispatcher.py
+++ b/modin/core/io/column_stores/column_store_dispatcher.py
@@ -121,7 +121,6 @@ class ColumnStoreDispatcher(FileDispatcher):
         row_lengths : list
             List with lengths of index chunks.
         """
-        num_partitions = NPartitions.get()
         index_len = (
             0 if len(partition_ids) == 0 else cls.materialize(partition_ids[-2][0])
         )
@@ -130,7 +129,9 @@ class ColumnStoreDispatcher(FileDispatcher):
         else:
             index = index_len
             index_len = len(index)
-        index_chunksize = compute_chunksize(index_len, num_partitions)
+        num_partitions = NPartitions.get()
+        min_block_size = MinPartitionSize.get()
+        index_chunksize = compute_chunksize(index_len, num_partitions, min_block_size)
         if index_chunksize > index_len:
             row_lengths = [index_len] + [0 for _ in range(num_partitions - 1)]
         else:

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -722,7 +722,9 @@ class ParquetDispatcher(ColumnStoreDispatcher):
                     for i in range(num_splits):
                         new_parts[offset + i].append(split[i])
 
-                new_row_lengths.extend(get_length_list(part_len, num_splits))
+                new_row_lengths.extend(
+                    get_length_list(part_len, num_splits, MinPartitionSize.get())
+                )
 
             remote_parts = np.array(new_parts)
             row_lengths = new_row_lengths
@@ -746,7 +748,9 @@ class ParquetDispatcher(ColumnStoreDispatcher):
                     for row_parts in remote_parts
                 ]
             )
-            column_widths = get_length_list(sum(column_widths), desired_col_nparts)
+            column_widths = get_length_list(
+                sum(column_widths), desired_col_nparts, MinPartitionSize.get()
+            )
 
         return remote_parts, row_lengths, column_widths
 

--- a/modin/core/io/text/text_file_dispatcher.py
+++ b/modin/core/io/text/text_file_dispatcher.py
@@ -30,7 +30,7 @@ import pandas._libs.lib as lib
 from pandas.core.dtypes.common import is_list_like
 from pandas.io.common import stringify_path
 
-from modin.config import NPartitions
+from modin.config import MinPartitionSize, NPartitions
 from modin.core.io.file_dispatcher import FileDispatcher, OpenFile
 from modin.core.io.text.utils import CustomNewlineIterator
 from modin.core.storage_formats.pandas.utils import compute_chunksize
@@ -571,7 +571,8 @@ class TextFileDispatcher(FileDispatcher):
         """
         # This is the number of splits for the columns
         num_splits = min(len(column_names) or 1, NPartitions.get())
-        column_chunksize = compute_chunksize(df.shape[1], num_splits)
+        min_block_size = MinPartitionSize.get()
+        column_chunksize = compute_chunksize(df.shape[1], num_splits, min_block_size)
         if column_chunksize > len(column_names):
             column_widths = [len(column_names)]
             # This prevents us from unnecessarily serializing a bunch of empty

--- a/modin/core/storage_formats/cudf/parser.py
+++ b/modin/core/storage_formats/cudf/parser.py
@@ -20,6 +20,7 @@ from pandas.core.dtypes.cast import find_common_type
 from pandas.core.dtypes.concat import union_categoricals
 from pandas.io.common import infer_compression
 
+from modin.config import MinPartitionSize
 from modin.core.execution.ray.implementations.cudf_on_ray.partitioning.partition_manager import (
     GPU_MANAGERS,
 )
@@ -39,7 +40,9 @@ def _split_result_for_readers(axis, num_splits, df):  # pragma: no cover
     Returns:
         A list of pandas DataFrames.
     """
-    splits = split_result_of_axis_func_pandas(axis, num_splits, df)
+    splits = split_result_of_axis_func_pandas(
+        axis, num_splits, df, min_block_size=MinPartitionSize.get()
+    )
     if not isinstance(splits, list):
         splits = [splits]
     return splits

--- a/modin/core/storage_formats/pandas/parsers.py
+++ b/modin/core/storage_formats/pandas/parsers.py
@@ -54,6 +54,7 @@ from pandas.core.dtypes.concat import union_categoricals
 from pandas.io.common import infer_compression
 from pandas.util._decorators import doc
 
+from modin.config import MinPartitionSize
 from modin.core.io.file_dispatcher import OpenFile
 from modin.core.storage_formats.pandas.utils import split_result_of_axis_func_pandas
 from modin.db_conn import ModinDatabaseConnection
@@ -113,7 +114,9 @@ def _split_result_for_readers(axis, num_splits, df):  # pragma: no cover
     list
         A list of pandas DataFrames.
     """
-    splits = split_result_of_axis_func_pandas(axis, num_splits, df)
+    splits = split_result_of_axis_func_pandas(
+        axis, num_splits, df, min_block_size=MinPartitionSize.get()
+    )
     if not isinstance(splits, list):
         splits = [splits]
     return splits

--- a/modin/core/storage_formats/pandas/utils.py
+++ b/modin/core/storage_formats/pandas/utils.py
@@ -125,6 +125,7 @@ def generate_result_of_axis_func_pandas(
             length_list = get_length_list(
                 result.shape[axis], num_splits, min_block_size
             )
+        # print(f"{length_list=}")
         # Inserting the first "zero" to properly compute cumsum indexing slices
         length_list = np.insert(length_list, obj=0, values=[0])
         sums = np.cumsum(length_list)

--- a/modin/core/storage_formats/pandas/utils.py
+++ b/modin/core/storage_formats/pandas/utils.py
@@ -13,17 +13,19 @@
 
 """Contains utility functions for frame partitioning."""
 
+from __future__ import annotations
+
 import re
 from math import ceil
-from typing import Hashable, List
+from typing import Generator, Hashable, List, Optional
 
 import numpy as np
 import pandas
 
-from modin.config import MinPartitionSize, NPartitions
+from modin.config import NPartitions
 
 
-def compute_chunksize(axis_len, num_splits, min_block_size=None):
+def compute_chunksize(axis_len: int, num_splits: int, min_block_size: int) -> int:
     """
     Compute the number of elements (rows/columns) to include in each partition.
 
@@ -35,26 +37,18 @@ def compute_chunksize(axis_len, num_splits, min_block_size=None):
         Element count in an axis.
     num_splits : int
         The number of splits.
-    min_block_size : int, optional
+    min_block_size : int
         Minimum number of rows/columns in a single split.
-        If not specified, the value is assumed equal to ``MinPartitionSize``.
 
     Returns
     -------
     int
         Integer number of rows/columns to split the DataFrame will be returned.
-
-    Notes
-    -----
-    To use this function in remote kernels, it is necessary to always explicitly
-    pass `min_block_size` parameter, since it is unsafe to use `MinPartitionSize`
-    configuration variable due to the fact that changes in its value in the main
-    process are not propagated to worker processes.
     """
-    if min_block_size is None:
-        min_block_size = MinPartitionSize.get()
-
-    assert min_block_size > 0, "`min_block_size` should be > 0"
+    if not isinstance(min_block_size, int) or min_block_size <= 0:
+        raise ValueError(
+            f"'min_block_size' should be int > 0, passed: {min_block_size=}"
+        )
 
     chunksize = axis_len // num_splits
     if axis_len % num_splits:
@@ -65,8 +59,12 @@ def compute_chunksize(axis_len, num_splits, min_block_size=None):
 
 
 def split_result_of_axis_func_pandas(
-    axis, num_splits, result, length_list=None, min_block_size=None
-):
+    axis: int,
+    num_splits: int,
+    result: pandas.DataFrame,
+    min_block_size: int,
+    length_list: Optional[list] = None,
+) -> list[pandas.DataFrame]:
     """
     Split pandas DataFrame evenly based on the provided number of splits.
 
@@ -79,12 +77,11 @@ def split_result_of_axis_func_pandas(
         This parameter is ignored if `length_list` is specified.
     result : pandas.DataFrame
         DataFrame to split.
+    min_block_size : int
+        Minimum number of rows/columns in a single split.
     length_list : list of ints, optional
         List of slice lengths to split DataFrame into. This is used to
         return the DataFrame to its original partitioning schema.
-    min_block_size : int, optional
-        Minimum number of rows/columns in a single split.
-        If not specified, the value is assumed equal to ``MinPartitionSize``.
 
     Returns
     -------
@@ -93,14 +90,18 @@ def split_result_of_axis_func_pandas(
     """
     return list(
         generate_result_of_axis_func_pandas(
-            axis, num_splits, result, length_list, min_block_size
+            axis, num_splits, result, min_block_size, length_list
         )
     )
 
 
 def generate_result_of_axis_func_pandas(
-    axis, num_splits, result, length_list=None, min_block_size=None
-):
+    axis: int,
+    num_splits: int,
+    result: pandas.DataFrame,
+    min_block_size: int,
+    length_list: Optional[list] = None,
+) -> Generator:
     """
     Generate pandas DataFrame evenly based on the provided number of splits.
 
@@ -113,12 +114,11 @@ def generate_result_of_axis_func_pandas(
         This parameter is ignored if `length_list` is specified.
     result : pandas.DataFrame
         DataFrame to split.
+    min_block_size : int
+        Minimum number of rows/columns in a single split.
     length_list : list of ints, optional
         List of slice lengths to split DataFrame into. This is used to
         return the DataFrame to its original partitioning schema.
-    min_block_size : int, optional
-        Minimum number of rows/columns in a single split.
-        If not specified, the value is assumed equal to ``MinPartitionSize``.
 
     Yields
     ------
@@ -132,7 +132,6 @@ def generate_result_of_axis_func_pandas(
             length_list = get_length_list(
                 result.shape[axis], num_splits, min_block_size
             )
-        # print(f"{length_list=}")
         # Inserting the first "zero" to properly compute cumsum indexing slices
         length_list = np.insert(length_list, obj=0, values=[0])
         sums = np.cumsum(length_list)
@@ -154,7 +153,7 @@ def generate_result_of_axis_func_pandas(
             yield chunk
 
 
-def get_length_list(axis_len: int, num_splits: int, min_block_size=None) -> list:
+def get_length_list(axis_len: int, num_splits: int, min_block_size: int) -> list:
     """
     Compute partitions lengths along the axis with the specified number of splits.
 
@@ -164,9 +163,8 @@ def get_length_list(axis_len: int, num_splits: int, min_block_size=None) -> list
         Element count in an axis.
     num_splits : int
         Number of splits along the axis.
-    min_block_size : int, optional
+    min_block_size : int
         Minimum number of rows/columns in a single split.
-        If not specified, the value is assumed equal to ``MinPartitionSize``.
 
     Returns
     -------

--- a/modin/core/storage_formats/pandas/utils.py
+++ b/modin/core/storage_formats/pandas/utils.py
@@ -43,6 +43,13 @@ def compute_chunksize(axis_len, num_splits, min_block_size=None):
     -------
     int
         Integer number of rows/columns to split the DataFrame will be returned.
+
+    Notes
+    -----
+    To use this function in remote kernels, it is necessary to always explicitly
+    pass `min_block_size` parameter, since it is unsafe to use `MinPartitionSize`
+    configuration variable due to the fact that changes in its value in the main
+    process are not propagated to worker processes.
     """
     if min_block_size is None:
         min_block_size = MinPartitionSize.get()

--- a/modin/core/storage_formats/pandas/utils.py
+++ b/modin/core/storage_formats/pandas/utils.py
@@ -22,7 +22,7 @@ from typing import Generator, Hashable, List, Optional
 import numpy as np
 import pandas
 
-from modin.config import NPartitions
+from modin.config import MinPartitionSize, NPartitions
 
 
 def compute_chunksize(axis_len: int, num_splits: int, min_block_size: int) -> int:
@@ -251,7 +251,11 @@ def merge_partitioning(left, right, axis=1):
 
     if lshape is not None and rshape is not None:
         res_shape = sum(lshape) + sum(rshape)
-        chunk_size = compute_chunksize(axis_len=res_shape, num_splits=NPartitions.get())
+        chunk_size = compute_chunksize(
+            axis_len=res_shape,
+            num_splits=NPartitions.get(),
+            min_block_size=MinPartitionSize.get(),
+        )
         return ceil(res_shape / chunk_size)
     else:
         lsplits = left._partitions.shape[axis]

--- a/modin/tests/core/storage_formats/pandas/test_internals.py
+++ b/modin/tests/core/storage_formats/pandas/test_internals.py
@@ -141,6 +141,7 @@ def construct_modin_df_by_scheme(pandas_df, partitioning_scheme):
         axis=0,
         num_splits=len(row_lengths),
         result=pandas_df,
+        min_block_size=MinPartitionSize.get(),
         length_list=row_lengths,
     )
     partitions = [
@@ -148,6 +149,7 @@ def construct_modin_df_by_scheme(pandas_df, partitioning_scheme):
             axis=1,
             num_splits=len(column_widths),
             result=row_part,
+            min_block_size=MinPartitionSize.get(),
             length_list=column_widths,
         )
         for row_part in row_partitions

--- a/modin/tests/pandas/dataframe/test_map_metadata.py
+++ b/modin/tests/pandas/dataframe/test_map_metadata.py
@@ -17,7 +17,7 @@ import pandas
 import pytest
 
 import modin.pandas as pd
-from modin.config import NPartitions, StorageFormat
+from modin.config import MinPartitionSize, NPartitions, StorageFormat
 from modin.core.dataframe.pandas.metadata import LazyProxyCategoricalDtype
 from modin.core.storage_formats.pandas.utils import split_result_of_axis_func_pandas
 from modin.pandas.testing import assert_index_equal, assert_series_equal
@@ -598,7 +598,11 @@ class TestCategoricalProxyDtype:
         original_dtype = pandas_df.astype({"a": "category"}).dtypes["a"]
 
         chunks = split_result_of_axis_func_pandas(
-            axis=0, num_splits=nchunks, result=pandas_df, length_list=[2, 2, 2]
+            axis=0,
+            num_splits=nchunks,
+            result=pandas_df,
+            min_block_size=MinPartitionSize.get(),
+            length_list=[2, 2, 2],
         )
 
         if StorageFormat.get() == "Pandas":

--- a/modin/tests/pandas/internals/test_repartition.py
+++ b/modin/tests/pandas/internals/test_repartition.py
@@ -11,10 +11,11 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import numpy as np
 import pytest
 
 import modin.pandas as pd
-from modin.config import NPartitions
+from modin.config import NPartitions, context
 
 NPartitions.put(4)
 
@@ -58,3 +59,9 @@ def test_repartition(axis, dtype):
         }
 
     assert obj._query_compiler._modin_frame._partitions.shape == results[axis]
+
+
+def test_repartition_7170():
+    with context(MinPartitionSize=102, NPartitions=5):
+        df = pd.DataFrame(np.random.rand(10000, 100))
+        _ = df._repartition(axis=1).to_numpy()


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

The problem is that setting a new value for configuration variables is not automatically propagated to all Modin processes.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7170 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
