### PR TITLE
REFACTOR-#7260: Use `extract_dtype` internal function in more places

### DIFF
--- a/modin/core/dataframe/pandas/metadata/dtypes.py
+++ b/modin/core/dataframe/pandas/metadata/dtypes.py
@@ -1228,22 +1228,9 @@ def extract_dtype(value) -> DtypeObj | pandas.Series:
     -------
     DtypeObj or pandas.Series of DtypeObj
     """
-    from modin.pandas.utils import is_scalar
+    try:
+        dtype = pandas.api.types.pandas_dtype(value)
+    except TypeError:
+        dtype = pandas.Series(value).dtype
 
-    if hasattr(value, "dtype"):
-        # If we're dealing with a numpy scalar (np.int, np.datetime64, ...)
-        # we would like to get its internal dtype
-        return value.dtype
-    elif hasattr(value, "dtypes"):
-        return value.dtypes
-    elif hasattr(value, "to_numpy"):
-        # If we're dealing with a scalar that can be converted to numpy (for example pandas.Timestamp)
-        # we would like to convert it and get its proper internal dtype
-        return value.to_numpy().dtype
-    elif is_scalar(value):
-        if value is None:
-            # previous type was object instead of 'float64'
-            return pandas.api.types.pandas_dtype(value)
-        return pandas.api.types.pandas_dtype(type(value))
-    else:
-        return pandas.Series(value).dtype
+    return dtype


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7260 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
