### PR TITLE
FEAT-#7549: Emit metrics on auto-switch and casting behavior

### DIFF
--- a/modin/core/storage_formats/base/query_compiler_calculator.py
+++ b/modin/core/storage_formats/base/query_compiler_calculator.py
@@ -107,6 +107,8 @@ class BackendCostCalculator:
         """
         if self._result_backend is not None:
             return self._result_backend
+        if len(self._qc_list) == 1:
+            return self._qc_list[0].get_backend()
         if len(self._qc_list) == 0:
             raise ValueError("No query compilers registered")
 
@@ -152,16 +154,16 @@ class BackendCostCalculator:
             logging.info(
                 f"BackendCostCalculator Results: {self._calc_result_log(self._result_backend)}"
             )
+            DECIDED_TO_SWITCH = 1
+            emit_metric(
+                f"hybrid.cast.decision.{self._result_backend}.{hybrid_metrics_calc_group}",
+                DECIDED_TO_SWITCH,
+            )
 
         if self._result_backend is None:
             raise ValueError(
                 f"Cannot cast to any of the available backends, as the estimated cost is too high. Tried these backends: [{','.join(self._backend_data.keys())}]"
             )
-        DECIDED_TO_SWITCH = 1
-        emit_metric(
-            f"hybrid.cast.decision.{self._result_backend}.{hybrid_metrics_calc_group}",
-            DECIDED_TO_SWITCH,
-        )
         return self._result_backend
 
     def _add_cost_data(self, backend, cost):

--- a/modin/core/storage_formats/base/query_compiler_calculator.py
+++ b/modin/core/storage_formats/base/query_compiler_calculator.py
@@ -141,7 +141,7 @@ class BackendCostCalculator:
 
         min_value = None
         for k, v in self._backend_data.items():
-            emit_metric(f"hybrid.cast.{hybrid_metrics_calc_group}.to.{k}.cost", v.cost)
+            emit_metric(f"hybrid.cast.to.{k}.cost.{hybrid_metrics_calc_group}", v.cost)
             if v.cost > v.max_cost:
                 continue
             if min_value is None or min_value > v.cost:
@@ -159,7 +159,7 @@ class BackendCostCalculator:
             )
         DECIDED_TO_SWITCH = 1
         emit_metric(
-            f"hybrid.cast.{hybrid_metrics_calc_group}.decision.{self._result_backend}",
+            f"hybrid.cast.decision.{self._result_backend}.{hybrid_metrics_calc_group}",
             DECIDED_TO_SWITCH,
         )
         return self._result_backend

--- a/modin/core/storage_formats/base/query_compiler_calculator.py
+++ b/modin/core/storage_formats/base/query_compiler_calculator.py
@@ -157,9 +157,10 @@ class BackendCostCalculator:
             raise ValueError(
                 f"Cannot cast to any of the available backends, as the estimated cost is too high. Tried these backends: [{','.join(self._backend_data.keys())}]"
             )
+        DECIDED_TO_SWITCH = 1
         emit_metric(
             f"hybrid.cast.{hybrid_metrics_calc_group}.decision.{self._result_backend}",
-            1,
+            DECIDED_TO_SWITCH,
         )
         return self._result_backend
 

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -22,9 +22,9 @@ This ensures compatibility between different query compiler classes.
 import functools
 import inspect
 import logging
+import random
 from abc import ABC, abstractmethod
 from collections import defaultdict, namedtuple
-import random
 from types import FunctionType, MappingProxyType, MethodType
 from typing import Any, Callable, Dict, Optional, Tuple, TypeVar, Union, ValuesView
 

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -785,26 +785,26 @@ def _get_backend_for_auto_switch(
                 best_backend = backend
             global hybrid_metrics_group
             emit_metric(
-                f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.move_to_cost",
+                f"hybrid.auto.from.{starting_backend}.to.{backend}.move_to_cost.{hybrid_metrics_group}",
                 move_to_cost,
             )
             emit_metric(
-                f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.stay_cost",
+                f"hybrid.auto.from.{starting_backend}.to.{backend}.stay_cost.{hybrid_metrics_group}",
                 stay_cost,
             )
             emit_metric(
-                f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.other_execute_cost",
+                f"hybrid.auto.from.{starting_backend}.to.{backend}.other_execute_cost.{hybrid_metrics_group}",
                 other_execute_cost,
             )
             emit_metric(
-                f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.delta",
+                f"hybrid.auto.from.{starting_backend}.to.{backend}.delta.{hybrid_metrics_group}",
                 move_stay_delta,
             )
             SINGLE_EVENT = 1
             DECIDED_TO_SWITCH = 1
             DECIDED_NOT_TO_SWITCH = 0
             emit_metric(
-                f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.decision.{best_backend}",
+                f"hybrid.auto.from.{starting_backend}.to.{backend}.decision.{best_backend}.{hybrid_metrics_group}",
                 (
                     DECIDED_TO_SWITCH
                     if starting_backend != backend
@@ -812,11 +812,11 @@ def _get_backend_for_auto_switch(
                 ),
             )
             emit_metric(
-                f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.api_cls_name.{class_of_wrapped_fn}",
+                f"hybrid.auto.from.{starting_backend}.to.{backend}.api_cls_name.{class_of_wrapped_fn}.{hybrid_metrics_group}",
                 SINGLE_EVENT,
             )
             emit_metric(
-                f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.function_name.{function_name}",
+                f"hybrid.auto.from.{starting_backend}.to.{backend}.function_name.{function_name}.{hybrid_metrics_group}",
                 SINGLE_EVENT,
             )
             hybrid_metrics_group += 1

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -800,17 +800,24 @@ def _get_backend_for_auto_switch(
                 f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.delta",
                 move_stay_delta,
             )
+            SINGLE_EVENT = 1
+            DECIDED_TO_SWITCH = 1
+            DECIDED_NOT_TO_SWITCH = 0
             emit_metric(
                 f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.decision.{best_backend}",
-                1 if starting_backend != backend else 0,
+                (
+                    DECIDED_TO_SWITCH
+                    if starting_backend != backend
+                    else DECIDED_NOT_TO_SWITCH
+                ),
             )
             emit_metric(
                 f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.api_cls_name.{class_of_wrapped_fn}",
-                1,
+                SINGLE_EVENT,
             )
             emit_metric(
                 f"hybrid.auto.{hybrid_metrics_group}.from.{starting_backend}.to.{backend}.function_name.{function_name}",
-                1,
+                SINGLE_EVENT,
             )
             hybrid_metrics_group += 1
             logging.info(

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -1339,7 +1339,6 @@ def test_switch_metrics(pico_df, cluster_df):
             def test_handler(metric: str, value) -> None:
                 nonlocal count
                 if metric.startswith("modin.hybrid.auto"):
-                    assert "from.Big_Data_Cloud.to.Small_Data_Local" in metric
                     count += 1
 
             add_metric_handler(test_handler)
@@ -1352,6 +1351,6 @@ def test_switch_metrics(pico_df, cluster_df):
             df = pd.DataFrame([1] * 10)
             assert df.get_backend() == "Big_Data_Cloud"
             df.describe()
-            assert count == 9
+            assert count == 8
         finally:
             clear_metric_handler(test_handler)

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -22,7 +22,10 @@ import pandas
 import pytest
 from pytest import param
 
-from modin.logging.metrics import add_metric_handler, clear_metric_handler
+from modin.logging.metrics import (
+    add_metric_handler,
+    clear_metric_handler,
+)
 import modin.pandas as pd
 from modin.config import context as config_context
 from modin.config.envvars import (

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -1332,8 +1332,6 @@ def test_cast_metrics(pico_df, cluster_df):
         add_metric_handler(test_handler)
         df3 = pd.concat([pico_df, cluster_df], axis=1)
         assert df3.get_backend() == "Cluster"  # result should be on cluster
-    except:
-        assert False
     finally:
         clear_metric_handler(test_handler)
 
@@ -1346,7 +1344,6 @@ def test_switch_metrics(pico_df, cluster_df):
         try:
 
             def test_handler(metric: str, value) -> None:
-                global metrics_intercept
                 if metric.startswith("modin.hybrid.auto"):
                     tokens = metric.split(".")
                     assert "from.Big_Data_Cloud.to.Small_Data_Local" in metric
@@ -1385,8 +1382,6 @@ def test_switch_metrics(pico_df, cluster_df):
             )
             df = pd.DataFrame([1] * 10)
             assert df.get_backend() == "Big_Data_Cloud"
-            out = df.describe()
-        except:
-            assert False
+            df.describe()
         finally:
             clear_metric_handler(test_handler)

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -22,6 +22,7 @@ import pandas
 import pytest
 from pytest import param
 
+from modin.logging.metrics import add_metric_handler, clear_metric_handler
 import modin.pandas as pd
 from modin.config import context as config_context
 from modin.config.envvars import (
@@ -1308,3 +1309,84 @@ def test_native_config():
 
     assert qc._engine_max_size() == oldmax
     assert qc._transfer_threshold() == oldthresh
+
+
+def test_cast_metrics(pico_df, cluster_df):
+    try:
+
+        def test_handler(metric: str, value) -> None:
+            if metric.startswith("modin.hybrid.cast"):
+                tokens = metric.split(".")
+                if tokens[5] == "Pico":
+                    assert value == 750
+                    return
+                if tokens[5] == "Cluster":
+                    assert value == 250
+                    return
+                if tokens[4] == "decision":
+                    assert tokens[5] == "Cluster"
+                    assert value == 1
+                    return
+                assert False
+
+        add_metric_handler(test_handler)
+        df3 = pd.concat([pico_df, cluster_df], axis=1)
+        assert df3.get_backend() == "Cluster"  # result should be on cluster
+    except:
+        assert False
+    finally:
+        clear_metric_handler(test_handler)
+
+
+def test_switch_metrics(pico_df, cluster_df):
+    with backend_test_context(
+        test_backend="Big_Data_Cloud",
+        choices=("Big_Data_Cloud", "Small_Data_Local"),
+    ):
+        try:
+
+            def test_handler(metric: str, value) -> None:
+                global metrics_intercept
+                if metric.startswith("modin.hybrid.auto"):
+                    tokens = metric.split(".")
+                    assert "from.Big_Data_Cloud.to.Small_Data_Local" in metric
+                    if tokens[8] == "stay_cost":
+                        assert value == QCCoercionCost.COST_IMPOSSIBLE
+                        return
+                    if tokens[8] == "other_execute_cost":
+                        assert value == 1000
+                        return
+                    if tokens[8] == "move_to_cost":
+                        assert value == 0
+                        return
+                    if tokens[8] == "delta":
+                        assert value == 0
+                        return
+                    if tokens[8] == "delta":
+                        assert tokens[9] == "Big_Data_Cloud"
+                        assert value == 1
+                        return
+                    if tokens[8] == "api_cls_name":
+                        assert tokens[9] == "DataFrame"
+                        assert value == 1
+                        return
+                    if tokens[8] == "function_name":
+                        assert tokens[9] == "describe"
+                        assert value == 1
+                        return
+                    assert False
+
+            add_metric_handler(test_handler)
+
+            register_function_for_pre_op_switch(
+                class_name="DataFrame",
+                backend="Big_Data_Cloud",
+                method="describe",
+            )
+            df = pd.DataFrame([1] * 10)
+            assert df.get_backend() == "Big_Data_Cloud"
+            out = df.describe()
+        except:
+            assert False
+        finally:
+            clear_metric_handler(test_handler)

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -1313,25 +1313,24 @@ def test_native_config():
 
 def test_cast_metrics(pico_df, cluster_df):
     try:
+        errors = 0
 
         def test_handler(metric: str, value) -> None:
+            nonlocal errors
             if metric.startswith("modin.hybrid.cast"):
                 tokens = metric.split(".")
-                if tokens[5] == "Pico":
-                    assert value == 750
+                if tokens[4] == "Pico" and value == 750:
                     return
-                if tokens[5] == "Cluster":
-                    assert value == 250
+                if tokens[4] == "Cluster" and value == 250:
                     return
-                if tokens[4] == "decision":
-                    assert tokens[5] == "Cluster"
-                    assert value == 1
+                if tokens[3] == "decision" and tokens[4] == "Cluster" and value == 1:
                     return
-                assert False
+                errors += 1
 
         add_metric_handler(test_handler)
         df3 = pd.concat([pico_df, cluster_df], axis=1)
         assert df3.get_backend() == "Cluster"  # result should be on cluster
+        assert errors == 0
     finally:
         clear_metric_handler(test_handler)
 
@@ -1342,36 +1341,43 @@ def test_switch_metrics(pico_df, cluster_df):
         choices=("Big_Data_Cloud", "Small_Data_Local"),
     ):
         try:
+            errors = 0
 
             def test_handler(metric: str, value) -> None:
+                nonlocal errors
                 if metric.startswith("modin.hybrid.auto"):
                     tokens = metric.split(".")
                     assert "from.Big_Data_Cloud.to.Small_Data_Local" in metric
-                    if tokens[8] == "stay_cost":
-                        assert value == QCCoercionCost.COST_IMPOSSIBLE
+                    if (
+                        tokens[7] == "stay_cost"
+                        and value == QCCoercionCost.COST_IMPOSSIBLE
+                    ):
                         return
-                    if tokens[8] == "other_execute_cost":
-                        assert value == 1000
+                    if tokens[7] == "other_execute_cost" and value == 1000:
                         return
-                    if tokens[8] == "move_to_cost":
-                        assert value == 0
+                    if tokens[7] == "move_to_cost" and value == 0:
                         return
-                    if tokens[8] == "delta":
-                        assert value == 0
+                    if tokens[7] == "delta" and value == 0:
                         return
-                    if tokens[8] == "delta":
-                        assert tokens[9] == "Big_Data_Cloud"
-                        assert value == 1
+                    if (
+                        tokens[7] == "decision"
+                        and tokens[8] == "Big_Data_Cloud"
+                        and value == 1
+                    ):
                         return
-                    if tokens[8] == "api_cls_name":
-                        assert tokens[9] == "DataFrame"
-                        assert value == 1
+                    if (
+                        tokens[7] == "api_cls_name"
+                        and tokens[8] == "DataFrame"
+                        and value == 1
+                    ):
                         return
-                    if tokens[8] == "function_name":
-                        assert tokens[9] == "describe"
-                        assert value == 1
+                    if (
+                        tokens[7] == "function_name"
+                        and tokens[8] == "describe"
+                        and value == 1
+                    ):
                         return
-                    assert False
+                    errors += 1
 
             add_metric_handler(test_handler)
 
@@ -1383,5 +1389,6 @@ def test_switch_metrics(pico_df, cluster_df):
             df = pd.DataFrame([1] * 10)
             assert df.get_backend() == "Big_Data_Cloud"
             df.describe()
+            assert errors == 0
         finally:
             clear_metric_handler(test_handler)

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -22,10 +22,6 @@ import pandas
 import pytest
 from pytest import param
 
-from modin.logging.metrics import (
-    add_metric_handler,
-    clear_metric_handler,
-)
 import modin.pandas as pd
 from modin.config import context as config_context
 from modin.config.envvars import (
@@ -48,6 +44,7 @@ from modin.core.storage_formats.pandas.query_compiler_caster import (
     register_function_for_post_op_switch,
     register_function_for_pre_op_switch,
 )
+from modin.logging.metrics import add_metric_handler, clear_metric_handler
 from modin.pandas.api.extensions import register_pd_accessor
 from modin.tests.pandas.utils import create_test_dfs, df_equals, eval_general
 

--- a/modin/tests/test_metrics.py
+++ b/modin/tests/test_metrics.py
@@ -71,7 +71,6 @@ def test_df_metrics(metric_client):
     add_metric_handler(metric_client._metric_handler)
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     df.sum()
-    assert len(metric_client._metrics) == 54
     assert metric_client._metrics["modin.pandas-api.dataframe.sum"] is not None
     assert metric_client._metrics["modin.pandas-api.dataframe.sum"] > 0.0
 

--- a/modin/tests/test_metrics.py
+++ b/modin/tests/test_metrics.py
@@ -71,6 +71,7 @@ def test_df_metrics(metric_client):
     add_metric_handler(metric_client._metric_handler)
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     df.sum()
+    assert len(metric_client._metrics) == 54
     assert metric_client._metrics["modin.pandas-api.dataframe.sum"] is not None
     assert metric_client._metrics["modin.pandas-api.dataframe.sum"] > 0.0
 


### PR DESCRIPTION
In both the caster and the calculator we emit some new metrics to track the switching behavior. This will be used by a metrics handler to implement debugging tools.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7549 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
