### PR TITLE
FIX-#7538: set_backend should exit early if there is nothing to do

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4469,6 +4469,8 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
             except ImportError:
                 # Iterate over blank range(2) if tqdm is not installed
                 pass
+        else:
+            return self
         # If tqdm is imported and a conversion is necessary, then display a progress bar.
         next(progress_iter)
         pandas_self = self._query_compiler.to_pandas()

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4470,7 +4470,7 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
                 # Iterate over blank range(2) if tqdm is not installed
                 pass
         else:
-            return self
+            return None if inplace else Self
         # If tqdm is imported and a conversion is necessary, then display a progress bar.
         next(progress_iter)
         pandas_self = self._query_compiler.to_pandas()

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4470,7 +4470,7 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
                 # Iterate over blank range(2) if tqdm is not installed
                 pass
         else:
-            return None if inplace else Self
+            return None if inplace else self
         # If tqdm is imported and a conversion is necessary, then display a progress bar.
         next(progress_iter)
         pandas_self = self._query_compiler.to_pandas()

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -155,8 +155,12 @@ def test_same_backend():
         tqdm.auto, "trange", return_value=range(2)
     ) as mock_trange, config_context(Backend="Python_Test"):
         df = pd.DataFrame([1])
-        df.set_backend("Python_Test")
+        new_df = df.set_backend("Python_Test")
         mock_trange.assert_not_called()
+        assert new_df.get_backend() == "Python_Test"
+        new_df = df.set_backend("Python_Test", inplace=True)
+        mock_trange.assert_not_called()
+        assert new_df is None
         assert df.get_backend() == "Python_Test"
 
 

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -162,8 +162,6 @@ def test_set_nonexistent_backend():
         pd.DataFrame([1]).set_backend("does_not_exist")
 
 
-
-
 @pytest.mark.parametrize("backend", [None, 1, [], {}])
 def test_wrong_backend_type(backend):
     with pytest.raises(

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -150,6 +150,16 @@ def test_set_valid_backend(
             mock_trange.assert_called_once()
 
 
+def test_same_backend():
+    with patch.object(
+        tqdm.auto, "trange", return_value=range(2)
+    ) as mock_trange, config_context(Backend="Python_Test"):
+        df = pd.DataFrame([1])
+        df.set_backend("Python_Test")
+        mock_trange.assert_not_called()
+        assert df.get_backend() == "Python_Test"
+
+
 def test_set_nonexistent_backend():
     backend_choice_string = ", ".join(f"'{choice}'" for choice in Backend.choices)
     with pytest.raises(

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -162,6 +162,8 @@ def test_set_nonexistent_backend():
         pd.DataFrame([1]).set_backend("does_not_exist")
 
 
+
+
 @pytest.mark.parametrize("backend", [None, 1, [], {}])
 def test_wrong_backend_type(backend):
     with pytest.raises(


### PR DESCRIPTION
FIX-#7538: set_backend materializes to pandas even if it is the same backend

Add an else clause.

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7538 <!-- issue must be created for each patch -->
- [x] tests added and passing (existing tests pass through this code path, it was just inefficient before)
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
