### PR TITLE
FEAT-#7523: Improve formal definition of the automatic switching algorithm

### DIFF
--- a/docs/development/architecture.rst
+++ b/docs/development/architecture.rst
@@ -102,21 +102,21 @@ QCCoercionCost in the range of 0-1000.
 
 These functions have precise meanings:
 * `move_to_cost` is the transmission cost of moving the data, including known serialization costs
-   from the perspective of that particular compiler. Colloquially, the question being asked of the
-   query compiler is, "What is the normalized cost of moving my data to the other engine?"
+  from the perspective of that particular compiler. Colloquially, the question being asked of the
+  query compiler is, "What is the normalized cost of moving my data to the other engine?"
 * `move_to_me_cost` is the execution cost for the data and operation on the proposed *destination*
-   query compiler. Since this method is called before the data has been migrated this is a class
-   method and the destination query_compiler may have very limited information on the possible cost
-   after migration. Factors that may be considered here include available memory, cpu, and the
-   unique characteristics of the engine. The question being asked is, "If this data were moved to
-   me, what would be the normalized execution cost to perform that operation?"
+  query compiler. Since this method is called before the data has been migrated this is a class
+  method and the destination query_compiler may have very limited information on the possible cost
+  after migration. Factors that may be considered here include available memory, cpu, and the
+  unique characteristics of the engine. The question being asked is, "If this data were moved to
+  me, what would be the normalized execution cost to perform that operation?"
 * `stay_cost` is the execution cost on the current query compilier ( where the data is ). The question
-   asked of the query compiler is, "If I were to keep this data on my engine, what would the normalized
-   execution cost?"
+  asked of the query compiler is, "If I were to keep this data on my engine, what would the normalized
+  execution cost?"
 * `max_cost` is the maximum cost allowed by this query compiler across all data movements. This method
-   sets a normalized upper bound for situations where multiple data frames from different engines all
-   need to move to the same engine. The value returned by this method can exceed 
-   QCCoercionCost.COST_IMPOSSIBLE
+  sets a normalized upper bound for situations where multiple data frames from different engines all
+  need to move to the same engine. The value returned by this method can exceed 
+  QCCoercionCost.COST_IMPOSSIBLE
 
 There are generally two places where automatic casting is considered: When two or more DataFrames on
 different engines are participating in an operation ( such as pd.concat ) or at registered functions

--- a/docs/development/architecture.rst
+++ b/docs/development/architecture.rst
@@ -101,6 +101,7 @@ points in cost opimization. With the exception of `max_cost` these methods need 
 QCCoercionCost in the range of 0-1000.
 
 These functions have precise meanings:
+
 * `move_to_cost` is the transmission cost of moving the data, including known serialization costs
   from the perspective of that particular compiler. Colloquially, the question being asked of the
   query compiler is, "What is the normalized cost of moving my data to the other engine?"

--- a/docs/development/architecture.rst
+++ b/docs/development/architecture.rst
@@ -89,12 +89,39 @@ Dataframe.
 In the interest of reducing the pandas API, the Query Compiler layer closely follows the
 pandas API, but cuts out a large majority of the repetition.
 
+Automatic Engine Switching and Casting
+""""""""""""""""""""""""""""""""""""""
+
 QueryCompilers which are derived from QueryCompilerCaster can participate in automatic casting when
 different query compilers, representing different underlying engines, are used together in a
 function. A relative "cost" of casting is used to determine which query compiler everything should
 be moved to. Each query compiler must implement the functions, `move_to_cost`, `move_to_me_cost`, 
 `max_cost` and `stay_cost` to provide information and query costs associated with different decision
