### PR TITLE
FIX-#7381: Fix Series binary operators ignoring fill_value

### DIFF
--- a/modin/core/storage_formats/base/doc_utils.py
+++ b/modin/core/storage_formats/base/doc_utils.py
@@ -193,6 +193,14 @@ def doc_binary_method(operation, sign, self_on_right=False, op_type="arithmetic"
         fill_value : float or None
             Value to fill missing elements during frame alignment.
         """,
+        "series_comparison": """
+        level : int or label
+            In case of MultiIndex match index values on the passed level.
+        fill_value : float or None
+            Value to fill missing elements during frame alignment.
+        axis : {{0, 1}}
+            Unused. Parameter needed for compatibility with DataFrame.
+        """,
     }
 
     verbose_substitution = (

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -647,7 +647,9 @@ class BaseQueryCompiler(
     def eq(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.eq)(self, other=other, **kwargs)
 
-    @doc_utils.add_refer_to("Series.eq")
+    @doc_utils.doc_binary_method(
+        operation="equality comparison", sign="==", op_type="series_comparison"
+    )
     def series_eq(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.eq)(
             self,
@@ -695,7 +697,11 @@ class BaseQueryCompiler(
     def ge(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.ge)(self, other=other, **kwargs)
 
-    @doc_utils.add_refer_to("Series.ge")
+    @doc_utils.doc_binary_method(
+        operation="greater than or equal comparison",
+        sign=">=",
+        op_type="series_comparison",
+    )
     def series_ge(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.ge)(
             self,
@@ -711,7 +717,9 @@ class BaseQueryCompiler(
     def gt(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.gt)(self, other=other, **kwargs)
 
-    @doc_utils.add_refer_to("Series.gt")
+    @doc_utils.doc_binary_method(
+        operation="greater than comparison", sign=">", op_type="series_comparison"
+    )
     def series_gt(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.gt)(
             self,
@@ -727,7 +735,11 @@ class BaseQueryCompiler(
     def le(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.le)(self, other=other, **kwargs)
 
-    @doc_utils.add_refer_to("Series.le")
+    @doc_utils.doc_binary_method(
+        operation="less than or equal comparison",
+        sign="<=",
+        op_type="series_comparison",
+    )
     def series_le(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.le)(
             self,
@@ -743,7 +755,9 @@ class BaseQueryCompiler(
     def lt(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.lt)(self, other=other, **kwargs)
 
-    @doc_utils.add_refer_to("Series.lt")
+    @doc_utils.doc_binary_method(
+        operation="less than", sign="<", op_type="series_comparison"
+    )
     def series_lt(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.lt)(
             self,
@@ -868,7 +882,9 @@ class BaseQueryCompiler(
     def ne(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.ne)(self, other=other, **kwargs)
 
-    @doc_utils.add_refer_to("Series.ne")
+    @doc_utils.doc_binary_method(
+        operation="not equal comparison", sign="!=", op_type="series_comparison"
+    )
     def series_ne(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.ne)(
             self,

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -652,7 +652,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=True,
+            squeeze_other=isinstance(other, pandas.DataFrame),
             **kwargs,
         )
 
@@ -699,7 +699,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=True,
+            squeeze_other=isinstance(other, pandas.DataFrame),
             **kwargs,
         )
 
@@ -714,7 +714,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=True,
+            squeeze_other=isinstance(other, pandas.DataFrame),
             **kwargs,
         )
 
@@ -729,7 +729,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=True,
+            squeeze_other=isinstance(other, pandas.DataFrame),
             **kwargs,
         )
 
@@ -744,7 +744,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=True,
+            squeeze_other=isinstance(other, pandas.DataFrame),
             **kwargs,
         )
 
@@ -868,7 +868,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=True,
+            squeeze_other=isinstance(other, pandas.DataFrame),
             **kwargs,
         )
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -647,6 +647,15 @@ class BaseQueryCompiler(
     def eq(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.eq)(self, other=other, **kwargs)
 
+    def series_eq(self, other, **kwargs):
+        return BinaryDefault.register(pandas.Series.eq)(
+            self,
+            other=other,
+            squeeze_self=True,
+            squeeze_other=True,
+            **kwargs,
+        )
+
     @doc_utils.add_refer_to("DataFrame.equals")
     def equals(self, other):  # noqa: PR01, RT01
         return BinaryDefault.register(pandas.DataFrame.equals)(self, other=other)
@@ -685,11 +694,29 @@ class BaseQueryCompiler(
     def ge(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.ge)(self, other=other, **kwargs)
 
+    def series_ge(self, other, **kwargs):
+        return BinaryDefault.register(pandas.Series.ge)(
+            self,
+            other=other,
+            squeeze_self=True,
+            squeeze_other=True,
+            **kwargs,
+        )
+
     @doc_utils.doc_binary_method(
         operation="greater than comparison", sign=">", op_type="comparison"
     )
     def gt(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.gt)(self, other=other, **kwargs)
+
+    def series_gt(self, other, **kwargs):
+        return BinaryDefault.register(pandas.Series.gt)(
+            self,
+            other=other,
+            squeeze_self=True,
+            squeeze_other=True,
+            **kwargs,
+        )
 
     @doc_utils.doc_binary_method(
         operation="less than or equal comparison", sign="<=", op_type="comparison"
@@ -697,11 +724,29 @@ class BaseQueryCompiler(
     def le(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.le)(self, other=other, **kwargs)
 
+    def series_le(self, other, **kwargs):
+        return BinaryDefault.register(pandas.Series.le)(
+            self,
+            other=other,
+            squeeze_self=True,
+            squeeze_other=True,
+            **kwargs,
+        )
+
     @doc_utils.doc_binary_method(
         operation="less than comparison", sign="<", op_type="comparison"
     )
     def lt(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.lt)(self, other=other, **kwargs)
+
+    def series_lt(self, other, **kwargs):
+        return BinaryDefault.register(pandas.Series.lt)(
+            self,
+            other=other,
+            squeeze_self=True,
+            squeeze_other=True,
+            **kwargs,
+        )
 
     @doc_utils.doc_binary_method(operation="modulo", sign="%")
     def mod(self, other, **kwargs):  # noqa: PR02
@@ -817,6 +862,15 @@ class BaseQueryCompiler(
     )
     def ne(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.ne)(self, other=other, **kwargs)
+
+    def series_ne(self, other, **kwargs):
+        return BinaryDefault.register(pandas.Series.ne)(
+            self,
+            other=other,
+            squeeze_self=True,
+            squeeze_other=True,
+            **kwargs,
+        )
 
     @doc_utils.doc_binary_method(operation="exponential power", sign="**")
     def pow(self, other, **kwargs):  # noqa: PR02

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -655,7 +655,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=isinstance(other, pandas.DataFrame),
+            squeeze_other=kwargs.pop("squeeze_other", False),
             **kwargs,
         )
 
@@ -707,7 +707,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=isinstance(other, pandas.DataFrame),
+            squeeze_other=kwargs.pop("squeeze_other", False),
             **kwargs,
         )
 
@@ -725,7 +725,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=isinstance(other, pandas.DataFrame),
+            squeeze_other=kwargs.pop("squeeze_other", False),
             **kwargs,
         )
 
@@ -745,7 +745,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=isinstance(other, pandas.DataFrame),
+            squeeze_other=kwargs.pop("squeeze_other", False),
             **kwargs,
         )
 
@@ -763,7 +763,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=isinstance(other, pandas.DataFrame),
+            squeeze_other=kwargs.pop("squeeze_other", False),
             **kwargs,
         )
 
@@ -890,7 +890,7 @@ class BaseQueryCompiler(
             self,
             other=other,
             squeeze_self=True,
-            squeeze_other=isinstance(other, pandas.DataFrame),
+            squeeze_other=kwargs.pop("squeeze_other", False),
             **kwargs,
         )
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -647,6 +647,7 @@ class BaseQueryCompiler(
     def eq(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.eq)(self, other=other, **kwargs)
 
+    @doc_utils.add_refer_to("Series.eq")
     def series_eq(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.eq)(
             self,
@@ -694,6 +695,7 @@ class BaseQueryCompiler(
     def ge(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.ge)(self, other=other, **kwargs)
 
+    @doc_utils.add_refer_to("Series.ge")
     def series_ge(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.ge)(
             self,
@@ -709,6 +711,7 @@ class BaseQueryCompiler(
     def gt(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.gt)(self, other=other, **kwargs)
 
+    @doc_utils.add_refer_to("Series.gt")
     def series_gt(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.gt)(
             self,
@@ -724,6 +727,7 @@ class BaseQueryCompiler(
     def le(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.le)(self, other=other, **kwargs)
 
+    @doc_utils.add_refer_to("Series.le")
     def series_le(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.le)(
             self,
@@ -739,6 +743,7 @@ class BaseQueryCompiler(
     def lt(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.lt)(self, other=other, **kwargs)
 
+    @doc_utils.add_refer_to("Series.lt")
     def series_lt(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.lt)(
             self,
@@ -863,6 +868,7 @@ class BaseQueryCompiler(
     def ne(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.DataFrame.ne)(self, other=other, **kwargs)
 
+    @doc_utils.add_refer_to("Series.ne")
     def series_ne(self, other, **kwargs):
         return BinaryDefault.register(pandas.Series.ne)(
             self,

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -650,7 +650,7 @@ class BaseQueryCompiler(
     @doc_utils.doc_binary_method(
         operation="equality comparison", sign="==", op_type="series_comparison"
     )
-    def series_eq(self, other, **kwargs):
+    def series_eq(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.Series.eq)(
             self,
             other=other,
@@ -702,7 +702,7 @@ class BaseQueryCompiler(
         sign=">=",
         op_type="series_comparison",
     )
-    def series_ge(self, other, **kwargs):
+    def series_ge(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.Series.ge)(
             self,
             other=other,
@@ -720,7 +720,7 @@ class BaseQueryCompiler(
     @doc_utils.doc_binary_method(
         operation="greater than comparison", sign=">", op_type="series_comparison"
     )
-    def series_gt(self, other, **kwargs):
+    def series_gt(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.Series.gt)(
             self,
             other=other,
@@ -740,7 +740,7 @@ class BaseQueryCompiler(
         sign="<=",
         op_type="series_comparison",
     )
-    def series_le(self, other, **kwargs):
+    def series_le(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.Series.le)(
             self,
             other=other,
@@ -758,7 +758,7 @@ class BaseQueryCompiler(
     @doc_utils.doc_binary_method(
         operation="less than", sign="<", op_type="series_comparison"
     )
-    def series_lt(self, other, **kwargs):
+    def series_lt(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.Series.lt)(
             self,
             other=other,
@@ -885,7 +885,7 @@ class BaseQueryCompiler(
     @doc_utils.doc_binary_method(
         operation="not equal comparison", sign="!=", op_type="series_comparison"
     )
-    def series_ne(self, other, **kwargs):
+    def series_ne(self, other, **kwargs):  # noqa: PR02
         return BinaryDefault.register(pandas.Series.ne)(
             self,
             other=other,

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -268,7 +268,7 @@ def _series_logical_binop(func):
     """
     return lambda x, y, **kwargs: func(
         x.squeeze(axis=1),
-        y.squeeze(axis=1) if isinstance(y, pandas.DataFrame) else y,
+        y.squeeze(axis=1) if kwargs.pop("squeeze_other", False) else y,
         **kwargs,
     ).to_frame()
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -256,6 +256,15 @@ def copy_df_for_func(func, display_name: str = None):
 def _series_logical_binop(func):
     """
     Build a callable function to pass to Binary.register for Series logical operators.
+
+    Parameters
+    ----------
+    func : callable
+        Binary operator method of pandas.Series to be applied.
+
+    Returns
+    -------
+    callable
     """
     return lambda x, y, **kwargs: func(
         x.squeeze(axis=1),

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -258,7 +258,9 @@ def _series_logical_binop(func):
     Build a callable function to pass to Binary.register for Series logical operators.
     """
     return lambda x, y, **kwargs: func(
-        x.squeeze(axis=1), y.squeeze(axis=1), **kwargs
+        x.squeeze(axis=1),
+        y.squeeze(axis=1) if isinstance(y, pandas.DataFrame) else y,
+        **kwargs,
     ).to_frame()
 
 

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -257,7 +257,9 @@ def _series_logical_binop(func):
     """
     Build a callable function to pass to Binary.register for Series logical operators.
     """
-    return lambda x, y, **kwargs: func(x.squeeze(axis=1), y.squeeze(axis=1), **kwargs).to_frame()
+    return lambda x, y, **kwargs: func(
+        x.squeeze(axis=1), y.squeeze(axis=1), **kwargs
+    ).to_frame()
 
 
 @_inherit_docstrings(BaseQueryCompiler)
@@ -530,12 +532,24 @@ class PandasQueryCompiler(BaseQueryCompiler, QueryCompilerCaster):
     )
 
     # Series logical operators take an additional fill_value flag that dataframe does not
-    series_eq = Binary.register(_series_logical_binop(pandas.Series.eq), infer_dtypes="bool")
-    series_ge = Binary.register(_series_logical_binop(pandas.Series.ge), infer_dtypes="bool")
-    series_gt = Binary.register(_series_logical_binop(pandas.Series.gt), infer_dtypes="bool")
-    series_le = Binary.register(_series_logical_binop(pandas.Series.le), infer_dtypes="bool")
-    series_lt = Binary.register(_series_logical_binop(pandas.Series.lt), infer_dtypes="bool")
-    series_ne = Binary.register(_series_logical_binop(pandas.Series.ne), infer_dtypes="bool")
+    series_eq = Binary.register(
+        _series_logical_binop(pandas.Series.eq), infer_dtypes="bool"
+    )
+    series_ge = Binary.register(
+        _series_logical_binop(pandas.Series.ge), infer_dtypes="bool"
+    )
+    series_gt = Binary.register(
+        _series_logical_binop(pandas.Series.gt), infer_dtypes="bool"
+    )
+    series_le = Binary.register(
+        _series_logical_binop(pandas.Series.le), infer_dtypes="bool"
+    )
+    series_lt = Binary.register(
+        _series_logical_binop(pandas.Series.lt), infer_dtypes="bool"
+    )
+    series_ne = Binary.register(
+        _series_logical_binop(pandas.Series.ne), infer_dtypes="bool"
+    )
 
     # Needed for numpy API
     _logical_and = Binary.register(

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -253,6 +253,13 @@ def copy_df_for_func(func, display_name: str = None):
     return caller
 
 
+def _series_logical_binop(func):
+    """
+    Build a callable function to pass to Binary.register for Series logical operators.
+    """
+    return lambda x, y, **kwargs: func(x.squeeze(axis=1), y.squeeze(axis=1), **kwargs).to_frame()
+
+
 @_inherit_docstrings(BaseQueryCompiler)
 class PandasQueryCompiler(BaseQueryCompiler, QueryCompilerCaster):
     """
@@ -521,6 +528,14 @@ class PandasQueryCompiler(BaseQueryCompiler, QueryCompilerCaster):
         join_type="left",
         sort=False,
     )
+
+    # Series logical operators take an additional fill_value flag that dataframe does not
+    series_eq = Binary.register(_series_logical_binop(pandas.Series.eq), infer_dtypes="bool")
+    series_ge = Binary.register(_series_logical_binop(pandas.Series.ge), infer_dtypes="bool")
+    series_gt = Binary.register(_series_logical_binop(pandas.Series.gt), infer_dtypes="bool")
+    series_le = Binary.register(_series_logical_binop(pandas.Series.le), infer_dtypes="bool")
+    series_lt = Binary.register(_series_logical_binop(pandas.Series.lt), infer_dtypes="bool")
+    series_ne = Binary.register(_series_logical_binop(pandas.Series.ne), infer_dtypes="bool")
 
     # Needed for numpy API
     _logical_and = Binary.register(

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -509,6 +509,17 @@ class BasePandasDataset(ClassLogger):
         ]
         if op in exclude_list:
             kwargs.pop("axis")
+        # Series logical operations take an additional fill_value argument that DF does not
+        series_specialize_list = [
+            "eq",
+            "ge",
+            "gt",
+            "le",
+            "lt",
+            "ne",
+        ]
+        if not self._is_dataframe and op in series_specialize_list:
+            op = "series_" + op
         new_query_compiler = getattr(self._query_compiler, op)(other, **kwargs)
         return self._create_or_update_from_compiler(new_query_compiler)
 

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1031,7 +1031,9 @@ class Series(BasePandasDataset):
         Return Equal to of series and `other`, element-wise (binary operator `eq`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return new_self._binary_op("eq", new_other, level=level, fill_value=fill_value, axis=axis)
+        return new_self._binary_op(
+            "eq", new_other, level=level, fill_value=fill_value, axis=axis
+        )
 
     def equals(self, other) -> bool:  # noqa: PR01, RT01, D200
         """
@@ -1140,7 +1142,9 @@ class Series(BasePandasDataset):
         Return greater than or equal to of series and `other`, element-wise (binary operator `ge`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return new_self._binary_op("ge", new_other, level=level, fill_value=fill_value, axis=axis)
+        return new_self._binary_op(
+            "ge", new_other, level=level, fill_value=fill_value, axis=axis
+        )
 
     def groupby(
         self,
@@ -1188,7 +1192,9 @@ class Series(BasePandasDataset):
         Return greater than of series and `other`, element-wise (binary operator `gt`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return new_self._binary_op("gt", new_other, level=level, fill_value=fill_value, axis=axis)
+        return new_self._binary_op(
+            "gt", new_other, level=level, fill_value=fill_value, axis=axis
+        )
 
     def hist(
         self,
@@ -1306,7 +1312,9 @@ class Series(BasePandasDataset):
         Return less than or equal to of series and `other`, element-wise (binary operator `le`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return new_self._binary_op("le", new_other, level=level, fill_value=fill_value, axis=axis)
+        return new_self._binary_op(
+            "le", new_other, level=level, fill_value=fill_value, axis=axis
+        )
 
     def lt(
         self, other, level=None, fill_value=None, axis=0
@@ -1315,7 +1323,9 @@ class Series(BasePandasDataset):
         Return less than of series and `other`, element-wise (binary operator `lt`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return new_self._binary_op("lt", new_other, level=level, fill_value=fill_value, axis=axis)
+        return new_self._binary_op(
+            "lt", new_other, level=level, fill_value=fill_value, axis=axis
+        )
 
     def map(self, arg, na_action=None) -> Series:  # noqa: PR01, RT01, D200
         """
@@ -1442,7 +1452,9 @@ class Series(BasePandasDataset):
         Return not equal to of series and `other`, element-wise (binary operator `ne`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return new_self._binary_op("ne", new_other, level=level, fill_value=fill_value, axis=axis)
+        return new_self._binary_op(
+            "ne", new_other, level=level, fill_value=fill_value, axis=axis
+        )
 
     def nlargest(self, n=5, keep="first") -> Series:  # noqa: PR01, RT01, D200
         """

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1032,7 +1032,12 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return new_self._binary_op(
-            "eq", new_other, level=level, fill_value=fill_value, axis=axis
+            "eq",
+            new_other,
+            level=level,
+            fill_value=fill_value,
+            axis=axis,
+            squeeze_other=isinstance(other, (pandas.Series, Series)),
         )
 
     def equals(self, other) -> bool:  # noqa: PR01, RT01, D200
@@ -1143,7 +1148,12 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return new_self._binary_op(
-            "ge", new_other, level=level, fill_value=fill_value, axis=axis
+            "ge",
+            new_other,
+            level=level,
+            fill_value=fill_value,
+            axis=axis,
+            squeeze_other=isinstance(other, (pandas.Series, Series)),
         )
 
     def groupby(
@@ -1193,7 +1203,12 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return new_self._binary_op(
-            "gt", new_other, level=level, fill_value=fill_value, axis=axis
+            "gt",
+            new_other,
+            level=level,
+            fill_value=fill_value,
+            axis=axis,
+            squeeze_other=isinstance(other, (pandas.Series, Series)),
         )
 
     def hist(
@@ -1313,7 +1328,12 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return new_self._binary_op(
-            "le", new_other, level=level, fill_value=fill_value, axis=axis
+            "le",
+            new_other,
+            level=level,
+            fill_value=fill_value,
+            axis=axis,
+            squeeze_other=isinstance(other, (pandas.Series, Series)),
         )
 
     def lt(
@@ -1324,7 +1344,12 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return new_self._binary_op(
-            "lt", new_other, level=level, fill_value=fill_value, axis=axis
+            "lt",
+            new_other,
+            level=level,
+            fill_value=fill_value,
+            axis=axis,
+            squeeze_other=isinstance(other, (pandas.Series, Series)),
         )
 
     def map(self, arg, na_action=None) -> Series:  # noqa: PR01, RT01, D200
@@ -1453,7 +1478,12 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return new_self._binary_op(
-            "ne", new_other, level=level, fill_value=fill_value, axis=axis
+            "ne",
+            new_other,
+            level=level,
+            fill_value=fill_value,
+            axis=axis,
+            squeeze_other=isinstance(other, (pandas.Series, Series)),
         )
 
     def nlargest(self, n=5, keep="first") -> Series:  # noqa: PR01, RT01, D200

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1031,7 +1031,7 @@ class Series(BasePandasDataset):
         Return Equal to of series and `other`, element-wise (binary operator `eq`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).eq(new_other, level=level, axis=axis)
+        return new_self._binary_op("eq", new_other, level=level, fill_value=fill_value, axis=axis)
 
     def equals(self, other) -> bool:  # noqa: PR01, RT01, D200
         """
@@ -1130,7 +1130,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).floordiv(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     def ge(
@@ -1140,7 +1140,7 @@ class Series(BasePandasDataset):
         Return greater than or equal to of series and `other`, element-wise (binary operator `ge`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).ge(new_other, level=level, axis=axis)
+        return new_self._binary_op("ge", new_other, level=level, fill_value=fill_value, axis=axis)
 
     def groupby(
         self,
@@ -1188,7 +1188,7 @@ class Series(BasePandasDataset):
         Return greater than of series and `other`, element-wise (binary operator `gt`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).gt(new_other, level=level, axis=axis)
+        return new_self._binary_op("gt", new_other, level=level, fill_value=fill_value, axis=axis)
 
     def hist(
         self,
@@ -1306,7 +1306,7 @@ class Series(BasePandasDataset):
         Return less than or equal to of series and `other`, element-wise (binary operator `le`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).le(new_other, level=level, axis=axis)
+        return new_self._binary_op("le", new_other, level=level, fill_value=fill_value, axis=axis)
 
     def lt(
         self, other, level=None, fill_value=None, axis=0
@@ -1315,7 +1315,7 @@ class Series(BasePandasDataset):
         Return less than of series and `other`, element-wise (binary operator `lt`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).lt(new_other, level=level, axis=axis)
+        return new_self._binary_op("lt", new_other, level=level, fill_value=fill_value, axis=axis)
 
     def map(self, arg, na_action=None) -> Series:  # noqa: PR01, RT01, D200
         """
@@ -1402,7 +1402,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).mod(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     def mode(self, dropna=True) -> Series:  # noqa: PR01, RT01, D200
@@ -1419,7 +1419,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).mul(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     multiply = mul
@@ -1432,7 +1432,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rmul(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     def ne(
@@ -1442,7 +1442,7 @@ class Series(BasePandasDataset):
         Return not equal to of series and `other`, element-wise (binary operator `ne`).
         """
         new_self, new_other = self._prepare_inter_op(other)
-        return super(Series, new_self).ne(new_other, level=level, axis=axis)
+        return new_self._binary_op("ne", new_other, level=level, fill_value=fill_value, axis=axis)
 
     def nlargest(self, n=5, keep="first") -> Series:  # noqa: PR01, RT01, D200
         """
@@ -1562,7 +1562,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).pow(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     @_inherit_docstrings(pandas.Series.prod, apilink="pandas.Series.prod")
@@ -1763,7 +1763,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rfloordiv(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     def rmod(
@@ -1774,7 +1774,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rmod(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     def rpow(
@@ -1785,7 +1785,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rpow(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     def rsub(
@@ -1796,7 +1796,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rsub(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     def rtruediv(
@@ -1807,7 +1807,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).rtruediv(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     rdiv = rtruediv
@@ -1955,7 +1955,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).sub(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     subtract = sub
@@ -2130,7 +2130,7 @@ class Series(BasePandasDataset):
         """
         new_self, new_other = self._prepare_inter_op(other)
         return super(Series, new_self).truediv(
-            new_other, level=level, fill_value=None, axis=axis
+            new_other, level=level, fill_value=fill_value, axis=axis
         )
 
     div = divide = truediv

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1037,7 +1037,7 @@ class Series(BasePandasDataset):
             level=level,
             fill_value=fill_value,
             axis=axis,
-            squeeze_other=isinstance(other, (pandas.Series, Series)),
+            squeeze_other=isinstance(other, Series),
         )
 
     def equals(self, other) -> bool:  # noqa: PR01, RT01, D200
@@ -1153,7 +1153,7 @@ class Series(BasePandasDataset):
             level=level,
             fill_value=fill_value,
             axis=axis,
-            squeeze_other=isinstance(other, (pandas.Series, Series)),
+            squeeze_other=isinstance(other, Series),
         )
 
     def groupby(
@@ -1208,7 +1208,7 @@ class Series(BasePandasDataset):
             level=level,
             fill_value=fill_value,
             axis=axis,
-            squeeze_other=isinstance(other, (pandas.Series, Series)),
+            squeeze_other=isinstance(other, Series),
         )
 
     def hist(
@@ -1333,7 +1333,7 @@ class Series(BasePandasDataset):
             level=level,
             fill_value=fill_value,
             axis=axis,
-            squeeze_other=isinstance(other, (pandas.Series, Series)),
+            squeeze_other=isinstance(other, Series),
         )
 
     def lt(
@@ -1349,7 +1349,7 @@ class Series(BasePandasDataset):
             level=level,
             fill_value=fill_value,
             axis=axis,
-            squeeze_other=isinstance(other, (pandas.Series, Series)),
+            squeeze_other=isinstance(other, Series),
         )
 
     def map(self, arg, na_action=None) -> Series:  # noqa: PR01, RT01, D200
@@ -1483,7 +1483,7 @@ class Series(BasePandasDataset):
             level=level,
             fill_value=fill_value,
             axis=axis,
-            squeeze_other=isinstance(other, (pandas.Series, Series)),
+            squeeze_other=isinstance(other, Series),
         )
 
     def nlargest(self, n=5, keep="first") -> Series:  # noqa: PR01, RT01, D200

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -5096,34 +5096,37 @@ def test__reduce__():
     df_equals(result_md, result_pd)
 
 
-@pytest.mark.parametrize("op", [
-    "add",
-    "radd",
-    "divmod",
-    "eq",
-    "floordiv",
-    "ge",
-    "gt",
-    "le",
-    "lt",
-    "mod",
-    "mul",
-    "rmul",
-    "ne",
-    "pow",
-    "rdivmod",
-    "rfloordiv",
-    "rmod",
-    "rpow",
-    "rsub",
-    "rtruediv",
-    "sub",
-    "truediv",
-])
+@pytest.mark.parametrize(
+    "op",
+    [
+        "add",
+        "radd",
+        "divmod",
+        "eq",
+        "floordiv",
+        "ge",
+        "gt",
+        "le",
+        "lt",
+        "mod",
+        "mul",
+        "rmul",
+        "ne",
+        "pow",
+        "rdivmod",
+        "rfloordiv",
+        "rmod",
+        "rpow",
+        "rsub",
+        "rtruediv",
+        "sub",
+        "truediv",
+    ],
+)
 def test_binary_with_fill_value_issue_7381(op):
     # Ensures that series binary operations respect the fill_value flag
     series_md, series_pd = create_test_series([0, 1, 2, 3])
     rhs_md, rhs_pd = create_test_series([0])
     result_md = getattr(series_md, op)(rhs_md, fill_value=2)
     result_pd = getattr(series_pd, op)(rhs_pd, fill_value=2)
-    df_equals(result_md, result_pd)    
+    df_equals(result_md, result_pd)

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -5094,3 +5094,36 @@ def test__reduce__():
         .rename("league")
     )
     df_equals(result_md, result_pd)
+
+
+@pytest.mark.parametrize("op", [
+    "add",
+    "radd",
+    "divmod",
+    "eq",
+    "floordiv",
+    "ge",
+    "gt",
+    "le",
+    "lt",
+    "mod",
+    "mul",
+    "rmul",
+    "ne",
+    "pow",
+    "rdivmod",
+    "rfloordiv",
+    "rmod",
+    "rpow",
+    "rsub",
+    "rtruediv",
+    "sub",
+    "truediv",
+])
+def test_binary_with_fill_value_issue_7381(op):
+    # Ensures that series binary operations respect the fill_value flag
+    series_md, series_pd = create_test_series([0, 1, 2, 3])
+    rhs_md, rhs_pd = create_test_series([0])
+    result_md = getattr(series_md, op)(rhs_md, fill_value=2)
+    result_pd = getattr(series_pd, op)(rhs_pd, fill_value=2)
+    df_equals(result_md, result_pd)    

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -5130,3 +5130,12 @@ def test_binary_with_fill_value_issue_7381(op):
     result_md = getattr(series_md, op)(rhs_md, fill_value=2)
     result_pd = getattr(series_pd, op)(rhs_pd, fill_value=2)
     df_equals(result_md, result_pd)
+
+
+@pytest.mark.parametrize("op", ["eq", "ge", "gt", "le", "lt", "ne"])
+def test_logical_binary_with_list(op):
+    series_md, series_pd = create_test_series([0, 1, 2])
+    rhs = [2, 1, 0]
+    result_md = getattr(series_md, op)(rhs)
+    result_pd = getattr(series_pd, op)(rhs)
+    df_equals(result_md, result_pd)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Many binary operators in the frontend Series class were not passing their `fillna` parameters to the query compiler (not sure why this wasn't caught in linting). For arithmetic functions, the fix is simply to propagate `fillna`, but for logical operators (`eq`/`ge` etc.), the equivalent DataFrame method does not take a `fillna` parameter, so we need to add a separate query compiler method to handle this case.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7381 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
