### PR TITLE
DOCS-#0000: Adds RunLLM widget to docs

### DIFF
--- a/docs/_static/custom.js
+++ b/docs/_static/custom.js
@@ -1,0 +1,16 @@
+document.addEventListener("DOMContentLoaded", function () {
+  var script = document.createElement("script");
+  script.type = "module";
+  script.id = "runllm-widget-script"
+
+  script.src = "https://cdn.jsdelivr.net/npm/@runllm/search-widget@stable/dist/run-llm-search-widget.es.js";
+
+  script.setAttribute("version", "stable");
+  script.setAttribute("runllm-keyboard-shortcut", "Mod+j"); // cmd-j or ctrl-j to open the widget.
+  script.setAttribute("runllm-name", "Modin");
+  script.setAttribute("runllm-position", "BOTTOM_RIGHT");
+  script.setAttribute("runllm-assistant-id", "164");
+
+  script.async = true;
+  document.head.appendChild(script);
+});

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -115,6 +115,8 @@ language = "en"
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path .
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+html_static_path = ["_static"]
+html_js_files = ["custom.js"]
 
 # The name of the Pygments (syntax highlighting) style to use.
 pygments_style = "sphinx"


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Adds the [RunLLM](https://runllm.com) widget, customized to Modin, to the documentation page. RunLLM is a custom technical support assistant that helps developers unblock themselves by answering conceptual questions, generating code, and helping debug.

Here's an example response from RunLLM:
<img width="1899" alt="image" src="https://github.com/modin-project/modin/assets/867892/e2a675c1-bc04-43e2-a049-5a3245cd995b">

Just a note that I put the `custom.js` file in a new directory called `_static`, which seems to be the convention for Sphinx, and I updated `conf.py` accordingly. I didn't see any existing uses of `html_static_paths`, but please let me know if there's a different preferred organization.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [N/A] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [N/A] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [N/A] Resolves #? <!-- issue must be created for each patch -->
- [N/A] tests added and passing
- [N/A] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
