### PR TITLE
FIX-#7093: Make sure `idxmax` and `idxmin` can work with string columns

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1868,8 +1868,6 @@ class BasePandasDataset(ClassLogger):
         """
         Return index of first occurrence of maximum over requested axis.
         """
-        if not all(d != pandas.api.types.pandas_dtype("O") for d in self._get_dtypes()):
-            raise TypeError("reduce operation 'argmax' not allowed for this dtype")
         axis = self._get_axis_number(axis)
         return self._reduce_dimension(
             self._query_compiler.idxmax(
@@ -1881,8 +1879,6 @@ class BasePandasDataset(ClassLogger):
         """
         Return index of first occurrence of minimum over requested axis.
         """
-        if not all(d != pandas.api.types.pandas_dtype("O") for d in self._get_dtypes()):
-            raise TypeError("reduce operation 'argmin' not allowed for this dtype")
         axis = self._get_axis_number(axis)
         return self._reduce_dimension(
             self._query_compiler.idxmin(

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -620,7 +620,7 @@ class DataFrame(BasePandasDataset):
             query_compiler=self._query_compiler.transpose(*args)
         )
 
-    T = property(transpose)
+    T: DataFrame = property(transpose)
 
     def add(
         self, other, axis="columns", level=None, fill_value=None

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -2088,7 +2088,7 @@ class Series(BasePandasDataset):
         """
         return self
 
-    T = property(transpose)
+    T: Series = property(transpose)
 
     def truediv(
         self, other, level=None, fill_value=None, axis=0

--- a/modin/tests/pandas/dataframe/test_reduce.py
+++ b/modin/tests/pandas/dataframe/test_reduce.py
@@ -220,6 +220,14 @@ def test_idxmin_idxmax(data, axis, skipna, is_transposed, method):
     )
 
 
+@pytest.mark.parametrize("axis", [0, 1])
+def test_idxmin_idxmax_string_columns(axis):
+    # https://github.com/modin-project/modin/issues/7093
+    modin_df, pandas_df = create_test_dfs([["a", "b"]])
+    eval_general(modin_df, pandas_df, lambda df: df.idxmax(axis=axis))
+    eval_general(modin_df, pandas_df, lambda df: df.idxmin(axis=axis))
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_last_valid_index(data):
     modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)

--- a/modin/tests/pandas/utils.py
+++ b/modin/tests/pandas/utils.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+from __future__ import annotations
+
 import csv
 import functools
 import itertools
@@ -1084,14 +1086,14 @@ def eval_io_from_str(csv_str: str, unique_filename: str, **kwargs):
     )
 
 
-def create_test_dfs(*args, **kwargs):
+def create_test_dfs(*args, **kwargs) -> tuple[pd.DataFrame, pandas.DataFrame]:
     post_fn = kwargs.pop("post_fn", lambda df: df)
-    return map(
-        post_fn, [pd.DataFrame(*args, **kwargs), pandas.DataFrame(*args, **kwargs)]
+    return tuple(
+        map(post_fn, [pd.DataFrame(*args, **kwargs), pandas.DataFrame(*args, **kwargs)])
     )
 
 
-def create_test_series(vals, sort=False, **kwargs):
+def create_test_series(vals, sort=False, **kwargs) -> tuple[pd.Series, pandas.Series]:
     if isinstance(vals, dict):
         modin_series = pd.Series(vals[next(iter(vals.keys()))], **kwargs)
         pandas_series = pandas.Series(vals[next(iter(vals.keys()))], **kwargs)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7093 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
