### PR TITLE
FIX-#7551: Fix name ambiguity for `value_counts()` on Pandas backend

### DIFF
--- a/modin/tests/pandas/dataframe/test_join_sort.py
+++ b/modin/tests/pandas/dataframe/test_join_sort.py
@@ -1017,7 +1017,9 @@ def test_compare(align_axis, keep_shape, keep_equal):
 @pytest.mark.parametrize("backend", ["Pandas", "Ray"])
 def test_df_value_counts(backend):
     Backend.put(backend)
-    df = pd.DataFrame([[4, 1, 3, 2], [2, 5, 6, 5], [4, 3, 3, 5]], columns=["a", "b", "c", "d"])
+    df = pd.DataFrame(
+        [[4, 1, 3, 2], [2, 5, 6, 5], [4, 3, 3, 5]], columns=["a", "b", "c", "d"]
+    )
 
     result = df["a"].value_counts()
     expected = df._to_pandas()["a"].value_counts()


### PR DESCRIPTION
## What do these changes do?

Implements index and column renaming for `sort_values()` in the Pandas backend, similarly as in the Ray backend, to fix the name ambiguity error in `value_counts()`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7551 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->