### PR TITLE
FEAT-#7401: Implement DataFrame/Series.attrs

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -114,8 +114,11 @@ class Series(BasePandasDataset):
         # Siblings are other dataframes that share the same query compiler. We
         # use this list to update inplace when there is a shallow copy.
         self._siblings = []
+        self._attrs = {}
         if isinstance(data, type(self)):
             query_compiler = data._query_compiler.copy()
+            if len(data._attrs):
+                self._attrs = copy.deepcopy(data._attrs)
             if index is not None:
                 if any(i not in data.index for i in index):
                     raise NotImplementedError(
@@ -2263,17 +2266,6 @@ class Series(BasePandasDataset):
             axis=axis,
             level=level,
         )
-
-    @property
-    def attrs(self) -> dict:  # noqa: RT01, D200
-        """
-        Return dictionary of global attributes of this dataset.
-        """
-
-        def attrs(df):
-            return df.attrs
-
-        return self._default_to_pandas(attrs)
 
     @property
     def array(self) -> ExtensionArray:  # noqa: RT01, D200


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

[STILL A DRAFT] Implement df.attrs by annotating relevant functions with a new @propagate_self_attrs annotation that automatically copies `self._attrs` if the result is detected to be a new DataFrame/Series.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #7401 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
