### PR TITLE
FIX-#7138: Stop reloading modules for custom docstrings.

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -13,7 +13,6 @@
 
 """Module houses Modin configs originated from environment variables."""
 
-import importlib
 import os
 import secrets
 import sys
@@ -770,36 +769,6 @@ class DocModule(EnvironmentVariable, type=ExactStr):
 
     varname = "MODIN_DOC_MODULE"
     default = "pandas"
-
-    @classmethod
-    def put(cls, value: str) -> None:
-        """
-        Assign a value to the DocModule config.
-
-        Parameters
-        ----------
-        value : str
-            Config value to set.
-        """
-        super().put(value)
-        # Reload everything to apply the documentation. This is required since the
-        # docs might already have been created and the implementation will assume
-        # that the new docs are applied when the config is set. This set of operations
-        # does this.
-        import modin.pandas as pd
-
-        importlib.reload(pd.accessor)
-        importlib.reload(pd.base)
-        importlib.reload(pd.dataframe)
-        importlib.reload(pd.general)
-        importlib.reload(pd.groupby)
-        importlib.reload(pd.io)
-        importlib.reload(pd.iterator)
-        importlib.reload(pd.series)
-        importlib.reload(pd.series_utils)
-        importlib.reload(pd.utils)
-        importlib.reload(pd.window)
-        importlib.reload(pd)
 
 
 class DaskThreadsPerWorker(EnvironmentVariable, type=int):

--- a/modin/tests/config/test_envvars.py
+++ b/modin/tests/config/test_envvars.py
@@ -13,6 +13,7 @@
 
 import os
 
+import pandas
 import pytest
 
 import modin.config as cfg
@@ -79,34 +80,47 @@ def test_custom_help(make_custom_envvar):
     assert "custom var" in make_custom_envvar.get_help()
 
 
-def test_doc_module():
-    import pandas
+class TestDocModule:
+    """
+    Test using a module to replace default docstrings.
+    """
 
-    import modin.pandas as pd
-    from modin.config import DocModule
+    def test_overrides(self):
+        cfg.DocModule.put("modin.tests.config.docs_module")
 
-    DocModule.put("modin.tests.config.docs_module")
+        # Test for override
+        assert (
+            pd.DataFrame.apply.__doc__
+            == "This is a test of the documentation module for DataFrame."
+        )
+        # Test for pandas doc when method is not defined on the plugin module
+        assert pandas.DataFrame.isna.__doc__ in pd.DataFrame.isna.__doc__
+        assert pandas.DataFrame.isnull.__doc__ in pd.DataFrame.isnull.__doc__
+        # Test for override
+        assert (
+            pd.Series.isna.__doc__
+            == "This is a test of the documentation module for Series."
+        )
+        # Test for pandas doc when method is not defined on the plugin module
+        assert pandas.Series.isnull.__doc__ in pd.Series.isnull.__doc__
+        assert pandas.Series.apply.__doc__ in pd.Series.apply.__doc__
+        # Test for override
+        assert pd.read_csv.__doc__ == "Test override for functions on the module."
+        # Test for pandas doc when function is not defined on module.
+        assert pandas.read_table.__doc__ in pd.read_table.__doc__
 
-    # Test for override
-    assert (
-        pd.DataFrame.apply.__doc__
-        == "This is a test of the documentation module for DataFrame."
-    )
-    # Test for pandas doc when method is not defined on the plugin module
-    assert pandas.DataFrame.isna.__doc__ in pd.DataFrame.isna.__doc__
-    assert pandas.DataFrame.isnull.__doc__ in pd.DataFrame.isnull.__doc__
-    # Test for override
-    assert (
-        pd.Series.isna.__doc__
-        == "This is a test of the documentation module for Series."
-    )
-    # Test for pandas doc when method is not defined on the plugin module
-    assert pandas.Series.isnull.__doc__ in pd.Series.isnull.__doc__
-    assert pandas.Series.apply.__doc__ in pd.Series.apply.__doc__
-    # Test for override
-    assert pd.read_csv.__doc__ == "Test override for functions on the module."
-    # Test for pandas doc when function is not defined on module.
-    assert pandas.read_table.__doc__ in pd.read_table.__doc__
+    def test_not_redefining_classes_modin_issue_7138(self):
+        original_dataframe_class = pd.DataFrame
+
+        cfg.DocModule.put("modin.tests.config.docs_module")
+
+        # Test for override
+        assert (
+            pd.DataFrame.apply.__doc__
+            == "This is a test of the documentation module for DataFrame."
+        )
+
+        assert pd.DataFrame is original_dataframe_class
 
 
 @pytest.mark.skipif(cfg.Engine.get() != "Ray", reason="Ray specific test")

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -403,7 +403,7 @@ def _update_inherited_docstrings(doc_module: DocModule) -> None:
         The current DocModule
     """
     for doc_inheritance_call in _docstring_inheritance_calls:
-        doc_inheritance_call(doc_module.get())
+        doc_inheritance_call(doc_module=doc_module.get())  # type: ignore[call-arg]
 
 
 def _inherit_docstrings_in_place(

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -417,8 +417,9 @@ def _update_inherited_docstrings(doc_module: DocModule) -> None:
     doc_module : DocModule
         The current DocModule.
     """
