### PR TITLE
FIX-#7582: Add copy parameter to __array__ methods.

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -3884,7 +3884,9 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
     def __rand__(self, other) -> Self:
         return self._binary_op("__rand__", other, axis=0)
 
-    def __array__(self, dtype=None) -> np.ndarray:
+    def __array__(
+        self, dtype: npt.DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray:
         """
         Return the values as a NumPy array.
 
@@ -3892,6 +3894,9 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
         ----------
         dtype : str or np.dtype, optional
             The dtype of returned array.
+        copy : bool, default: None
+            This parameter has no effect; the method always returns a copy of
+            the data.
 
         Returns
         -------

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -238,10 +238,9 @@ class Series(BasePandasDataset):
 
     # add `_inherit_docstrings` decorator to force method link addition.
     @_inherit_docstrings(pandas.Series.__array__, apilink="pandas.Series.__array__")
-    def __array__(self, dtype=None) -> np.ndarray:  # noqa: PR01, RT01, D200
-        """
-        Return the values as a NumPy array.
-        """
+    def __array__(
+        self, dtype: npt.DTypeLike | None = None, copy: bool | None = None
+    ) -> np.ndarray:
         return super(Series, self).__array__(dtype).flatten()
 
     def __column_consortium_standard__(

--- a/modin/tests/pandas/dataframe/test_default.py
+++ b/modin/tests/pandas/dataframe/test_default.py
@@ -1443,9 +1443,25 @@ def test_unstack_multiindex_types(multi_col, multi_idx):
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test___array__(data):
+@pytest.mark.parametrize("copy_kwargs", ({"copy": True}, {"copy": None}, {}))
+def test___array__(data, copy_kwargs):
     modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
-    assert_array_equal(modin_df.__array__(), pandas_df.__array__())
+    assert_array_equal(
+        modin_df.__array__(**copy_kwargs), pandas_df.__array__(**copy_kwargs)
+    )
+
+
+@pytest.mark.xfail(
+    raises=AssertionError, reason="https://github.com/modin-project/modin/issues/4650"
+)
+def test___array__copy_false_creates_view():
+    def do_in_place_update_via_copy(df):
+        array = np.array(df, copy=False)
+        array[0, 0] += 1
+
+    eval_general(
+        *create_test_dfs([[11]]), do_in_place_update_via_copy, __inplace__=True
+    )
 
 
 @pytest.mark.parametrize("data", [[False], [True], [1, 2]])

--- a/modin/tests/pandas/dataframe/test_default.py
+++ b/modin/tests/pandas/dataframe/test_default.py
@@ -1444,11 +1444,15 @@ def test_unstack_multiindex_types(multi_col, multi_idx):
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("copy_kwargs", ({"copy": True}, {"copy": None}, {}))
-def test___array__(data, copy_kwargs):
-    modin_df, pandas_df = pd.DataFrame(data), pandas.DataFrame(data)
-    assert_array_equal(
-        modin_df.__array__(**copy_kwargs), pandas_df.__array__(**copy_kwargs)
-    )
+@pytest.mark.parametrize(
+    "get_array",
+    (
+        lambda df, copy_kwargs: df.__array__(**copy_kwargs),
+        lambda df, copy_kwargs: np.array(df, **copy_kwargs),
+    ),
+)
+def test___array__(data, copy_kwargs, get_array):
+    assert_array_equal(*(get_array(df, copy_kwargs) for df in create_test_dfs(data)))
 
 
 @pytest.mark.xfail(

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -314,10 +314,15 @@ def test___and__(data, request):
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
 @pytest.mark.parametrize("copy_kwargs", ({"copy": True}, {"copy": None}, {}))
-def test___array__(data, copy_kwargs):
-    modin_series, pandas_series = create_test_series(data)
-    modin_result = modin_series.__array__(**copy_kwargs)
-    assert_array_equal(modin_result, pandas_series.__array__(**copy_kwargs))
+@pytest.mark.parametrize(
+    "get_array",
+    (
+        lambda df, copy_kwargs: df.__array__(**copy_kwargs),
+        lambda df, copy_kwargs: np.array(df, **copy_kwargs),
+    ),
+)
+def test___array__(data, copy_kwargs, get_array):
+    assert_array_equal(*(get_array(df, copy_kwargs) for df in create_test_series(data)))
 
 
 @pytest.mark.xfail(

--- a/modin/tests/pandas/test_series.py
+++ b/modin/tests/pandas/test_series.py
@@ -313,10 +313,24 @@ def test___and__(data, request):
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)
-def test___array__(data):
+@pytest.mark.parametrize("copy_kwargs", ({"copy": True}, {"copy": None}, {}))
+def test___array__(data, copy_kwargs):
     modin_series, pandas_series = create_test_series(data)
-    modin_result = modin_series.__array__()
-    assert_array_equal(modin_result, pandas_series.__array__())
+    modin_result = modin_series.__array__(**copy_kwargs)
+    assert_array_equal(modin_result, pandas_series.__array__(**copy_kwargs))
+
+
+@pytest.mark.xfail(
+    raises=AssertionError, reason="https://github.com/modin-project/modin/issues/4650"
+)
+def test___array__copy_false_creates_view():
+    def do_in_place_update_via_copy(series):
+        array = np.array(series, copy=False)
+        array[0] += 1
+
+    eval_general(
+        *create_test_series([11]), do_in_place_update_via_copy, __inplace__=True
+    )
 
 
 @pytest.mark.parametrize("data", test_data_values, ids=test_data_keys)


### PR DESCRIPTION
The new signature of `__array__` should be backwards-compatible with callers that do not pass the `copy` keyword argument at all.

I tested this change locally with python 3.10 and 3.12. In CI, we test python 3.10 and python 3.11 [periodically](https://github.com/modin-project/modin/blob/cc19143ba2abe7b18e0fbd6efd26c7dcad5e39d6/.github/workflows/ci.yml#L39-L44), as [here](https://github.com/modin-project/modin/actions/runs/15152514188/job/42601094103).

Fixes #7582 

---------------
Signed-off-by: sfc-gh-mvashishtha <mahesh.vashishtha@snowflake.com>