### PR TITLE
FIX-#7355: Cpu count would be set incorrectly on a cluster

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -333,6 +333,24 @@ class CpuCount(EnvironmentVariable, type=int):
     varname = "MODIN_CPUS"
 
     @classmethod
+    def _put(cls, value: int) -> None:
+        """
+        Put specific value if CpuCount wasn't set by a user yet.
+
+        Parameters
+        ----------
+        value : int
+            Config value to set.
+
+        Notes
+        -----
+        This method is used to set CpuCount from cluster resources internally
+        and should not be called by a user.
+        """
+        if cls.get_value_source() == ValueSource.DEFAULT:
+            cls.put(value)
+
+    @classmethod
     def _get_default(cls) -> int:
         """
         Get default value of the config.

--- a/modin/core/execution/dask/common/utils.py
+++ b/modin/core/execution/dask/common/utils.py
@@ -74,3 +74,4 @@ def initialize_dask():
 
     num_cpus = len(client.ncores())
     NPartitions._put(num_cpus)
+    CpuCount._put(num_cpus)

--- a/modin/core/execution/ray/common/utils.py
+++ b/modin/core/execution/ray/common/utils.py
@@ -151,6 +151,7 @@ def initialize_ray(
 
     num_cpus = int(ray.cluster_resources()["CPU"])
     NPartitions._put(num_cpus)
+    CpuCount._put(num_cpus)
 
     # TODO(https://github.com/ray-project/ray/issues/28216): remove this
     # workaround once Ray gives a better way to suppress task errors.

--- a/modin/core/execution/unidist/common/utils.py
+++ b/modin/core/execution/unidist/common/utils.py
@@ -42,6 +42,7 @@ def initialize_unidist():
 
     num_cpus = sum(v["CPU"] for v in unidist.cluster_resources().values())
     modin_cfg.NPartitions._put(num_cpus)
+    modin_cfg.CpuCount._put(num_cpus)
 
 
 def deserialize(obj):  # pragma: no cover


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #7355 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
