### PR TITLE
FIX-#7562: Raise AttributeError for missing extension properties.

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -59,7 +59,6 @@ _NON_EXTENDABLE_ATTRIBUTES = {
     "__delattr__",
     "__getattr__",
     "_getattribute__from_extension_impl",
-    "_getattr__from_extension_impl",
     "get_backend",
     "move_to",
     "_update_inplace",

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2644,11 +2644,6 @@ class DataFrame(BasePandasDataset):
         """
         # NOTE that to get an attribute, python calls __getattribute__() first and
         # then falls back to __getattr__() if the former raises an AttributeError.
-
-        if key not in _EXTENSION_NO_LOOKUP:
-            extension = self._getattr__from_extension_impl(key, __class__._extensions)
-            if extension is not sentinel:
-                return extension
         try:
             return super().__getattr__(key)
         except AttributeError as err:

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -387,10 +387,6 @@ class Series(BasePandasDataset):
         """
         # NOTE that to get an attribute, python calls __getattribute__() first and
         # then falls back to __getattr__() if the former raises an AttributeError.
-        if key not in _EXTENSION_NO_LOOKUP:
-            extension = self._getattr__from_extension_impl(key, __class__._extensions)
-            if extension is not sentinel:
-                return extension
         try:
             return super().__getattr__(key)
         except AttributeError as err:

--- a/modin/tests/pandas/extensions/test_base_extensions.py
+++ b/modin/tests/pandas/extensions/test_base_extensions.py
@@ -217,12 +217,22 @@ class TestProperty:
         )
 
         modin_object = data_class({"a": [1, 2, 3], "b": [4, 5, 6]}).set_backend(backend)
-        assert hasattr(modin_object, public_property_name)
         setattr(modin_object, public_property_name, "value")
         assert getattr(modin_object, public_property_name) == "value"
         delattr(modin_object, public_property_name)
         # check that the deletion works.
         assert not hasattr(modin_object, private_property_name)
+
+    def test_get_property_that_raises_attribute_error_on_get_modin_issue_7562(
+        self, data_class
+    ):
+        def get_property(self):
+            raise AttributeError
+
+        register_base_accessor(name="extension_property")(property(fget=get_property))
+        modin_object = data_class()
+        with pytest.raises(AttributeError):
+            getattr(modin_object, "extension_property")
 
     def test_non_settable_extension_property(self, Backend1, data_class):
         modin_object = data_class([0])


### PR DESCRIPTION
Stop falling back to `__getattr__` for missing extensions. The `_getattr__from_extension_impl` implementation didn't access properties correctly, but we don't need to fall back to `__getattr__` at all, and we can implement extension property access with just `__getattribute__`.

Resolves #7562
