### PR TITLE
FEAT-#7265: Automatic publication of Modin wheel to PyPI

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -14,6 +14,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+        fetch-tags: true
     - name: Set up Python
       uses: actions/setup-python@v5
       with:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,6 @@
 name: Publish Modin wheel to PyPI
 
-on: pull_request
+on: push
 
 jobs:
   build-n-publish:
@@ -28,4 +28,4 @@ jobs:
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
-        password: ${{ secrets.NON_EXISTENT_TOKEN }}
+        password: ${{ secrets.PUBLISH_TO_PYPI_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,8 +1,9 @@
 name: Publish Modin wheel to PyPI
 
-on: push
-  tags:
-    - '*'
+on:
+  push:
+    tags:
+      - '*'
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,9 +1,10 @@
 name: Publish Modin wheel to PyPI
 
 on:
+  schedule:
+    - cron: "42 0 * * WED"
   push:
-    tags:
-    - '*'
+  workflow_dispatch:
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,12 +1,16 @@
 name: Publish Modin wheel to PyPI
 
 on: push
+  tags:
+    - '*'
 
 jobs:
   build-n-publish:
     name: Build and publish Modin wheel to PyPI
     environment: release
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
 
     steps:
     - uses: actions/checkout@v4
@@ -28,5 +32,3 @@ jobs:
     - name: Publish Modin wheel to PyPI
       if: startsWith(github.ref, 'refs/tags')
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        password: ${{ secrets.PUBLISH_TO_PYPI_TOKEN }}

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -5,6 +5,7 @@ on: push
 jobs:
   build-n-publish:
     name: Build and publish Modin wheel to PyPI
+    environment: release
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -4,6 +4,8 @@ on:
   schedule:
     - cron: "42 0 * * WED"
   push:
+    tags:        
+      - '*'
   workflow_dispatch:
 
 jobs:
@@ -19,6 +21,9 @@ jobs:
       with:
         fetch-depth: 0
         fetch-tags: true
+    - name: Checkout latest git tag
+      run: git checkout $(git describe --tags "$(git rev-list --tags --max-count=1)")
+      if: github.event_name == 'push'
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -35,5 +40,5 @@ jobs:
         path: ./dist/
 
     - name: Publish Modin wheel to PyPI
-      if: startsWith(github.ref, 'refs/tags')
+      if: github.event_name == 'push'
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,7 +3,7 @@ name: Publish Modin wheel to PyPI
 on:
   push:
     tags:
-      - '*'
+    - '*'
 
 jobs:
   build-n-publish:

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,31 @@
+name: Publish Modin wheel to PyPI
+
+on: pull_request
+
+jobs:
+  build-n-publish:
+    name: Build and publish Modin wheel to PyPI
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.9.x"
+
+    - name: Install/update tools
+      run: python3 -m pip install --upgrade build wheel
+    - name: Build a pure Python wheel
+      run: python3 setup.py sdist bdist_wheel
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: modin-wheel-and-source-tarball 
+        path: ./dist/
+
+    - name: Publish Modin wheel to PyPI
+      if: startsWith(github.ref, 'refs/tags')
+      uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        password: ${{ secrets.NON_EXISTENT_TOKEN }}


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7265 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
