### PR TITLE
FIX-#7375: Fix Series.duplicated dropping name

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1022,7 +1022,11 @@ class Series(BasePandasDataset):
         """
         Indicate duplicate Series values.
         """
-        return self.to_frame().duplicated(keep=keep)
+        name = self.name
+        result = self.to_frame().duplicated(keep=keep)
+        # DataFrame.duplicated drops the name, so we need to manually restore it
+        result.name = name
+        return result
 
     def eq(
         self, other, level=None, fill_value=None, axis=0

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1025,7 +1025,8 @@ class Series(BasePandasDataset):
         name = self.name
         result = self.to_frame().duplicated(keep=keep)
         # DataFrame.duplicated drops the name, so we need to manually restore it
-        result.name = name
+        if name is not None:
+            result.name = name
         return result
 
     def eq(

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -1942,6 +1942,12 @@ def test_duplicated(data, keep):
     df_equals(modin_result, pandas_series.duplicated(keep=keep))
 
 
+def test_duplicated_keeps_name_issue_7375():
+    # Ensure that the name property of a series is preserved across duplicated
+    modin_series, pandas_series = create_test_series([1, 2, 3, 1], name="a")
+    df_equals(modin_series.duplicated(), pandas_series.duplicated())
+
+
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 def test_empty(data):
     modin_series, pandas_series = create_test_series(data)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Series.duplicated uses DataFrame.duplicated in implementation, but since this drops the original Series's name, we need to manually restore it after the computation.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7375 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
