### PR TITLE
FIX-#7495: Separate extensions for aliases.

### DIFF
--- a/modin/tests/pandas/dataframe/test_binary.py
+++ b/modin/tests/pandas/dataframe/test_binary.py
@@ -21,6 +21,9 @@ from modin.config import NPartitions, StorageFormat
 from modin.core.dataframe.pandas.partitioning.axis_partition import (
     PandasDataframeAxisPartition,
 )
+from modin.core.storage_formats.pandas.query_compiler_caster import (
+    _assert_casting_functions_wrap_same_implementation,
+)
 from modin.tests.pandas.utils import (
     CustomIntegerForAddition,
     NonCommutativeMultiplyInteger,
@@ -186,7 +189,9 @@ def test_math_functions_level(op):
     ],
 )
 def test_math_alias(math_op, alias):
-    assert getattr(pd.DataFrame, math_op) == getattr(pd.DataFrame, alias)
+    _assert_casting_functions_wrap_same_implementation(
+        getattr(pd.DataFrame, math_op), getattr(pd.DataFrame, alias)
+    )
 
 
 @pytest.mark.parametrize("other", ["as_left", 4, 4.0, "a"])

--- a/modin/tests/pandas/dataframe/test_udf.py
+++ b/modin/tests/pandas/dataframe/test_udf.py
@@ -19,6 +19,9 @@ from pandas.core.dtypes.common import is_list_like
 
 import modin.pandas as pd
 from modin.config import MinRowPartitionSize, NPartitions
+from modin.core.storage_formats.pandas.query_compiler_caster import (
+    _assert_casting_functions_wrap_same_implementation,
+)
 from modin.tests.pandas.utils import (
     agg_func_except_keys,
     agg_func_except_values,
@@ -115,7 +118,9 @@ def test_agg_apply_axis_names(axis, func, op, request):
 
 
 def test_aggregate_alias():
-    assert pd.DataFrame.agg == pd.DataFrame.aggregate
+    _assert_casting_functions_wrap_same_implementation(
+        pd.DataFrame.agg, pd.DataFrame.aggregate
+    )
 
 
 def test_aggregate_error_checking():

--- a/modin/tests/pandas/extensions/test_dataframe_extensions.py
+++ b/modin/tests/pandas/extensions/test_dataframe_extensions.py
@@ -69,6 +69,33 @@ def test_dataframe_extension_overrides_existing_method(Backend1):
     assert df.set_backend(Backend1).sort_values().iloc[0, 0] == 3
 
 
+@pytest.mark.parametrize(
+    "method_name",
+    [
+        "pow",
+        "__pow__",
+        "__ipow__",
+    ],
+)
+def test_dataframe_extension_overrides_pow_github_issue_7495(method_name):
+    register_dataframe_accessor(method_name, backend="Pandas")(
+        lambda *args, **kwargs: 4
+    )
+    assert getattr(pd.DataFrame([1]).set_backend("Pandas"), method_name)() == 4
+
+
+def test_override_pow_and__pow__to_different_implementations():
+    register_dataframe_accessor("pow", backend="Pandas")(
+        lambda *args, **kwargs: "pow_result"
+    )
+    register_dataframe_accessor("__pow__", backend="Pandas")(
+        lambda *args, **kwargs: "__pow___result"
+    )
+    df = pd.DataFrame([1]).set_backend("pandas")
+    assert df.pow() == "pow_result"
+    assert df.__pow__() == "__pow___result"
+
+
 def test_dataframe_extension_method_uses_superclass_method(Backend1):
     df = pd.DataFrame([3, 2, 1])
     assert df.sort_values(0).iloc[0, 0] == 1

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -31,6 +31,9 @@ from pandas.errors import PerformanceWarning, SpecificationError
 
 import modin.pandas as pd
 from modin.config import Engine, NPartitions, StorageFormat
+from modin.core.storage_formats.pandas.query_compiler_caster import (
+    _assert_casting_functions_wrap_same_implementation,
+)
 from modin.pandas.io import to_pandas
 from modin.tests.test_utils import (
     current_execution_is_native,
@@ -764,7 +767,9 @@ def test_add_custom_class():
 
 def test_aggregate_alias():
     # It's optimization. If failed, Series.agg should be tested explicitly
-    assert pd.Series.aggregate == pd.Series.agg
+    _assert_casting_functions_wrap_same_implementation(
+        pd.Series.aggregate, pd.Series.agg
+    )
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
@@ -2373,7 +2378,9 @@ def test_keys(data):
 def test_kurtosis_alias():
     # It's optimization. If failed, Series.kurt should be tested explicitly
     # in tests: `test_kurt_kurtosis`, `test_kurt_kurtosis_level`.
-    assert pd.Series.kurt == pd.Series.kurtosis
+    _assert_casting_functions_wrap_same_implementation(
+        pd.Series.kurt, pd.Series.kurtosis
+    )
 
 
 @pytest.mark.parametrize("axis", [0, 1])
@@ -2783,7 +2790,9 @@ def test_pow(data):
 
 
 def test_product_alias():
-    assert pd.Series.prod == pd.Series.product
+    _assert_casting_functions_wrap_same_implementation(
+        pd.Series.prod, pd.Series.product
+    )
 
 
 @pytest.mark.parametrize("axis", [0, 1])


### PR DESCRIPTION
Prior to this commit, synonyms like `DataFrame.__pow__` and `DataFrame.pow` would use the same extension set, but would address it with different names. That would cause confusing behavior. Now we define separate wrappers for each alias, so that each alias has its own set of extensions and can draw from that set of extensions appropriately.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7495
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
