### PR TITLE
FIX-#7134: Use a separate docstring class for BasePandasDataset.

### DIFF
--- a/modin/tests/config/docs_module/__init__.py
+++ b/modin/tests/config/docs_module/__init__.py
@@ -11,7 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from .classes import DataFrame, Series
+from .classes import BasePandasDataset, DataFrame, Series
 from .functions import read_csv
 
-__all__ = ["DataFrame", "Series", "read_csv"]
+__all__ = ["BasePandasDataset", "DataFrame", "Series", "read_csv"]

--- a/modin/tests/config/docs_module/classes.py
+++ b/modin/tests/config/docs_module/classes.py
@@ -22,3 +22,11 @@ class Series:
     def isna(self):
         """This is a test of the documentation module for Series."""
         return
+
+
+class BasePandasDataset:
+    """This is a test of the documentation module for BasePandasDataSet."""
+
+    def apply():
+        """This is a test of the documentation module for BasePandasDataSet.apply."""
+        return

--- a/modin/tests/config/test_envvars.py
+++ b/modin/tests/config/test_envvars.py
@@ -20,6 +20,7 @@ import modin.config as cfg
 import modin.pandas as pd
 from modin.config.envvars import _check_vars
 from modin.config.pubsub import _UNSET, ExactStr
+from modin.pandas.base import BasePandasDataset
 
 
 def reset_vars(*vars: tuple[cfg.Parameter]):
@@ -89,6 +90,12 @@ class TestDocModule:
         cfg.DocModule.put("modin.tests.config.docs_module")
 
         # Test for override
+        assert BasePandasDataset.__doc__ == (
+            "This is a test of the documentation module for BasePandasDataSet."
+        )
+        assert BasePandasDataset.apply.__doc__ == (
+            "This is a test of the documentation module for BasePandasDataSet.apply."
+        )
         assert (
             pd.DataFrame.apply.__doc__
             == "This is a test of the documentation module for DataFrame."
@@ -96,6 +103,7 @@ class TestDocModule:
         # Test for pandas doc when method is not defined on the plugin module
         assert pandas.DataFrame.isna.__doc__ in pd.DataFrame.isna.__doc__
         assert pandas.DataFrame.isnull.__doc__ in pd.DataFrame.isnull.__doc__
+        assert BasePandasDataset.astype.__doc__ in pd.DataFrame.astype.__doc__
         # Test for override
         assert (
             pd.Series.isna.__doc__

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -462,7 +462,18 @@ def _inherit_docstrings_in_place(
     if doc_module != DocModule.default and "pandas" in str(
         getattr(parent, "__module__", "")
     ):
-        parent = getattr(imported_doc_module, getattr(parent, "__name__", ""), parent)
+        parent_name = (
+            # DocModule should use the class BasePandasDataset to override the
+            # docstrings of BasePandasDataset, even if BasePandasDataset
+            # normally inherits docstrings from a different `parent`.
+            "BasePandasDataset"
+            if getattr(cls_or_func, "__name__", "") == "BasePandasDataset"
+            # For other classes, override docstrings with the class that has the
+            # same name as the `parent` class, e.g. DataFrame inherits
+            # docstrings from doc_module.DataFrame.
+            else getattr(parent, "__name__", "")
+        )
+        parent = getattr(imported_doc_module, parent_name, parent)
     if parent != default_parent:
         # Reset API link in case the docs are overridden.
         apilink = None


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #7134 
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
