### PR TITLE
FIX-#7465: Properly implement Series.rename_axis

### DIFF
--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1735,8 +1735,7 @@ class Series(BasePandasDataset):
         self._get_axis_number(axis)  # raises ValueError if not 0
         renamed = self if inplace else self.copy()
         renamed.index = renamed.index.set_names(name)
-        if not inplace:
-            return renamed
+        return None if inplace else renamed
 
     def rename(
         self,

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1714,6 +1714,30 @@ class Series(BasePandasDataset):
             mapper=mapper, index=index, axis=axis, copy=copy, inplace=inplace
         )
 
+    def _set_axis_name(self, name, axis=0, inplace=False) -> Union[Series, None]:
+        """
+        Alter the name of the axis.
+
+        Parameters
+        ----------
+        name : str
+            Name for the Series.
+        axis : str or int, default: 0
+            The axis to set the label.
+            Only 0 is valid for Series.
+        inplace : bool, default: False
+            Whether to modify `self` directly or return a copy.
+
+        Returns
+        -------
+        Series or None
+        """
+        axis = self._get_axis_number(axis)  # raises ValueError if not 0
+        renamed = self if inplace else self.copy()
+        renamed.index = renamed.index.set_names(name)
+        if not inplace:
+            return renamed
+
     def rename(
         self,
         index=None,

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -1732,7 +1732,7 @@ class Series(BasePandasDataset):
         -------
         Series or None
         """
-        axis = self._get_axis_number(axis)  # raises ValueError if not 0
+        self._get_axis_number(axis)  # raises ValueError if not 0
         renamed = self if inplace else self.copy()
         renamed.index = renamed.index.set_names(name)
         if not inplace:

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -5210,7 +5210,7 @@ def test_rename_axis():
     df_equals(series_md, series_pd)
     # axis=1 is invalid for series
     try:
-        series_pd.rename_axis("name", 1)
+        series_pd.rename_axis("name", axis=1)
     except Exception as err:
         with pytest.raises(type(err)):
-            series_md.rename_axis("name", 1)
+            series_md.rename_axis("name", axis=1)

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -5197,3 +5197,20 @@ def test_argmax_argmin_7413(op):
     result_md = getattr(series_md, op)()
     result_pd = getattr(series_pd, op)()
     assert result_md == result_pd
+
+
+def test_rename_axis():
+    series_md, series_pd = create_test_series([0, 1, 2])
+    renamed_md = series_md.rename_axis("name")
+    renamed_pd = series_pd.rename_axis("name")
+    assert series_md.index.name is None
+    df_equals(renamed_md, renamed_pd)
+    series_md.rename_axis("name", inplace=True)
+    series_pd.rename_axis("name", inplace=True)
+    df_equals(series_md, series_pd)
+    # axis=1 is invalid for series
+    try:
+        series_pd.rename_axis("name", 1)
+    except Exception as err:
+        with pytest.raises(type(err)):
+            series_md.rename_axis("name", 1)

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -5201,16 +5201,17 @@ def test_argmax_argmin_7413(op):
 
 def test_rename_axis():
     series_md, series_pd = create_test_series([0, 1, 2])
-    renamed_md = series_md.rename_axis("name")
-    renamed_pd = series_pd.rename_axis("name")
-    assert series_md.index.name is None
-    df_equals(renamed_md, renamed_pd)
-    series_md.rename_axis("new_name", inplace=True)
-    series_pd.rename_axis("new_name", inplace=True)
-    df_equals(series_md, series_pd)
+    eval_general(series_md, series_pd, lambda ser: ser.rename_axis("name"))
+    eval_general(
+        series_md,
+        series_pd,
+        lambda ser: ser.rename_axis("new_name", inplace=True),
+        __inplace__=True,
+    )
     # axis=1 is invalid for series
-    try:
-        series_pd.rename_axis("name", axis=1)
-    except Exception as err:
-        with pytest.raises(type(err)):
-            series_md.rename_axis("name", axis=1)
+    eval_general(
+        series_md,
+        series_pd,
+        lambda ser: ser.rename_axis("newer_name", axis=1),
+        expected_exception=ValueError("No axis named 1 for object type Series"),
+    )

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -5205,8 +5205,8 @@ def test_rename_axis():
     renamed_pd = series_pd.rename_axis("name")
     assert series_md.index.name is None
     df_equals(renamed_md, renamed_pd)
-    series_md.rename_axis("name", inplace=True)
-    series_pd.rename_axis("name", inplace=True)
+    series_md.rename_axis("new_name", inplace=True)
+    series_pd.rename_axis("new_name", inplace=True)
     df_equals(series_md, series_pd)
     # axis=1 is invalid for series
     try:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Implements `Series._set_axis_name` to remove an `AttributeError` raised from `Series.rename_axis`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7465 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
