### PR TITLE
FIX-#6967: Remove read_pickle_distributed/to_pickle_distributed functions as deprecated

### DIFF
--- a/modin/experimental/pandas/__init__.py
+++ b/modin/experimental/pandas/__init__.py
@@ -33,7 +33,6 @@ Examples
 """
 
 from modin.pandas import *  # noqa F401, F403
-from modin.utils import func_from_deprecated_location
 
 from .io import (  # noqa F401
     read_csv_glob,
@@ -43,11 +42,4 @@ from .io import (  # noqa F401
     read_pickle_glob,
     read_sql,
     read_xml_glob,
-)
-
-read_pickle_distributed = func_from_deprecated_location(
-    "read_pickle_glob",
-    "modin.experimental.pandas.io",
-    "`modin.experimental.pandas.read_pickle_distributed` is deprecated and will be removed in a future version. "
-    + "Please use `modin.experimental.pandas.to_pickle_glob` instead.",
 )

--- a/modin/pandas/accessor.py
+++ b/modin/pandas/accessor.py
@@ -331,22 +331,6 @@ class ModinAPI:
             storage_options=storage_options,
         )
 
-    def to_pickle_distributed(
-        self,
-        filepath_or_buffer,
-        compression: CompressionOptions = "infer",
-        protocol: int = pickle.HIGHEST_PROTOCOL,
-        storage_options: StorageOptions = None,
-    ) -> None:  # noqa
-        warnings.warn(
-            "`DataFrame.modin.to_pickle_distributed` is deprecated and will be removed in a future version. "
-            + "Please use `DataFrame.modin.to_pickle_glob` instead.",
-            category=FutureWarning,
-        )
-        return self.to_pickle_glob(
-            filepath_or_buffer, compression, protocol, storage_options
-        )
-
     def to_parquet_glob(
         self,
         path,

--- a/modin/tests/experimental/test_io_exp.py
+++ b/modin/tests/experimental/test_io_exp.py
@@ -253,8 +253,8 @@ def test_read_multiple_csv_s3_storage_opts(
 @pytest.mark.parametrize(
     "filename", ["test_default_to_pickle.pkl", "test_to_pickle*.pkl"]
 )
-@pytest.mark.parametrize("read_func", ["read_pickle_glob", "read_pickle_distributed"])
-@pytest.mark.parametrize("to_func", ["to_pickle_glob", "to_pickle_distributed"])
+@pytest.mark.parametrize("read_func", ["read_pickle_glob"])
+@pytest.mark.parametrize("to_func", ["to_pickle_glob"])
 def test_distributed_pickling(
     tmp_path, filename, compression, pathlike, read_func, to_func
 ):


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6967 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
