### PR TITLE
FEAT-#6808: Implement `__arrow_array__` for Series

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -517,6 +517,14 @@ class Series(BasePandasDataset):
             data = pd.Categorical(data, dtype=self.dtype)
         return data
 
+    def __arrow_array__(self, type=None):  # noqa: GL08
+        # Although pandas.Series does not implement this method (true for version 2.2.*),
+        # however, pyarrow has support for it. This method emulates this behavior and
+        # allows pyarrow to work with modin.pandas.Series.
+        import pyarrow
+
+        return pyarrow.array(self._to_pandas(), type=type)
+
     def add(
         self, other, level=None, fill_value=None, axis=0
     ) -> Series:  # noqa: PR01, RT01, D200

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -1387,6 +1387,30 @@ def test_constructor_arrow_extension_array():
     df_equals(md_ser.dtypes, pd_ser.dtypes)
 
 
+def test_pyarrow_array_retrieve():
+    pa = pytest.importorskip("pyarrow")
+    modin_series, pandas_series = create_test_series(
+        [1, 2, None], dtype="uint8[pyarrow]"
+    )
+    eval_general(
+        modin_series,
+        pandas_series,
+        lambda ser: pa.array(ser),
+    )
+
+
+def test___arrow_array__():
+    # https://github.com/modin-project/modin/issues/6808
+    pa = pytest.importorskip("pyarrow")
+    mpd_df_1 = pd.DataFrame({"a": ["1", "2", "3"], "b": ["4", "5", "6"]})
+    mpd_df_2 = pd.DataFrame({"a": ["7", "8", "9"], "b": ["10", "11", "12"]})
+    test_df = pd.concat([mpd_df_1, mpd_df_2])
+
+    res_from_md = pa.Table.from_pandas(df=test_df)
+    res_from_pd = pa.Table.from_pandas(df=test_df._to_pandas())
+    assert res_from_md.equals(res_from_pd)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_copy(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Need also for https://github.com/modin-project/modin/pull/7199

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6808 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
