### PR TITLE
FIX-#7532: Display choices in error message of environment vars

### DIFF
--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -510,7 +510,7 @@ class Backend(EnvironmentVariableDisallowingExecutionAndBackendBothSet, type=str
         """
         if not all(i in cls._BACKEND_TO_EXECUTION for i in new_choices):
             raise ValueError(
-                "Active backend choices {new_choices} are not all registered."
+                f"Active backend choices {new_choices} are not all registered."
             )
         cls.choices = new_choices
 


### PR DESCRIPTION

## What do these changes do?
This small PR displays the choices in error message of environment vars.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7532
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
