### PR TITLE
FIX-#7206: df.melt cannot does not handle duplicate value_vars correctly

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1311,7 +1311,7 @@ class DataFrame(BasePandasDataset):
         if not is_list_like(id_vars):
             id_vars = [id_vars]
         if value_vars is None:
-            value_vars = self.columns.difference(id_vars)
+            value_vars = self.columns.drop(id_vars)
         if var_name is None:
             columns_name = self._query_compiler.get_index_name(axis=1)
             var_name = columns_name if columns_name is not None else "variable"

--- a/modin/tests/pandas/dataframe/test_default.py
+++ b/modin/tests/pandas/dataframe/test_default.py
@@ -586,6 +586,21 @@ def test_melt(data, id_vars, value_vars):
     )
 
 
+# Functional test for BUG:7206
+def test_melt_duplicate_col_names():
+    if StorageFormat.get() == "Hdk":
+        pass
+    data = {"data": [[1, 2], [3, 4]], "columns": ["dupe", "dupe"]}
+
+    def melt(df, *args, **kwargs):
+        return df.melt(*args, **kwargs).sort_values(["variable", "value"])
+
+    eval_general(
+        *create_test_dfs(**data),
+        lambda df, *args, **kwargs: melt(df, *args, **kwargs).reset_index(drop=True),
+    )
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize(
     "index",


### PR DESCRIPTION
FIX-#7206: df.melt cannot does not handle duplicate value_vars correctly

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7206
- [x] tests added and passing

