### PR TITLE
FIX-#7528: Dispatch module-level extensions to the correct backend

### DIFF
--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -743,6 +743,13 @@ def clean_up_extensions():
     _GENERAL_EXTENSIONS.clear()
     _GENERAL_EXTENSIONS.update(original_general_extensions)
 
+    from modin.pandas.api.extensions.extensions import _attrs_to_delete_on_test
+
+    for k, v in _attrs_to_delete_on_test.items():
+        for obj in v:
+            delattr(k, obj)
+    _attrs_to_delete_on_test.clear()
+
 
 @pytest.fixture(autouse=True)
 def clean_up_auto_backend_switching():

--- a/modin/conftest.py
+++ b/modin/conftest.py
@@ -743,13 +743,6 @@ def clean_up_extensions():
     _GENERAL_EXTENSIONS.clear()
     _GENERAL_EXTENSIONS.update(original_general_extensions)
 
-    from modin.pandas.api.extensions.extensions import _attrs_to_delete_on_test
-
-    for k, v in _attrs_to_delete_on_test.items():
-        for obj in v:
-            delattr(k, obj)
-    _attrs_to_delete_on_test.clear()
-
 
 @pytest.fixture(autouse=True)
 def clean_up_auto_backend_switching():

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -35,6 +35,7 @@ del version
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
     import inspect
+
     from modin.core.storage_formats.pandas.query_compiler_caster import (
         wrap_free_function_in_argument_caster,
     )
@@ -208,7 +209,6 @@ from .io import (
 )
 from .plotting import Plotting as plotting
 from .series import Series
-
 
 __getattr__ = __getattr___impl
 

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -31,69 +31,84 @@ if (
 # to not pollute namespace
 del version
 
+
 with warnings.catch_warnings():
     warnings.simplefilter("ignore")
-    from pandas import (
-        eval,
-        factorize,
-        test,
-        date_range,
-        period_range,
-        Index,
-        MultiIndex,
-        CategoricalIndex,
-        bdate_range,
-        DatetimeIndex,
-        Timedelta,
-        Timestamp,
-        set_eng_float_format,
-        options,
-        describe_option,
-        set_option,
-        get_option,
-        reset_option,
-        option_context,
-        NaT,
-        PeriodIndex,
-        Categorical,
-        Interval,
-        UInt8Dtype,
-        UInt16Dtype,
-        UInt32Dtype,
-        UInt64Dtype,
-        SparseDtype,
-        Int8Dtype,
-        Int16Dtype,
-        Int32Dtype,
-        Int64Dtype,
-        StringDtype,
-        BooleanDtype,
-        CategoricalDtype,
-        DatetimeTZDtype,
-        IntervalDtype,
-        PeriodDtype,
-        RangeIndex,
-        TimedeltaIndex,
-        IntervalIndex,
-        IndexSlice,
-        Grouper,
-        array,
-        Period,
-        DateOffset,
-        timedelta_range,
-        infer_freq,
-        interval_range,
-        ExcelWriter,
-        NamedAgg,
-        NA,
-        api,
-        ArrowDtype,
-        Flags,
-        Float32Dtype,
-        Float64Dtype,
-        from_dummies,
-        testing,
+    import inspect
+    from modin.core.storage_formats.pandas.query_compiler_caster import (
+        wrap_free_function_in_argument_caster,
     )
+
+    # To allow the extensions system to override these methods, we must wrap all objects re-exported
+    # from pandas in a backend dispatcher.
+    _reexport_list = (
+        "eval",
+        "factorize",
+        "test",
+        "date_range",
+        "period_range",
+        "Index",
+        "MultiIndex",
+        "CategoricalIndex",
+        "bdate_range",
+        "DatetimeIndex",
+        "Timedelta",
+        "Timestamp",
+        "set_eng_float_format",
+        "options",
+        "describe_option",
+        "set_option",
+        "get_option",
+        "reset_option",
+        "option_context",
+        "NaT",
+        "PeriodIndex",
+        "Categorical",
+        "Interval",
+        "UInt8Dtype",
+        "UInt16Dtype",
+        "UInt32Dtype",
+        "UInt64Dtype",
+        "SparseDtype",
+        "Int8Dtype",
+        "Int16Dtype",
+        "Int32Dtype",
+        "Int64Dtype",
+        "StringDtype",
+        "BooleanDtype",
+        "CategoricalDtype",
+        "DatetimeTZDtype",
+        "IntervalDtype",
+        "PeriodDtype",
+        "RangeIndex",
+        "TimedeltaIndex",
+        "IntervalIndex",
+        "IndexSlice",
+        "Grouper",
+        "array",
+        "Period",
+        "DateOffset",
+        "timedelta_range",
+        "infer_freq",
+        "interval_range",
+        "ExcelWriter",
+        "NamedAgg",
+        "NA",
+        "api",
+        "ArrowDtype",
+        "Flags",
+        "Float32Dtype",
+        "Float64Dtype",
+        "from_dummies",
+        "testing",
+    )
+    for name in _reexport_list:
+        item = getattr(pandas, name)
+        if inspect.isfunction(item):
+            # Note that this is applied to only functions, not classes.
+            item = wrap_free_function_in_argument_caster(name)(item)
+        globals()[name] = item
+    del inspect, item, _reexport_list, name, wrap_free_function_in_argument_caster
 
 import os
 
@@ -193,6 +208,7 @@ from .io import (
 )
 from .plotting import Plotting as plotting
 from .series import Series
+
 
 __getattr__ = __getattr___impl
 

--- a/modin/pandas/api/extensions/extensions.py
+++ b/modin/pandas/api/extensions/extensions.py
@@ -12,7 +12,6 @@
 # governing permissions and limitations under the License.
 
 import inspect
-from collections import defaultdict
 from types import MethodType, ModuleType
 from typing import Any, Dict, Optional, Union
 

--- a/modin/pandas/api/extensions/extensions.py
+++ b/modin/pandas/api/extensions/extensions.py
@@ -12,6 +12,7 @@
 # governing permissions and limitations under the License.
 
 import inspect
+from collections import defaultdict
 from types import MethodType, ModuleType
 from typing import Any, Dict, Optional, Union
 
@@ -23,6 +24,8 @@ from modin.core.storage_formats.pandas.query_compiler_caster import (
     EXTENSION_DICT_TYPE,
     wrap_function_in_argument_caster,
 )
+
+_attrs_to_delete_on_test = defaultdict(set)
 
 # Track a dict of module-level classes that are re-exported from pandas that may need to dynamically
 # change when overridden by the extensions system, such as pd.Index.
@@ -116,6 +119,9 @@ def _set_attribute_on_obj(
                     name=name,
                 ),
             )
+            # "Free" functions are permanently kept in the wrapper, so no need to clear them in tests.
+            if obj is not pd:
+                _attrs_to_delete_on_test[obj].add(name)
         return new_attr
 
     return decorator

--- a/modin/pandas/api/extensions/extensions.py
+++ b/modin/pandas/api/extensions/extensions.py
@@ -25,7 +25,7 @@ from modin.core.storage_formats.pandas.query_compiler_caster import (
     wrap_function_in_argument_caster,
 )
 
-_attrs_to_delete_on_test = defaultdict(list)
+_attrs_to_delete_on_test = defaultdict(set)
 
 # Track a dict of module-level classes that are re-exported from pandas that may need to dynamically
 # change when overridden by the extensions system, such as pd.Index.
@@ -119,7 +119,7 @@ def _set_attribute_on_obj(
                     name=name,
                 ),
             )
