### PR TITLE
TEST-#7571: xfail test_read_csv_s3_issue4658 due to missing s3 bucket

### DIFF
--- a/modin/tests/pandas/test_io.py
+++ b/modin/tests/pandas/test_io.py
@@ -983,6 +983,9 @@ class TestCsv:
             storage_options=storage_options,
         )
 
+    @pytest.mark.xfail(
+        reason="S3 file gone missing, see https://github.com/modin-project/modin/issues/7571"
+    )
     def test_read_csv_s3_issue4658(self):
         eval_io(
             fn_name="read_csv",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

`"s3://dask-data/nyc-taxi/2015/yellow_tripdata_2015-01.csv"` looks to no longer be available. I couldn't find another link that reproduces the issue fixed in #4658, so for now I'm xfailing the test to unblock CI.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7571 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