-points in cost opimization.
+points in cost opimization. With the exception of `max_cost` these methods need to return a 
+QCCoercionCost in the range of 0-1000.
+
+These functions have precise meanings:
+* `move_to_cost` is the transmission cost of moving the data, including known serialization costs
+   from the perspective of that particular compiler. Colloquially, the question being asked of the
+   query compiler is, "What is the normalized cost of moving my data to the other engine?"
+* `move_to_me_cost` is the execution cost for the data and operation on the proposed *destination*
+   query compiler. Since this method is called before the data has been migrated this is a class
+   method and the destination query_compiler may have very limited information on the possible cost
+   after migration. Factors that may be considered here include available memory, cpu, and the
+   unique characteristics of the engine. The question being asked is, "If this data were moved to
+   me, what would be the normalized execution cost to perform that operation?"
+* `stay_cost` is the execution cost on the current query compilier ( where the data is ). The question
+   asked of the query compiler is, "If I were to keep this data on my engine, what would the normalized
+   execution cost?"
+* `max_cost` is the maximum cost allowed by this query compiler across all data movements. This method
+   sets a normalized upper bound for situations where multiple data frames from different engines all
+   need to move to the same engine. The value returned by this method can exceed 
+   QCCoercionCost.COST_IMPOSSIBLE
+
+There are generally two places where automatic casting is considered: When two or more DataFrames on
+different engines are participating in an operation ( such as pd.concat ) or at registered functions
+for particular engines through the `register_function_for_pre_op_switch` and 
+`register_function_for_post_op_switch` methods.
 
 Core Modin Dataframe
 """"""""""""""""""""

--- a/docs/development/architecture.rst
+++ b/docs/development/architecture.rst
@@ -112,7 +112,7 @@ These functions have precise meanings:
   unique characteristics of the engine. The question being asked is, "If this data were moved to
   me, what would be the normalized execution cost to perform that operation?"
 * `stay_cost` is the execution cost on the current query compilier ( where the data is ). The question
-  asked of the query compiler is, "If I were to keep this data on my engine, what would the normalized
+  asked of the query compiler is, "If I were to keep this data on my engine, what would be the normalized
   execution cost?"
 * `max_cost` is the maximum cost allowed by this query compiler across all data movements. This method
   sets a normalized upper bound for situations where multiple data frames from different engines all

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -491,7 +491,7 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
         )
 
     @classmethod
-    def set_active_backends(cls, new_choices: tuple[str, ...]) -> None:
+    def set_active_backends(cls, new_choices : tuple) -> None:
         """
         Sets the active backends available for manual and automatic switching.
 
@@ -500,7 +500,7 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
 
         Parameters
         ----------
-        new_choices: tuple[str, ...]
+        new_choices: tuple
             Choices to add.
 
         Raises

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -491,32 +491,34 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
         )
 
     @classmethod
-    def set_active_backends(cls, new_choices:tuple[str,...]):
+    def set_active_backends(cls, new_choices: tuple[str, ...]):
         """
         Sets the active backends available for manual and automatic switching.
-        
+
         Other backends may have been registered, and those backends remain registered, but the
         set of engines that can be used is dynamically modified.
-        
+
         Parameters
         ----------
         new_choices: tuple[str, ...]
             Choices to add.
-            
+
         Raises
         ------
         ValueError
             Raises a ValueError when the set of new_choices are not already registered
         """
         if not all(i in cls._BACKEND_TO_EXECUTION.keys() for i in new_choices):
-            raise ValueError("Active backend choices {new_choices} are not all registered." )
+            raise ValueError(
+                "Active backend choices {new_choices} are not all registered."
+            )
         cls.choices = new_choices
-        
+
     @classmethod
     def get_active_backends(cls):
         """
         Gets the active backends available for manual and automatic switching.
-                    
+
         Returns
         ------
         tuple[str, ...]

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -508,7 +508,7 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
         ValueError
             Raises a ValueError when the set of new_choices are not already registered
         """
-        if not all(i in cls._BACKEND_TO_EXECUTION.keys() for i in new_choices):
+        if not all(i in cls._BACKEND_TO_EXECUTION for i in new_choices):
             raise ValueError(
                 "Active backend choices {new_choices} are not all registered."
             )

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -491,16 +491,16 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
         )
 
     @classmethod
-    def set_active_backends(cls, new_choices : tuple) -> None:
+    def set_active_backends(cls, new_choices: tuple) -> None:
         """
