### PR TITLE
FEAT-#7573: Dispatch __array_ufunc__ to query compilers

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -24,7 +24,7 @@ import warnings
 from enum import IntEnum
 from functools import cached_property
 from types import MappingProxyType
-from typing import TYPE_CHECKING, Any, Hashable, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, Hashable, List, Literal, Optional, Union
 
 import numpy as np
 import pandas
@@ -65,6 +65,8 @@ if TYPE_CHECKING:
     # TODO: should be ModinDataframe
     # https://github.com/modin-project/modin/issues/7244
     from modin.core.dataframe.pandas.dataframe.dataframe import PandasDataframe
+    from modin.pandas import DataFrame, Series
+    from modin.pandas.base import BasePandasDataset
 
 
 def _get_axis(axis):
@@ -804,6 +806,73 @@ class BaseQueryCompiler(
         return DataFrameDefault.register(pandas.DataFrame.to_numpy)(self, **kwargs)
 
     # END To NumPy
+
+    def do_array_ufunc_implementation(
+        self,
+        frame: BasePandasDataset,
+        ufunc: np.ufunc,
+        method: str,
+        *inputs: Any,
+        **kwargs: Any,
+    ) -> Union["DataFrame", "Series", Any]:
+        """
+        Apply the provided numpy ufunc to the underlying data.
+
+        This method is called by the ``__array_ufunc__`` dispatcher on BasePandasDataset.
+
+        Unlike other query compiler methods, this function directly operates on the input DataFrame/Series
+        to allow for easier argument processing. The default implementation defaults to pandas, but
+        a query compiler sub-class may override this method to provide a distributed implementation.
+
+        See numpy docs: https://numpy.org/doc/stable/user/basics.subclassing.html#array-ufunc-for-ufuncs
+
+        Parameters
+        ----------
+        frame : BasePandasDataset
+            The DataFrame or Series on which the ufunc was called. Its query compiler must match ``self``.
+
+        ufunc : np.ufunc
+            The function to apply.
+
+        method : str
+            The name of the function to apply.
+
+        *inputs : Any
+            Positional arguments to pass to ``ufunc``.
+
+        **kwargs : Any
+            Keyword arguments to pass to ``ufunc``.
+        """
+        assert (
+            self is frame._query_compiler
+        ), "array ufunc called with mismatched query compiler and input frame"
+        # we can't use the regular default_to_pandas() method because self is one of the
+        # `inputs` to __array_ufunc__, and pandas has some checks on the identity of the
+        # inputs [1]. The usual default to pandas will call _to_pandas() on the inputs
+        # as well as on self, but that gives inputs[0] a different identity from self.
+        #
+        # [1] https://github.com/pandas-dev/pandas/blob/2c4c072ade78b96a9eb05097a5fcf4347a3768f3/pandas/_libs/ops_dispatch.pyx#L99-L109
+        ErrorMessage.default_to_pandas(message="__array_ufunc__")
+        pandas_self = frame._to_pandas()
+        pandas_result = pandas_self.__array_ufunc__(
+            ufunc,
+            method,
+            *(
+                pandas_self if each_input is frame else try_cast_to_pandas(each_input)
+                for each_input in inputs
+            ),
+            **try_cast_to_pandas(kwargs),
+        )
+        if isinstance(pandas_result, pandas.DataFrame):
+            from modin.pandas import DataFrame
+
+            return DataFrame(pandas_result)
+        elif isinstance(pandas_result, pandas.Series):
+            from modin.pandas import Series
+
+            return Series(pandas_result)
+        # ufuncs are required to be one-to-one mappings, so this branch should never be hit
+        return pandas_result  # pragma: no cover
 
     # Dataframe exchange protocol
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -857,7 +857,7 @@ class BaseQueryCompiler(
         # as well as on self, but that gives inputs[0] a different identity from self.
         #
         # [1] https://github.com/pandas-dev/pandas/blob/2c4c072ade78b96a9eb05097a5fcf4347a3768f3/pandas/_libs/ops_dispatch.pyx#L99-L109
-        ErrorMessage.default_to_pandas(message="__array_ufunc__")
+        self._maybe_warn_on_default(message="__array_ufunc__")
         pandas_self = frame._to_pandas()
         pandas_result = pandas_self.__array_ufunc__(
             ufunc,

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -816,7 +816,7 @@ class BaseQueryCompiler(
         **kwargs: Any,
     ) -> Union["DataFrame", "Series", Any]:
         """
-        Apply the provided numpy ufunc to the underlying data.
+        Apply the provided NumPy ufunc to the underlying data.
 
         This method is called by the ``__array_ufunc__`` dispatcher on BasePandasDataset.
 
@@ -824,7 +824,7 @@ class BaseQueryCompiler(
         to allow for easier argument processing. The default implementation defaults to pandas, but
         a query compiler sub-class may override this method to provide a distributed implementation.
 
-        See numpy docs: https://numpy.org/doc/stable/user/basics.subclassing.html#array-ufunc-for-ufuncs
+        See NumPy docs: https://numpy.org/doc/stable/user/basics.subclassing.html#array-ufunc-for-ufuncs
 
         Parameters
         ----------
@@ -842,6 +842,11 @@ class BaseQueryCompiler(
 
         **kwargs : Any
             Keyword arguments to pass to ``ufunc``.
+
+        Returns
+        -------
+        DataFrame, Series, or Any
+            The result of applying the ufunc to ``frame``.
         """
         assert (
             self is frame._query_compiler

--- a/modin/tests/pandas/dataframe/test_default.py
+++ b/modin/tests/pandas/dataframe/test_default.py
@@ -29,6 +29,7 @@ from modin.tests.pandas.utils import (
     axis_keys,
     axis_values,
     create_test_dfs,
+    create_test_series,
     default_to_pandas_ignore_string,
     df_equals,
     eval_general,
@@ -1540,3 +1541,10 @@ def test_series_does_not_warn_distributing_takes_time():
 def test_empty_df_dtypes(dtype):
     df = pd.DataFrame({"A": []}, dtype=dtype)
     assert df.dtypes["A"] == dtype
+
+
+def test_array_ufunc():
+    modin_df, pandas_df = create_test_dfs([[1, 2], [3, 4]])
+    eval_general(modin_df, pandas_df, lambda df: np.sqrt(df))
+    modin_ser, pandas_ser = create_test_series([1, 2, 3, 4, 9])
+    eval_general(modin_ser, pandas_ser, lambda ser: np.sqrt(ser))

--- a/modin/tests/pandas/dataframe/test_default.py
+++ b/modin/tests/pandas/dataframe/test_default.py
@@ -1545,6 +1545,6 @@ def test_empty_df_dtypes(dtype):
 
 def test_array_ufunc():
     modin_df, pandas_df = create_test_dfs([[1, 2], [3, 4]])
-    eval_general(modin_df, pandas_df, lambda df: np.sqrt(df))
+    eval_general(modin_df, pandas_df, np.sqrt)
     modin_ser, pandas_ser = create_test_series([1, 2, 3, 4, 9])
-    eval_general(modin_ser, pandas_ser, lambda ser: np.sqrt(ser))
+    eval_general(modin_ser, pandas_ser, np.sqrt)

--- a/modin/tests/pandas/native_df_interoperability/test_default.py
+++ b/modin/tests/pandas/native_df_interoperability/test_default.py
@@ -122,7 +122,6 @@ def test_array_ufunc():
     )
     df_equals(np.sqrt(modin_ser), np.sqrt(pandas_ser))
 
-
 def test_asfreq(df_mode_pair):
     index = pd.date_range("1/1/2000", periods=4, freq="min")
     series, _ = create_test_series_in_defined_mode(

--- a/modin/tests/pandas/native_df_interoperability/test_default.py
+++ b/modin/tests/pandas/native_df_interoperability/test_default.py
@@ -114,6 +114,15 @@ def test_to_numpy(data):
     assert_array_equal(modin_df.values, pandas_df.values)
 
 
+def test_array_ufunc():
+    modin_df, pandas_df = create_test_df_in_defined_mode([[1, 2], [3, 4]], native=True)
+    df_equals(np.sqrt(modin_df), np.sqrt(pandas_df))
+    modin_ser, pandas_ser = create_test_series_in_defined_mode(
+        [1, 2, 3, 4, 9], native=True
+    )
+    df_equals(np.sqrt(modin_ser), np.sqrt(pandas_ser))
+
+
 def test_asfreq(df_mode_pair):
     index = pd.date_range("1/1/2000", periods=4, freq="min")
     series, _ = create_test_series_in_defined_mode(

--- a/modin/tests/pandas/native_df_interoperability/test_default.py
+++ b/modin/tests/pandas/native_df_interoperability/test_default.py
@@ -122,6 +122,7 @@ def test_array_ufunc():
     )
     df_equals(np.sqrt(modin_ser), np.sqrt(pandas_ser))
 
+
 def test_asfreq(df_mode_pair):
     index = pd.date_range("1/1/2000", periods=4, freq="min")
     series, _ = create_test_series_in_defined_mode(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

When a numpy function like `np.sqrt` is called on an object with the `__array_ufunc__` method, it will call `__array_ufunc__` to determine the appropriate implementation. Modin currently defaults to pandas for all operations in this case, but ideally should provide the option for backends to provide distributed implementations.

This PR creates the `do_array_ufunc_implementation` query compiler method. This method is unusual in that it takes the original DataFrame/Series object as argument, but this is done for convenience to allow direct calls to pandas API methods without the need to re-wrap the query compiler in a DataFrame/Series object.

The default `BaseQueryCompiler` implementation defaults to pandas as before, but the `NativeQueryCompiler` implementation now directly calls the `__array_ufunc__` method of the backing pandas DF instead of calling `to_pandas`, which would cause a copy. This leads to a modest performance improvement (though the operation was quite fast to begin with): the average runtime of a benchmark running `np.sqrt` on a 1000x1000 frame with the `Pandas` backend improved from 3.5 ms to 2.6 ms.

Benchmark code (run with `python3 -W ignore ufunc_bench.py`):
```python
from time import perf_counter
import modin.pandas as pd
import numpy as np
from modin.config import Backend
Backend.put("Pandas")

df = pd.DataFrame([list(range(1000))] * 1000)

start = perf_counter()
np.sqrt(df)
end = perf_counter()
print(end - start)
```

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7573 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
