### PR TITLE
FEAT-#6574: UserWarning no longer displayed when Series/DataFrames are small

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -205,9 +205,6 @@ class DataFrame(BasePandasDataset):
                 self._query_compiler = distributed_frame._query_compiler
                 return
 
-            warnings.warn(
-                "Distributing {} object. This may take some time.".format(type(data))
-            )
             if isinstance(data, pandas.Index):
                 pass
             elif (
@@ -253,6 +250,12 @@ class DataFrame(BasePandasDataset):
             pandas_df = pandas.DataFrame(
                 data=data, index=index, columns=columns, dtype=dtype, copy=copy
             )
+            if pandas_df.size >= 1_000_000:
+                warnings.warn(
+                    "Distributing {} object. This may take some time.".format(
+                        type(data)
+                    )
+                )
             self._query_compiler = from_pandas(pandas_df)._query_compiler
         else:
             self._query_compiler = query_compiler

--- a/modin/tests/pandas/dataframe/test_default.py
+++ b/modin/tests/pandas/dataframe/test_default.py
@@ -1473,3 +1473,37 @@ def test_df_from_series_with_tuple_name():
     df_equals(pd.DataFrame(pandas.Series(name=("a", 1))), pandas_result)
     # 2. Creating a Modin DF from Modin Series
     df_equals(pd.DataFrame(pd.Series(name=("a", 1))), pandas_result)
+
+
+def test_large_df_warns_distributing_takes_time():
+    # https://github.com/modin-project/modin/issues/6574
+
+    regex = r"Distributing (.*) object\. This may take some time\."
+    with pytest.warns(UserWarning, match=regex):
+        pd.DataFrame(np.random.randint(1_000_000, size=(100_000, 10)))
+
+
+def test_large_series_warns_distributing_takes_time():
+    # https://github.com/modin-project/modin/issues/6574
+
+    regex = r"Distributing (.*) object\. This may take some time\."
+    with pytest.warns(UserWarning, match=regex):
+        pd.Series(np.random.randint(1_000_000, size=(2_500_000)))
+
+
+def test_df_does_not_warn_distributing_takes_time():
+    # https://github.com/modin-project/modin/issues/6574
+
+    regex = r"Distributing (.*) object\. This may take some time\."
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", regex, UserWarning)
+        pd.DataFrame(np.random.randint(1_000_000, size=(100_000, 9)))
+
+
+def test_series_does_not_warn_distributing_takes_time():
+    # https://github.com/modin-project/modin/issues/6574
+
+    regex = r"Distributing (.*) object\. This may take some time\."
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", regex, UserWarning)
+        pd.Series(np.random.randint(1_000_000, size=(2_400_000)))

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -18,6 +18,7 @@ import itertools
 import json
 import sys
 import unittest.mock as mock
+import warnings
 
 import matplotlib
 import numpy as np
@@ -26,7 +27,7 @@ import pandas._libs.lib as lib
 import pytest
 from numpy.testing import assert_array_equal
 from pandas.core.indexing import IndexingError
-from pandas.errors import SpecificationError
+from pandas.errors import SpecificationError, PerformanceWarning
 
 import modin.pandas as pd
 from modin.config import Engine, NPartitions, StorageFormat
@@ -3429,13 +3430,10 @@ def test_sub(data):
 
 def test_6782():
     datetime_scalar = datetime.datetime(1970, 1, 1, 0, 0)
-    with pytest.warns(UserWarning) as warns:
-        _ = pd.Series([datetime.datetime(2000, 1, 1)]) - datetime_scalar
-        for warn in warns.list:
-            assert (
-                "Adding/subtracting object-dtype array to DatetimeArray not vectorized"
-                not in str(warn)
-            )
+    match = "Adding/subtracting object-dtype array to DatetimeArray not vectorized"
+    with warnings.catch_warnings():
+        warnings.filterwarnings("error", match, PerformanceWarning)
+        pd.Series([datetime.datetime(2000, 1, 1)]) - datetime_scalar
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -27,7 +27,7 @@ import pandas._libs.lib as lib
 import pytest
 from numpy.testing import assert_array_equal
 from pandas.core.indexing import IndexingError
-from pandas.errors import SpecificationError, PerformanceWarning
+from pandas.errors import PerformanceWarning, SpecificationError
 
 import modin.pandas as pd
 from modin.config import Engine, NPartitions, StorageFormat


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

When creating a DataFrame or Series, no longer display `UserWarning: Distributing <class 'NoneType'> object. This may take some time.` when the size of the DataFrame or Series is small.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #6574 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
