### PR TITLE
DRAFT: Track engine and storage format at query compiler level.

### DIFF
--- a/modin/config/__init__.py
+++ b/modin/config/__init__.py
@@ -60,7 +60,6 @@ from modin.config.pubsub import Parameter, ValueSource, context
 
 __all__ = [
     "EnvironmentVariable",
-    "DataFrameVariable" # dataframe specific configuration
     "Parameter",
     "ValueSource",
     "context",

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -32,6 +32,7 @@ from modin.config.pubsub import (
     ValueSource,
 )
 
+
 class EnvironmentVariable(Parameter, type=str, abstract=True):
     """Base class for environment variables-based configuration."""
 
@@ -169,13 +170,10 @@ class IsDebug(EnvironmentVariable, type=bool):
     varname = "MODIN_DEBUG"
 
 
-class DataFrameVariable(EnvironmentVariable, type=str):
-    @classmethod
-    def get(cls) -> Any:
-        return super().get()
-
-class Engine(DataFrameVariable, type=str):
-    """Distribution engine to run queries by."""
+class Engine(EnvironmentVariable, type=str):
+    # TODO(hybrid-execution): We should probably rename this to DefaultEngine
+    # to prevent confusing it with the per-dataframe engine.
+    """The default engine for new dataframes."""
 
     varname = "MODIN_ENGINE"
     choices = ("Ray", "Dask", "Python", "Unidist")
@@ -196,6 +194,7 @@ class Engine(DataFrameVariable, type=str):
         str
         """
         from modin.utils import MIN_DASK_VERSION, MIN_RAY_VERSION, MIN_UNIDIST_VERSION
+
         # If there's a custom engine, we don't need to check for any engine
         # dependencies. Return the default "Python" engine.
         if IsDebug.get() or cls.has_custom_engine:

--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -33,7 +33,6 @@ from pandas.core.dtypes.common import is_dtype_equal, is_list_like, is_numeric_d
 from pandas.core.indexes.api import Index, RangeIndex
 
 from modin.config import (
-    Engine,
     IsRayCluster,
     MinColumnPartitionSize,
     MinRowPartitionSize,
@@ -1677,7 +1676,9 @@ class PandasDataframe(
         )
 
     @lazy_metadata_decorator(apply_axis="both")
-    def astype(self, col_dtypes, errors: str = "raise"):
+    def astype(
+        self, col_dtypes, engine: str, storage_format: str, errors: str = "raise"
+    ):
         """
         Convert the columns dtypes to given dtypes.
 
@@ -1707,7 +1708,7 @@ class PandasDataframe(
                         new_dtypes = self_dtypes.copy()
                     # Update the new dtype series to the proper pandas dtype
                     new_dtype = pandas.api.types.pandas_dtype(dtype)
-                    if self._getEngineConfig().get() == "Dask" and hasattr(dtype, "_is_materialized"):
+                    if engine == "Dask" and hasattr(dtype, "_is_materialized"):
                         # FIXME: https://github.com/dask/distributed/issues/8585
                         _ = dtype._materialize_categories()
 
@@ -1736,7 +1737,7 @@ class PandasDataframe(
             if not (col_dtypes == self_dtypes).all():
                 new_dtypes = self_dtypes.copy()
                 new_dtype = pandas.api.types.pandas_dtype(col_dtypes)
-                if self._getEngineConfig().get() == "Dask" and hasattr(new_dtype, "_is_materialized"):
+                if engine == "Dask" and hasattr(new_dtype, "_is_materialized"):
                     # FIXME: https://github.com/dask/distributed/issues/8585
                     _ = new_dtype._materialize_categories()
                 if isinstance(new_dtype, pandas.CategoricalDtype):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -31,7 +31,6 @@ from typing import (
     Union,
 )
 
-from modin.config.envvars import Engine, StorageFormat
 import numpy as np
 import pandas
 import pandas.core.generic
@@ -75,6 +74,7 @@ from pandas.util._validators import (
 )
 
 from modin import pandas as pd
+from modin.config.envvars import Engine, StorageFormat
 from modin.error_message import ErrorMessage
 from modin.logging import ClassLogger, disable_logging
 from modin.pandas.accessor import CachedAccessor, ModinAPI
@@ -211,18 +211,22 @@ class BasePandasDataset(ClassLogger):
     _siblings: list[BasePandasDataset]
     _engine_override: Engine = None
     _storage_override: StorageFormat = None
-    
+
     def _getEngineConfig(self) -> Engine:
         if self._engine_override is not None:
             return self._engine_override
-        else: 
+        else:
             return Engine
-    
+
     def _getStorageConfig(self) -> Engine:
         if self._storage_override is not None:
             return self._storage_override
-        else: 
+        else:
             return StorageFormat
+
+    engine = property(lambda self: self._query_compiler.engine)
+
+    storage_format = property(lambda self: self._query_compiler.storage_format)
 
     @cached_property
     def _is_dataframe(self) -> bool:

--- a/per_dataframe_engine_demo.ipynb
+++ b/per_dataframe_engine_demo.ipynb
@@ -1,0 +1,81 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2025-01-17 22:53:54,581\tINFO worker.py:1821 -- Started a local Ray instance.\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "('Ray', 'Pandas')\n",
+      "['Ray', 'Ray', 'Ray', 'Ray']\n",
+      "('Python', 'Pandas')\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "FutureWarning: The behavior of array concatenation with empty entries is deprecated. In a future version, this will no longer exclude empty items when determining the result dtype. To retain the old behavior, exclude the empty entries before the concat operation.\n"
+     ]
+    }
+   ],
+   "source": [
+    "import modin.pandas as pd\n",
+    "from modin.config import StorageFormat, Engine\n",
+    "\n",
+    "StorageFormat.put('Pandas')\n",
+    "Engine.put('ray')\n",
+    "\n",
+    "ray_df = pd.DataFrame([[0, 1], [2, 3]])\n",
+    "\n",
+    "print((ray_df.engine, ray_df.storage_format))\n",
+    "\n",
+    "# We should propagate engine through all operations\n",
+    "print([df.engine for df in\n",
+    " (\n",
+    "    ray_df.sort_values(0),\n",
+    "    ray_df.astype(str),\n",
+    "    ray_df.groupby(0).sum(),\n",
+    "    ray_df * ray_df,\n",
+    " )\n",
+    "])\n",
+    "\n",
+    "# Make a python dataframe\n",
+    "Engine.put('Python')\n",
+    "python_df = pd.DataFrame([[4, 5], [6, 7]])\n",
+    "print((python_df.engine, python_df.storage_format))"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "modin-dev",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.21"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
Demo: https://github.com/sfc-gh-mvashishtha/modin/blob/mvashishtha/SNOW-1856014/track-engine-and-storage-format-at-query-compiler-level/per_dataframe_engine_demo.ipynb

Summary:

- Keep the `modin.config` environment variable `Engine`, though we should probably rename this variable to `DefaultEngine`. Likewise for `StorageFormat`. These variables represent the execution method that we use for new dataframes created out of something other than an existing Modin dataframe/series. For example, we would use those variables to choose an execution method for the result of `pd.DataFrame([[0, 1]])` or of `pd.read_csv()`.
- Require query compilers to implement immutable properties for their `engine` and `storage_format`. We need each query compiler to know these properties because we never want to be guessing a compiler's execution.
- For `PandasQueryCompiler`, which we use for `PandasOnPython`, `PandasOnRay`, `PandasOnDask` , and `PandasOnUnidist` (including on MPI) executions, make the `engine` and `storage_format` required constructor parameters.
- `SnowflakeQueryCompiler` can return a static engine and storage format because it never changes engine / storage format.
- All the query compilers in Modin continue to assume that methods that take multiple query compilers (e.g. joins) take query compilers that all use the same execution. For example, a pandas-on-python query compiler's `add` method assumes that the RHS is a pandas-on-python query compiler. [`QueryCompilerCaster`](https://github.com/modin-project/modin/blob/4cae985ef7d9bab57373b698c27f0af849b9fb55/modin/core/storage_formats/pandas/query_compiler_caster.py#L34C7-L34C26) helps somewhat with this issue but remember that while it checks for different classes, it does not consider storage format or engine.

Design / UI considerations:

- Initially we were thinking of tracking engine + storage format at the `DataFrame` / `Series` level, but I found that tracking the execution method with this approach required changing more code than this approach did. Also, it seemed that the query compiler can already tell us that the result of most operations will preserve its engine, and we had to add a sort of redundant tracking of `engine` and `storage_format` every time we used a query compiler method at the API level
  - I tried out the dataframe-level tracking and posted a preliminary draft here: https://github.com/modin-project/modin/pull/7425
- In this draft, `Series` and `DataFrame` expose the variables `engine` and `storage_format`, which they get from their query compilers. So far Modin has avoided providing non-underscored variables that don't match pandas  (going so far as to underscore `to_pandas`). We do want users to be able to check `engine` and `storage_format`. Maybe we should add leading underscores for consistency with `to_pandas`.

Productionising this PR: 

- I have neglected to add the `engine` and `storage_format` to some points where we construct `PandasQueryCompiler`, so we have to fix those.
- There are many points where we check the global `Engine` and `StorageFormat`, but really we should check the individual frame's `Engine` and `StorageFormat`.