### PR TITLE
TEST-#7497: Skip tests requiring lxml on windows.

### DIFF
--- a/modin/tests/experimental/test_io_exp.py
+++ b/modin/tests/experimental/test_io_exp.py
@@ -11,6 +11,7 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 import json
+import platform
 from pathlib import Path
 
 import numpy as np
@@ -323,6 +324,10 @@ def test_json_glob(tmp_path, filename):
 @pytest.mark.parametrize(
     "filename",
     ["test_xml_glob.xml", "test_xml_glob*.xml"],
+)
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="https://github.com/modin-project/modin/issues/7497",
 )
 def test_xml_glob(tmp_path, filename):
     data = test_data["int_data"]

--- a/modin/tests/pandas/test_io.py
+++ b/modin/tests/pandas/test_io.py
@@ -14,6 +14,7 @@
 import csv
 import inspect
 import os
+import platform
 import sys
 import unittest.mock as mock
 from collections import defaultdict
@@ -2726,6 +2727,10 @@ class TestSql:
 
 @pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestHtml:
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="https://github.com/modin-project/modin/issues/7497",
+    )
     def test_read_html(self, make_html_file):
         eval_io(fn_name="read_html", io=make_html_file())
 
@@ -3160,6 +3165,10 @@ class TestPickle:
 
 @pytest.mark.filterwarnings(default_to_pandas_ignore_string)
 class TestXml:
+    @pytest.mark.skipif(
+        platform.system() == "Windows",
+        reason="https://github.com/modin-project/modin/issues/7497",
+    )
     def test_read_xml(self):
         # example from pandas
         data = """<?xml version='1.0' encoding='utf-8'?>
@@ -3295,6 +3304,10 @@ def test_to_latex():
 
 
 @pytest.mark.filterwarnings(default_to_pandas_ignore_string)
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="https://github.com/modin-project/modin/issues/7497",
+)
 def test_to_xml():
     # `lxml` is a required dependency for `to_xml`, but optional for Modin.
     # For some engines we do not install it.


### PR DESCRIPTION
On Windows, skip tests requiring libxml while we wait for libxml 2.14.1  to appear in conda.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7497
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
