### PR TITLE
FIX-#5961: Preserve dtypes when inserting column to empty frame.

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3115,6 +3115,15 @@ class PandasQueryCompiler(BaseQueryCompiler):
         )
 
     def setitem(self, axis, key, value):
+        # Default to pandas for empty frames to avoid complex partitioning issues
+        if axis == 0 and len(self.index) == 0:
+
+            def do_setitem(df: pandas.DataFrame, key, value) -> pandas.DataFrame:
+                df[key] = value
+                return df
+
+            return self.default_to_pandas(do_setitem, key=key, value=value)
+
         if axis == 0:
             value = self._wrap_column_data(value)
         return self._setitem(axis=axis, key=key, value=value, how=None)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -3116,7 +3116,7 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     def setitem(self, axis, key, value):
         # Default to pandas for empty frames to avoid complex partitioning issues
-        if axis == 0 and len(self.index) == 0:
+        if axis == 0 and not self.lazy_row_count and self.get_axis_len(0) == 0:
 
             def do_setitem(df: pandas.DataFrame, key, value) -> pandas.DataFrame:
                 df[key] = value

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2829,12 +2829,9 @@ class DataFrame(BasePandasDataset):
             if not isinstance(value, (Series, Categorical, np.ndarray, list, range)):
                 value = list(value)
 
-        if not self._query_compiler.lazy_row_count and len(self) == 0:
-            self._default_to_pandas(pandas.DataFrame.__setitem__, key, value)
-        else:
-            if isinstance(value, Series):
-                value = value._query_compiler
-            self._update_inplace(self._query_compiler.setitem(0, key, value))
+        if isinstance(value, Series):
+            value = value._query_compiler
+        self._update_inplace(self._query_compiler.setitem(axis=0, key=key, value=value))
 
     def __iter__(self) -> Iterable[Hashable]:
         """

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -2830,8 +2830,7 @@ class DataFrame(BasePandasDataset):
                 value = list(value)
 
         if not self._query_compiler.lazy_row_count and len(self) == 0:
-            new_self = self.__constructor__({key: value}, columns=self.columns)
-            self._update_inplace(new_self._query_compiler)
+            self._default_to_pandas(pandas.DataFrame.__setitem__, key, value)
         else:
             if isinstance(value, Series):
                 value = value._query_compiler

--- a/modin/tests/pandas/native_df_interoperability/test_indexing.py
+++ b/modin/tests/pandas/native_df_interoperability/test_indexing.py
@@ -27,6 +27,7 @@ from modin.tests.pandas.native_df_interoperability.utils import (
 from modin.tests.pandas.utils import (
     RAND_HIGH,
     RAND_LOW,
+    assert_dtypes_equal,
     default_to_pandas_ignore_string,
     df_equals,
     eval_general,
@@ -390,16 +391,16 @@ def test_setitem_on_empty_df(data, value, convert_to_series, new_col_id, df_mode
         modin_df,
         pandas_df,
         applyier,
-        # https://github.com/modin-project/modin/issues/5961
-        comparator_kwargs={
-            "check_dtypes": not (len(pandas_df) == 0 and len(pandas_df.columns) != 0)
-        },
         expected_exception=expected_exception,
         check_for_execution_propagation=False,
         no_check_for_execution_propagation_reason=(
             "https://github.com/modin-project/modin/issues/7428"
         ),
+        __inplace__=True,
     )
+    # Because of https://github.com/modin-project/modin/issues/7600,
+    # df_equals does not check dtypes equality for empty frames.
+    assert_dtypes_equal(modin_df, pandas_df)
 
 
 def test_setitem_on_empty_df_4407(df_mode_pair):


### PR DESCRIPTION
Default to pandas when inserting a column in an empty frame.

Resolves #5961