-        Sets the active backends available for manual and automatic switching.
+        Set the active backends available for manual and automatic switching.
 
         Other backends may have been registered, and those backends remain registered, but the
         set of engines that can be used is dynamically modified.
 
         Parameters
         ----------
-        new_choices: tuple
+        new_choices : tuple
             Choices to add.
 
         Raises
@@ -517,10 +517,10 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
     @classmethod
     def get_active_backends(cls) -> tuple[str, ...]:
         """
-        Gets the active backends available for manual and automatic switching.
+        Get the active backends available for manual and automatic switching.
 
         Returns
-        ------
+        -------
         tuple[str, ...]
             returns the active set of backends for switching
         """

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -491,6 +491,40 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
         )
 
     @classmethod
+    def set_active_backends(cls, new_choices:tuple[str,...]):
+        """
+        Sets the active backends available for manual and automatic switching.
+        
+        Other backends may have been registered, and those backends remain registered, but the
+        set of engines that can be used is dynamically modified.
+        
+        Parameters
+        ----------
+        new_choices: tuple[str, ...]
+            Choices to add.
+            
+        Raises
+        ------
+        ValueError
+            Raises a ValueError when the set of new_choices are not already registered
+        """
+        if not all(i in cls._BACKEND_TO_EXECUTION.keys() for i in new_choices):
+            raise ValueError("Active backend choices {new_choices} are not all registered." )
+        cls.choices = new_choices
+        
+    @classmethod
+    def get_active_backends(cls):
+        """
+        Gets the active backends available for manual and automatic switching.
+                    
+        Returns
+        ------
+        tuple[str, ...]
+            returns the active set of backends for switching
+        """
+        return cls.choices
+
+    @classmethod
     def get_backend_for_execution(cls, execution: Execution) -> str:
         """
         Get the backend for the execution.

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -491,7 +491,7 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
         )
 
     @classmethod
-    def set_active_backends(cls, new_choices: tuple[str, ...]) -> NoReturn:
+    def set_active_backends(cls, new_choices: tuple[str, ...]) -> None:
         """
         Sets the active backends available for manual and automatic switching.
 

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -491,7 +491,7 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
         )
 
     @classmethod
