### PR TITLE
REFACTOR-#7294: Reduce access of methods _modin_frame methods from query compiler objects

### DIFF
--- a/modin/core/dataframe/algebra/binary.py
+++ b/modin/core/dataframe/algebra/binary.py
@@ -70,18 +70,15 @@ def maybe_compute_dtypes_common_cast(
     The dtypes of the operands are supposed to be known.
     """
     if not trigger_computations:
-        if not first._modin_frame.has_materialized_dtypes:
+        if not first.frame_has_materialized_dtypes:
             return None
 
-        if (
-            isinstance(second, type(first))
-            and not second._modin_frame.has_materialized_dtypes
-        ):
+        if isinstance(second, type(first)) and not second.frame_has_materialized_dtypes:
             return None
 
-    dtypes_first = first._modin_frame.dtypes.to_dict()
+    dtypes_first = first.dtypes.to_dict()
     if isinstance(second, type(first)):
-        dtypes_second = second._modin_frame.dtypes.to_dict()
+        dtypes_second = second.dtypes.to_dict()
         columns_first = set(first.columns)
         columns_second = set(second.columns)
         common_columns = columns_first.intersection(columns_second)

--- a/modin/core/dataframe/algebra/tree_reduce.py
+++ b/modin/core/dataframe/algebra/tree_reduce.py
@@ -67,7 +67,7 @@ class TreeReduce(Operator):
             _axis = kwargs.get("axis") if axis is None else axis
 
             new_dtypes = None
-            if compute_dtypes and query_compiler._modin_frame.has_materialized_dtypes:
+            if compute_dtypes and query_compiler.frame_has_materialized_dtypes:
                 new_dtypes = str(compute_dtypes(query_compiler.dtypes, *args, **kwargs))
 
             return query_compiler.__constructor__(

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -4521,6 +4521,59 @@ class BaseQueryCompiler(
         assert axis == 1
         return isinstance(self.columns, pandas.MultiIndex)
 
+    @property
+    def frame_has_materialized_dtypes(self) -> bool:
+        """
+        Check if the undelying dataframe has materialized dtypes.
+
+        Returns
+        -------
+        bool
+        """
+        return self._modin_frame.has_materialized_dtypes
+
+    def set_frame_dtypes_cache(self, dtypes):
+        """
+        Set dtypes cache for the underlying dataframe frame.
+
+        Parameters
+        ----------
+        dtypes : pandas.Series, ModinDtypes, callable or None
+        """
+        self._modin_frame.set_dtypes_cache(dtypes)
+
+    def set_frame_index_cache(self, index):
+        """
+        Set index cache for underlying dataframe.
+
+        Parameters
+        ----------
+        index : sequence, callable or None
+        """
+        self._modin_frame.set_index_cache(index)
+
+    @property
+    def frame_has_index_cache(self):
+        """
+        Check if the index cache exists for underlying dataframe.
+
+        Returns
+        -------
+        bool
+        """
+        return self._modin_frame.has_index_cache
+
+    @property
+    def frame_has_dtypes_cache(self) -> bool:
+        """
+        Check if the dtypes cache exists for the underlying dataframe.
+
+        Returns
+        -------
+        bool
+        """
+        return self._modin_frame.has_dtypes_cache
+
     def get_index_name(self, axis=0):
         """
         Get index name of specified axis.

--- a/modin/core/storage_formats/pandas/aggregations.py
+++ b/modin/core/storage_formats/pandas/aggregations.py
@@ -71,8 +71,8 @@ class CorrCovBuilder:
                     np.repeat(pandas.api.types.pandas_dtype("float"), len(new_columns)),
                     index=new_columns,
                 )
-            elif numeric_only and qc._modin_frame.has_materialized_dtypes:
-                old_dtypes = qc._modin_frame.dtypes
+            elif numeric_only and qc.frame_has_materialized_dtypes:
+                old_dtypes = qc.dtypes
 
                 new_columns = old_dtypes[old_dtypes.map(is_numeric_dtype)].index
                 new_index = new_columns.copy()

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -1070,8 +1070,8 @@ class BasePandasDataset(ClassLogger):
 
         if not copy:
             # If the new types match the old ones, then copying can be avoided
-            if self._query_compiler._modin_frame.has_materialized_dtypes:
-                frame_dtypes = self._query_compiler._modin_frame.dtypes
+            if self._query_compiler.frame_has_materialized_dtypes:
+                frame_dtypes = self._query_compiler.dtypes
                 if isinstance(dtype, dict):
                     for col in dtype:
                         if dtype[col] != frame_dtypes[col]:

--- a/modin/tests/pandas/dataframe/test_indexing.py
+++ b/modin/tests/pandas/dataframe/test_indexing.py
@@ -1473,7 +1473,7 @@ def test_reindex_multiindex():
 def test_reset_index(data, test_async_reset_index):
     modin_df, pandas_df = create_test_dfs(data)
     if test_async_reset_index:
-        modin_df._query_compiler._modin_frame.set_index_cache(None)
+        modin_df._query_compiler.set_frame_index_cache(None)
     modin_result = modin_df.reset_index(inplace=False)
     pandas_result = pandas_df.reset_index(inplace=False)
     df_equals(modin_result, pandas_result)
@@ -1481,7 +1481,7 @@ def test_reset_index(data, test_async_reset_index):
     modin_df_cp = modin_df.copy()
     pd_df_cp = pandas_df.copy()
     if test_async_reset_index:
