### PR TITLE
TEST-#7431: Fix formatting for isort 6 and black 25

### DIFF
--- a/modin/core/dataframe/pandas/metadata/dtypes.py
+++ b/modin/core/dataframe/pandas/metadata/dtypes.py
@@ -1191,7 +1191,7 @@ class LazyProxyCategoricalDtype(pandas.CategoricalDtype):
 
 
 def get_categories_dtype(
-    cdt: Union[LazyProxyCategoricalDtype, pandas.CategoricalDtype]
+    cdt: Union[LazyProxyCategoricalDtype, pandas.CategoricalDtype],
 ) -> DtypeObj:
     """
     Get the categories dtype.

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -1133,7 +1133,7 @@ def to_pandas(modin_obj: SupportsPublicToPandas) -> DataFrame | Series:
 
 
 def to_numpy(
-    modin_obj: Union[SupportsPrivateToNumPy, SupportsPublicToNumPy]
+    modin_obj: Union[SupportsPrivateToNumPy, SupportsPublicToNumPy],
 ) -> np.ndarray:
     """
     Convert a Modin object to a NumPy array.

--- a/modin/tests/pandas/test_io.py
+++ b/modin/tests/pandas/test_io.py
@@ -69,7 +69,9 @@ from .utils import (
     parse_dates_values_by_id,
 )
 from .utils import test_data as utils_test_data
-from .utils import time_parsing_csv_path
+from .utils import (
+    time_parsing_csv_path,
+)
 
 if StorageFormat.get() == "Pandas":
     import modin.pandas as pd


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7431
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
