### PR TITLE
FEAT-#7509: Add AutoSwitchBackend configuration variable

### DIFF
--- a/modin/config/__init__.py
+++ b/modin/config/__init__.py
@@ -17,6 +17,7 @@ from modin.config.envvars import (
     AsvDataSizeConfig,
     AsvImplementation,
     AsyncReadMode,
+    AutoSwitchBackend,
     Backend,
     BenchmarkMode,
     CIAWSAccessKeyID,
@@ -74,6 +75,7 @@ __all__ = [
     "Memory",
     "Backend",
     "Execution",
+    "AutoSwitchBackend",
     # Ray specific
     "IsRayCluster",
     "RayRedisAddress",

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -590,6 +590,8 @@ Backend.register_backend("Pandas", Execution("Native", "Native"))
 
 class AutoSwitchBackend(EnvironmentVariable, type=bool):
     """
+    Whether automatic backend switching is allowed.
+
     When this flag is set, a Modin backend can attempt to automatically choose an appropriate backend
     for different operations based on features of the input data. When disabled, backends should
     avoid implicit backend switching outside of explicit operations like `to_pandas` and `to_ray`.

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -588,6 +588,27 @@ Backend.register_backend("Unidist", Execution("Pandas", "Unidist"))
 Backend.register_backend("Pandas", Execution("Native", "Native"))
 
 
+class AutoSwitchBackend(EnvironmentVariable, type=bool):
+    """
+    When this flag is set, a Modin backend can attempt to automatically choose an appropriate backend
+    for different operations based on features of the input data. When disabled, backends should
+    avoid implicit backend switching outside of explicit operations like `to_pandas` and `to_ray`.
+    """
+
+    varname = "MODIN_AUTO_SWITCH_BACKENDS"
+    default = True
+
+    @classmethod
+    def enable(cls) -> None:
+        """Enable automatic backend switching."""
+        cls.put(True)
+
+    @classmethod
+    def disable(cls) -> None:
+        """Disable automatic backend switching."""
+        cls.put(False)
+
+
 class IsExperimental(EnvironmentVariable, type=bool):
     """Whether to Turn on experimental features."""
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This PR adds the `AutoSwitchBackend` configuration variable. Backend that wish to dynamically switch to other backends should respect this variable before applying any heuristics.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7509 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
