### PR TITLE
FIX-#7486: Add support for `.astype(pandas.CategoricalDtype(…))`

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -1758,7 +1758,7 @@ class PandasDataframe(
 
         else:
             # Assume that the dtype is a scalar.
-            if not (col_dtypes == self_dtypes).all():
+            if not (self_dtypes == col_dtypes).all():
                 new_dtypes = self_dtypes.copy()
                 new_dtype = pandas.api.types.pandas_dtype(col_dtypes)
                 if self.engine == "Dask" and hasattr(new_dtype, "_is_materialized"):

--- a/modin/tests/pandas/dataframe/test_map_metadata.py
+++ b/modin/tests/pandas/dataframe/test_map_metadata.py
@@ -566,13 +566,13 @@ def test_astype_category_large():
     df_equals(modin_result, pandas_result)
     assert modin_result.dtypes.equals(pandas_result.dtypes)
 
-    dtype = pd.CategoricalDtype(categories=["A", "B"])
+    dtype = pd.CategoricalDtype(categories=["str0", "str1"])
     modin_result = modin_df.astype({"col1": dtype})
     pandas_result = pandas_df.astype({"col1": dtype})
     df_equals(modin_result, pandas_result)
     assert modin_result.dtypes.equals(pandas_result.dtypes)
 
-    dtype = pd.CategoricalDtype(categories=["A", "B"])
+    dtype = pd.CategoricalDtype(categories=["str0", "str1"])
     modin_result = modin_df.astype(dtype)
     pandas_result = pandas_df.astype(dtype)
     df_equals(modin_result, pandas_result)

--- a/modin/tests/pandas/dataframe/test_map_metadata.py
+++ b/modin/tests/pandas/dataframe/test_map_metadata.py
@@ -528,6 +528,18 @@ def test_astype_category():
     df_equals(modin_result, pandas_result)
     assert modin_result.dtypes.equals(pandas_result.dtypes)
 
+    dtype = pd.CategoricalDtype(categories=["A", "B"])
+    modin_result = modin_df.astype({"col1": dtype})
+    pandas_result = pandas_df.astype({"col1": dtype})
+    df_equals(modin_result, pandas_result)
+    assert modin_result.dtypes.equals(pandas_result.dtypes)
+
+    dtype = pd.CategoricalDtype(categories=["A", "B"])
+    modin_result = modin_df.astype(dtype)
+    pandas_result = pandas_df.astype(dtype)
+    df_equals(modin_result, pandas_result)
+    assert modin_result.dtypes.equals(pandas_result.dtypes)
+
 
 def test_astype_category_large():
     series_length = 10_000
@@ -551,6 +563,18 @@ def test_astype_category_large():
 
     modin_result = modin_df.astype("category")
     pandas_result = pandas_df.astype("category")
+    df_equals(modin_result, pandas_result)
+    assert modin_result.dtypes.equals(pandas_result.dtypes)
+
+    dtype = pd.CategoricalDtype(categories=["A", "B"])
+    modin_result = modin_df.astype({"col1": dtype})
+    pandas_result = pandas_df.astype({"col1": dtype})
+    df_equals(modin_result, pandas_result)
+    assert modin_result.dtypes.equals(pandas_result.dtypes)
+
+    dtype = pd.CategoricalDtype(categories=["A", "B"])
+    modin_result = modin_df.astype(dtype)
+    pandas_result = pandas_df.astype(dtype)
     df_equals(modin_result, pandas_result)
     assert modin_result.dtypes.equals(pandas_result.dtypes)
 

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -1120,6 +1120,12 @@ def test_astype_categorical(data):
     df_equals(modin_result, pandas_result)
     assert modin_result.dtype == pandas_result.dtype
 
+    dtype = pd.CategoricalDtype(categories=sorted(set(data)))
+    modin_result = modin_df.astype(dtype)
+    pandas_result = pandas_df.astype(dtype)
+    df_equals(modin_result, pandas_result)
+    assert modin_result.dtype == pandas_result.dtype
+
 
 @pytest.mark.parametrize("data", [["a", "a", "b", "c", "c", "d", "b", "d"]])
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7486 <!-- issue must be created for each patch -->
- [x] tests added and passing: extended 2 existing tests for converting Categorical/Category data types
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
