### PR TITLE
FIX-#7246: Pin pyarrow>=10.0.1 as pandas 2.2.* does

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,7 +14,7 @@ dependencies:
   # optional dependencies
   # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
   - ray-core>=2.1.0,!=2.5.0
-  - pyarrow>=7.0.0
+  - pyarrow>=10.0.1
   # workaround for https://github.com/conda/conda/issues/11744
   - grpcio!=1.45.*
   - grpcio!=1.46.*

--- a/modin/core/io/column_stores/parquet_dispatcher.py
+++ b/modin/core/io/column_stores/parquet_dispatcher.py
@@ -210,11 +210,7 @@ class PyArrowDataset(ColumnStoreDataset):
 
     @functools.cached_property
     def files(self):
-        try:
-            files = self.dataset.files
-        except AttributeError:
-            # compatibility at least with 3.0.0 <= pyarrow < 8.0.0
-            files = self.dataset._dataset.files
+        files = self.dataset.files
         return self._get_files(files)
 
     def to_pandas_dataframe(

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ psutil>=5.8.0
 ## optional dependencies
 # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
 ray>=2.1.0,!=2.5.0
-pyarrow>=7.0.0
+pyarrow>=10.0.1
 dask[complete]>=2.22.0
 distributed>=2.22.0
 xarray>=2022.12.0

--- a/requirements/env_unidist_linux.yml
+++ b/requirements/env_unidist_linux.yml
@@ -14,7 +14,7 @@ dependencies:
   - psutil>=5.8.0
 
   # optional dependencies
-  - pyarrow>=7.0.0
+  - pyarrow>=10.0.1
   - xarray>=2022.12.0
   - jinja2>=3.1.2
   - scipy>=1.10.0

--- a/requirements/env_unidist_win.yml
+++ b/requirements/env_unidist_win.yml
@@ -14,7 +14,7 @@ dependencies:
   - psutil>=5.8.0
 
   # optional dependencies
-  - pyarrow>=7.0.0
+  - pyarrow>=10.0.1
   - xarray>=2022.12.0
   - jinja2>=3.1.2
   - scipy>=1.10.0

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -11,7 +11,7 @@ dependencies:
   - psutil>=5.8.0
 
   # optional dependencies
-  - pyarrow>=7.0.0
+  - pyarrow>=10.0.1
   - xarray>=2022.12.0
   - jinja2>=3.1.2
   - scipy>=1.10.0

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
 
 dask_deps = ["dask>=2.22.0", "distributed>=2.22.0"]
 # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
-ray_deps = ["ray>=2.1.0,!=2.5.0", "pyarrow>=7.0.0"]
+ray_deps = ["ray>=2.1.0,!=2.5.0", "pyarrow>=10.0.1"]
 mpi_deps = ["unidist[mpi]>=0.2.1"]
 consortium_standard_deps = ["dataframe-api-compat>=0.2.7"]
 spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7246 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
