### PR TITLE
FEAT-#7337: Using dynamic partitionning in broadcast_apply

### DIFF
--- a/modin/core/dataframe/algebra/groupby.py
+++ b/modin/core/dataframe/algebra/groupby.py
@@ -655,9 +655,11 @@ class GroupByReduce(TreeReduce):
                     )
 
             native_res_part = [] if native_agg_res is None else [native_agg_res]
-            result = pandas.concat(
-                [*native_res_part, *custom_results], axis=1, copy=False
-            )
+            parts = [*native_res_part, *custom_results]
+            if parts:
+                result = pandas.concat(parts, axis=1, copy=False)
+            else:
+                result = pandas.DataFrame(columns=result_columns)
 
             # The order is naturally preserved if there's no custom aggregations
             if preserve_aggregation_order and len(custom_aggs):

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -33,6 +33,7 @@ from pandas.core.dtypes.common import is_dtype_equal, is_list_like, is_numeric_d
 from pandas.core.indexes.api import Index, RangeIndex
 
 from modin.config import (
+    CpuCount,
     Engine,
     IsRayCluster,
     MinColumnPartitionSize,
@@ -210,6 +211,22 @@ class PandasDataframe(
         int
         """
         return np.prod(self._partitions.shape)
+
+    @property
+    def size(self) -> Optional[int]:
+        """
+        Get an int representing the number of elements in this frame, if known.
+
+        Returns
+        -------
+        int or None
+        """
+        if self.has_index_cache and self.has_columns_cache:
+            return len(self.index) * len(self.columns)
+        elif self._row_lengths_cache and self._column_widths_cache:
+            return sum(self._row_lengths_cache) * sum(self._column_widths_cache)
+        else:
+            return None
 
     @property
     def row_lengths(self):
@@ -3265,9 +3282,31 @@ class PandasDataframe(
                 axis
             ), self.copy_axis_cache(axis)
 
-        new_frame = self._partition_mgr_cls.broadcast_apply(
-            axis, func, left_parts, right_parts
-        )
+        # check the conditions for use of dynamic partitioning
+        use_dynamic_partitioning = False
+        if self.num_parts <= 1.5 * CpuCount.get():
+            use_dynamic_partitioning = True
+
+            # When the frame is large, dynamic partitioning
+            # performs worse than the based approach
+            frame_size = self.size
+            if frame_size and (frame_size >= 4 * 10**9 or len(self) >= 10**7):
+                use_dynamic_partitioning = False
+
+        if use_dynamic_partitioning:
+            new_frame = self._partition_mgr_cls.broadcast_axis_partitions(
+                axis=axis ^ 1,
+                left=left_parts,
+                right=right_parts,
+                apply_func=func,
+                broadcast_all=False,
+                keep_partitioning=True,
+            )
+        else:
+            new_frame = self._partition_mgr_cls.broadcast_apply(
+                axis, func, left_parts, right_parts
+            )
+
         if isinstance(dtypes, str) and dtypes == "copy":
             dtypes = self.copy_dtypes_cache()
 

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3265,7 +3265,9 @@ class PandasDataframe(
                 axis
             ), self.copy_axis_cache(axis)
 
-        new_frame = self._partition_mgr_cls.apply(axis, func, left_parts, right_parts)
+        new_frame = self._partition_mgr_cls.broadcast_apply(
+            axis, func, left_parts, right_parts
+        )
         if isinstance(dtypes, str) and dtypes == "copy":
             dtypes = self.copy_dtypes_cache()
 

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -3265,9 +3265,7 @@ class PandasDataframe(
                 axis
             ), self.copy_axis_cache(axis)
 
-        new_frame = self._partition_mgr_cls.broadcast_apply(
-            axis, func, left_parts, right_parts
-        )
+        new_frame = self._partition_mgr_cls.apply(axis, func, left_parts, right_parts)
         if isinstance(dtypes, str) and dtypes == "copy":
             dtypes = self.copy_dtypes_cache()
 

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -533,7 +533,7 @@ class PandasDataframePartitionManager(
             then the number of splits is preserved.
         apply_indices : list of ints, default: None
             Indices of `axis ^ 1` to apply function over.
-        send_all_right: bool, default: True
+        send_all_right : bool, default: True
             Whether or not to pass all right axis partitions to each of the left axis partitions.
         enumerate_partitions : bool, default: False
             Whether or not to pass partition index into `apply_func`.
@@ -663,8 +663,7 @@ class PandasDataframePartitionManager(
         right,
     ):
         """
-        Broadcast the `right` partitions to `left` and apply `apply_func` function
-        using different approaches to achieve the best performance.
+        Broadcast the `right` partitions to `left` and apply `apply_func` function using different approaches to achieve the best performance.
 
         Parameters
         ----------
@@ -682,12 +681,9 @@ class PandasDataframePartitionManager(
         np.ndarray
             NumPy array of result partition objects.
         """
-        # The condition for the execution of `broadcast_apply` is different from
-        # the same condition in the `map_partitions`, since the columnar partitioning approach
-        # cannot be implemented for the `apply`. This is due to the fact that different
-        # partitions of the left and right dataframes are possible for the `apply`,
-        # as a result of which it is necessary to merge partitions on both axes at once,
-        # which leads to large slowdowns.
+        # The `broadcast_apply` runtime condition differs from
+        # the same condition in `map_partitions` because the columnar
+        # approach for `broadcast_apply` results in a slowdown.
         if np.prod(left.shape) <= 1.5 * CpuCount.get():
             # block-wise broadcast
             new_partitions = cls.base_broadcast_apply(

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -440,7 +440,7 @@ class PandasDataframePartitionManager(
 
     @classmethod
     @wait_computations_if_benchmark_mode
-    def base_broadcast_apply(cls, axis, apply_func, left, right):
+    def broadcast_apply(cls, axis, apply_func, left, right):
         """
         Broadcast the `right` partitions to `left` and apply `apply_func` function.
 
@@ -652,57 +652,6 @@ class PandasDataframePartitionManager(
                 for row_of_parts in partitions
             ]
         )
-
-    @classmethod
-    @wait_computations_if_benchmark_mode
-    def broadcast_apply(
-        cls,
-        axis,
-        apply_func,
-        left,
-        right,
-    ):
-        """
-        Broadcast the `right` partitions to `left` and apply `apply_func` function using different approaches to achieve the best performance.
-
-        Parameters
-        ----------
-        axis : {0, 1}
-            Axis to apply and broadcast over.
-        apply_func : callable
-            Function to apply.
-        left : np.ndarray
-            NumPy array of left partitions.
-        right : np.ndarray
-            NumPy array of right partitions.
-
-        Returns
-        -------
-        np.ndarray
-            NumPy array of result partition objects.
-        """
-        # The `broadcast_apply` runtime condition differs from
-        # the same condition in `map_partitions` because the columnar
-        # approach for `broadcast_apply` results in a slowdown.
-        if np.prod(left.shape) <= 1.5 * CpuCount.get():
-            # block-wise broadcast
-            new_partitions = cls.base_broadcast_apply(
-                axis,
-                apply_func,
-                left,
-                right,
-            )
-        else:
-            # axis-wise broadcast
-            new_partitions = cls.broadcast_axis_partitions(
-                axis=axis ^ 1,
-                left=left,
-                right=right,
-                apply_func=apply_func,
-                broadcast_all=False,
-                keep_partitioning=True,
-            )
-        return new_partitions
 
     @classmethod
     @wait_computations_if_benchmark_mode

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -681,10 +681,7 @@ class PandasDataframePartitionManager(
         np.ndarray
             NumPy array of result partition objects.
         """
-        # The `broadcast_apply` runtime condition differs from
-        # the same condition in `map_partitions` because the columnar
-        # approach for `broadcast_apply` results in a slowdown.
-        if np.prod(left.shape) <= 1.5 * CpuCount.get():
+        if not DynamicPartitioning.get():
             # block-wise broadcast
             new_partitions = cls.base_broadcast_apply(
                 axis,
@@ -693,6 +690,8 @@ class PandasDataframePartitionManager(
                 right,
             )
         else:
+            # The dynamic partitioning behavior of `broadcast_apply` differs from that of `map_partitions`,
+            # since the columnar approach for `broadcast_apply` results in slowdown.
             # axis-wise broadcast
             new_partitions = cls.broadcast_axis_partitions(
                 axis=axis ^ 1,

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -513,10 +513,6 @@ class PandasDataframePartitionManager(
             Left partitions.
         right : NumPy 2D array
             Right partitions.
-        keep_partitioning : boolean, default: False
-            The flag to keep partition boundaries for Modin Frame if possible.
-            Setting it to True disables shuffling data from one partition to another in case the resulting
-            number of splits is equal to the initial number of splits.
 
         Returns
         -------

--- a/modin/core/dataframe/pandas/partitioning/partition_manager.py
+++ b/modin/core/dataframe/pandas/partitioning/partition_manager.py
@@ -504,7 +504,7 @@ class PandasDataframePartitionManager(
         keep_partitioning=False,
         num_splits=None,
         apply_indices=None,
-        send_all_right=True,
+        broadcast_all=True,
         enumerate_partitions=False,
         lengths=None,
         apply_func_args=None,
@@ -533,7 +533,7 @@ class PandasDataframePartitionManager(
             then the number of splits is preserved.
         apply_indices : list of ints, default: None
             Indices of `axis ^ 1` to apply function over.
-        send_all_right : bool, default: True
+        broadcast_all : bool, default: True
             Whether or not to pass all right axis partitions to each of the left axis partitions.
         enumerate_partitions : bool, default: False
             Whether or not to pass partition index into `apply_func`.
@@ -596,7 +596,7 @@ class PandasDataframePartitionManager(
                     preprocessed_map_func,
                     *(apply_func_args if apply_func_args else []),
                     other_axis_partition=(
-                        right_partitions if send_all_right else right_partitions[i]
+                        right_partitions if broadcast_all else right_partitions[i]
                     ),
                     **kw,
                     **({"partition_idx": idx} if enumerate_partitions else {}),
@@ -699,7 +699,8 @@ class PandasDataframePartitionManager(
                 left=left,
                 right=right,
                 apply_func=apply_func,
-                send_all_right=False,
+                broadcast_all=False,
+                keep_partitioning=True,
             )
         return new_partitions
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -45,7 +45,7 @@ from pandas.core.indexes.api import ensure_index_from_sequences
 from pandas.core.indexing import check_bool_indexer
 from pandas.errors import DataError
 
-from modin.config import CpuCount, RangePartitioning
+from modin.config import RangePartitioning
 from modin.core.dataframe.algebra import (
     Binary,
     Fold,
@@ -3157,14 +3157,8 @@ class PandasQueryCompiler(BaseQueryCompiler):
             lib.no_default,
             None,
         )
-        # FIXME: this is a naive workaround for this problem: https://github.com/modin-project/modin/issues/5394
-        # if there are too many partitions then all non-full-axis implementations start acting very badly.
-        # The here threshold is pretty random though it works fine on simple scenarios
-        processable_amount_of_partitions = (
-            self._modin_frame.num_parts < CpuCount.get() * 32
-        )
 
-        if is_column_wise and no_thresh_passed and processable_amount_of_partitions:
+        if is_column_wise and no_thresh_passed:
             how = kwargs.get("how", "any")
             subset = kwargs.get("subset")
             how = "any" if how in (lib.no_default, None) else how

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -45,8 +45,7 @@ from pandas.core.indexes.api import ensure_index_from_sequences
 from pandas.core.indexing import check_bool_indexer
 from pandas.errors import DataError
 
-from modin.config import RangePartitioning
-from modin.config.envvars import CpuCount
+from modin.config import CpuCount, RangePartitioning
 from modin.core.dataframe.algebra import (
     Binary,
     Fold,

--- a/modin/tests/pandas/test_groupby.py
+++ b/modin/tests/pandas/test_groupby.py
@@ -22,11 +22,11 @@ import pytest
 
 import modin.pandas as pd
 from modin.config import (
-    DynamicPartitioning,
     IsRayCluster,
     NPartitions,
     RangePartitioning,
     StorageFormat,
+    context,
 )
 from modin.core.dataframe.algebra.default2pandas.groupby import GroupBy
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
@@ -2438,8 +2438,6 @@ def test_multi_column_groupby_different_partitions(
 
 
 def test_empty_partitions_after_groupby():
-    DynamicPartitioning.put(True)
-
     def func_to_apply(grp):
         return grp.agg(
             {
@@ -2452,15 +2450,16 @@ def test_empty_partitions_after_groupby():
     md_df, pd_df = create_test_dfs(data)
     by = pd_df.columns[0]
 
-    md_grp, pd_grp = (
-        md_df.groupby(by),
-        pd_df.groupby(by),
-    )
-    eval_general(
-        md_grp,
-        pd_grp,
-        func_to_apply,
-    )
+    with context(DynamicPartitioning=True):
+        md_grp, pd_grp = (
+            md_df.groupby(by),
+            pd_df.groupby(by),
+        )
+        eval_general(
+            md_grp,
+            pd_grp,
+            func_to_apply,
+        )
 
 
 @pytest.mark.parametrize(

--- a/modin/tests/pandas/test_groupby.py
+++ b/modin/tests/pandas/test_groupby.py
@@ -21,7 +21,13 @@ import pandas._libs.lib as lib
 import pytest
 
 import modin.pandas as pd
-from modin.config import IsRayCluster, NPartitions, RangePartitioning, StorageFormat
+from modin.config import (
+    DynamicPartitioning,
+    IsRayCluster,
+    NPartitions,
+    RangePartitioning,
+    StorageFormat,
+)
 from modin.core.dataframe.algebra.default2pandas.groupby import GroupBy
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
@@ -2428,6 +2434,32 @@ def test_multi_column_groupby_different_partitions(
     # FIXME: https://github.com/modin-project/modin/issues/7034
     eval___getitem__(
         md_grp, pd_grp, [md_df.columns[1], md_df.columns[2]], expected_exception=False
+    )
+
+
+def test_empty_partitions_after_groupby():
+    DynamicPartitioning.put(True)
+
+    def func_to_apply(grp):
+        return grp.agg(
+            {
+                list(test_data_values[0].keys())[1]: "sum",
+                list(test_data_values[0].keys())[-1]: "sum",
+            }
+        )
+
+    data = test_data_values[0]
+    md_df, pd_df = create_test_dfs(data)
+    by = pd_df.columns[0]
+
+    md_grp, pd_grp = (
+        md_df.groupby(by),
+        pd_df.groupby(by),
+    )
+    eval_general(
+        md_grp,
+        pd_grp,
+        func_to_apply,
     )
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7337? <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

Performance results were obtained by using Dataframe with shape (20000, 5000).
| Operation        | Modin main | This PR |
| ---------------- | ------------- | --------- |
| fillna(df_value) | 32.460861    | 1.79279 |

