### PR TITLE
FIX-#0000: Fix type hint

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -20,7 +20,16 @@ import pickle as pkl
 import re
 import warnings
 from functools import cached_property
-from typing import TYPE_CHECKING, Any, Callable, Hashable, Literal, Optional, Sequence
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Hashable,
+    Literal,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import numpy as np
 import pandas
@@ -2147,7 +2156,7 @@ class BasePandasDataset(ClassLogger):
     def _stat_operation(
         self,
         op_name: str,
-        axis: int | str,
+        axis: Optional[Union[int, str]],
         skipna: bool,
         numeric_only: Optional[bool] = False,
         **kwargs,


### PR DESCRIPTION
## What do these changes do?
Fix a type check warning reported by Pyre@Google, which was outdated after code modification.

## Detail
update the parameter `axis` of function `_stat_operation` from `int | str` to `Optional[Union[int, str]]`, since it could be `None` after commit https://github.com/modin-project/modin/commit/d192e8778d4eed1862a7f90200970af54e43f6d1
