### PR TITLE
FEAT-#7505: Support post-operation automatic backend switch.

### DIFF
--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -749,3 +749,15 @@ def clean_up_extensions():
         for obj in v:
             delattr(k, obj)
     _attrs_to_delete_on_test.clear()
+
+
+@pytest.fixture(autouse=True)
+def clean_up_auto_backend_switching():
+    from modin.core.storage_formats.pandas.query_compiler_caster import (
+        _CLASS_AND_BACKEND_TO_POST_OP_SWITCH_METHODS,
+    )
+
+    originals = copy.deepcopy(_CLASS_AND_BACKEND_TO_POST_OP_SWITCH_METHODS)
+    yield
+    _CLASS_AND_BACKEND_TO_POST_OP_SWITCH_METHODS.clear()
+    _CLASS_AND_BACKEND_TO_POST_OP_SWITCH_METHODS.update(originals)

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -346,10 +346,9 @@ class BaseQueryCompiler(
     @disable_logging
     def stay_cost(
         self,
-        other_qc_type: type,
         api_cls_name: Optional[str] = None,
         operation: Optional[str] = None,
-    ) -> int:
+    ) -> Optional[int]:
         """
         Return the "opportunity cost" of not moving the data.
 
@@ -366,8 +365,6 @@ class BaseQueryCompiler(
 
         Parameters
         ----------
-        other_qc_type : QueryCompiler Class
-            The query compiler class to which we should return the cost of switching.
         api_cls_name : str, default: None
             The class name performing the operation which can be used as a
             consideration for the costing analysis. `None` means the function is
@@ -378,12 +375,9 @@ class BaseQueryCompiler(
 
         Returns
         -------
-        int
-            Cost of migrating the data from this qc to the other_qc or
-            None if the cost cannot be determined.
+        Optional[int]
+            Cost of doing this operation on the current backend.
         """
-        if isinstance(self, other_qc_type):
-            return QCCoercionCost.COST_ZERO
         return None
 
     @disable_logging

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -358,7 +358,7 @@ def _maybe_switch_backend_post_op(
     # backend.
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
-    min_move_cost = None
+    min_move_stay_delta = None
     best_backend = None
 
     for backend in Backend._BACKEND_TO_EXECUTION:
@@ -385,15 +385,17 @@ def _maybe_switch_backend_post_op(
             operation=function_name,
         )
         if move_to_cost is not None and stay_cost is not None:
-            move_cost = move_to_cost - stay_cost
-            if move_cost < 0 and (min_move_cost is None or move_cost < min_move_cost):
-                min_move_cost = move_cost
+            move_stay_delta = move_to_cost - stay_cost
+            if move_stay_delta < 0 and (
+                min_move_stay_delta is None or move_stay_delta < min_move_stay_delta
+            ):
+                min_move_stay_delta = move_stay_delta
                 best_backend = backend
             logging.info(
                 f"After {class_of_wrapped_fn} function {function_name}, "
                 + f"considered moving to backend {backend} with move_to_cost "
-                + f"{move_to_cost}, stay_cost {stay_cost}, and net cost "
-                + f"{move_cost}"
+                + f"{move_to_cost}, stay_cost {stay_cost}, and move-stay delta "
+                + f"{move_stay_delta}"
             )
     if best_backend is None:
         logging.info(f"Chose not to switch backends after operation {function_name}")

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -518,7 +518,6 @@ def wrap_function_in_argument_caster(
             kwargs = visit_nested_args(kwargs, cast_to_qc)
         else:
             result_backend = Backend.get()
-
         if name in extensions[result_backend]:
             f_to_apply = extensions[result_backend][name]
         else:

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -361,6 +361,10 @@ def _maybe_switch_backend_post_op(
     min_move_stay_delta = None
     best_backend = None
 
+    stay_cost = result_query_compiler.stay_cost(
+        api_cls_name=class_of_wrapped_fn,
+        operation=function_name,
+    )
     for backend in Backend._BACKEND_TO_EXECUTION:
         if backend in ("Ray", "Unidist", "Dask"):
             # Disable automatically switching to these engines for now, because
@@ -375,11 +379,6 @@ def _maybe_switch_backend_post_op(
             backend=backend
         ).io_cls.query_compiler_cls
         move_to_cost = result_query_compiler.move_to_cost(
-            move_to_class,
-            api_cls_name=class_of_wrapped_fn,
-            operation=function_name,
-        )
-        stay_cost = result_query_compiler.stay_cost(
             move_to_class,
             api_cls_name=class_of_wrapped_fn,
             operation=function_name,

--- a/modin/pandas/api/extensions/extensions.py
+++ b/modin/pandas/api/extensions/extensions.py
@@ -80,7 +80,7 @@ def _set_attribute_on_obj(
                 obj,
                 name,
                 wrap_function_in_argument_caster(
-                    klass=type(obj),
+                    klass=obj if isinstance(obj, type) else None,
                     f=new_attr,
                     wrapping_function_type=(
                         MethodType if isinstance(obj, type) else None

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -67,7 +67,7 @@ class CloudQC(NativeQueryCompiler):
             OmniscientLazyQC: None,
         }[other_qc_cls]
 
-    def stay_cost(self, other_qc_type, api_cls_name, op):
+    def stay_cost(self, api_cls_name, op):
         return QCCoercionCost.COST_HIGH
 
 
@@ -204,7 +204,7 @@ class CloudForBigDataQC(NativeQueryCompiler):
             else None
         )
 
-    def stay_cost(self, other_qc_type, api_cls_name, operation):
+    def stay_cost(self, api_cls_name, operation):
         return QCCoercionCost.COST_MEDIUM
 
 
@@ -524,7 +524,7 @@ def test_stay_or_move_evaluation(cloud_df, default_df):
     default_cls = type(default_df._get_query_compiler())
     cloud_cls = type(cloud_df._get_query_compiler())
 
-    stay_cost = cloud_df._get_query_compiler().stay_cost(default_cls, "Series", "myop")
+    stay_cost = cloud_df._get_query_compiler().stay_cost("Series", "myop")
     move_cost = cloud_df._get_query_compiler().move_to_cost(
         default_cls, "Series", "myop"
     )
@@ -534,7 +534,7 @@ def test_stay_or_move_evaluation(cloud_df, default_df):
     else:
         assert False
 
-    stay_cost = df._get_query_compiler().stay_cost(cloud_cls, "Series", "myop")
+    stay_cost = df._get_query_compiler().stay_cost("Series", "myop")
     move_cost = df._get_query_compiler().move_to_cost(cloud_cls, "Series", "myop")
     assert stay_cost is None
     assert move_cost is None


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7505
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
