### PR TITLE
FIX-#7240: Allow `doc_checker.py` works with `functools.cached_property`

### DIFF
--- a/.github/workflows/ci-required.yml
+++ b/.github/workflows/ci-required.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/python-only
       # The `numpydoc` version here MUST match the versions in the dev requirements files.
-      - run: pip install pytest pytest-cov pydocstyle numpydoc==1.1.0
+      - run: pip install pytest pytest-cov pydocstyle numpydoc==1.6.0
       - run: python -m pytest scripts/test
       - run: pip install -e ".[all]"
       - run: |

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -69,4 +69,4 @@ dependencies:
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
-      - numpydoc==1.1.0
+      - numpydoc==1.6.0

--- a/requirements/env_hdk.yml
+++ b/requirements/env_hdk.yml
@@ -45,4 +45,4 @@ dependencies:
   - pip:
       - dataframe-api-compat>=0.2.7
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
-      - numpydoc==1.1.0
+      - numpydoc==1.6.0

--- a/requirements/env_unidist_linux.yml
+++ b/requirements/env_unidist_linux.yml
@@ -58,4 +58,4 @@ dependencies:
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - connectorx>=0.2.6a4
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
-      - numpydoc==1.1.0
+      - numpydoc==1.6.0

--- a/requirements/env_unidist_win.yml
+++ b/requirements/env_unidist_win.yml
@@ -59,4 +59,4 @@ dependencies:
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       - connectorx>=0.2.6a4
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
-      - numpydoc==1.1.0
+      - numpydoc==1.6.0

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -52,4 +52,4 @@ dependencies:
       # Fixes breaking ipywidgets changes, but didn't release yet.
       - git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
       # The `numpydoc` version should match the version installed in the `lint-pydocstyle` job of the CI.
-      - numpydoc==1.1.0
+      - numpydoc==1.6.0

--- a/scripts/doc_checker.py
+++ b/scripts/doc_checker.py
@@ -32,8 +32,8 @@ import sys
 import types
 from typing import List
 
-from numpydoc.docscrape import NumpyDocString
-from numpydoc.validate import Docstring
+from numpydoc.docscrape import NumpyDocString, get_doc_object
+from numpydoc.validate import Validator
 
 # Let the other modules to know that the doc checker is running.
 os.environ["_MODIN_DOC_CHECKER_"] = "1"
@@ -73,14 +73,14 @@ MODIN_ERROR_CODES = {
 }
 
 
-def get_optional_args(doc: Docstring) -> dict:
+def get_optional_args(doc: Validator) -> dict:
     """
     Get optional parameters for the object for which the docstring is checked.
 
     Parameters
     ----------
-    doc : numpydoc.validate.Docstring
-        Docstring handler.
+    doc : numpydoc.validate.Validator
+        Validator handler.
 
     Returns
     -------
@@ -98,13 +98,13 @@ def get_optional_args(doc: Docstring) -> dict:
     }
 
 
-def check_optional_args(doc: Docstring) -> list:
+def check_optional_args(doc: Validator) -> list:
     """
     Check type description of optional arguments.
 
     Parameters
     ----------
-    doc : numpydoc.validate.Docstring
+    doc : numpydoc.validate.Validator
 
     Returns
     -------
@@ -139,14 +139,14 @@ def check_optional_args(doc: Docstring) -> list:
     return errors
 
 
-def check_spelling_words(doc: Docstring) -> list:
+def check_spelling_words(doc: Validator) -> list:
     """
     Check spelling of chosen words in doc.
 
     Parameters
     ----------
-    doc : numpydoc.validate.Docstring
-        Docstring handler.
+    doc : numpydoc.validate.Validator
+        Validator handler.
 
     Returns
     -------
@@ -188,9 +188,18 @@ def check_spelling_words(doc: Docstring) -> list:
     ]
 
     docstring_start_line = None
-    for idx, line in enumerate(inspect.getsourcelines(doc.code_obj)[0]):
+    code_obj = doc.code_obj
+    if isinstance(code_obj, property):
+        # inspect.getsourcelines doesn't work with property
+        code_obj = code_obj.fget
+    elif isinstance(code_obj, functools.cached_property):
+        # inspect.getsourcelines doesn't work with cached_property
+        code_obj = code_obj.func
+
+    rows, starting_line = inspect.getsourcelines(code_obj)
+    for idx, line in enumerate(rows):
         if '"""' in line or "'''" in line:
-            docstring_start_line = doc.source_file_def_line + idx
+            docstring_start_line = starting_line + idx
             break
 
     errors = []
@@ -210,14 +219,14 @@ def check_spelling_words(doc: Docstring) -> list:
     return errors
 
 
-def check_docstring_indention(doc: Docstring) -> list:
+def check_docstring_indention(doc: Validator) -> list:
     """
     Check indention of docstring since numpydoc reports weird results.
 
     Parameters
     ----------
-    doc : numpydoc.validate.Docstring
-        Docstring handler.
+    doc : numpydoc.validate.Validator
+        Validator handler.
 
     Returns
     -------
@@ -240,14 +249,14 @@ def check_docstring_indention(doc: Docstring) -> list:
     return errors
 
 
-def validate_modin_error(doc: Docstring, results: dict) -> list:
+def validate_modin_error(doc: Validator, results: dict) -> list:
     """
     Validate custom Modin errors.
 
     Parameters
     ----------
