### PR TITLE
FIX-#7224: Importing modin.pandas.api.extensions overwrites re-export of pandas.api submodules

### DIFF
--- a/modin/tests/pandas/extensions/test_api_reexport.py
+++ b/modin/tests/pandas/extensions/test_api_reexport.py
@@ -12,9 +12,22 @@
 # governing permissions and limitations under the License.
 
 
-# Re-export all other pandas.api submodules
-from pandas.api import indexers, interchange, types, typing
+import pandas
 
-from modin.pandas.api import extensions
+import modin.pandas as pd
 
-__all__ = ["extensions", "interchange", "indexers", "types", "typing"]
+
+def test_extensions_does_not_overwrite_pandas_api():
+    # Ensure that importing modin.pandas.api.extensions does not overwrite our re-export
+    # of pandas.api submodules.
+    import modin.pandas.api.extensions as ext
+
+    # Top-level submodules should remain the same
+    assert set(pd.api.__all__) == set(pandas.api.__all__)
+    # Methods we define, like ext.register_dataframe_accessor should be different
+    assert (
+        ext.register_dataframe_accessor
+        is not pandas.api.extensions.register_dataframe_accessor
+    )
+    # Methods from other submodules, like pd.api.types.is_bool_dtype, should be the same
+    assert pd.api.types.is_bool_dtype is pandas.api.types.is_bool_dtype


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR re-exports the submodules of `pandas.api` from within `modin/pandas/api/__init__.py` to ensure they are not overwritten when a user tries to import `modin.pandas.api.extensions`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7224 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
