### PR TITLE
FIX-#7578: Change groupby extension allow list and fix cached_property extensions

### DIFF
--- a/modin/pandas/api/extensions/extensions.py
+++ b/modin/pandas/api/extensions/extensions.py
@@ -13,6 +13,7 @@
 
 import inspect
 from collections import defaultdict
+from functools import cached_property
 from types import MethodType, ModuleType
 from typing import Any, Dict, Optional, Union
 
@@ -94,6 +95,10 @@ def _set_attribute_on_obj(
             original_attr = getattr(pd, name)
             _reexport_classes[name] = original_attr
             delattr(pd, name)
+        # If the attribute is an instance of functools.cached_property, we must manually call __set_name__ on it.
+        # https://stackoverflow.com/a/62161136
+        if isinstance(new_attr, cached_property):
+            new_attr.__set_name__(obj, name)
         extensions[None if backend is None else Backend.normalize(backend)][
             name
         ] = new_attr

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -1874,11 +1874,6 @@ class DataFrameGroupBy(ClassLogger, QueryCompilerCaster):  # noqa: GL08
 @_inherit_docstrings(pandas.core.groupby.SeriesGroupBy)
 class SeriesGroupBy(DataFrameGroupBy):  # noqa: GL08
     _pandas_class = pandas.core.groupby.SeriesGroupBy
-
-    # TODO(https://github.com/modin-project/modin/issues/7543):
-    # Currently this _extensions dict doesn't do anything, but we should
-    # add methods to register groupby accessors and make the groupby classes
-    # use this _extensions dict.
     _extensions: EXTENSION_DICT_TYPE = EXTENSION_DICT_TYPE(dict)
 
     @disable_logging

--- a/modin/pandas/groupby.py
+++ b/modin/pandas/groupby.py
@@ -91,6 +91,21 @@ _DEFAULT_BEHAVIOUR = EXTENSION_NO_LOOKUP | {
     "_wrap_aggregation",
 }
 
+GROUPBY_EXTENSION_NO_LOOKUP = EXTENSION_NO_LOOKUP | {
+    "_axis",
+    "_idx_name",
+    "_df",
+    "_query_compiler",
+    "_columns",
+    "_by",
+    "_drop",
+    "_return_tuple_when_iterating",
+    "_is_multi_by",
+    "_level",
+    "_kwargs",
+    "_get_query_compiler",
+}
+
 
 @_inherit_docstrings(pandas.core.groupby.DataFrameGroupBy)
 class DataFrameGroupBy(ClassLogger, QueryCompilerCaster):  # noqa: GL08
@@ -98,10 +113,6 @@ class DataFrameGroupBy(ClassLogger, QueryCompilerCaster):  # noqa: GL08
     _return_tuple_when_iterating = False
     _df: Union[DataFrame, Series]
     _query_compiler: BaseQueryCompiler
-    # TODO(https://github.com/modin-project/modin/issues/7543):
-    # Currently this _extensions dict doesn't do anything, but we should
-    # add methods to register groupby accessors and make the groupby classes
-    # use this _extensions dict.
     _extensions: EXTENSION_DICT_TYPE = EXTENSION_DICT_TYPE(dict)
 
     def __init__(
@@ -248,7 +259,7 @@ class DataFrameGroupBy(ClassLogger, QueryCompilerCaster):  # noqa: GL08
         try:
             return self._getattr__from_extension_impl(
                 key=key,
-                default_behavior_attributes=_DEFAULT_BEHAVIOUR,
+                default_behavior_attributes=GROUPBY_EXTENSION_NO_LOOKUP,
                 extensions=__class__._extensions,
             )
         except AttributeError as err:
@@ -275,7 +286,7 @@ class DataFrameGroupBy(ClassLogger, QueryCompilerCaster):  # noqa: GL08
         Any
             The value of the attribute.
         """
-        if item not in _DEFAULT_BEHAVIOUR:
+        if item not in GROUPBY_EXTENSION_NO_LOOKUP:
             extensions_result = self._getattribute__from_extension_impl(
                 item, __class__._extensions
             )
@@ -1888,7 +1899,7 @@ class SeriesGroupBy(DataFrameGroupBy):  # noqa: GL08
         Any
             The value of the attribute.
         """
-        if item not in _DEFAULT_BEHAVIOUR:
+        if item not in GROUPBY_EXTENSION_NO_LOOKUP:
             extensions_result = self._getattribute__from_extension_impl(
                 item, __class__._extensions
             )
@@ -1901,7 +1912,7 @@ class SeriesGroupBy(DataFrameGroupBy):  # noqa: GL08
     def __getattr__(self, key: str) -> Any:
         return self._getattr__from_extension_impl(
             key=key,
-            default_behavior_attributes=_DEFAULT_BEHAVIOUR,
+            default_behavior_attributes=GROUPBY_EXTENSION_NO_LOOKUP,
             extensions=__class__._extensions,
         )
 

--- a/modin/tests/pandas/extensions/test_groupby_extensions.py
+++ b/modin/tests/pandas/extensions/test_groupby_extensions.py
@@ -250,7 +250,6 @@ class TestProperty:
             return {"group": pd.Index(["test"])}
 
         register_accessor("groups", backend="Pandas")(groups)
-        pd.DataFrame({"col0": [1], "col1": [2]})
         pandas_df = pd.DataFrame({"col0": [1], "col1": [2]}).move_to("pandas")
         assert get_groupby(pandas_df).groups == {"group": pd.Index(["test"])}
 


### PR DESCRIPTION
## What do these changes do?

Fixes the linked issue by calling __set_name__ on extensions defined with the cached_property decorator, and loosens restrictions on methods that can be extended on `DataFrameGroupBy` and `SeriesGroupBy` objects.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7578 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
