### PR TITLE
FIX-#7555: Get the correct extension when AutoSwitchBackend is False.

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -792,25 +792,6 @@ def wrap_function_in_argument_caster(
         # 4. If there are multiple query compilers, at least two of which are pinned to distinct
         #    backends, raise a ValueError.
 
-        if not AutoSwitchBackend.get() or (
-            len(input_query_compilers) < 2 and pin_target_backend is not None
-        ):
-            f_to_apply = _get_extension_for_method(
-                name=name,
-                extensions=extensions,
-                backend=(
-                    pin_target_backend
-                    if pin_target_backend is not None
-                    else Backend.get()
-                ),
-                args=args,
-                wrapping_function_type=wrapping_function_type,
-            )
-            result = f_to_apply(*args, **kwargs)
-            if isinstance(result, QueryCompilerCaster):
-                result._set_backend_pinned(True, inplace=True)
-            return result
-
         if len(input_query_compilers) == 0:
             # For nullary functions, we need to create a dummy query compiler
             # to calculate the cost of switching backends.
@@ -825,6 +806,25 @@ def wrap_function_in_argument_caster(
         else:
             input_qc_for_pre_op_switch = input_query_compilers[0]
             input_backend = input_qc_for_pre_op_switch.get_backend()
+
+        if not AutoSwitchBackend.get() or (
+            len(input_query_compilers) < 2 and pin_target_backend is not None
+        ):
+            f_to_apply = _get_extension_for_method(
+                name=name,
+                extensions=extensions,
+                backend=(
+                    pin_target_backend
+                    if pin_target_backend is not None
+                    else input_backend
+                ),
+                args=args,
+                wrapping_function_type=wrapping_function_type,
+            )
+            result = f_to_apply(*args, **kwargs)
+            if isinstance(result, QueryCompilerCaster):
+                result._set_backend_pinned(True, inplace=True)
+            return result
 
         # Bind the arguments using the function implementation for the input
         # backend. TODO(https://github.com/modin-project/modin/issues/7525):

--- a/modin/tests/pandas/extensions/test_dataframe_extensions.py
+++ b/modin/tests/pandas/extensions/test_dataframe_extensions.py
@@ -331,3 +331,14 @@ def test_correct_backend_with_pin(Backend1):
         df.pin_backend(inplace=True)
         assert df.get_backend() == Backend1
         assert repr(df) == "fake_repr"
+
+
+def test_get_extension_from_dataframe_that_is_on_non_default_backend_when_auto_switch_is_false(
+    Backend1,
+):
+    with config_context(AutoSwitchBackend=False, Backend=Backend1):
+        pandas_df = pd.DataFrame([1, 2]).move_to("Pandas")
+        register_dataframe_accessor("sum", backend="Pandas")(
+            lambda df: "small_sum_result"
+        )
+        assert pandas_df.sum() == "small_sum_result"


### PR DESCRIPTION
Previously, we would always use `Backend.get()`, or the pinned backend if one of the inputs was pinned.

Resolves #7555