+    _doc_module = doc_module.get()
     for doc_inheritance_call in _docstring_inheritance_calls:
-        doc_inheritance_call(doc_module=doc_module.get())  # type: ignore[call-arg]
+        doc_inheritance_call(doc_module=_doc_module)  # type: ignore[call-arg]
 
 
 def _inherit_docstrings_in_place(

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -386,7 +386,19 @@ _docstring_inheritance_calls: list[Callable[[str], None]] = []
 
 
 def _documentable_obj(obj: object) -> bool:
-    """Check if `obj` docstring could be patched."""
+    """
+    Check whether we can replace the docstring of `obj`.
+
+    Parameters
+    ----------
+    obj : object
+        Object whose docstring we want to replace.
+
+    Returns
+    -------
+    bool
+        Whether we can replace the docstring.
+    """
     return bool(
         callable(obj)
         and not inspect.isclass(obj)
@@ -399,10 +411,11 @@ def _documentable_obj(obj: object) -> bool:
 def _update_inherited_docstrings(doc_module: DocModule) -> None:
     """
     Update all inherited docstrings.
+
     Parameters
     ----------
-    doc_module: DocModule
-        The current DocModule
+    doc_module : DocModule
+        The current DocModule.
     """
     for doc_inheritance_call in _docstring_inheritance_calls:
         doc_inheritance_call(doc_module=doc_module.get())  # type: ignore[call-arg]
@@ -416,6 +429,27 @@ def _inherit_docstrings_in_place(
     overwrite_existing: bool = False,
     apilink: Optional[Union[str, List[str]]] = None,
 ) -> None:
+    """
+    Replace `cls_or_func` docstrings with `parent` docstrings in place.
+
+    Parameters
+    ----------
+    cls_or_func : Fn
+        The class or function whose docstrings we need to update.
+    doc_module : str
+        The docs module.
+    parent : object
+        Parent object from which the decorated object inherits __doc__.
+    excluded : list, default: []
+        List of parent objects from which the class does not
+        inherit docstrings.
+    overwrite_existing : bool, default: False
+        Allow overwriting docstrings that already exist in
+        the decorated class.
+    apilink : str | List[str], optional
+        If non-empty, insert the link(s) to pandas API documentation.
+        Should be the prefix part in the URL template, e.g. "pandas.DataFrame".
+    """
     # Import the docs module and get the class (e.g. `DataFrame`).
     imported_doc_module = importlib.import_module(doc_module)
     # Set the default parent so we can use it in case some docs are missing from

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -389,7 +389,9 @@ def _documentable_obj(obj: object) -> bool:
     """Check if `obj` docstring could be patched."""
     return bool(
         callable(obj)
+        and not inspect.isclass(obj)
         or (isinstance(obj, property) and obj.fget)
+        or (isinstance(obj, functools.cached_property))
         or (isinstance(obj, (staticmethod, classmethod)) and obj.__func__)
     )
 
@@ -432,12 +434,7 @@ def _inherit_docstrings_in_place(
         overwrite_existing = True
 
     if parent not in excluded:
-        _replace_doc(
-            parent,
-            cls_or_func,
-            overwrite_existing,
-            apilink,
-        )
+        _replace_doc(parent, cls_or_func, overwrite_existing, apilink)
 
     if not isinstance(cls_or_func, types.FunctionType):
         seen = set()


### PR DESCRIPTION
Signed-off-by: sfc-gh-mvashishtha <mahesh.vashishtha@snowflake.com><!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Stop reloading modules for custom docstrings. See #7138 for motivation.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7138
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
