### PR TITLE
FIX-#7295: Unpin numexpr to allow versions >= 2.8.4 to match pandas

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -36,8 +36,7 @@ dependencies:
   - psycopg2>=2.9.6
   - fastparquet>=2022.12.0
   - tqdm>=4.60.0
-  # pandas isn't compatible with numexpr=2.8.5: https://github.com/modin-project/modin/issues/6469
-  - numexpr<2.8.5
+  - numexpr>=2.8.4
 
   # dependencies for making release
   - pygithub>=v1.58.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -31,8 +31,7 @@ connectorx>=0.2.6a4
 fastparquet>=2022.12.0
 flask-cors
 tqdm>=4.60.0
-# pandas isn't compatible with numexpr=2.8.5: https://github.com/modin-project/modin/issues/6469
-numexpr<2.8.5
+numexpr>=2.8.4
 # Latest modin-spreadsheet with widget fix
 git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
 dataframe-api-compat>=0.2.7

--- a/requirements/env_unidist_linux.yml
+++ b/requirements/env_unidist_linux.yml
@@ -31,8 +31,7 @@ dependencies:
   - psycopg2>=2.9.6
   - fastparquet>=2022.12.0
   - tqdm>=4.60.0
-  # pandas isn't compatible with numexpr=2.8.5: https://github.com/modin-project/modin/issues/6469
-  - numexpr<2.8.5
+  - numexpr>=2.8.4
 
   # dependencies for making release
   - pygithub>=v1.58.0

--- a/requirements/env_unidist_win.yml
+++ b/requirements/env_unidist_win.yml
@@ -31,8 +31,7 @@ dependencies:
   - psycopg2>=2.9.6
   - fastparquet>=2022.12.0
   - tqdm>=4.60.0
-  # pandas isn't compatible with numexpr=2.8.5: https://github.com/modin-project/modin/issues/6469
-  - numexpr<2.8.5
+  - numexpr>=2.8.4
 
   # dependencies for making release
   - pygithub>=v1.58.0

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -24,8 +24,7 @@ dependencies:
   - pandas-gbq>=0.19.0
   - pytables>=3.8.0
   - tqdm>=4.60.0
-  # pandas isn't compatible with numexpr=2.8.5: https://github.com/modin-project/modin/issues/6469
-  - numexpr<2.8.5
+  - numexpr>=2.8.4
 
   # dependencies for making release
   - pygithub>=v1.58.0


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7295 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
