### PR TITLE
FIX-#7611: Display 'modin.pandas' instead of 'None' in backend switching feedback

### DIFF
--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -603,10 +603,13 @@ def _maybe_switch_backend_pre_op(
             and arg.get_backend() != result_backend
         ):
             return arg
+        class_name_str = (
+            class_of_wrapped_fn if class_of_wrapped_fn is not None else "modin.pandas"
+        )
         arg.set_backend(
             result_backend,
             inplace=True,
-            switch_operation=f"{class_of_wrapped_fn}.{function_name}",
+            switch_operation=f"{class_name_str}.{function_name}",
         )
         return arg
 
@@ -676,6 +679,9 @@ def _maybe_switch_backend_post_op(
         and isinstance(result, QueryCompilerCaster)
         and (input_qc := result._get_query_compiler()) is not None
     ):
+        class_name_str = (
+            class_of_wrapped_fn if class_of_wrapped_fn is not None else "modin.pandas"
+        )
         return result.move_to(
             _get_backend_for_auto_switch(
                 input_qc=input_qc,
@@ -683,7 +689,7 @@ def _maybe_switch_backend_post_op(
                 function_name=function_name,
                 arguments=arguments,
             ),
-            switch_operation=f"{class_of_wrapped_fn}.{function_name}",
+            switch_operation=f"{class_name_str}.{function_name}",
         )
     return result
 
@@ -1075,8 +1081,13 @@ def wrap_function_in_argument_caster(
                     and arg.get_backend() != result_backend
                 ):
                     return arg
+                class_name_str = (
+                    class_of_wrapped_fn
+                    if class_of_wrapped_fn is not None
+                    else "modin.pandas"
+                )
                 cast = arg.set_backend(
-                    result_backend, switch_operation=f"{class_of_wrapped_fn}.{name}"
+                    result_backend, switch_operation=f"{class_name_str}.{name}"
                 )
                 inplace_update_trackers.append(
                     InplaceUpdateTracker(

--- a/modin/core/storage_formats/pandas/query_compiler_caster.py
+++ b/modin/core/storage_formats/pandas/query_compiler_caster.py
@@ -811,8 +811,13 @@ def _get_backend_for_auto_switch(
                 move_stay_delta,
             )
 
+            class_name_str = (
+                class_of_wrapped_fn
+                if class_of_wrapped_fn is not None
+                else "modin.pandas"
+            )
             get_logger().info(
-                f"After {class_of_wrapped_fn} function {function_name}, "
+                f"After {class_name_str} function {function_name}, "
                 + f"considered moving to backend {backend} with "
                 + f"(transfer_cost {move_to_cost} + other_execution_cost {other_execute_cost}) "
                 + f", stay_cost {stay_cost}, and move-stay delta "

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -772,7 +772,7 @@ class TestSwitchBackendPostOpDependingOnDataSize:
         assert log_records[0].name == DEFAULT_LOGGER_NAME
         assert log_records[0].levelno == logging.INFO
         assert log_records[0].message.startswith(
-            "After None function read_json, considered moving to backend Small_Data_Local with"
+            "After modin.pandas function read_json, considered moving to backend Small_Data_Local with"
         )
 
         assert log_records[1].name == DEFAULT_LOGGER_NAME
@@ -804,7 +804,7 @@ class TestSwitchBackendPostOpDependingOnDataSize:
         assert log_records[0].name == DEFAULT_LOGGER_NAME
         assert log_records[0].levelno == logging.INFO
         assert log_records[0].message.startswith(
-            "After None function read_json, considered moving to backend Small_Data_Local with"
+            "After modin.pandas function read_json, considered moving to backend Small_Data_Local with"
         )
 
         assert log_records[1].name == DEFAULT_LOGGER_NAME


### PR DESCRIPTION
Resolves #7611