### PR TITLE
FIX-#7143: Constructing a DataFrame from a Modin Series with tuple name should produce MultiIndex columns

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -181,7 +181,11 @@ class Series(BasePandasDataset):
         """
         if name is None:
             name = MODIN_UNNAMED_SERIES_LABEL
-        self._query_compiler.columns = [name]
+        if isinstance(name, tuple):
+            columns = pandas.MultiIndex.from_tuples(tuples=[name])
+        else:
+            columns = [name]
+        self._query_compiler.columns = columns
 
     name: Hashable = property(_get_name, _set_name)
     _parent = None

--- a/modin/tests/pandas/dataframe/test_default.py
+++ b/modin/tests/pandas/dataframe/test_default.py
@@ -1485,3 +1485,13 @@ def test_setattr_axes():
 def test_attrs(data):
     modin_df, pandas_df = create_test_dfs(data)
     eval_general(modin_df, pandas_df, lambda df: df.attrs)
+
+
+def test_df_from_series_with_tuple_name():
+    # Tests that creating a DataFrame from a series with a tuple name results in
+    # a DataFrame with MultiIndex columns.
+    pandas_result = pandas.DataFrame(pandas.Series(name=("a", 1)))
+    # 1. Creating a Modin DF from native pandas Series
+    df_equals(pd.DataFrame(pandas.Series(name=("a", 1))), pandas_result)
+    # 2. Creating a Modin DF from Modin Series
+    df_equals(pd.DataFrame(pd.Series(name=("a", 1))), pandas_result)

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -2642,6 +2642,23 @@ def test_name(data):
     assert modin_series._query_compiler.columns == ["New_name"]
 
 
+def test_tuple_name():
+    names = [("a", 1), ("a", "b", "c"), "flat"]
+    s = pd.Series(name=names[0])
+    # The internal representation of the Series stores the name as a column label.
+    # When it is a tuple, this label is a MultiIndex object, and this test ensures that
+    # the Series's name property remains a tuple.
+    assert s.name == names[0]
+    assert isinstance(s.name, tuple)
+    # Setting the name to a tuple of a different level or a non-tuple should not error.
+    s.name = names[1]
+    assert s.name == names[1]
+    assert isinstance(s.name, tuple)
+    s.name = names[2]
+    assert s.name == names[2]
+    assert isinstance(s.name, str)
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_nbytes(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Fixes a bug where creating a DF from a Series with tuple name did not give the DF a MultiIndex object for its `columns` property. This PR sets the underlying query compiler's object to be a MultiIndex when the Series is created.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7143 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
