### PR TITLE
FIX-#7371: Fix inserting datelike values into a DataFrame

### DIFF
--- a/modin/core/dataframe/pandas/metadata/dtypes.py
+++ b/modin/core/dataframe/pandas/metadata/dtypes.py
@@ -1225,7 +1225,7 @@ def extract_dtype(value) -> DtypeObj | pandas.Series:
     """
     try:
         dtype = pandas.api.types.pandas_dtype(value)
-    except TypeError:
+    except (TypeError, ValueError):
         dtype = pandas.Series(value).dtype
 
     return dtype

--- a/modin/tests/pandas/dataframe/test_map_metadata.py
+++ b/modin/tests/pandas/dataframe/test_map_metadata.py
@@ -1837,3 +1837,18 @@ def test_constructor_from_index():
     data = pd.Index([1, 2, 3], name="pricing_date")
     modin_df, pandas_df = create_test_dfs(data)
     df_equals(modin_df, pandas_df)
+
+
+def test_insert_datelike_string_issue_7371():
+    # When a new value is inserted into a frame, we call pandas.api.types.pandas_dtype(value) to
+    # extract the dtype of an object like a pandas Series or numpy array. When a scalar value is passed,
+    # this usually raises a TypeError, so we construct a local pandas Series from the object and
+    # extract the dtype from there.
+    # When the passed value is a date-like string, pandas will instead raise a ValueError because
+    # it tries to parse it as a numpy structured dtype. After fixing GH#7371, we now catch
+    # ValueError in addition to TypeError to handle this case.
+    modin_df = pd.DataFrame({"a": [0]})
+    modin_df["c"] = "2020-01-01"
+    pandas_df = pandas.DataFrame({"a": [0]})
+    pandas_df["c"] = "2020-01-01"
+    df_equals(modin_df, pandas_df)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

When a new value is inserted into a frame, we call `pandas.api.types.pandas_dtype(value)` to extract the dtype of an object like a pandas Series or numpy array. After #7261, when a scalar value is passed, this usually raises a TypeError, so we construct a local pandas Series from the object and extract the dtype from there.
 
When the passed value is a date-like string, pandas will instead raise a ValueError because it tries to parse it as a numpy structured dtype. After this fix, we now catch ValueError in addition to TypeError to handle this case.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7371 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