-    def set_active_backends(cls, new_choices: tuple[str, ...]):
+    def set_active_backends(cls, new_choices: tuple[str, ...]) -> NoReturn:
         """
         Sets the active backends available for manual and automatic switching.
 
@@ -515,7 +515,7 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
         cls.choices = new_choices
 
     @classmethod
-    def get_active_backends(cls):
+    def get_active_backends(cls) -> tuple[str, ...]:
         """
         Gets the active backends available for manual and automatic switching.
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -321,7 +321,7 @@ class BaseQueryCompiler(
         This is called for forced casting and opportunistic switching
         decision points. Values returned must be within the acceptable
         range of QCCoercionCost
-        
+
         The question is: What are the transfer costs associated with
         moving this data to the other_qc_type?
 
@@ -362,7 +362,7 @@ class BaseQueryCompiler(
         move_to_cost may include the cost of network transmission to
         the other engine, where as the cost returned by 'stay_cost'
         may be simply the cost of running the operation locally.
-        
+
         The question is: What is the cost of running this operation on
         the current dataframe?
 
@@ -401,12 +401,12 @@ class BaseQueryCompiler(
         since this class is not yet instantiated it may have a different
         implementation. It may also include hidden transport or serialization
         costs.
-        
+
         Values returned must be within the acceptable range of QCCoercionCost.
-        
+
         The question is: What is the cost of executing this operation if it
         were to move to this query compiler?
-        
+
         Parameters
         ----------
         other_qc : BaseQueryCompiler

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -321,6 +321,9 @@ class BaseQueryCompiler(
         This is called for forced casting and opportunistic switching
         decision points. Values returned must be within the acceptable
         range of QCCoercionCost
+        
+        The question is: What are the transfer costs associated with
+        moving this data to the other_qc_type?
 
         Parameters
         ----------
@@ -359,6 +362,9 @@ class BaseQueryCompiler(
         move_to_cost may include the cost of network transmission to
         the other engine, where as the cost returned by 'stay_cost'
         may be simply the cost of running the operation locally.
+        
+        The question is: What is the cost of running this operation on
+        the current dataframe?
 
         Values returned must be within the acceptable range of
         QCCoercionCost
@@ -389,12 +395,18 @@ class BaseQueryCompiler(
         operation: Optional[str] = None,
     ) -> Optional[int]:
         """
-        Return the coercion costs from other_qc to this qc type.
+        Return the execution and hidden coercion costs from other_qc.
 
-        This is called for forced casting decision points, where one or more
-        DataFrames from different engines must interoperate. Values returned
-        must be within the acceptable range of QCCoercionCost
-
+        This can be implemented as a class method version of stay_cost, though
+        since this class is not yet instantiated it may have a different
+        implementation. It may also include hidden transport or serialization
+        costs.
+        
+        Values returned must be within the acceptable range of QCCoercionCost.
+        
+        The question is: What is the cost of executing this operation if it
+        were to move to this query compiler?
+        
         Parameters
         ----------
         other_qc : BaseQueryCompiler

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -504,11 +504,15 @@ def _get_backend_for_auto_switch(
             operation=function_name,
         )
         other_execute_cost = move_to_class.move_to_me_cost(
-            input_qc, 
-            api_cls_name=class_of_wrapped_fn, 
+            input_qc,
+            api_cls_name=class_of_wrapped_fn,
             operation=function_name,
         )
-        if move_to_cost is not None and stay_cost is not None and other_execute_cost is not None:
+        if (
+            move_to_cost is not None
+            and stay_cost is not None
+            and other_execute_cost is not None
+        ):
             if stay_cost >= QCCoercionCost.COST_IMPOSSIBLE:
                 # We cannot execute the workload on the current engine
                 # disregard the move_to_cost and just consider whether

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -35,6 +35,7 @@ from modin.config import Backend
 from modin.config import context as config_context
 from modin.core.storage_formats.base.query_compiler import (
     BaseQueryCompiler,
+    QCCoercionCost,
 )
 from modin.core.storage_formats.base.query_compiler_calculator import (
     BackendCostCalculator,
@@ -484,7 +485,7 @@ def _get_backend_for_auto_switch(
         api_cls_name=class_of_wrapped_fn,
         operation=function_name,
     )
-    for backend in Backend._BACKEND_TO_EXECUTION:
+    for backend in Backend.get_active_backends():
         if backend in ("Ray", "Unidist", "Dask"):
             # Disable automatically switching to these engines for now, because
             # 1) _get_prepared_factory_for_backend() currently calls
@@ -502,8 +503,21 @@ def _get_backend_for_auto_switch(
             api_cls_name=class_of_wrapped_fn,
             operation=function_name,
         )
-        if move_to_cost is not None and stay_cost is not None:
-            move_stay_delta = move_to_cost - stay_cost
+        other_execute_cost = move_to_class.move_to_me_cost(
+            input_qc, 
+            api_cls_name=class_of_wrapped_fn, 
+            operation=function_name,
+        )
+        if move_to_cost is not None and stay_cost is not None and other_execute_cost is not None:
+            if stay_cost >= QCCoercionCost.COST_IMPOSSIBLE:
+                # We cannot execute the workload on the current engine
+                # disregard the move_to_cost and just consider whether
+                # the other engine can execute the workload
+                move_stay_delta = other_execute_cost - stay_cost
+            else:
+                # We can execute this workload if we need to, consider
+                # move_to_cost/transfer time in our decision
+                move_stay_delta = (move_to_cost + other_execute_cost) - stay_cost
             if move_stay_delta < 0 and (
                 min_move_stay_delta is None or move_stay_delta < min_move_stay_delta
             ):
@@ -511,8 +525,9 @@ def _get_backend_for_auto_switch(
                 best_backend = backend
             logging.info(
                 f"After {class_of_wrapped_fn} function {function_name}, "
-                + f"considered moving to backend {backend} with move_to_cost "
-                + f"{move_to_cost}, stay_cost {stay_cost}, and move-stay delta "
+                + f"considered moving to backend {backend} with "
+                + f"(transfer_cost {move_to_cost} + other_execution_cost {other_execute_cost}) "
+                + f", stay_cost {stay_cost}, and move-stay delta "
                 + f"{move_stay_delta}"
             )
     if best_backend == starting_backend:

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -201,7 +201,7 @@ class BaseTestAutoMover(NativeQueryCompiler):
     # four variables can handle reasonably
     # complex behavior, though the operation overhead
     # (both initial and per-row) values may vary
-    # by engine
+    # by engine of course
     _MAX_SIZE_THIS_ENGINE_CAN_HANDLE = BIG_DATA_CLOUD_MIN_NUM_ROWS
     _OPERATION_INITIALIZATION_OVERHEAD = 0
     _OPERATION_PER_ROW_OVERHEAD = 0
@@ -210,7 +210,7 @@ class BaseTestAutoMover(NativeQueryCompiler):
     def __init__(self, pandas_frame):
         super().__init__(pandas_frame)
         
-        # transmission cost
+    # transmission cost
     def move_to_cost(self, other_qc_type, api_cls_name, operation):
         if self._TRANSFER_THRESHOLD <= 0:
             return QCCoercionCost.COST_ZERO
@@ -249,6 +249,7 @@ class BaseTestAutoMover(NativeQueryCompiler):
 
 class CloudForBigDataQC(BaseTestAutoMover):
     """Represents a cloud-hosted query compiler that prefers to stay on the cloud only for big data"""
+    # Operations are more costly on this engine, even though it can handle larger datasets
     _MAX_SIZE_THIS_ENGINE_CAN_HANDLE = BIG_DATA_CLOUD_MIN_NUM_ROWS*10
     _OPERATION_INITIALIZATION_OVERHEAD = QCCoercionCost.COST_MEDIUM
     _OPERATION_PER_ROW_OVERHEAD = 10
@@ -266,6 +267,7 @@ class CloudForBigDataQC(BaseTestAutoMover):
     
 class LocalForSmallDataQC(BaseTestAutoMover):
     """Represents a local query compiler that prefers small data."""
+    # Operations are cheap on this engine for small data, but there is an upper bound
     _MAX_SIZE_THIS_ENGINE_CAN_HANDLE = BIG_DATA_CLOUD_MIN_NUM_ROWS
     _OPERATION_PER_ROW_OVERHEAD = 1
 

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -22,7 +22,6 @@ import pytest
 from pytest import param
 
 import modin.pandas as pd
-from modin.config import context as config_context
 from modin.config.envvars import Backend, Engine, Execution
 from modin.core.execution.dispatching.factories import factories
 from modin.core.execution.dispatching.factories.factories import BaseFactory
@@ -637,7 +636,6 @@ def test_stay_or_move_evaluation(cloud_df, default_df):
 
 @contextlib.contextmanager
 def backend_test_context(test_backend: str, choices: set) -> Iterator[None]:
-    import modin.config as cfg
 
     old_default_backend = Backend.get()
     old_backend_choices = Backend.get_active_backends()


### PR DESCRIPTION
We add the move_to_me_cost function as something to be consulted during automatic switching. This allows for the /other/ query compiler to have more of a say in a potential data migration. This also helps to formalize the questions being asked of each participating query compiler, specifically the move_to_cost can be precisely defined as just the transmission and serialization cost of data movement.

We also allow ourselves to disregard transmission cost, or the move_to_cost when the current engine is simply unable to execute the current workload.

We also modify the Backend environment variable to allow for setting and getting the choices in order to constrain the set of engines considered during automatic switching.

In a future commit we will implement a default function similar to what is configured in the tests.
A separate future commit will add a public method to set the active backends.

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7523 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