-            _attrs_to_delete_on_test[obj].append(name)
+            _attrs_to_delete_on_test[obj].add(name)
         return new_attr
 
     return decorator

--- a/modin/pandas/api/extensions/extensions.py
+++ b/modin/pandas/api/extensions/extensions.py
@@ -11,10 +11,10 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-from collections import defaultdict
 import inspect
+from collections import defaultdict
 from types import MethodType, ModuleType
-from typing import Any, Optional, Union, Dict
+from typing import Any, Dict, Optional, Union
 
 import modin.pandas as pd
 from modin.config import Backend
@@ -24,8 +24,6 @@ from modin.core.storage_formats.pandas.query_compiler_caster import (
     EXTENSION_DICT_TYPE,
     wrap_function_in_argument_caster,
 )
-
-_attrs_to_delete_on_test = defaultdict(set)
 
 # Track a dict of module-level classes that are re-exported from pandas that may need to dynamically
 # change when overridden by the extensions system, such as pd.Index.
@@ -119,7 +117,6 @@ def _set_attribute_on_obj(
                     name=name,
                 ),
             )
-            _attrs_to_delete_on_test[obj].add(name)
         return new_attr
 
     return decorator

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -36,6 +36,7 @@ from typing import (
 
 import numpy as np
 import pandas
+from pandas import Categorical
 from pandas._libs import lib
 from pandas._typing import (
     CompressionOptions,
@@ -62,7 +63,6 @@ from modin.config import PersistentPickle
 from modin.core.storage_formats.pandas.query_compiler_caster import EXTENSION_DICT_TYPE
 from modin.error_message import ErrorMessage
 from modin.logging import disable_logging
-from modin.pandas import Categorical
 from modin.pandas.io import from_non_pandas, from_pandas, to_pandas
 from modin.utils import (
     MODIN_UNNAMED_SERIES_LABEL,

--- a/modin/tests/pandas/extensions/test_pd_extensions.py
+++ b/modin/tests/pandas/extensions/test_pd_extensions.py
@@ -167,3 +167,21 @@ class TestRegisterForOneBackend:
             pd.concat([modin_on_python_df, modin_on_pandas_df])
             == "python_concat_result"
         )
+
+    def test_index_class_override(self):
+        class FakeIndex:
+            def __init__(self, _values):
+                pass
+
+            def fake_method(self) -> str:
+                return "python_fake_index"
+
+        register_pd_accessor("Index", backend="Python_Test")(FakeIndex)
+
+        with config_context(Backend="Pandas"):
+            # Should return an actual native pandas index object
+            df_equals(pd.Index([1]).to_series(), pd.Series([1], index=[1]))
+
+        with config_context(Backend="Python_Test"):
+            # Should just return a string
+            assert pd.Index([1]).fake_method() == "python_fake_index"

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -825,6 +825,7 @@ class TestSwitchBackendPreOp:
                 ).move_to("Small_Data_Local")
             )
         )
+        pandas_read_json.__name__ = "read_json"
         cloud_read_json = mock.Mock(
             wraps=(
                 lambda *args, **kwargs: _GENERAL_EXTENSIONS[None]["read_json"](
@@ -832,6 +833,7 @@ class TestSwitchBackendPreOp:
                 ).move_to("Big_Data_Cloud")
             )
         )
+        cloud_read_json.__name__ = "read_json"
 
         register_pd_accessor("read_json", backend="Small_Data_Local")(pandas_read_json)
         register_pd_accessor("read_json", backend="Big_Data_Cloud")(cloud_read_json)


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

In this PR, the extensions system tracks objects that were re-exported from pandas, and either wraps them in `wrap_free_function_in_argument_caster` if it is a function, or removes them from the namespace and dispatches via `__getattr__` if it is a class. Technically the `__getattr__` approach can be used for all objects, but this remains more consistent with how we handle dispatch for top-level functions that modin itself defines.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7528 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
