### PR TITLE
REFACTOR-#7271: Remove `instance_type` attribute of axis partitions

### DIFF
--- a/modin/core/dataframe/base/partitioning/axis_partition.py
+++ b/modin/core/dataframe/base/partitioning/axis_partition.py
@@ -14,7 +14,7 @@
 """Base class of an axis partition for a Modin Dataframe."""
 
 from abc import ABC, abstractmethod
-from typing import Any, Callable, Iterable, Optional, Tuple, Union
+from typing import Any, Callable, Iterable, Optional, Tuple, Type, Union
 
 from modin.logging import ClassLogger
 from modin.logging.config import LogLevel
@@ -95,8 +95,7 @@ class BaseDataframeAxisPartition(
         pass
 
     # Child classes must have these in order to correctly subclass.
-    instance_type = None
-    partition_type = None
+    partition_type: Type
     _PARTITIONS_METADATA_LEN = 0
 
     def _wrap_partitions(
@@ -119,7 +118,6 @@ class BaseDataframeAxisPartition(
             List of wrapped remote partition objects.
         """
         assert self.partition_type is not None
-        assert self.instance_type is not None  # type: ignore
 
         if extract_metadata is None:
             # If `_PARTITIONS_METADATA_LEN == 0` then the execution doesn't support metadata

--- a/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
+++ b/modin/core/execution/dask/implementations/pandas_on_dask/partitioning/virtual_partition.py
@@ -14,7 +14,6 @@
 """Module houses classes responsible for storing a virtual partition and applying a function to it."""
 
 import pandas
-from distributed import Future
 from distributed.utils import get_ip
 
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
@@ -51,7 +50,6 @@ class PandasOnDaskDataframeVirtualPartition(PandasDataframeAxisPartition):
     axis = None
     _PARTITIONS_METADATA_LEN = 3  # (length, width, ip)
     partition_type = PandasOnDaskDataframePartition
-    instance_type = Future
 
     @property
     def list_of_ips(self):

--- a/modin/core/execution/python/implementations/pandas_on_python/partitioning/virtual_partition.py
+++ b/modin/core/execution/python/implementations/pandas_on_python/partitioning/virtual_partition.py
@@ -13,8 +13,6 @@
 
 """The module defines interface for a virtual partition with pandas storage format and python engine."""
 
-import pandas
-
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
@@ -48,7 +46,6 @@ class PandasOnPythonDataframeAxisPartition(PandasDataframeAxisPartition):
     """
 
     partition_type = PandasOnPythonDataframePartition
-    instance_type = pandas.DataFrame
 
 
 @_inherit_docstrings(PandasOnPythonDataframeAxisPartition.__init__)

--- a/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/axis_partition.py
+++ b/modin/core/execution/ray/implementations/cudf_on_ray/partitioning/axis_partition.py
@@ -13,8 +13,6 @@
 
 """Module houses classes of axis partitions implemented using Ray and cuDF."""
 
-import cudf
-
 from modin.core.execution.ray.common import RayWrapper
 
 from .partition import cuDFOnRayDataframePartition
@@ -34,7 +32,6 @@ class cuDFOnRayDataframeAxisPartition(object):
         self.partitions = [obj for obj in partitions]
 
     partition_type = cuDFOnRayDataframePartition
-    instance_type = cudf.DataFrame
 
 
 class cuDFOnRayDataframeColumnPartition(cuDFOnRayDataframeAxisPartition):

--- a/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
+++ b/modin/core/execution/ray/implementations/pandas_on_ray/partitioning/virtual_partition.py
@@ -51,7 +51,6 @@ class PandasOnRayDataframeVirtualPartition(PandasDataframeAxisPartition):
 
     _PARTITIONS_METADATA_LEN = 3  # (length, width, ip)
     partition_type = PandasOnRayDataframePartition
-    instance_type = ray.ObjectRef
     axis = None
 
     # these variables are intentionally initialized at runtime (see #6023)

--- a/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
+++ b/modin/core/execution/unidist/implementations/pandas_on_unidist/partitioning/virtual_partition.py
@@ -52,7 +52,6 @@ class PandasOnUnidistDataframeVirtualPartition(PandasDataframeAxisPartition):
 
     _PARTITIONS_METADATA_LEN = 3  # (length, width, ip)
     partition_type = PandasOnUnidistDataframePartition
-    instance_type = unidist.core.base.object_ref.ObjectRef
     axis = None
 
     # these variables are intentionally initialized at runtime (see #6023)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7271 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
