### PR TITLE
TEST-#7437: Check execution-filter outputs correctly in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -518,13 +518,13 @@ jobs:
         execution:
           - name: ray
             shell-ex: "python -m pytest"
-            if: needs.execution-filter.ray != 'true'
+            if: needs.execution-filter.outputs.ray != 'true'
           - name: dask
             shell-ex: "python -m pytest"
-            if: needs.execution-filter.dask != 'true'
+            if: needs.execution-filter.outputs.dask != 'true'
           - name: unidist
             shell-ex: "mpiexec -n 1 -genv AWS_ACCESS_KEY_ID foobar_key -genv AWS_SECRET_ACCESS_KEY foobar_secret python -m pytest"
-            if: needs.execution-filter.unidist != 'true'
+            if: needs.execution-filter.outputs.unidist != 'true'
     runs-on: ${{ matrix.os }}-latest
     defaults:
       run:
@@ -580,9 +580,9 @@ jobs:
                   modin/tests/experimental/xgboost/test_default.py \
                   modin/tests/experimental/xgboost/test_xgboost.py \
                   modin/tests/experimental/xgboost/test_dmatrix.py
-        if: matrix.os != 'windows' && needs.execution-filter.experimental == 'true'
+        if: matrix.os != 'windows' && needs.execution-filter.outputs.experimental == 'true'
       - run: ${{ matrix.execution.shell-ex }} $PARALLEL modin/tests/experimental/test_pipeline.py
-        if: matrix.os != 'windows' && matrix.execution.name != 'unidist' && needs.execution-filter.experimental == 'true'
+        if: matrix.os != 'windows' && matrix.execution.name != 'unidist' && needs.execution-filter.outputs.experimental == 'true'
       - name: "test DF: binary, default, iter"
         run: |
           ${{ matrix.execution.shell-ex }} $PARALLEL \


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->


- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7437
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
