### PR TITLE
FEAT-#7472: Register dataframe and series accessors with a particular backend.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,6 +157,7 @@ jobs:
       - run: python -m pytest modin/tests/test_dataframe_api_standard.py
       - run: python -m pytest modin/tests/test_logging.py
       - run: python -m pytest modin/tests/test_metrics.py
+      - run: python -m pytest modin/tests/pandas/extensions
       - uses: ./.github/actions/upload-coverage
 
   test-defaults:

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -239,7 +239,9 @@ def get_unique_base_execution():
     execution_name = f"{format_name}On{engine_name}"
 
     # Dynamically building all the required classes to form a new execution
-    base_qc = type(format_name, (TestQC,), {})
+    base_qc = type(
+        format_name, (TestQC,), {"get_backend": (lambda self: execution_name)}
+    )
     base_io = type(
         f"{execution_name}IO", (BaseOnPythonIO,), {"query_compiler_cls": base_qc}
     )
@@ -252,7 +254,7 @@ def get_unique_base_execution():
     # Setting up the new execution
     setattr(factories, f"{execution_name}Factory", base_factory)
     Backend.register_backend(
-        "execution_name", Execution(engine=engine_name, storage_format=format_name)
+        execution_name, Execution(engine=engine_name, storage_format=format_name)
     )
     old_engine, old_format = modin.set_execution(
         engine=engine_name, storage_format=format_name

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -52,6 +52,7 @@ from modin.core.dataframe.base.interchange.dataframe_protocol.dataframe import (
 from modin.error_message import ErrorMessage
 from modin.logging import ClassLogger
 from modin.logging.config import LogLevel
+from modin.logging.logger_decorator import disable_logging
 from modin.utils import MODIN_UNNAMED_SERIES_LABEL, try_cast_to_pandas
 
 from . import doc_utils
@@ -166,6 +167,7 @@ class BaseQueryCompiler(
         if self._should_warn_on_default_to_pandas:
             ErrorMessage.default_to_pandas(message=message, reason=reason)
 
+    @disable_logging
     def get_backend(self) -> str:
         """
         Get the backend for this query compiler.

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -30,6 +30,7 @@ import pandas.core.resample
 from pandas._typing import DtypeBackend, IndexLabel, Suffixes
 from pandas.core.dtypes.common import is_number, is_scalar
 
+from modin.config import Backend, Execution
 from modin.core.dataframe.algebra.default2pandas import (
     BinaryDefault,
     CatDefault,
@@ -164,6 +165,22 @@ class BaseQueryCompiler(
         """
         if self._should_warn_on_default_to_pandas:
             ErrorMessage.default_to_pandas(message=message, reason=reason)
+
+    def get_backend(self) -> str:
+        """
+        Get the backend for this query compiler.
+
+        Returns
+        -------
+        str
+            The backend for this query compiler.
+        """
+        return Backend.get_backend_for_execution(
+            Execution(
+                engine=self.engine,
+                storage_format=self.storage_format,
+            )
+        )
 
     @property
     @abc.abstractmethod

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -248,10 +248,8 @@ def apply_argument_cast(obj: Fn) -> Fn:
         -------
         Any
         """
-        if len(args) == 0:
-            # this is a hack to handle methods like __new__() which don't have
-            # any arguments
-            return obj(*args, **kwargs)
+        if len(args) == 0 and len(kwargs) == 0:
+            return
         current_qc = args[0]
         calculator = QueryCompilerCasterCalculator()
         calculator.add_query_compiler(current_qc)

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -150,6 +150,10 @@ def apply_argument_cast(obj: Fn) -> Fn:
         -------
         Any
         """
+        if len(args) == 0:
+            # this is a hack to handle methods like __new__() which don't have
+            # any arguments
+            return obj(*args, **kwargs)
         current_qc = args[0]
         if isinstance(current_qc, BaseQueryCompiler):
             kwargs = cast_nested_args_to_current_qc_type(kwargs, current_qc)

--- a/modin/pandas/api/extensions/__init__.py
+++ b/modin/pandas/api/extensions/__init__.py
@@ -12,12 +12,14 @@
 # governing permissions and limitations under the License.
 
 from .extensions import (
+    register_base_accessor,
     register_dataframe_accessor,
     register_pd_accessor,
     register_series_accessor,
 )
 
 __all__ = [
+    "register_base_accessor",
     "register_dataframe_accessor",
     "register_series_accessor",
     "register_pd_accessor",

--- a/modin/pandas/api/extensions/extensions.py
+++ b/modin/pandas/api/extensions/extensions.py
@@ -14,15 +14,16 @@
 import inspect
 from collections import defaultdict
 from functools import wraps
-from typing import Any, Callable
+from typing import Any, Callable, Optional
 
 import modin.pandas as pd
 from modin.config import Backend
 
-# This type describes a defaultdict that maps backend name to the dictionary of
+# This type describes a defaultdict that maps backend name (or `None` for
+# method implementation and not bound to any one extension) to the dictionary of
 # extensions for that backend. The keys of the inner dictionary are the names of
 # the extensions, and the values are the extensions themselves.
-EXTENSION_DICT_TYPE = defaultdict[str, dict[str, Any]]
+EXTENSION_DICT_TYPE = defaultdict[Optional[str], dict[str, Any]]
 
 _attrs_to_delete_on_test = defaultdict(list)
 
@@ -36,8 +37,9 @@ _NON_EXTENDABLE_ATTRIBUTES = (
     "set_backend",
     "__getattr__",
     "_get_extension",
-    "getattribute__from_extension_impl",
-    "getattr__from_extension_impl",
+    "_getattribute__from_extension_impl",
+    "_getattr__from_extension_impl",
+    "_query_compiler",
 )
 
 

--- a/modin/pandas/api/extensions/extensions.py
+++ b/modin/pandas/api/extensions/extensions.py
@@ -290,7 +290,7 @@ def wrap_method_in_backend_dispatcher(
 
     @wraps(method)
     def method_dispatcher(*args, **kwargs):
-        if len(args) == 0:
+        if len(args) == 0 and len(kwargs) == 0:
             # Handle some cases like __init__()
             return method(*args, **kwargs)
         # TODO(https://github.com/modin-project/modin/issues/7470): this

--- a/modin/pandas/api/extensions/extensions.py
+++ b/modin/pandas/api/extensions/extensions.py
@@ -11,15 +11,29 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from types import ModuleType
-from typing import Any, Union
+import inspect
+from collections import defaultdict
+from functools import wraps
+from typing import Any, Callable
 
 import modin.pandas as pd
+from modin.config import Backend
+
+_attrs_to_delete_on_test = defaultdict(list)
+
+_NON_EXTENDABLE_ATTRIBUTES = (
+    # we use these attributes to implement the extension system, so it's very
+    # difficult to
+    "__getattribute__",
+    "__setattr__",
+    "__delattr__",
+    "get_backend",
+    "set_backend",
+    "__getattr__",
+)
 
 
-def _set_attribute_on_obj(
-    name: str, extensions_dict: dict, obj: Union[pd.DataFrame, pd.Series, ModuleType]
-):
+def _set_attribute_on_obj(name: str, extensions_dict: dict, backend: str, obj: type):
     """
     Create a new or override existing attribute on obj.
 
@@ -37,10 +51,12 @@ def _set_attribute_on_obj(
     decorator
         Returns the decorator function.
     """
+    if name in _NON_EXTENDABLE_ATTRIBUTES:
+        raise ValueError(f"Cannot register an extension with the reserved name {name}.")
 
     def decorator(new_attr: Any):
         """
-        The decorator for a function or class to be assigned to name
+        Decorate a function or class to be assigned to the given name.
 
         Parameters
         ----------
@@ -52,14 +68,23 @@ def _set_attribute_on_obj(
         new_attr
             Unmodified new_attr is return from the decorator.
         """
-        extensions_dict[name] = new_attr
-        setattr(obj, name, new_attr)
+        extensions_dict[Backend.normalize(backend)][name] = new_attr
+        if callable(new_attr) and name not in dir(obj):
+            # For callable extensions, we add a method to the class that
+            # dispatches to the correct implementation (and eventually, casts
+            # its inputs correctly).
+            setattr(
+                obj,
+                name,
+                wrap_method_in_backend_dispatcher(name, new_attr, extensions_dict),
+            )
+            _attrs_to_delete_on_test[obj].append(name)
         return new_attr
 
     return decorator
 
 
-def register_dataframe_accessor(name: str):
+def register_dataframe_accessor(*, name: str, backend: str):
     """
     Registers a dataframe attribute with the name provided.
 
@@ -88,13 +113,15 @@ def register_dataframe_accessor(name: str):
     -------
     decorator
         Returns the decorator function.
+    backend : str
+        The backend to which the accessor applies.
     """
     return _set_attribute_on_obj(
-        name, pd.dataframe._DATAFRAME_EXTENSIONS_, pd.DataFrame
+        name, pd.dataframe._DATAFRAME_EXTENSIONS_, backend, pd.dataframe.DataFrame
     )
 
 
-def register_series_accessor(name: str):
+def register_series_accessor(*, name: str, backend: str):
     """
     Registers a series attribute with the name provided.
 
@@ -118,13 +145,59 @@ def register_series_accessor(name: str):
     ----------
     name : str
         The name of the attribute to assign to Series.
+    backend : str
+        The backend to which the accessor applies.
 
     Returns
     -------
     decorator
         Returns the decorator function.
     """
-    return _set_attribute_on_obj(name, pd.series._SERIES_EXTENSIONS_, pd.Series)
+    return _set_attribute_on_obj(
+        name, pd.series._SERIES_EXTENSIONS_, backend=backend, obj=pd.series.Series
+    )
+
+
+def register_base_accessor(*, name: str, backend: str):
+    """
+    Register a base attribute with the name provided.
+
+    This is a decorator that assigns a new attribute to BasePandasDataset. It can be used
+    with the following syntax:
+
+    ```
+    @register_base_accessor("new_method")
+    def register_base_accessor(*args, **kwargs):
+        # logic goes here
+        return
+    ```
+
+    The new attribute can then be accessed with the name provided:
+
+    ```
+    s.new_method(*my_args, **my_kwargs)
+    ```
+
+    Parameters
+    ----------
+    name : str
+        The name of the attribute to assign to BasePandasDataset.
+    backend : str
+        The backend to which the accessor applies.
+
+    Returns
+    -------
+    decorator
+        Returns the decorator function.
+    """
+    import modin.pandas.base
+
+    return _set_attribute_on_obj(
+        name,
+        modin.pandas.base._BASE_EXTENSIONS,
+        backend=backend,
+        obj=modin.pandas.base.BasePandasDataset,
+    )
 
 
 def register_pd_accessor(name: str):
@@ -160,4 +233,121 @@ def register_pd_accessor(name: str):
     decorator
         Returns the decorator function.
     """
-    return _set_attribute_on_obj(name, pd._PD_EXTENSIONS_, pd)
+
+    def decorator(new_attr: Any):
+        """
+        The decorator for a function or class to be assigned to name
+
+        Parameters
+        ----------
+        new_attr : Any
+            The new attribute to assign to name.
+
+        Returns
+        -------
+        new_attr
+            Unmodified new_attr is return from the decorator.
+        """
+        pd._PD_EXTENSIONS_[name] = new_attr
+        setattr(pd, name, new_attr)
+        return new_attr
+
+    return decorator
+
+
+def wrap_method_in_backend_dispatcher(
+    name: str, method: Callable, extensions_dict: defaultdict
+) -> Callable:
+    """
+    Wraps a method to dispatch to the correct backend implementation.
+
+    This function is a wrapper that is used to dispatch to the correct backend
+    implementation of a method.
+
+    Parameters
+    ----------
+    name : str
+        The name of the method being wrapped.
+    method : Callable
+        The method being wrapped.
+    extensions_dict : defaultdict
+        The extensions dictionary for the class this method is defined on.
+
+    Returns
+    -------
+    Callable
+        Returns the wrapped function.
+    """
+
+    @wraps(method)
+    def wrapped(*args, **kwargs):
+        if len(args) == 0:
+            # Handle some cases like __init__()
+            return method(*args, **kwargs)
+        # TODO(https://github.com/modin-project/modin/issues/7470): this
+        # method may take dataframes and series backed by different backends
+        # as input, e.g. if we are here because of a call like
+        # `pd.DataFrame().set_backend('python_test').merge(pd.DataFrame().set_backend('pandas'))`.
+        # In that case, we should determine which backend to cast to, cast all
+        # arguments to that backend, and then choose the appropriate extension
+        # method, if it exists.
+
+        # Assume that `self` is the first argument.
+        self = args[0]
+        remaining_args = args[1:]
+        if (
+            hasattr(self, "_query_compiler")
+            and self.get_backend() in extensions_dict
+            and name in extensions_dict[self.get_backend()]
+        ):
+            # If `self` is using a query compiler whose backend has an
+            # extension for this method, use that extension.
+            return extensions_dict[self.get_backend()][name](
+                self, *remaining_args, **kwargs
+            )
+        else:
+            # Otherwise, use the default implementation.
+            return extensions_dict[None][name](self, *remaining_args, **kwargs)
+
+    return wrapped
+
+
+def wrap_class_methods_in_backend_dispatcher(extensions_dict: defaultdict) -> Callable:
+    """
+    Get a function that can wrap a class's instance methods so that they dispatch to the correct backend.
+
+    Parameters
+    ----------
+    extensions_dict : defaultdict
+        The extension dictionary for the class.
+
+    Returns
+    -------
+    Callable
+        The class wrapper.
+    """
+
+    def wrap_methods(cls: type):
+        # We want to avoid wrapping synonyms like __add__() and add() with
+        # different wrappers, so keep a dict mapping methods we've wrapped
+        # to their wrapped versions.
+        already_seen_to_wrapped: dict[Callable, Callable] = {}
+        for method_name, method_value in inspect.getmembers(
+            cls, predicate=inspect.isfunction
+        ):
+            if method_value in already_seen_to_wrapped:
+                setattr(cls, method_name, already_seen_to_wrapped[method_value])
+                continue
+            elif method_name not in _NON_EXTENDABLE_ATTRIBUTES:
+                extensions_dict[None][method_name] = method_value
+                setattr(
+                    cls,
+                    method_name,
+                    wrap_method_in_backend_dispatcher(
+                        method_name, method_value, extensions_dict
+                    ),
+                )
+                already_seen_to_wrapped[method_value] = getattr(cls, method_name)
+        return cls
+
+    return wrap_methods

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4510,7 +4510,6 @@ class BasePandasDataset(ClassLogger):
                 return extensions_for_backend[name]
         return sentinel
 
-    @disable_logging
     @doc(GET_BACKEND_DOC, class_name=__qualname__)
     @disable_logging
     def get_backend(self) -> str:

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4508,6 +4508,8 @@ class BasePandasDataset(ClassLogger):
             extensions_for_backend = extensions[self.get_backend()]
             if name in extensions_for_backend:
                 return extensions_for_backend[name]
+            if name in extensions[None]:
+                return extensions[None][name]
         return sentinel
 
     @doc(GET_BACKEND_DOC, class_name=__qualname__)

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -76,6 +76,7 @@ from pandas.util._validators import (
 )
 
 from modin import pandas as pd
+from modin.config import Backend
 from modin.error_message import ErrorMessage
 from modin.logging import ClassLogger, disable_logging
 from modin.pandas.accessor import CachedAccessor, ModinAPI

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4463,6 +4463,7 @@ class BasePandasDataset(ClassLogger):
     move_to = set_backend
 
     @doc(GET_BACKEND_DOC, class_name=__qualname__)
+    @disable_logging
     def get_backend(self) -> str:
         return self._query_compiler.get_backend()
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -103,7 +103,8 @@ if TYPE_CHECKING:
 # special meaning and needs to be distinguished from a user explicitly passing None.
 sentinel = object()
 
-# Do not look up these attributes when searching for extensions.
+# Do not look up these attributes when searching for extensions. We use them
+# to implement the extension lookup itself.
 _EXTENSION_NO_LOOKUP = {
     "_get_extension",
     "_query_compiler",

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2658,7 +2658,7 @@ class DataFrame(BasePandasDataset):
         try:
             return super().__getattr__(key)
         except AttributeError as err:
-            if key not in _ATTRS_NO_LOOKUP and key in self._query_compiler.columns:
+            if key not in _ATTRS_NO_LOOKUP and key in self.columns:
                 return self[key]
             raise err
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2604,6 +2604,7 @@ class DataFrame(BasePandasDataset):
             s._parent_axis = 1
         return s
 
+    @disable_logging
     def __getattribute__(self, item: str) -> Any:
         """
         Return attribute from the `BasePandasDataset`.
@@ -3389,6 +3390,7 @@ class DataFrame(BasePandasDataset):
     move_to = set_backend
 
     @doc(GET_BACKEND_DOC, class_name=__qualname__)
+    @disable_logging
     def get_backend(self) -> str:
         return super().get_backend()
 

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2672,6 +2672,10 @@ class DataFrame(BasePandasDataset):
             Key to set.
         value : Any
             Value to set.
+
+        Returns
+        -------
+        None
         """
         # While we let users assign to a column labeled "x" with "df.x" , there
         # are some attributes that we should assume are NOT column names and

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2622,7 +2622,7 @@ class DataFrame(BasePandasDataset):
         # then falls back to __getattr__() if the former raises an AttributeError.
 
         if item not in _EXTENSION_NO_LOOKUP:
-            extensions_result = self.getattribute__from_extension_impl(
+            extensions_result = self._getattribute__from_extension_impl(
                 item, _DATAFRAME_EXTENSIONS_
             )
             if extensions_result is not sentinel:
@@ -2652,17 +2652,13 @@ class DataFrame(BasePandasDataset):
         # then falls back to __getattr__() if the former raises an AttributeError.
 
         if key not in _EXTENSION_NO_LOOKUP:
-            extension = self.getattr__from_extension_impl(key, _DATAFRAME_EXTENSIONS_)
+            extension = self._getattr__from_extension_impl(key, _DATAFRAME_EXTENSIONS_)
             if extension is not sentinel:
                 return extension
         try:
             return super().__getattr__(key)
         except AttributeError as err:
-            if (
-                key not in _EXTENSION_NO_LOOKUP
-                and key not in _ATTRS_NO_LOOKUP
-                and key in self._query_compiler.columns
-            ):
+            if key not in _ATTRS_NO_LOOKUP and key in self._query_compiler.columns:
                 return self[key]
             raise err
 

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -362,7 +362,7 @@ class Series(BasePandasDataset):
         # NOTE that to get an attribute, python calls __getattribute__() first and
         # then falls back to __getattr__() if the former raises an AttributeError.
         if key not in _EXTENSION_NO_LOOKUP:
-            extensions_result = self.getattribute__from_extension_impl(
+            extensions_result = self._getattribute__from_extension_impl(
                 key, _SERIES_EXTENSIONS_
             )
             if extensions_result is not sentinel:
@@ -392,17 +392,13 @@ class Series(BasePandasDataset):
         # NOTE that to get an attribute, python calls __getattribute__() first and
         # then falls back to __getattr__() if the former raises an AttributeError.
         if key not in _EXTENSION_NO_LOOKUP:
-            extension = self.getattr__from_extension_impl(key, _SERIES_EXTENSIONS_)
+            extension = self._getattr__from_extension_impl(key, _SERIES_EXTENSIONS_)
             if extension is not sentinel:
                 return extension
         try:
             return super().__getattr__(key)
         except AttributeError as err:
-            if (
-                key not in _EXTENSION_NO_LOOKUP
-                and key not in _ATTRS_NO_LOOKUP
-                and key in self._query_compiler.index
-            ):
+            if key not in _ATTRS_NO_LOOKUP and key in self._query_compiler.index:
                 return self[key]
             raise err
 

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -585,7 +585,7 @@ class Series(BasePandasDataset):
             and hasattr(_SERIES_EXTENSIONS_[self.get_backend()][name], "__set__")
         ):
             return _SERIES_EXTENSIONS_[self.get_backend()][name].__set__(self, value)
-        super().__setattr__(name, value)
+        return super().__setattr__(name, value)
 
     @disable_logging
     def __delattr__(self, name) -> None:
@@ -2882,5 +2882,6 @@ class Series(BasePandasDataset):
     move_to = set_backend
 
     @doc(GET_BACKEND_DOC, class_name=__qualname__)
+    @disable_logging
     def get_backend(self) -> str:
         return super().get_backend()

--- a/modin/tests/config/test_envvars.py
+++ b/modin/tests/config/test_envvars.py
@@ -147,8 +147,12 @@ class TestDocModule:
         )
         # Test scenario 2 from https://github.com/modin-project/modin/issues/7113:
         # We can correctly override the docstring for BasePandasDataset.astype,
-        # which is the same method as Series.astype.
-        assert pd.Series.astype is BasePandasDataset.astype
+        # which is the same method (modulo some wrapping that we add to handle
+        # extensions) as Series.astype.
+        assert (
+            pd.Series.astype.__wrapped__.__wrapped__
+            is BasePandasDataset.astype.__wrapped__
+        )
         assert BasePandasDataset.astype.__doc__ == (
             "This is a test of the documentation module for BasePandasDataSet.astype."
         )

--- a/modin/tests/pandas/extensions/conftest.py
+++ b/modin/tests/pandas/extensions/conftest.py
@@ -1,0 +1,60 @@
+import copy
+
+import pytest
+
+import modin.pandas as pd
+from modin.config import Backend, Engine, Execution, StorageFormat
+from modin.core.execution.dispatching.factories import factories
+from modin.core.execution.dispatching.factories.factories import BaseFactory, NativeIO
+from modin.core.storage_formats.pandas.native_query_compiler import NativeQueryCompiler
+
+
+class Test1QueryCompiler(NativeQueryCompiler):
+    storage_format = property(lambda self: "Test1_Storage_Format")
+    engine = property(lambda self: "Test1_Engine")
+
+
+class Test1IO(NativeIO):
+    query_compiler_cls = Test1QueryCompiler
+
+
+class Test1Factory(BaseFactory):
+
+    @classmethod
+    def prepare(cls):
+        cls.io_cls = Test1IO
+
+
+@pytest.fixture(autouse=True)
+def clean_up_extensions():
+
+    original_dataframe_extensions = copy.deepcopy(pd.dataframe._DATAFRAME_EXTENSIONS_)
+    original_series_extensions = copy.deepcopy(pd.series._SERIES_EXTENSIONS_)
+    original_base_extensions = copy.deepcopy(pd.base._BASE_EXTENSIONS)
+    yield
+    pd.dataframe._DATAFRAME_EXTENSIONS_.clear()
+    pd.dataframe._DATAFRAME_EXTENSIONS_.update(original_dataframe_extensions)
+    pd.series._SERIES_EXTENSIONS_.clear()
+    pd.series._SERIES_EXTENSIONS_.update(original_series_extensions)
+    pd.base._BASE_EXTENSIONS.clear()
+    pd.base._BASE_EXTENSIONS.update(original_base_extensions)
+
+    from modin.pandas.api.extensions.extensions import _attrs_to_delete_on_test
+
+    for k, v in _attrs_to_delete_on_test.items():
+        for obj in v:
+            delattr(k, obj)
+    _attrs_to_delete_on_test.clear()
+
+
+@pytest.fixture
+def Backend1():
+    factories.Test1_Storage_FormatOnTest1_EngineFactory = Test1Factory
+    if "Backend1" not in Backend.choices:
+        StorageFormat.add_option("Test1_storage_format")
+        Engine.add_option("Test1_engine")
+        Backend.register_backend(
+            "Backend1",
+            Execution(storage_format="Test1_Storage_Format", engine="Test1_Engine"),
+        )
+    return "Backend1"

--- a/modin/tests/pandas/extensions/conftest.py
+++ b/modin/tests/pandas/extensions/conftest.py
@@ -1,3 +1,16 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 import copy
 
 import pytest

--- a/modin/tests/pandas/extensions/test_base_extensions.py
+++ b/modin/tests/pandas/extensions/test_base_extensions.py
@@ -1,0 +1,177 @@
+import re
+
+import pytest
+
+import modin.pandas as pd
+from modin.pandas.api.extensions import register_base_accessor
+from modin.pandas.api.extensions.extensions import _NON_EXTENDABLE_ATTRIBUTES
+from modin.tests.pandas.utils import df_equals
+
+
+@pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+def test_add_simple_method(Backend1, data_class):
+    expected_string_val = "Some string value"
+    method_name = "new_method"
+    modin_object = data_class([1, 2, 3]).set_backend(Backend1)
+
+    @register_base_accessor(name=method_name, backend=Backend1)
+    def my_method_implementation(self):
+        return expected_string_val
+
+    assert hasattr(data_class, method_name)
+    assert modin_object.new_method() == expected_string_val
+
+
+@pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+def test_add_non_method(Backend1, data_class):
+    expected_val = 4
+    attribute_name = "four"
+    register_base_accessor(name=attribute_name, backend=Backend1)(expected_val)
+
+    assert data_class().set_backend(Backend1).four == expected_val
+
+
+@pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+def test_method_uses_existing_methods(Backend1, data_class):
+    modin_object = data_class([1, 2, 3]).set_backend(Backend1)
+    method_name = "self_accessor"
+    expected_result = modin_object.sum() / modin_object.count()
+
+    @register_base_accessor(name=method_name, backend=Backend1)
+    def my_average(self):
+        return self.sum() / self.count()
+
+    if data_class is pd.DataFrame:
+        df_equals(modin_object.self_accessor(), expected_result)
+    else:
+        assert modin_object.self_accessor() == expected_result
+
+
+@pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+def test_override_existing_method(Backend1, data_class):
+    modin_object = data_class([3, 2, 1])
+
+    @register_base_accessor(name="copy", backend=Backend1)
+    def my_copy(self, *args, **kwargs):
+        return self + 1
+
+    df_equals(modin_object.set_backend(Backend1).copy(), modin_object + 1)
+
+
+class TestDunders:
+    """
+    Make sure to test that we override special "dunder" methods like __len__
+    correctly. python calls these methods with DataFrame.__len__(obj)
+    rather than getattr(obj, "__len__")().
+    source: https://docs.python.org/3/reference/datamodel.html#special-lookup
+    """
+
+    @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+    def test_len(self, Backend1, data_class):
+        @register_base_accessor(name="__len__", backend=Backend1)
+        def always_get_1(self):
+            return 1
+
+        modin_object = data_class([1, 2, 3])
+        assert len(modin_object) == 3
+        backend_object = modin_object.set_backend(Backend1)
+        assert len(backend_object) == 1
+        assert backend_object.__len__() == 1
+
+
+class TestProperty:
+    @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+    def test_override_loc(self, Backend1, data_class):
+        modin_object = data_class([1, 2, 3])
+
+        @register_base_accessor(name="loc", backend=Backend1)
+        @property
+        def my_loc(self):
+            return self.index[0]
+
+        assert isinstance(modin_object.set_backend(Backend1).loc, int)
+        assert modin_object.set_backend(Backend1).loc == 0
+
+    @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+    def test_add_deletable_property(self, Backend1, data_class):
+        # register a public property `public_property_name` that is backed by
+        # a private attribute `private_property_name`.
+
+        public_property_name = "property_name"
+        private_property_name = "_property_name"
+
+        def get_property(self):
+            return getattr(self, private_property_name)
+
+        def set_property(self, value):
+            setattr(self, private_property_name, value)
+
+        def del_property(self):
+            delattr(self, private_property_name)
+
+        register_base_accessor(name=public_property_name, backend=Backend1)(
+            property(fget=get_property, fset=set_property, fdel=del_property)
+        )
+
+        modin_object = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        assert not hasattr(modin_object, public_property_name)
+        backend_object = modin_object.set_backend(Backend1)
+        setattr(backend_object, public_property_name, "value")
+        assert getattr(backend_object, public_property_name) == "value"
+        delattr(backend_object, public_property_name)
+        # check that the deletion works.
+        assert not hasattr(backend_object, private_property_name)
+
+    @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+    def test_non_settable_extension_property(self, Backend1, data_class):
+        modin_object = data_class([0])
+        property_name = "property_name"
+        register_base_accessor(name=property_name, backend=Backend1)(
+            property(fget=(lambda self: 4))
+        )
+
+        assert not hasattr(modin_object, property_name)
+        backend_object = modin_object.set_backend(Backend1)
+        assert getattr(backend_object, property_name) == 4
+        with pytest.raises(AttributeError):
+            setattr(backend_object, property_name, "value")
+
+    @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+    def test_delete_non_deletable_extension_property(self, Backend1, data_class):
+        modin_object = data_class([0])
+        property_name = "property_name"
+        register_base_accessor(name=property_name, backend=Backend1)(
+            property(fget=(lambda self: "value"))
+        )
+
+        assert not hasattr(modin_object, property_name)
+        backend_object = modin_object.set_backend(Backend1)
+        assert hasattr(backend_object, property_name)
+        with pytest.raises(AttributeError):
+            delattr(backend_object, property_name)
+
+
+@pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+def test_deleting_extension_that_is_not_property_raises_attribute_error(
+    Backend1, data_class
+):
+    expected_string_val = "Some string value"
+    method_name = "new_method"
+
+    @register_base_accessor(name=method_name, backend=Backend1)
+    def my_method_implementation(self):
+        return expected_string_val
+
+    modin_object = data_class([0]).set_backend(Backend1)
+    assert hasattr(data_class, method_name)
+    with pytest.raises(AttributeError):
+        delattr(modin_object, method_name)
+
+
+@pytest.mark.parametrize("name", _NON_EXTENDABLE_ATTRIBUTES)
+def test_disallowed_extensions(Backend1, name):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(f"Cannot register an extension with the reserved name {name}."),
+    ):
+        register_base_accessor(name=name, backend=Backend1)("unused_value")

--- a/modin/tests/pandas/extensions/test_base_extensions.py
+++ b/modin/tests/pandas/extensions/test_base_extensions.py
@@ -22,53 +22,103 @@ from modin.tests.pandas.utils import df_equals
 
 
 @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
-def test_add_simple_method(Backend1, data_class):
-    expected_string_val = "Some string value"
-    method_name = "new_method"
-    modin_object = data_class([1, 2, 3]).set_backend(Backend1)
+class TestOverrideMethodForOneBackend:
+    def test_add_simple_method(self, Backend1, data_class):
+        expected_string_val = "Some string value"
+        method_name = "new_method"
+        modin_object = data_class([1, 2, 3]).set_backend(Backend1)
 
-    @register_base_accessor(name=method_name, backend=Backend1)
-    def my_method_implementation(self):
-        return expected_string_val
+        @register_base_accessor(name=method_name, backend=Backend1)
+        def my_method_implementation(self):
+            return expected_string_val
 
-    assert hasattr(data_class, method_name)
-    assert modin_object.new_method() == expected_string_val
+        assert hasattr(data_class, method_name)
+        assert getattr(modin_object, method_name)() == expected_string_val
+        with pytest.raises(
+            AttributeError,
+            match=re.escape(
+                f"{data_class.__name__} object has no attribute {method_name}"
+            ),
+        ):
+            getattr(modin_object.set_backend("pandas"), method_name)()
+
+    def test_add_non_method(self, Backend1, data_class):
+        expected_val = 4
+        attribute_name = "four"
+        register_base_accessor(name=attribute_name, backend=Backend1)(expected_val)
+
+        assert data_class().set_backend(Backend1).four == expected_val
+        assert not hasattr(data_class().set_backend("pandas"), attribute_name)
+
+    def test_method_uses_existing_methods(self, Backend1, data_class):
+        modin_object = data_class([1, 2, 3]).set_backend(Backend1)
+        method_name = "self_accessor"
+        expected_result = modin_object.sum() / modin_object.count()
+
+        @register_base_accessor(name=method_name, backend=Backend1)
+        def my_average(self):
+            return self.sum() / self.count()
+
+        if data_class is pd.DataFrame:
+            df_equals(modin_object.self_accessor(), expected_result)
+        else:
+            assert modin_object.self_accessor() == expected_result
+
+    def test_override_existing_method(self, Backend1, data_class):
+        modin_object = data_class([3, 2, 1])
+
+        @register_base_accessor(name="copy", backend=Backend1)
+        def my_copy(self, *args, **kwargs):
+            return self + 1
+
+        df_equals(modin_object.set_backend(Backend1).copy(), modin_object + 1)
 
 
 @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
-def test_add_non_method(Backend1, data_class):
-    expected_val = 4
-    attribute_name = "four"
-    register_base_accessor(name=attribute_name, backend=Backend1)(expected_val)
+@pytest.mark.parametrize("backend", ["pandas", "python_test"])
+class TestOverrideMethodForAllBackends:
+    def test_add_simple_method(self, backend, data_class):
+        expected_string_val = "Some string value"
+        method_name = "new_method"
 
-    assert data_class().set_backend(Backend1).four == expected_val
+        @register_base_accessor(name=method_name)
+        def my_method_implementation(self):
+            return expected_string_val
 
+        modin_object = data_class([1, 2, 3]).set_backend(backend)
 
-@pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
-def test_method_uses_existing_methods(Backend1, data_class):
-    modin_object = data_class([1, 2, 3]).set_backend(Backend1)
-    method_name = "self_accessor"
-    expected_result = modin_object.sum() / modin_object.count()
+        assert getattr(modin_object, method_name)() == expected_string_val
+        assert modin_object.new_method() == expected_string_val
 
-    @register_base_accessor(name=method_name, backend=Backend1)
-    def my_average(self):
-        return self.sum() / self.count()
+    def test_add_non_method(self, data_class, backend):
+        expected_val = 4
+        attribute_name = "four"
+        register_base_accessor(name=attribute_name)(expected_val)
 
-    if data_class is pd.DataFrame:
-        df_equals(modin_object.self_accessor(), expected_result)
-    else:
-        assert modin_object.self_accessor() == expected_result
+        assert data_class().set_backend(backend).four == expected_val
 
+    def test_method_uses_existing_methods(self, data_class, backend):
+        modin_object = data_class([1, 2, 3]).set_backend(backend)
+        method_name = "self_accessor"
+        expected_result = modin_object.sum() / modin_object.count()
 
-@pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
-def test_override_existing_method(Backend1, data_class):
-    modin_object = data_class([3, 2, 1])
+        @register_base_accessor(name=method_name)
+        def my_average(self):
+            return self.sum() / self.count()
 
-    @register_base_accessor(name="copy", backend=Backend1)
-    def my_copy(self, *args, **kwargs):
-        return self + 1
+        if data_class is pd.DataFrame:
+            df_equals(modin_object.self_accessor(), expected_result)
+        else:
+            assert modin_object.self_accessor() == expected_result
 
-    df_equals(modin_object.set_backend(Backend1).copy(), modin_object + 1)
+    def test_override_existing_method(self, data_class, backend):
+        modin_object = data_class([3, 2, 1])
+
+        @register_base_accessor(name="copy")
+        def my_copy(self, *args, **kwargs):
+            return self + 1
+
+        df_equals(modin_object.set_backend(backend).copy(), modin_object + 1)
 
 
 class TestDunders:
@@ -92,9 +142,9 @@ class TestDunders:
         assert backend_object.__len__() == 1
 
 
+@pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
 class TestProperty:
-    @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
-    def test_override_loc(self, Backend1, data_class):
+    def test_override_loc_for_one_backend(self, Backend1, data_class):
         modin_object = data_class([1, 2, 3])
 
         @register_base_accessor(name="loc", backend=Backend1)
@@ -105,7 +155,18 @@ class TestProperty:
         assert isinstance(modin_object.set_backend(Backend1).loc, int)
         assert modin_object.set_backend(Backend1).loc == 0
 
-    @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+    @pytest.mark.parametrize("backend", ["pandas", "python_test"])
+    def test_override_loc_for_all_backends(self, backend, data_class):
+        @register_base_accessor(name="loc", backend=None)
+        @property
+        def my_loc(self):
+            return self.index[0]
+
+        modin_object = data_class([1, 2, 3])
+
+        assert isinstance(modin_object.set_backend(backend).loc, int)
+        assert modin_object.set_backend(backend).loc == 0
+
     def test_add_deletable_property(self, Backend1, data_class):
         # register a public property `public_property_name` that is backed by
         # a private attribute `private_property_name`.
@@ -126,7 +187,7 @@ class TestProperty:
             property(fget=get_property, fset=set_property, fdel=del_property)
         )
 
-        modin_object = pd.DataFrame({"a": [1, 2, 3], "b": [4, 5, 6]})
+        modin_object = data_class({"a": [1, 2, 3], "b": [4, 5, 6]})
         assert not hasattr(modin_object, public_property_name)
         backend_object = modin_object.set_backend(Backend1)
         setattr(backend_object, public_property_name, "value")
@@ -135,7 +196,35 @@ class TestProperty:
         # check that the deletion works.
         assert not hasattr(backend_object, private_property_name)
 
-    @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
+    @pytest.mark.parametrize("backend", ["pandas", "python_test"])
+    def test_add_deletable_property_for_all_backends(self, data_class, backend):
+        # register a public property `public_property_name` that is backed by
+        # a private attribute `private_property_name`.
+
+        public_property_name = "property_name"
+        private_property_name = "_property_name"
+
+        def get_property(self):
+            return getattr(self, private_property_name)
+
+        def set_property(self, value):
+            setattr(self, private_property_name, value)
+
+        def del_property(self):
+            delattr(self, private_property_name)
+
+        register_base_accessor(name=public_property_name)(
+            property(fget=get_property, fset=set_property, fdel=del_property)
+        )
+
+        modin_object = data_class({"a": [1, 2, 3], "b": [4, 5, 6]}).set_backend(backend)
+        assert hasattr(modin_object, public_property_name)
+        setattr(modin_object, public_property_name, "value")
+        assert getattr(modin_object, public_property_name) == "value"
+        delattr(modin_object, public_property_name)
+        # check that the deletion works.
+        assert not hasattr(modin_object, private_property_name)
+
     def test_non_settable_extension_property(self, Backend1, data_class):
         modin_object = data_class([0])
         property_name = "property_name"
@@ -149,7 +238,6 @@ class TestProperty:
         with pytest.raises(AttributeError):
             setattr(backend_object, property_name, "value")
 
-    @pytest.mark.parametrize("data_class", [pd.DataFrame, pd.Series])
     def test_delete_non_deletable_extension_property(self, Backend1, data_class):
         modin_object = data_class([0])
         property_name = "property_name"

--- a/modin/tests/pandas/extensions/test_base_extensions.py
+++ b/modin/tests/pandas/extensions/test_base_extensions.py
@@ -1,3 +1,16 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
 import re
 
 import pytest

--- a/modin/tests/pandas/extensions/test_dataframe_extensions.py
+++ b/modin/tests/pandas/extensions/test_dataframe_extensions.py
@@ -11,44 +11,192 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import re
+
+import pytest
+
 import modin.pandas as pd
 from modin.pandas.api.extensions import register_dataframe_accessor
+from modin.pandas.api.extensions.extensions import _NON_EXTENDABLE_ATTRIBUTES
 
 
-def test_dataframe_extension_simple_method():
+def test_dataframe_extension_simple_method(Backend1):
     expected_string_val = "Some string value"
     method_name = "new_method"
-    df = pd.DataFrame([1, 2, 3])
+    df = pd.DataFrame([1, 2, 3]).set_backend(Backend1)
 
-    @register_dataframe_accessor(method_name)
+    @register_dataframe_accessor(name=method_name, backend=Backend1)
     def my_method_implementation(self):
         return expected_string_val
 
-    assert method_name in pd.dataframe._DATAFRAME_EXTENSIONS_.keys()
-    assert pd.dataframe._DATAFRAME_EXTENSIONS_[method_name] is my_method_implementation
+    assert hasattr(pd.DataFrame, method_name)
     assert df.new_method() == expected_string_val
 
 
-def test_dataframe_extension_non_method():
+def test_dataframe_extension_non_method(Backend1):
     expected_val = 4
     attribute_name = "four"
-    register_dataframe_accessor(attribute_name)(expected_val)
-    df = pd.DataFrame([1, 2, 3])
+    register_dataframe_accessor(name=attribute_name, backend=Backend1)(expected_val)
+    df = pd.DataFrame([1, 2, 3]).set_backend(Backend1)
 
-    assert attribute_name in pd.dataframe._DATAFRAME_EXTENSIONS_.keys()
-    assert pd.dataframe._DATAFRAME_EXTENSIONS_[attribute_name] == 4
     assert df.four == expected_val
 
 
-def test_dataframe_extension_accessing_existing_methods():
-    df = pd.DataFrame([1, 2, 3])
+def test_dataframe_extension_accessing_existing_methods(Backend1):
+    df = pd.DataFrame([1, 2, 3]).set_backend(Backend1)
     method_name = "self_accessor"
     expected_result = df.sum() / df.count()
 
-    @register_dataframe_accessor(method_name)
+    @register_dataframe_accessor(name=method_name, backend=Backend1)
     def my_average(self):
         return self.sum() / self.count()
 
-    assert method_name in pd.dataframe._DATAFRAME_EXTENSIONS_.keys()
-    assert pd.dataframe._DATAFRAME_EXTENSIONS_[method_name] is my_average
     assert df.self_accessor().equals(expected_result)
+
+
+def test_dataframe_extension_overrides_existing_method(Backend1):
+    df = pd.DataFrame([3, 2, 1])
+    assert df.sort_values(0).iloc[0, 0] == 1
+
+    @register_dataframe_accessor(name="sort_values", backend=Backend1)
+    def my_sort_values(self):
+        return self
+
+    assert df.set_backend(Backend1).sort_values().iloc[0, 0] == 3
+
+
+class TestDunders:
+    """
+    Make sure to test that we override special "dunder" methods like __len__
+    correctly. python calls these methods with DataFrame.__len__(obj)
+    rather than getattr(obj, "__len__")().
+    source: https://docs.python.org/3/reference/datamodel.html#special-lookup
+    """
+
+    def test_len(self, Backend1):
+        @register_dataframe_accessor(name="__len__", backend=Backend1)
+        def always_get_1(self):
+            return 1
+
+        df = pd.DataFrame([1, 2, 3])
+        assert len(df) == 3
+        backend_df = df.set_backend(Backend1)
+        assert len(backend_df) == 1
+        assert backend_df.__len__() == 1
+
+    def test_repr(self, Backend1):
+        @register_dataframe_accessor(name="__repr__", backend=Backend1)
+        def simple_repr(self) -> str:
+            return "dataframe_string"
+
+        df = pd.DataFrame([1, 2, 3])
+        assert repr(df) == repr(df.modin.to_pandas())
+        backend_df = df.set_backend(Backend1)
+        assert repr(backend_df) == "dataframe_string"
+        assert backend_df.__repr__() == "dataframe_string"
+
+
+class TestProperty:
+    def test_override_columns(self, Backend1):
+        df = pd.DataFrame([["a", "b"]])
+
+        def set_columns(self, new_columns):
+            self._query_compiler.columns = [f"{v}_custom" for v in new_columns]
+
+        register_dataframe_accessor(name="columns", backend=Backend1)(
+            property(
+                fget=(lambda self: self._query_compiler.columns[::-1]), fset=set_columns
+            )
+        )
+
+        assert list(df.columns) == [0, 1]
+        backend_df = df.set_backend(Backend1)
+        assert list(backend_df.columns) == [1, 0]
+        backend_df.columns = [2, 3]
+        assert list(backend_df.columns) == [
+            "3_custom",
+            "2_custom",
+        ]
+
+    def test_add_deletable_property(self, Backend1):
+        public_property_name = "property_name"
+        private_property_name = "_property_name"
+
+        # register a public property `public_property_name` that is backed by
+        # a private attribute `private_property_name`.
+
+        def get_property(self):
+            return getattr(self, private_property_name)
+
+        def set_property(self, value):
+            setattr(self, private_property_name, value)
+
+        def del_property(self):
+            delattr(self, private_property_name)
+
+        register_dataframe_accessor(name=public_property_name, backend=Backend1)(
+            property(get_property, set_property, del_property)
+        )
+
+        df = pd.DataFrame([0])
+        assert not hasattr(df, public_property_name)
+        backend_df = df.set_backend(Backend1)
+        setattr(backend_df, public_property_name, "value")
+        assert hasattr(backend_df, private_property_name)
+        assert getattr(backend_df, private_property_name) == "value"
+        delattr(backend_df, public_property_name)
+        # check that the deletion works.
+        assert not hasattr(backend_df, private_property_name)
+
+    def test_non_settable_extension_property(self, Backend1):
+        df = pd.DataFrame([0])
+        property_name = "property_name"
+
+        register_dataframe_accessor(name=property_name, backend=Backend1)(
+            property(fget=(lambda self: 4))
+        )
+
+        assert not hasattr(df, property_name)
+        backend_df = df.set_backend(Backend1)
+        assert getattr(backend_df, property_name) == 4
+        with pytest.raises(AttributeError):
+            setattr(backend_df, property_name, "value")
+
+    def test_delete_non_deletable_extension_property(self, Backend1):
+        property_name = "property_name"
+
+        register_dataframe_accessor(name=property_name, backend=Backend1)(
+            property(fget=(lambda self: "value"))
+        )
+
+        df = pd.DataFrame([0])
+        assert not hasattr(df, property_name)
+        backend_df = df.set_backend(Backend1)
+        assert hasattr(backend_df, property_name)
+        with pytest.raises(AttributeError):
+            delattr(backend_df, property_name)
+
+
+def test_deleting_extension_that_is_not_property_raises_attribute_error(Backend1):
+    df = pd.DataFrame([0])
+    expected_string_val = "Some string value"
+    method_name = "new_method"
+    df = pd.DataFrame([1, 2, 3]).set_backend(Backend1)
+
+    @register_dataframe_accessor(name=method_name, backend=Backend1)
+    def my_method_implementation(self):
+        return expected_string_val
+
+    assert hasattr(pd.DataFrame, method_name)
+    assert df.new_method() == expected_string_val
+    with pytest.raises(AttributeError):
+        delattr(df, method_name)
+
+
+@pytest.mark.parametrize("name", _NON_EXTENDABLE_ATTRIBUTES)
+def test_disallowed_extensions(Backend1, name):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(f"Cannot register an extension with the reserved name {name}."),
+    ):
+        register_dataframe_accessor(name=name, backend=Backend1)("unused_value")

--- a/modin/tests/pandas/extensions/test_dataframe_extensions.py
+++ b/modin/tests/pandas/extensions/test_dataframe_extensions.py
@@ -65,6 +65,17 @@ def test_dataframe_extension_overrides_existing_method(Backend1):
     assert df.set_backend(Backend1).sort_values().iloc[0, 0] == 3
 
 
+def test_dataframe_extension_method_uses_superclass_method(Backend1):
+    df = pd.DataFrame([3, 2, 1])
+    assert df.sort_values(0).iloc[0, 0] == 1
+
+    @register_dataframe_accessor(name="sort_values", backend=Backend1)
+    def my_sort_values(self, by):
+        return super(pd.DataFrame, self).sort_values(by=by, ascending=False)
+
+    assert df.set_backend(Backend1).sort_values(by=0).iloc[0, 0] == 3
+
+
 class TestDunders:
     """
     Make sure to test that we override special "dunder" methods like __len__

--- a/modin/tests/pandas/extensions/test_dataframe_extensions.py
+++ b/modin/tests/pandas/extensions/test_dataframe_extensions.py
@@ -178,15 +178,14 @@ class TestProperty:
 
 
 def test_deleting_extension_that_is_not_property_raises_attribute_error(Backend1):
-    df = pd.DataFrame([0])
     expected_string_val = "Some string value"
     method_name = "new_method"
-    df = pd.DataFrame([1, 2, 3]).set_backend(Backend1)
 
     @register_dataframe_accessor(name=method_name, backend=Backend1)
     def my_method_implementation(self):
         return expected_string_val
 
+    df = pd.DataFrame([1, 2, 3]).set_backend(Backend1)
     assert hasattr(pd.DataFrame, method_name)
     assert df.new_method() == expected_string_val
     with pytest.raises(AttributeError):

--- a/modin/tests/pandas/extensions/test_pd_extensions.py
+++ b/modin/tests/pandas/extensions/test_pd_extensions.py
@@ -32,5 +32,6 @@ def test_dataframe_extension_non_method():
     expected_val = 4
     attribute_name = "four"
     register_pd_accessor(attribute_name)(expected_val)
+    assert attribute_name in pd._PD_EXTENSIONS_.keys()
     assert pd._PD_EXTENSIONS_[attribute_name] == 4
     assert pd.four == expected_val

--- a/modin/tests/pandas/extensions/test_pd_extensions.py
+++ b/modin/tests/pandas/extensions/test_pd_extensions.py
@@ -32,6 +32,5 @@ def test_dataframe_extension_non_method():
     expected_val = 4
     attribute_name = "four"
     register_pd_accessor(attribute_name)(expected_val)
-    assert attribute_name in pd.dataframe._DATAFRAME_EXTENSIONS_.keys()
     assert pd._PD_EXTENSIONS_[attribute_name] == 4
     assert pd.four == expected_val

--- a/modin/tests/pandas/extensions/test_series_extensions.py
+++ b/modin/tests/pandas/extensions/test_series_extensions.py
@@ -65,6 +65,17 @@ def test_series_extension_overrides_existing_method(Backend1):
     assert series.set_backend(Backend1).sort_values().iloc[0] == 3
 
 
+def test_series_extension_method_uses_superclass_method(Backend1):
+    series = pd.Series([3, 2, 1], name="name")
+    assert series.sort_values().iloc[0] == 1
+
+    @register_series_accessor(name="sort_values", backend=Backend1)
+    def my_sort_values(self):
+        return super(pd.Series, self).sort_values(by="name", ascending=False)
+
+    assert series.set_backend(Backend1).sort_values().iloc[0] == 3
+
+
 class TestDunders:
     """
     Make sure to test that we override special "dunder" methods like __len__

--- a/modin/tests/pandas/extensions/test_series_extensions.py
+++ b/modin/tests/pandas/extensions/test_series_extensions.py
@@ -11,44 +11,186 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
+import re
+
+import pytest
+
 import modin.pandas as pd
 from modin.pandas.api.extensions import register_series_accessor
+from modin.pandas.api.extensions.extensions import _NON_EXTENDABLE_ATTRIBUTES
 
 
-def test_series_extension_simple_method():
+def test_series_extension_simple_method(Backend1):
     expected_string_val = "Some string value"
     method_name = "new_method"
-    ser = pd.Series([1, 2, 3])
+    ser = pd.Series([1, 2, 3]).set_backend(Backend1)
 
-    @register_series_accessor(method_name)
+    @register_series_accessor(name=method_name, backend=Backend1)
     def my_method_implementation(self):
         return expected_string_val
 
-    assert method_name in pd.series._SERIES_EXTENSIONS_.keys()
-    assert pd.series._SERIES_EXTENSIONS_[method_name] is my_method_implementation
+    assert hasattr(pd.Series, method_name)
     assert ser.new_method() == expected_string_val
 
 
-def test_series_extension_non_method():
+def test_series_extension_non_method(Backend1):
     expected_val = 4
     attribute_name = "four"
-    register_series_accessor(attribute_name)(expected_val)
-    ser = pd.Series([1, 2, 3])
+    register_series_accessor(name=attribute_name, backend=Backend1)(expected_val)
+    ser = pd.Series([1, 2, 3]).set_backend(Backend1)
 
-    assert attribute_name in pd.series._SERIES_EXTENSIONS_.keys()
-    assert pd.series._SERIES_EXTENSIONS_[attribute_name] == 4
     assert ser.four == expected_val
 
 
-def test_series_extension_accessing_existing_methods():
-    ser = pd.Series([1, 2, 3])
+def test_series_extension_accessing_existing_methods(Backend1):
+    ser = pd.Series([1, 2, 3]).set_backend(Backend1)
     method_name = "self_accessor"
     expected_result = ser.sum() / ser.count()
 
-    @register_series_accessor(method_name)
+    @register_series_accessor(name=method_name, backend=Backend1)
     def my_average(self):
         return self.sum() / self.count()
 
-    assert method_name in pd.series._SERIES_EXTENSIONS_.keys()
-    assert pd.series._SERIES_EXTENSIONS_[method_name] is my_average
     assert ser.self_accessor() == expected_result
+
+
+def test_series_extension_overrides_existing_method(Backend1):
+    series = pd.Series([3, 2, 1])
+    assert series.sort_values().iloc[0] == 1
+
+    @register_series_accessor(name="sort_values", backend=Backend1)
+    def my_sort_values(self):
+        return self
+
+    assert series.set_backend(Backend1).sort_values().iloc[0] == 3
+
+
+class TestDunders:
+    """
+    Make sure to test that we override special "dunder" methods like __len__
+    correctly. python calls these methods with DataFrame.__len__(obj)
+    rather than getattr(obj, "__len__")().
+    source: https://docs.python.org/3/reference/datamodel.html#special-lookup
+    """
+
+    def test_len(self, Backend1):
+        @register_series_accessor(name="__len__", backend=Backend1)
+        def always_get_1(self):
+            return 1
+
+        series = pd.Series([1, 2, 3])
+        assert len(series) == 3
+        backend_series = series.set_backend(Backend1)
+        assert len(backend_series) == 1
+        assert backend_series.__len__() == 1
+
+    def test_repr(self, Backend1):
+        @register_series_accessor(name="__repr__", backend=Backend1)
+        def simple_repr(self) -> str:
+            return "series_string"
+
+        series = pd.Series([1, 2, 3])
+        assert repr(series) == repr(series.modin.to_pandas())
+        backend_series = series.set_backend(Backend1)
+        assert repr(backend_series) == "series_string"
+        assert backend_series.__repr__() == "series_string"
+
+
+class TestProperty:
+    def test_override_index(self, Backend1):
+        series = pd.Series(["a", "b"])
+
+        def set_index(self, new_index):
+            self._query_compiler.index = [f"{v}_custom" for v in new_index]
+
+        register_series_accessor(name="index", backend=Backend1)(
+            property(fget=lambda self: self._query_compiler.index[::-1], fset=set_index)
+        )
+
+        assert list(series.index) == [0, 1]
+        backend_series = series.set_backend(Backend1)
+        assert list(backend_series.index) == [1, 0]
+        backend_series.index = [2, 3]
+        assert list(backend_series.index) == ["3_custom", "2_custom"]
+
+    def test_add_deletable_property(self, Backend1):
+
+        # register a public property `public_property_name` that is backed by
+        # a private attribute `private_property_name`.
+
+        public_property_name = "property_name"
+        private_property_name = "_property_name"
+
+        def get_property(self):
+            return getattr(self, private_property_name)
+
+        def set_property(self, value):
+            setattr(self, private_property_name, value)
+
+        def del_property(self):
+            delattr(self, private_property_name)
+
+        register_series_accessor(name=public_property_name, backend=Backend1)(
+            property(get_property, set_property, del_property)
+        )
+
+        series = pd.Series([0])
+        assert not hasattr(series, public_property_name)
+        backend_series = series.set_backend(Backend1)
+        setattr(backend_series, public_property_name, "value")
+        assert hasattr(backend_series, private_property_name)
+        assert getattr(backend_series, public_property_name) == "value"
+        delattr(backend_series, public_property_name)
+        # check that the deletion works.
+        assert not hasattr(backend_series, private_property_name)
+
+    def test_non_settable_extension_property(self, Backend1):
+
+        property_name = "property_name"
+        register_series_accessor(name=property_name, backend=Backend1)(
+            property(fget=(lambda self: 4))
+        )
+
+        series = pd.Series([0])
+        assert not hasattr(series, property_name)
+        backend_series = series.set_backend(Backend1)
+        assert getattr(backend_series, property_name) == 4
+        with pytest.raises(AttributeError):
+            setattr(backend_series, property_name, "value")
+
+    def test_delete_non_deletable_extension_property(self, Backend1):
+
+        property_name = "property_name"
+        register_series_accessor(name=property_name, backend=Backend1)(
+            property(fget=(lambda self: "value"))
+        )
+
+        series = pd.Series([0])
+        assert not hasattr(series, property_name)
+        backend_series = series.set_backend(Backend1)
+        with pytest.raises(AttributeError):
+            delattr(backend_series, property_name)
+
+
+def test_deleting_extension_that_is_not_property_raises_attribute_error(Backend1):
+    expected_string_val = "Some string value"
+    method_name = "new_method"
+    series = pd.Series([1, 2, 3]).set_backend(Backend1)
+
+    @register_series_accessor(name=method_name, backend=Backend1)
+    def my_method_implementation(self):
+        return expected_string_val
+
+    assert hasattr(pd.Series, method_name)
+    assert series.new_method() == expected_string_val
+    with pytest.raises(AttributeError):
+        delattr(series, method_name)
+
+
+@pytest.mark.parametrize("name", _NON_EXTENDABLE_ATTRIBUTES)
+def test_disallowed_extensions(Backend1, name):
+    with pytest.raises(
+        ValueError,
+        match=re.escape(f"Cannot register an extension with the reserved name {name}."),
+    ):
+        register_series_accessor(name=name, backend=Backend1)("unused_value")


### PR DESCRIPTION
Associate each base, dataframe, and series extension with a particular backend. Also, add `register_base_extension()`.

Wrap each base, dataframe and series method in a dispatcher that checks the backend of its first argument and then dispatches to the corresponding backend's extension, if it exists. For non-method extensions, including properties and scalars (like ints), we have to extend `__getatribute__`, `__getattr__`, `__delattr__`, and `__setattr__` to implement the extension.

In the future, the dispatcher could choose an appropriate backend when it has inputs from multiple backends. It could then convert all arguments to the correct backend and then choose the extension matching that backend.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7472
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
