### PR TITLE
DOCS-#7566: Add pandas on snowflake + backend pinning to documentation page

### DIFF
--- a/docs/development/architecture.rst
+++ b/docs/development/architecture.rst
@@ -89,6 +89,8 @@ Dataframe.
 In the interest of reducing the pandas API, the Query Compiler layer closely follows the
 pandas API, but cuts out a large majority of the repetition.
 
+.. _auto-switch architecture:
+
 Automatic Engine Switching and Casting
 """"""""""""""""""""""""""""""""""""""
 
@@ -258,6 +260,10 @@ documentation page on :doc:`contributing </development/contributing>`.
     - Uses native python execution - mainly used for debugging.
     - The storage format is `pandas` and the in-memory partition type is a pandas DataFrame.
     - For more information on the execution path, see the :doc:`pandas on Python </flow/modin/core/execution/python/implementations/pandas_on_python/index>` page.
+- pandas on Snowflake
+    - Uses the Snowpark Python library to transpile pandas API calls to SQL queries.
+    - The storage format is the custom-defined `Snowflake` format; data remains within Snowflake warehouses until retrieved by pandas API calls.
+    - For more information on pandas on Snowflake, refer to Snowflake's `documentation <https://docs.snowflake.com/en/developer-guide/snowpark/python/pandas-on-snowflake>`_ (external link).
 
 .. _directory-tree:
 


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Adds a short blurb mentioning pandas on Snowflake to the architecture document, and a segment on configuring automatic backend switching to the optimization notes.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7556 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