-        modin_df._query_compiler._modin_frame.set_index_cache(None)
+        modin_df._query_compiler.set_frame_index_cache(None)
     modin_df_cp.reset_index(inplace=True)
     pd_df_cp.reset_index(inplace=True)
     df_equals(modin_df_cp, pd_df_cp)
@@ -1662,7 +1662,7 @@ def test_reset_index_with_multi_index_no_drop(
     if col_fill != "no_col_fill":
         kwargs["col_fill"] = col_fill
     if test_async_reset_index:
-        modin_df._query_compiler._modin_frame.set_index_cache(None)
+        modin_df._query_compiler.set_frame_index_cache(None)
     eval_general(
         modin_df,
         pandas_df,
@@ -1785,7 +1785,7 @@ def test_reset_index_with_named_index(
         modin_df.index = modin_df.index
         modin_df.modin.to_pandas()
 
-        modin_df._query_compiler._modin_frame.set_index_cache(None)
+        modin_df._query_compiler.set_frame_index_cache(None)
     df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
 
     if test_async_reset_index:
@@ -1793,7 +1793,7 @@ def test_reset_index_with_named_index(
         modin_df.index = modin_df.index
         modin_df.modin.to_pandas()
 
-        modin_df._query_compiler._modin_frame.set_index_cache(None)
+        modin_df._query_compiler.set_frame_index_cache(None)
     modin_df.reset_index(drop=True, inplace=True)
     pandas_df.reset_index(drop=True, inplace=True)
     df_equals(modin_df, pandas_df)
@@ -1806,7 +1806,7 @@ def test_reset_index_with_named_index(
         modin_df.index = modin_df.index
         modin_df._to_pandas()
 
-        modin_df._query_compiler._modin_frame.set_index_cache(None)
+        modin_df._query_compiler.set_frame_index_cache(None)
     df_equals(modin_df.reset_index(drop=False), pandas_df.reset_index(drop=False))
 
 
@@ -1829,7 +1829,7 @@ def test_reset_index_metadata_update(index, test_async_reset_index):
         modin_df.index = modin_df.index
         modin_df._to_pandas()
 
-        modin_df._query_compiler._modin_frame.set_index_cache(None)
+        modin_df._query_compiler.set_frame_index_cache(None)
     eval_general(modin_df, pandas_df, lambda df: df.reset_index())
 
 

--- a/modin/tests/pandas/dataframe/test_join_sort.py
+++ b/modin/tests/pandas/dataframe/test_join_sort.py
@@ -482,17 +482,17 @@ def test_merge_on_index(has_index_cache):
         if has_index_cache:
             modin_df1.index  # triggering index materialization
             modin_df2.index
-            assert modin_df1._query_compiler._modin_frame.has_index_cache
-            assert modin_df2._query_compiler._modin_frame.has_index_cache
+            assert modin_df1._query_compiler.frame_has_index_cache
+            assert modin_df2._query_compiler.frame_has_index_cache
         else:
             # Propagate deferred indices to partitions
             # The change in index is not automatically handled by Modin. See #3941.
             modin_df1.index = modin_df1.index
             modin_df1._to_pandas()
-            modin_df1._query_compiler._modin_frame.set_index_cache(None)
+            modin_df1._query_compiler.set_frame_index_cache(None)
             modin_df2.index = modin_df2.index
             modin_df2._to_pandas()
-            modin_df2._query_compiler._modin_frame.set_index_cache(None)
+            modin_df2._query_compiler.set_frame_index_cache(None)
 
     for on in (
         ["col_key1", "idx_key1"],

--- a/modin/tests/pandas/dataframe/test_map_metadata.py
+++ b/modin/tests/pandas/dataframe/test_map_metadata.py
@@ -473,13 +473,13 @@ def test_astype_copy(has_dtypes):
     data = [1]
     modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
     if not has_dtypes:
-        modin_df._query_compiler._modin_frame.set_dtypes_cache(None)
+        modin_df._query_compiler.set_frame_dtypes_cache(None)
     eval_general(modin_df, pandas_df, lambda df: df.astype(str, copy=False))
 
     # trivial case where copying can be avoided, behavior should match pandas
     s1 = pd.Series([1, 2])
     if not has_dtypes:
-        modin_df._query_compiler._modin_frame.set_dtypes_cache(None)
+        modin_df._query_compiler.set_frame_dtypes_cache(None)
     s2 = s1.astype("int64", copy=False)
     s2[0] = 10
     df_equals(s1, s2)

--- a/modin/tests/pandas/dataframe/test_udf.py
+++ b/modin/tests/pandas/dataframe/test_udf.py
@@ -455,7 +455,7 @@ def test_query(data, funcs, engine):
     else:
         modin_result = modin_df.query(funcs, engine=engine)
         # `dtypes` must be evaluated after `query` so we need to check cache
-        assert modin_result._query_compiler._modin_frame.has_dtypes_cache
+        assert modin_result._query_compiler.frame_has_dtypes_cache
         df_equals(modin_result, pandas_result)
         df_equals(modin_result.dtypes, pandas_result.dtypes)
 

--- a/modin/tests/pandas/test_groupby.py
+++ b/modin/tests/pandas/test_groupby.py
@@ -2740,7 +2740,7 @@ def test_groupby_on_empty_data(modin_df_recipe):
             df = pd.DataFrame(**self._df_kwargs)
             try:
                 # The frame would stop being lazy once index computation is triggered
-                df._query_compiler._modin_frame.set_index_cache(None)
+                df._query_compiler.set_frame_index_cache(None)
             except AttributeError:
                 pytest.skip(
                     reason="Selected execution doesn't support deferred indices."


### PR DESCRIPTION

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #7294  <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
