### PR TITLE
FEAT-#7468: Add progress bar for engine switch

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4411,11 +4411,12 @@ class BasePandasDataset(ClassLogger):
                     desc=f"Transferring data from {self.get_backend()} to {Backend.normalize(backend)} ...",
                 )
             except ImportError:
+                # Iterate over blank range(1) if tqdm is not installed
                 pass
         query_compiler = self._query_compiler
         # If tqdm is imported and a conversion is necessary, then display a progress bar.
         # Otherwise this assigns query_compiler exactly once.
-        for i in tqdm_range:
+        for _ in tqdm_range:
             pandas_self = self._query_compiler.to_pandas()
             query_compiler = FactoryDispatcher.from_pandas(
                 df=pandas_self, backend=backend

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4422,7 +4422,6 @@ class BasePandasDataset(ClassLogger):
             except ImportError:
                 # Iterate over blank range(2) if tqdm or IPython is not installed
                 pass
-        query_compiler = self._query_compiler
         # If tqdm is imported and a conversion is necessary, then display a progress bar.
         next(progress_iter)
         pandas_self = self._query_compiler.to_pandas()

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4402,7 +4402,7 @@ class BasePandasDataset(ClassLogger):
 
         progress_split_count = 2
         progress_iter = iter(range(progress_split_count))
-        if backend != self.get_backend():
+        if Backend.normalize(backend) != self.get_backend():
             try:
                 from tqdm.auto import trange
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4403,15 +4403,8 @@ class BasePandasDataset(ClassLogger):
         progress_split_count = 2
         progress_iter = iter(range(progress_split_count))
         if backend != self.get_backend():
-            # TODO declare TQDM as an optional setup.py dependency; it's used elsewhere in the codebase as well
             try:
-                # Check if we're in a notebook
-                from IPython import get_ipython
-
-                if get_ipython().__class__.__name__ == "ZMQInteractiveShell":
-                    from tqdm.notebook import trange  # pragma: no cover
-                else:
-                    from tqdm import trange
+                from tqdm.auto import trange
 
                 progress_iter = iter(
                     trange(
@@ -4420,7 +4413,7 @@ class BasePandasDataset(ClassLogger):
                     )
                 )
             except ImportError:
-                # Iterate over blank range(2) if tqdm or IPython is not installed
+                # Iterate over blank range(2) if tqdm is not installed
                 pass
         # If tqdm is imported and a conversion is necessary, then display a progress bar.
         next(progress_iter)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4402,7 +4402,7 @@ class BasePandasDataset(ClassLogger):
 
         progress_split_count = 2
         progress_iter = iter(range(progress_split_count))
-        if backend != self.get_backend:
+        if backend != self.get_backend():
             # TODO declare TQDM as an optional setup.py dependency; it's used elsewhere in the codebase as well
             try:
                 # Check if we're in a notebook

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -16,7 +16,7 @@ import re
 from unittest.mock import patch
 
 import pytest
-import tqdm
+import tqdm.auto
 
 import modin.pandas as pd
 from modin.config import Backend
@@ -120,7 +120,9 @@ def test_set_valid_backend(
     expected_result_backend,
 ):
     progress_iter_count = 2
-    with patch.object(tqdm, "trange", return_value=range(progress_iter_count)) as mock_trange:
+    with patch.object(
+        tqdm.auto, "trange", return_value=range(progress_iter_count)
+    ) as mock_trange:
         with config_context(Backend=starting_backend):
             original_df = data_class([1])
             # convert to pandas for comparison while still on the `starting_backend`.

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -16,7 +16,7 @@ import re
 from unittest.mock import patch
 
 import pytest
-import tqdm.notebook
+import tqdm
 
 import modin.pandas as pd
 from modin.config import Backend
@@ -119,7 +119,7 @@ def test_set_valid_backend(
     data_class,
     expected_result_backend,
 ):
-    with patch.object(tqdm.notebook, "trange", return_value=range(1)) as mock_trange:
+    with patch.object(tqdm, "trange", return_value=range(1)) as mock_trange:
         with config_context(Backend=starting_backend):
             original_df = data_class([1])
             # convert to pandas for comparison while still on the `starting_backend`.

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -122,33 +122,32 @@ def test_set_valid_backend(
     progress_iter_count = 2
     with patch.object(
         tqdm.auto, "trange", return_value=range(progress_iter_count)
-    ) as mock_trange:
-        with config_context(Backend=starting_backend):
-            original_df = data_class([1])
-            # convert to pandas for comparison while still on the `starting_backend`.
-            original_df_as_pandas = original_df.modin.to_pandas()
-            method_result = getattr(original_df, setter_method)(
-                new_backend, **inplace_kwargs
-            )
-            if inplace_kwargs.get("inplace", False):
-                assert method_result is None
-                result_df = original_df
-            else:
-                assert method_result is not None
-                result_df = method_result
-            assert result_df.get_backend() == expected_result_backend
-            df_equals(result_df, original_df_as_pandas)
-            # The global Backend should remain the same even if we change the
-            # backend for a single dataframe.
-            assert Backend.get() == Backend.normalize(starting_backend)
-            if Backend.normalize(starting_backend) == Backend.normalize(
-                expected_result_backend
-            ):
-                mock_trange.assert_not_called()
-            else:
-                # trange constructor is only called once and the iterator is consumed
-                # progress_iter_count times, but we can't easily assert on the number of iterations
-                mock_trange.assert_called_once()
+    ) as mock_trange, config_context(Backend=starting_backend):
+        original_df = data_class([1])
+        # convert to pandas for comparison while still on the `starting_backend`.
+        original_df_as_pandas = original_df.modin.to_pandas()
+        method_result = getattr(original_df, setter_method)(
+            new_backend, **inplace_kwargs
+        )
+        if inplace_kwargs.get("inplace", False):
+            assert method_result is None
+            result_df = original_df
+        else:
+            assert method_result is not None
+            result_df = method_result
+        assert result_df.get_backend() == expected_result_backend
+        df_equals(result_df, original_df_as_pandas)
+        # The global Backend should remain the same even if we change the
+        # backend for a single dataframe.
+        assert Backend.get() == Backend.normalize(starting_backend)
+        if Backend.normalize(starting_backend) == Backend.normalize(
+            expected_result_backend
+        ):
+            mock_trange.assert_not_called()
+        else:
+            # trange constructor is only called once and the iterator is consumed
+            # progress_iter_count times, but we can't easily assert on the number of iterations
+            mock_trange.assert_called_once()
 
 
 def test_set_nonexistent_backend():

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -141,7 +141,9 @@ def test_set_valid_backend(
             # The global Backend should remain the same even if we change the
             # backend for a single dataframe.
             assert Backend.get() == Backend.normalize(starting_backend)
-            if starting_backend == expected_result_backend:
+            if Backend.normalize(starting_backend) == Backend.normalize(
+                expected_result_backend
+            ):
                 mock_trange.assert_not_called()
             else:
                 # trange constructor is only called once and the iterator is consumed

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -119,7 +119,8 @@ def test_set_valid_backend(
     data_class,
     expected_result_backend,
 ):
-    with patch.object(tqdm, "trange", return_value=range(1)) as mock_trange:
+    progress_iter_count = 2
+    with patch.object(tqdm, "trange", return_value=range(progress_iter_count)) as mock_trange:
         with config_context(Backend=starting_backend):
             original_df = data_class([1])
             # convert to pandas for comparison while still on the `starting_backend`.
@@ -141,6 +142,8 @@ def test_set_valid_backend(
             if starting_backend == expected_result_backend:
                 mock_trange.assert_not_called()
             else:
+                # trange constructor is only called once and the iterator is consumed
+                # progress_iter_count times, but we can't easily assert on the number of iterations
                 mock_trange.assert_called_once()
 
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Adds a progress bar when materializing data in `BasePandasDataset.set_backend`. It looks like `tqdm` relies on timing individual iterations to display an actual estimate + extending bar, so right now the bar only moves between the to_pandas and FactoryDispatcher calls and isn't really meaningful aside from signaling that a transfer is in progress.

Notebook example:
![Screenshot 2025-03-18 at 15 41 28](https://github.com/user-attachments/assets/3adbe416-968d-4711-a544-d006402ce741)

Standard Python REPL example:
```
>>> import modin.pandas as pd
>>> pd.DataFrame([[1] * 5] * 5).set_backend("dask")
2025-03-18 15:40:43,301	INFO worker.py:1781 -- Started a local Ray instance.
Transferring data from Ray to Dask ...: 100%|█████████████████████████████████| 2/2 [00:01<00:00,  1.24it/s]
   0  1  2  3  4
0  1  1  1  1  1
1  1  1  1  1  1
2  1  1  1  1  1
3  1  1  1  1  1
4  1  1  1  1  1
```

IPython REPL example:
```
In [1]: import modin.pandas as pd
   ...: pd.DataFrame([[1] * 5] * 5).set_backend("dask")
2025-03-18 15:39:38,406	INFO worker.py:1781 -- Started a local Ray instance.
Transferring data from Ray to Dask ...: 100%|█████████████████████████████████| 2/2 [00:01<00:00,  1.20it/s]
Out[1]: 
   0  1  2  3  4
0  1  1  1  1  1
1  1  1  1  1  1
2  1  1  1  1  1
3  1  1  1  1  1
4  1  1  1  1  1
```

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7468 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
