### PR TITLE
FIX-#7221: Don't use `use_legacy_dataset=False` for `ParquetDataset`

### DIFF
--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -187,9 +187,7 @@ class PyArrowDataset(ColumnStoreDataset):
     def _init_dataset(self):  # noqa: GL08
         from pyarrow.parquet import ParquetDataset
 
-        return ParquetDataset(
-            self.fs_path, filesystem=self.fs, use_legacy_dataset=False
-        )
+        return ParquetDataset(self.fs_path, filesystem=self.fs)
 
     @property
     def pandas_metadata(self):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

This was originally added here: https://github.com/modin-project/modin/pull/3416/files, but the reason for it is not described.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7221 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