-    doc : numpydoc.validate.Docstring
-        Docstring handler.
+    doc : numpydoc.validate.Validator
+        Validator handler.
     results : dict
         Dictionary that numpydoc.validate.validate return.
 
@@ -263,14 +272,14 @@ def validate_modin_error(doc: Docstring, results: dict) -> list:
     return results
 
 
-def skip_check_if_noqa(doc: Docstring, err_code: str, noqa_checks: list) -> bool:
+def skip_check_if_noqa(doc: Validator, err_code: str, noqa_checks: list) -> bool:
     """
     Skip the check that matches `err_code` if `err_code` found in noqa string.
 
     Parameters
     ----------
-    doc : numpydoc.validate.Docstring
-        Docstring handler.
+    doc : numpydoc.validate.Validator
+        Validator handler.
     err_code : str
         Error code found by numpydoc.
     noqa_checks : list
@@ -286,22 +295,31 @@ def skip_check_if_noqa(doc: Docstring, err_code: str, noqa_checks: list) -> bool
 
     # GL08 - missing docstring in an arbitary object; numpydoc code
     if err_code == "GL08":
-        name = doc.name.split(".")[-1]
-        # Numpydoc recommends to add docstrings of __init__ method in class docstring.
-        # So there is no error if docstring is missing in __init__
-        if name == "__init__":
-            return True
+        try:
+            name = doc.name.split(".")[-1]
+            # Numpydoc recommends to add docstrings of __init__ method in class docstring.
+            # So there is no error if docstring is missing in __init__
+            if name == "__init__":
+                return True
+        except AttributeError as exc:
+            # Cashed properties are not used for constructors, so we can safely ignore this exception
+            if (
+                not len(exc.args) > 0
+                and exc.args[0]
+                == "'cached_property' object has no attribute '__name__'"
+            ):
+                raise exc
     return err_code in noqa_checks
 
 
-def get_noqa_checks(doc: Docstring) -> list:
+def get_noqa_checks(doc: Validator) -> list:
     """
     Get codes after `# noqa`.
 
     Parameters
     ----------
-    doc : numpydoc.validate.Docstring
-        Docstring handler.
+    doc : numpydoc.validate.Validator
+        Validator handler.
 
     Returns
     -------
@@ -343,6 +361,11 @@ def get_noqa_checks(doc: Docstring) -> list:
     return [check.strip() for check in noqa_checks]
 
 
+def construct_validator(import_path: str) -> Validator:  # GL08
+    # helper function
+    return Validator(get_doc_object(Validator._load_obj(import_path)))
+
+
 # code snippet from numpydoc
 def validate_object(import_path: str) -> list:
     """
@@ -361,7 +384,7 @@ def validate_object(import_path: str) -> list:
     from numpydoc.validate import validate
 
     errors = []
-    doc = Docstring(import_path)
+    doc = construct_validator(import_path)
     if getattr(doc.obj, "__doc_inherited__", False) or (
         isinstance(doc.obj, property)
         and getattr(doc.obj.fget, "__doc_inherited__", False)
@@ -520,15 +543,6 @@ def monkeypatching():
     sys.modules["sqlalchemy"] = Mock()
 
     modin.utils.instancer = functools.wraps(modin.utils.instancer)(lambda cls: cls)
-
-    # monkey-patch numpydoc for working correctly with properties
-    def load_obj(name, old_load_obj=Docstring._load_obj):
-        obj = old_load_obj(name)
-        if isinstance(obj, property):
-            obj = obj.fget
-        return obj
-
-    Docstring._load_obj = staticmethod(load_obj)
 
     # for testing hdk-engine docs without `pyhdk` installation
     sys.modules["pyhdk"] = Mock()

--- a/scripts/test/test_doc_checker.py
+++ b/scripts/test/test_doc_checker.py
@@ -12,12 +12,12 @@
 # governing permissions and limitations under the License.
 
 import pytest
-from numpydoc.validate import Docstring
 
 from scripts.doc_checker import (
     MODIN_ERROR_CODES,
     check_optional_args,
     check_spelling_words,
+    construct_validator,
     get_noqa_checks,
     get_optional_args,
 )
@@ -34,7 +34,7 @@ from scripts.doc_checker import (
     ],
 )
 def test_get_optional_args(import_path, result):
-    optional_args = get_optional_args(Docstring(import_path))
+    optional_args = get_optional_args(construct_validator(import_path))
     assert optional_args == result
 
 
@@ -57,7 +57,7 @@ def test_get_optional_args(import_path, result):
     ],
 )
 def test_check_optional_args(import_path, result):
-    errors = check_optional_args(Docstring(import_path))
+    errors = check_optional_args(construct_validator(import_path))
     assert errors == result
 
 
@@ -88,7 +88,7 @@ def test_check_spelling_words(import_path, result):
                 ),
             )
         )
-    errors = check_spelling_words(Docstring(import_path))
+    errors = check_spelling_words(construct_validator(import_path))
     # the order of incorrect words found on the same line is not guaranteed
     for error in errors:
         assert error in result_errors
@@ -105,5 +105,5 @@ def test_check_spelling_words(import_path, result):
     ],
 )
 def test_get_noqa_checks(import_path, result):
-    noqa_checks = get_noqa_checks(Docstring(import_path))
+    noqa_checks = get_noqa_checks(construct_validator(import_path))
     assert noqa_checks == result


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

PR also updates `numpydoc`: `1.1.0` -> `1.6.0`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7240 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
