### PR TITLE
FIX-#7616: Implement __array_function__ stub

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -918,6 +918,7 @@ class BaseQueryCompiler(
             a numpy array.
         """
         from modin.pandas.base import BasePandasDataset
+
         assert (
             self is frame._query_compiler
         ), "__array_function__ called with mismatched query compiler and input frame"

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -882,7 +882,7 @@ class BaseQueryCompiler(
     def do_array_function_implementation(
         self,
         frame: BasePandasDataset,
-        func: np.func,
+        func: callable,
         types: tuple,
         args: tuple,
         kwargs: dict,

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -917,6 +917,7 @@ class BaseQueryCompiler(
             The result of applying the function to this dataset. By default, it will return
             a numpy array.
         """
+        from modin.pandas.base import BasePandasDataset
         assert (
             self is frame._query_compiler
         ), "__array_function__ called with mismatched query compiler and input frame"

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -915,7 +915,7 @@ class BaseQueryCompiler(
         -------
         DataFrame | Series | Any
             The result of applying the function to this dataset. By default, it will return
-            a numpy array.
+            a NumPy array.
         """
         from modin.pandas.base import BasePandasDataset
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4393,6 +4393,44 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
             self, ufunc, method, *inputs, **kwargs
         )
 
+    def __array_function__(
+        self,
+        func: np.func,
+        types: tuple,
+        args: tuple,
+        kwargs: dict,
+    ) -> DataFrame | Series | Any:
+        """
+        Apply `func` to the `BasePandasDataset`.
+
+        This function implements NEP18-style dispatch for certain numpy functions:
+        https://numpy.org/neps/nep-0018-array-function-protocol.html#nep18
+
+        By default, this function will transparently call __array__, followed by __array_function__
+        on the returned numpy array. We implement this function to prevent bugs with the extension
+        system when another backend overrides this method.
+
+        Parameters
+        ----------
+        func : np.func
+            The NumPy func to apply.
+        types : tuple
+            The types of the args.
+        args : tuple
+            The args to the func.
+        kwargs : dict
+            Additional keyword arguments.
+
+        Returns
+        -------
+        DataFrame | Series | Any
+            The result of applying the function to this dataset. By default, it will return
+            a numpy array.
+        """
+        return self._query_compiler.do_array_function_implementation(
+            self, func, types, args, kwargs
+        )
+
     # namespace for additional Modin functions that are not available in Pandas
     modin: ModinAPI = CachedAccessor("modin", ModinAPI)
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4403,11 +4403,11 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
         """
         Apply `func` to the `BasePandasDataset`.
 
-        This function implements NEP18-style dispatch for certain numpy functions:
+        This function implements NEP18-style dispatch for certain NumPy functions:
         https://numpy.org/neps/nep-0018-array-function-protocol.html#nep18
 
         By default, this function will transparently call __array__, followed by __array_function__
-        on the returned numpy array. We implement this function to prevent bugs with the extension
+        on the returned NumPy array. We implement this function to prevent bugs with the extension
         system when another backend overrides this method.
 
         Parameters
@@ -4425,7 +4425,7 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
         -------
         DataFrame | Series | Any
             The result of applying the function to this dataset. By default, it will return
-            a numpy array.
+            a NumPy array.
         """
         return self._query_compiler.do_array_function_implementation(
             self, func, types, args, kwargs

--- a/modin/tests/pandas/test_general.py
+++ b/modin/tests/pandas/test_general.py
@@ -994,6 +994,11 @@ def test_df_immutability():
 
 def test_np_array_function():
     # first argument is a numpy array, second argument is modin frame
-    assert_array_equal(np.where(np.array([1, 0]), pd.Series([9, 9]), [-1, -1]), np.array([9, -1]))
+    assert_array_equal(
+        np.where(np.array([1, 0]), pd.Series([9, 9]), [-1, -1]), np.array([9, -1])
+    )
     # multiple arguments are modin objects
-    assert_array_equal(np.where(pd.DataFrame([[1, 0]]), pd.Series([9, 9]), [-1, -1]), np.array([[9, -1]]))
+    assert_array_equal(
+        np.where(pd.DataFrame([[1, 0]]), pd.Series([9, 9]), [-1, -1]),
+        np.array([[9, -1]]),
+    )

--- a/modin/tests/pandas/test_general.py
+++ b/modin/tests/pandas/test_general.py
@@ -990,3 +990,10 @@ def test_df_immutability():
     src_data.iloc[0, 0] = 100
 
     assert md_df._to_pandas().iloc[0, 0] == 1
+
+
+def test_np_array_function():
+    # first argument is a numpy array, second argument is modin frame
+    assert_array_equal(np.where(np.array([1, 0]), pd.Series([9, 9]), [-1, -1]), np.array([9, -1]))
+    # multiple arguments are modin objects
+    assert_array_equal(np.where(pd.DataFrame([[1, 0]]), pd.Series([9, 9]), [-1, -1]), np.array([[9, -1]]))


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Implements `__array_function__` to prevent errors when a backend implements the function as an extension method. See linked issue for details.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7616 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
