### PR TITLE
FEAT-#5394: Reduce amount of remote calls for TreeReduce and GroupByReduce operators

### DIFF
--- a/modin/tests/core/storage_formats/pandas/test_internals.py
+++ b/modin/tests/core/storage_formats/pandas/test_internals.py
@@ -2657,6 +2657,7 @@ def test_map_approaches(partitioning_scheme, expected_map_approach):
     df = pandas.DataFrame(data)
 
     modin_df = construct_modin_df_by_scheme(df, partitioning_scheme(df))
+    partitions = modin_df._query_compiler._modin_frame._partitions
     partition_mgr_cls = modin_df._query_compiler._modin_frame._partition_mgr_cls
 
     with mock.patch.object(
@@ -2664,7 +2665,7 @@ def test_map_approaches(partitioning_scheme, expected_map_approach):
         expected_map_approach,
         wraps=getattr(partition_mgr_cls, expected_map_approach),
     ) as expected_method:
-        try_cast_to_pandas(modin_df.map(lambda x: x * 2))
+        partition_mgr_cls.map_partitions(partitions, lambda x: x * 2)
         expected_method.assert_called()
 
 


### PR DESCRIPTION
Apply approaches from [PR-7136](https://github.com/modin-project/modin/pull/7136) for TreeReduce and GroupByReduce operators

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #5394  <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
