### PR TITLE
REFACTOR-#7534: Provide internal, overridable method for max_shape

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -528,13 +528,18 @@ class BaseQueryCompiler(
     lazy_column_labels = False
     lazy_column_count = False
 
-    def _estimated_row_count(self):
+    def _estimated_row_count(self) -> int:
         """
-        Returns the estimated row count.
+        Return the estimated row count.
 
         For lazily evaluated engines the row count may not be known exactly. This method provides a way
         to get an estimated row count, the default implementation of which is to eagerly evaluate the
         row count.
+
+        Returns
+        -------
+        int
+            An estimate of the row count or the actual row count from get_axis_len(axis=0).
         """
         return self.get_axis_len(axis=0)
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -536,7 +536,7 @@ class BaseQueryCompiler(
         Returns
         -------
         Tuple
-            Maximum shape of the dataframe (height, width)
+            Maximum shape of the dataframe (height, width).
         """
         return self.get_axis_len(axis=0), self.get_axis_len(axis=1)
 

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -643,6 +643,11 @@ def test_stay_or_move_evaluation(cloud_df, default_df):
     assert move_cost is None
 
 
+def test_max_shape(cloud_df):
+    # default implementation matches df.shape
+    assert cloud_df.shape == cloud_df._query_compiler._max_shape()
+
+
 @contextlib.contextmanager
 def backend_test_context(test_backend: str, choices: set) -> Iterator[None]:
 


### PR DESCRIPTION
Existing query compilers can call get_axis_len(axis=0) to get a row count, but this may be expensive on lazily evaluated systems. Instead we add a new function which can be overridden on a per-query compiler basis for the max row count, which can be sometimes calculated more cheaply.

The default implementation of this is to simply call get_axis_len but sub-classes may have cheaper ways of estimating the length of the dataset.

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #7534 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
