### PR TITLE
FIX-#7404: Implement interchange protocol for datetime columns

### DIFF
--- a/modin/core/dataframe/pandas/interchange/dataframe_protocol/column.py
+++ b/modin/core/dataframe/pandas/interchange/dataframe_protocol/column.py
@@ -169,6 +169,7 @@ class PandasProtocolColumn(ProtocolColumn):
             "u": DTypeKind.UINT,
             "f": DTypeKind.FLOAT,
             "b": DTypeKind.BOOL,
+            "M": DTypeKind.DATETIME,
         }
         kind = _np_kinds.get(dtype.kind, None)
         if kind is None:
@@ -337,7 +338,13 @@ class PandasProtocolColumn(ProtocolColumn):
             return self._data_buffer_cache
 
         dtype = self.dtype
-        if dtype[0] in (DTypeKind.INT, DTypeKind.UINT, DTypeKind.FLOAT, DTypeKind.BOOL):
+        if dtype[0] in (
+            DTypeKind.INT,
+            DTypeKind.UINT,
+            DTypeKind.FLOAT,
+            DTypeKind.BOOL,
+            DTypeKind.DATETIME,
+        ):
             buffer = PandasProtocolBuffer(
                 self._col.to_numpy().flatten(), allow_copy=self._allow_copy
             )

--- a/modin/tests/interchange/dataframe_protocol/pandas/test_protocol.py
+++ b/modin/tests/interchange/dataframe_protocol/pandas/test_protocol.py
@@ -68,3 +68,18 @@ def test_interchange_with_pandas_string():
     modin_df = pd.DataFrame({"fips": ["01001"]})
     pandas_df = pandas.api.interchange.from_dataframe(modin_df.__dataframe__())
     df_equals(modin_df, pandas_df)
+
+
+def test_interchange_with_datetime():
+    date_range = pd.date_range(
+        start=pd.Timestamp("2024-01-01", unit="ns"),
+        end=pd.Timestamp("2024-03-01", unit="ns"),
+        freq="D",
+    )
+    modin_df = pd.DataFrame(
+        {
+            "datetime_s": date_range.astype("datetime64[s]"),
+            "datetime_ns": date_range.astype("datetime64[ns]"),
+        }
+    )
+    eval_df_protocol(modin_df)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Implements the mapping between datetime64 types and the interchange DATETIME type.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7404 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
