### PR TITLE
PERF-#7299: Avoid using `synchronize_labels` for `combine` function

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2882,6 +2882,7 @@ class PandasDataframe(
             pandas_backend=self._pandas_backend,
         )
 
+    @lazy_metadata_decorator(apply_axis="both")
     def combine(self) -> PandasDataframe:
         """
         Create a single partition PandasDataframe from the partitions of the current dataframe.
@@ -2909,7 +2910,6 @@ class PandasDataframe(
             dtypes=self.copy_dtypes_cache(),
             pandas_backend=self._pandas_backend,
         )
-        result.synchronize_labels()
         return result
 
     @lazy_metadata_decorator(apply_axis="both")

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2882,7 +2882,6 @@ class PandasDataframe(
             pandas_backend=self._pandas_backend,
         )
 
-    @lazy_metadata_decorator(apply_axis="both")
     def combine(self) -> PandasDataframe:
         """
         Create a single partition PandasDataframe from the partitions of the current dataframe.
@@ -2892,7 +2891,15 @@ class PandasDataframe(
         PandasDataframe
             A single partition PandasDataframe.
         """
-        partitions = self._partition_mgr_cls.combine(self._partitions)
+        new_index = None
+        new_columns = None
+        if self.has_index_cache:
+            new_index = self.index
+        if self.has_columns_cache:
+            new_columns = self.columns
+        partitions = self._partition_mgr_cls.combine(
+            self._partitions, new_index, new_columns
+        )
         result = self.__constructor__(
             partitions,
             index=self.copy_index_cache(),

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -2893,9 +2893,9 @@ class PandasDataframe(
         """
         new_index = None
         new_columns = None
-        if self.has_index_cache:
+        if self._deferred_index:
             new_index = self.index
-        if self.has_columns_cache:
+        if self._deferred_column:
             new_columns = self.columns
         partitions = self._partition_mgr_cls.combine(
             self._partitions, new_index, new_columns

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1275,7 +1275,7 @@ class PandasDataframePartitionManager(
         np.ndarray
             A NumPy 2D array of a single partition.
         """
-        if partitions.size <= 1:
+        if partitions.size <= 1 and new_index is None and new_columns is None:
             return partitions
 
         def to_pandas_remote(df, partition_shape, *dfs):

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1269,6 +1269,12 @@ class PandasDataframePartitionManager(
         ----------
         partitions : np.ndarray
             The partitions which have to be converted to a single partition.
+        new_index : pandas.Index, optional
+            Index for propagation into internal partitions.
+            Optimization allowing to do this in one remote kernel.
+        new_columns : pandas.Index, optional
+            Columns for propagation into internal partitions.
+            Optimization allowing to do this in one remote kernel.
 
         Returns
         -------

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -1261,7 +1261,7 @@ class PandasDataframePartitionManager(
         return [obj.apply(preprocessed_func, **kwargs) for obj in partitions]
 
     @classmethod
-    def combine(cls, partitions):
+    def combine(cls, partitions, new_index=None, new_columns=None):
         """
         Convert a NumPy 2D array of partitions to a NumPy 2D array of a single partition.
 
@@ -1281,7 +1281,11 @@ class PandasDataframePartitionManager(
         def to_pandas_remote(df, partition_shape, *dfs):
             """Copy of ``cls.to_pandas()`` method adapted for a remote function."""
             return create_pandas_df_from_partitions(
-                (df,) + dfs, partition_shape, called_from_remote=True
+                (df,) + dfs,
+                partition_shape,
+                called_from_remote=True,
+                new_index=new_index,
+                new_columns=new_columns,
             )
 
         preprocessed_func = cls.preprocess_func(to_pandas_remote)

--- a/modin/core/dataframe/pandas/utils.py
+++ b/modin/core/dataframe/pandas/utils.py
@@ -72,7 +72,11 @@ def concatenate(dfs, copy=True):
 
 
 def create_pandas_df_from_partitions(
-    partition_data, partition_shape, called_from_remote=False
+    partition_data,
+    partition_shape,
+    called_from_remote=False,
+    new_index=None,
+    new_columns=None,
 ):
     """
     Convert partition data of multiple dataframes to a single dataframe.
@@ -129,4 +133,9 @@ def create_pandas_df_from_partitions(
     if len(df_rows) == 0:
         return pandas.DataFrame()
     else:
-        return concatenate(df_rows, copy=not called_from_remote)
+        res = concatenate(df_rows, copy=not called_from_remote)
+        if new_index is not None:
+            res.index = new_index
+        if new_columns is not None:
+            res.columns = new_columns
+        return res

--- a/modin/core/dataframe/pandas/utils.py
+++ b/modin/core/dataframe/pandas/utils.py
@@ -89,6 +89,12 @@ def create_pandas_df_from_partitions(
         Shape of the partitions NumPy array.
     called_from_remote : bool, default: False
         Flag used to check if explicit copy should be done in concat.
+    new_index : pandas.Index, optional
+        Index for propagation into internal partitions.
+        Optimization allowing to do this in one remote kernel.
+    new_columns : pandas.Index, optional
+        Columns for propagation into internal partitions.
+        Optimization allowing to do this in one remote kernel.
 
     Returns
     -------

--- a/modin/core/dataframe/pandas/utils.py
+++ b/modin/core/dataframe/pandas/utils.py
@@ -131,11 +131,13 @@ def create_pandas_df_from_partitions(
     del partition_data
 
     if len(df_rows) == 0:
-        return pandas.DataFrame()
+        res = pandas.DataFrame()
     else:
         res = concatenate(df_rows, copy=not called_from_remote)
-        if new_index is not None:
-            res.index = new_index
-        if new_columns is not None:
-            res.columns = new_columns
-        return res
+
+    if new_index is not None:
+        res.index = new_index
+    if new_columns is not None:
+        res.columns = new_columns
+
+    return res


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

Perf gain: ~15% against main branch with Ray 8 cores.

```python
import modin.pandas as pd
from modin.utils import execute
import numpy as np

from time import time

df1 = pd.DataFrame(np.random.randint(1_000_000, size=(10_000, 100)))
df2 = pd.DataFrame(np.random.randint(1_000_000, size=(1_000_000, 100)))

for _ in range(5):
    start = time()
    df2._query_compiler._modin_frame._deferred_index = True
    res = df1.merge(df2, on=3)
    execute(res)
    print(f"merge time: {time()-start}")


```

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7299 <!-- issue must be created for each patch -->
- [x] tests ~added and~ passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
