### PR TITLE
FIX-#7521: Fix wrong extension being used when backend is pinned

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -789,7 +789,18 @@ def wrap_function_in_argument_caster(
         if not AutoSwitchBackend.get() or (
             len(input_query_compilers) < 2 and pin_target_backend is not None
         ):
-            result = f(*args, **kwargs)
+            f_to_apply = _get_extension_for_method(
+                name=name,
+                extensions=extensions,
+                backend=(
+                    pin_target_backend
+                    if pin_target_backend is not None
+                    else Backend.get()
+                ),
+                args=args,
+                wrapping_function_type=wrapping_function_type,
+            )
+            result = f_to_apply(*args, **kwargs)
             if isinstance(result, QueryCompilerCaster):
                 result._set_backend_pinned(True, inplace=True)
             return result


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

This is a follow-up to #7522, which accidentally broke extension dispatch when an object is pinned. In the previous PR, the default method was being used rather than an extension, while the result backend was correctly preserved.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7521 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
