### PR TITLE
FIX-#7569: Fix handling of pyarrow dtype and empty dataframes

### DIFF
--- a/modin/core/dataframe/pandas/dataframe/dataframe.py
+++ b/modin/core/dataframe/pandas/dataframe/dataframe.py
@@ -174,7 +174,9 @@ class PandasDataframe(
         self._row_lengths_cache = row_lengths
         self._column_widths_cache = column_widths
         self._pandas_backend = pandas_backend
-        if pandas_backend != "pyarrow":
+        if pandas_backend != "pyarrow" or len(partitions) == 0:
+            # If the backend is pyarrow and there are no partitions, the computed dtype otherwise becomes NaN,
+            # which means we lost the dtype, so actually set it in that case
             self.set_dtypes_cache(dtypes)
         else:
             # In this case, the type precomputation may be incorrect; we need

--- a/modin/tests/pandas/dataframe/test_default.py
+++ b/modin/tests/pandas/dataframe/test_default.py
@@ -18,6 +18,7 @@ import matplotlib
 import numpy as np
 import pandas
 import pandas._libs.lib as lib
+import pyarrow as pa
 import pytest
 from numpy.testing import assert_array_equal
 
@@ -1533,3 +1534,9 @@ def test_series_does_not_warn_distributing_takes_time():
     with warnings.catch_warnings():
         warnings.filterwarnings("error", regex, UserWarning)
         pd.Series(np.random.randint(1_000_000, size=(2_400_000)))
+
+
+@pytest.mark.parametrize("dtype", [np.int64, pd.ArrowDtype(pa.int64())])
+def test_empty_df_dtypes(dtype):
+    df = pd.DataFrame({"A": []}, dtype=dtype)
+    assert df.dtypes["A"] == dtype


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Ensure empty Dataframes with pyarrow dtypes maintain the dtype metadata.

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7569 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
