### PR TITLE
FIX-#7278: Make sure `enable_logging` decorator preserve type hints

### DIFF
--- a/modin/logging/logger_decorator.py
+++ b/modin/logging/logger_decorator.py
@@ -17,9 +17,11 @@ Module contains the functions designed for the enable/disable of logging.
 ``enable_logging`` is used for decorating individual Modin functions or classes.
 """
 
+from __future__ import annotations
+
 from functools import wraps
 from types import FunctionType, MethodType
-from typing import Any, Callable, Dict, Optional, Tuple, Type, TypeVar, Union, overload
+from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, overload
 
 from modin.config import LogMode
 
@@ -27,10 +29,10 @@ from .config import LogLevel, get_logger
 
 _MODIN_LOGGER_NOWRAP = "__modin_logging_nowrap__"
 
-Fn = TypeVar("Fn", bound=Callable)
+Fn = TypeVar("Fn", bound=Any)
 
 
-def disable_logging(func: Callable) -> Callable:
+def disable_logging(func: Callable) -> Any:
     """
     Disable logging of one particular function. Useful for decorated classes.
 
@@ -51,14 +53,23 @@ def disable_logging(func: Callable) -> Callable:
 @overload
 def enable_logging(modin_layer: Fn) -> Fn:
     # This helps preserve typings when the decorator is used without parentheses
-    ...
+    pass
 
 
+@overload
 def enable_logging(
-    modin_layer: Union[str, Fn, Type] = "PANDAS-API",
+    modin_layer: str = "PANDAS-API",
     name: Optional[str] = None,
     log_level: LogLevel = LogLevel.INFO,
 ) -> Callable[[Fn], Fn]:
+    pass
+
+
+def enable_logging(
+    modin_layer: str | Fn = "PANDAS-API",
+    name: Optional[str] = None,
+    log_level: LogLevel = LogLevel.INFO,
+) -> Callable[[Fn], Fn] | Fn:
     """
     Log Decorator used on specific Modin functions or classes.
 
@@ -102,11 +113,11 @@ def enable_logging(
                         )(attr_value)
 
                     setattr(obj, attr_name, wrapped)
-            return obj
+            return obj  # type: ignore [return-value]
         elif isinstance(obj, classmethod):
-            return classmethod(decorator(obj.__func__))
+            return classmethod(decorator(obj.__func__))  # type: ignore [return-value, arg-type]
         elif isinstance(obj, staticmethod):
-            return staticmethod(decorator(obj.__func__))
+            return staticmethod(decorator(obj.__func__))  # type: ignore [return-value, arg-type]
 
         assert isinstance(modin_layer, str), "modin_layer is somehow not a string!"
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

For example:
![image](https://github.com/modin-project/modin/assets/45976948/68cdf30b-15cc-4371-9ef0-902c9e0c03a2)
instead of:
![image](https://github.com/modin-project/modin/assets/45976948/3a6854d3-0256-4f6e-9fea-c322a6857734)


- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7278 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
