### PR TITLE
FIX-#7536: setuptools / ray version conflict in pkg_resources._vendor 

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -12,8 +12,7 @@ pyyaml
 recommonmark
 sphinx<6.0.0
 sphinx-click
-# ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
-ray>=2.1.0,!=2.5.0
+ray>=2.10.0,<3
 # Override to latest version of modin-spreadsheet
 git+https://github.com/modin-project/modin-spreadsheet.git@49ffd89f683f54c311867d602c55443fb11bf2a5
 sphinxcontrib_plantuml

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -15,7 +15,7 @@ dependencies:
   # NOTE Keep the ray and dask dependencies in sync with the Linux and Windows
   # Unidist environment dependencies.
   # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
-  - ray-core>=2.1.0,!=2.5.0
+  - ray-core>=2.10.0
   - pyarrow>=10.0.1
   # workaround for https://github.com/conda/conda/issues/11744
   - grpcio!=1.45.*

--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -14,8 +14,7 @@ dependencies:
   # optional dependencies
   # NOTE Keep the ray and dask dependencies in sync with the Linux and Windows
   # Unidist environment dependencies.
-  # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
-  - ray-core>=2.10.0
+  - ray-core>=2.10.0,<3
   - pyarrow>=10.0.1
   # workaround for https://github.com/conda/conda/issues/11744
   - grpcio!=1.45.*

--- a/examples/tutorial/jupyter/execution/pandas_on_ray/cluster/modin-cluster.yaml
+++ b/examples/tutorial/jupyter/execution/pandas_on_ray/cluster/modin-cluster.yaml
@@ -166,7 +166,7 @@ setup_commands:
     # To run the nightly version of ray (as opposed to the latest), either use a rayproject docker image
     # that has the "nightly" (e.g. "rayproject/ray-ml:nightly-gpu") or uncomment the following line:
     # - pip install -U "ray[default] @ https://s3-us-west-2.amazonaws.com/ray-wheels/latest/ray-3.0.0.dev0-cp37-cp37m-manylinux2014_x86_64.whl"
-    - conda create -n "modin" -c conda-forge modin "ray-default">=2.1.0,!=2.5.0 -y
+    - conda create -n "modin" -c conda-forge modin "ray-default">=2.10.0,<3 -y
     - conda activate modin && pip install -U fsspec>=2022.11.0 boto3
     - echo "conda activate modin" >> ~/.bashrc
     # TODO(https://github.com/modin-project/modin/issues/7451): Use https once

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -86,7 +86,7 @@ class SupportsPrivateToNumPy(Protocol):  # noqa: PR01
         pass
 
 
-MIN_RAY_VERSION = version.parse("2.1.0")
+MIN_RAY_VERSION = version.parse("2.10.0")
 MIN_DASK_VERSION = version.parse("2.22.0")
 MIN_UNIDIST_VERSION = version.parse("0.2.1")
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,6 @@ packaging>=21.0
 psutil>=5.8.0
 
 ## optional dependencies
-setup
 ray>=2.10.0,<3
 pyarrow>=10.0.1
 dask[complete]>=2.22.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,8 +6,8 @@ packaging>=21.0
 psutil>=5.8.0
 
 ## optional dependencies
-# ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
-ray>=2.1.0,!=2.5.0
+setup
+ray>=2.10.0,<3
 pyarrow>=10.0.1
 dask[complete]>=2.22.0
 distributed>=2.22.0

--- a/requirements/env_unidist_linux.yml
+++ b/requirements/env_unidist_linux.yml
@@ -18,8 +18,7 @@ dependencies:
   # environment and the general environment-dev.yml.
   # We include the ray and dask dependencies here because we want to test
   # switching dataframe backends to ray or dask.
-  # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
-  - ray-core>=2.1.0,!=2.5.0
+  - ray-core>=2.10.0,<3
   # workaround for https://github.com/conda/conda/issues/11744
   - grpcio!=1.45.*
   - grpcio!=1.46.*

--- a/requirements/env_unidist_win.yml
+++ b/requirements/env_unidist_win.yml
@@ -18,7 +18,7 @@ dependencies:
   # environment and the general environment-dev.yml.
   # We include the ray and dask dependencies here because we want to test
   # switching dataframe backends to ray or dask.
-  - ray-core>=2.10.0
+  - ray-core>=2.10.0,<3
   # workaround for https://github.com/conda/conda/issues/11744
   - grpcio!=1.45.*
   - grpcio!=1.46.*

--- a/requirements/env_unidist_win.yml
+++ b/requirements/env_unidist_win.yml
@@ -18,8 +18,7 @@ dependencies:
   # environment and the general environment-dev.yml.
   # We include the ray and dask dependencies here because we want to test
   # switching dataframe backends to ray or dask.
-  # ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
-  - ray-core>=2.1.0,!=2.5.0
+  - ray-core>=2.10.0
   # workaround for https://github.com/conda/conda/issues/11744
   - grpcio!=1.45.*
   - grpcio!=1.46.*

--- a/setup.py
+++ b/setup.py
@@ -6,8 +6,7 @@ with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 dask_deps = ["dask>=2.22.0", "distributed>=2.22.0"]
-# ray==2.5.0 broken: https://github.com/conda-forge/ray-packages-feedstock/issues/100
-ray_deps = ["ray>=2.1.0,!=2.5.0", "pyarrow>=10.0.1"]
+ray_deps = ["ray>=2.10.0,<3", "pyarrow>=10.0.1"]
 mpi_deps = ["unidist[mpi]>=0.2.1"]
 consortium_standard_deps = ["dataframe-api-compat>=0.2.7"]
 spreadsheet_deps = ["modin-spreadsheet>=0.1.0"]


### PR DESCRIPTION
Newer versions of setuptools with older versions of ray may result in the following error:
ModuleNotFoundError: Make sure all required packages are installed: No module named 'pkg_resources._vendor'

Newer versions of setuptools have deprecated pkg_resources ( see: https://setuptools.pypa.io/en/latest/pkg_resources.html ) which versions of ray<2.09 still reference in ray.data.init. Ray has replaced imports of this package in 2.10

To fix this we update the ray dependency to ray 2.10+

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7536
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
