### PR TITLE
FEAT-#7627: Define move_to and move_from methods

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -722,8 +722,7 @@ class BaseQueryCompiler(
     # END Data Management Methods
 
     # Data Movement Methods
-    @abc.abstractmethod
-    def _move_to(self, target_backend: str, **kwargs) -> Union[BaseQueryCompiler, Any]:
+    def move_to(self, target_backend: str) -> Union[BaseQueryCompiler, Any]:
         """
         Move this query compiler to the specified backend.
 
@@ -736,15 +735,12 @@ class BaseQueryCompiler(
         -------
         BaseQueryCompiler or Any
             The new query compiler with the source data, or a sentinel `NotImplemented`
-            value if efficient transfer is not implemented.
+            value if transfer is not implemented.
         """
-        pass
+        return NotImplemented
 
     @classmethod
-    @abc.abstractmethod
-    def _move_from(
-        cls, source_qc: BaseQueryCompiler, **kwargs
-    ) -> Union[BaseQueryCompiler, Any]:
+    def move_from(cls, source_qc: BaseQueryCompiler) -> Union[BaseQueryCompiler, Any]:
         """
         Move the source query compiler to the current backend.
 
@@ -757,9 +753,9 @@ class BaseQueryCompiler(
         -------
         BaseQueryCompiler or Any
             A new query compiler with the source data, or a sentinel `NotImplemented`
-            value if efficient transfer is not implemented.
+            value if transfer is not implemented.
         """
-        pass
+        return NotImplemented
 
     # END Data Movement Methods
 

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -722,13 +722,43 @@ class BaseQueryCompiler(
     # END Data Management Methods
 
     # Data Movement Methods
-    def _move_to(self, target_backend: str, **kwargs) -> Optional[BaseQueryCompiler]:
+    @abc.abstractmethod
+    def _move_to(self, target_backend: str, **kwargs) -> Union[BaseQueryCompiler, Any]:
+        """
+        Move this query compiler to the specified backend.
+
+        Parameters
+        ----------
+        target_backend : str
+            The backend to move to.
+
+        Returns
+        -------
+        BaseQueryCompiler or Any
+            The new query compiler with the source data, or a sentinel `NotImplemented`
+            value if efficient transfer is not implemented.
+        """
         pass
 
     @classmethod
+    @abc.abstractmethod
     def _move_from(
         cls, source_qc: BaseQueryCompiler, **kwargs
-    ) -> Optional[BaseQueryCompiler]:
+    ) -> Union[BaseQueryCompiler, Any]:
+        """
+        Move the source query compiler to the current backend.
+
+        Parameters
+        ----------
+        source_qc : BaseQueryCompiler
+            The source query compiler to move data from.
+
+        Returns
+        -------
+        BaseQueryCompiler or Any
+            A new query compiler with the source data, or a sentinel `NotImplemented`
+            value if efficient transfer is not implemented.
+        """
         pass
 
     # END Data Movement Methods

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -721,6 +721,18 @@ class BaseQueryCompiler(
 
     # END Data Management Methods
 
+    # Data Movement Methods
+    def _move_to(self, target_backend: str, **kwargs) -> Optional[BaseQueryCompiler]:
+        pass
+
+    @classmethod
+    def _move_from(
+        cls, source_qc: BaseQueryCompiler, **kwargs
+    ) -> Optional[BaseQueryCompiler]:
+        pass
+
+    # END Data Movement Methods
+
     # To/From Pandas
     @abc.abstractmethod
     def to_pandas(self):

--- a/modin/core/storage_formats/pandas/native_query_compiler.py
+++ b/modin/core/storage_formats/pandas/native_query_compiler.py
@@ -214,6 +214,15 @@ class NativeQueryCompiler(BaseQueryCompiler):
     def finalize(self):
         return
 
+    def _move_to(self, target_backend: str, **kwargs) -> Optional[BaseQueryCompiler]:
+        return NotImplemented
+
+    @classmethod
+    def _move_from(
+        cls, source_qc: BaseQueryCompiler, **kwargs
+    ) -> Optional[BaseQueryCompiler]:
+        return NotImplemented
+
     @classmethod
     def _engine_max_size(cls):
         # do not return the custom configuration for sub-classes

--- a/modin/core/storage_formats/pandas/native_query_compiler.py
+++ b/modin/core/storage_formats/pandas/native_query_compiler.py
@@ -214,13 +214,11 @@ class NativeQueryCompiler(BaseQueryCompiler):
     def finalize(self):
         return
 
-    def _move_to(self, target_backend: str, **kwargs) -> Union[BaseQueryCompiler, Any]:
+    def move_to(self, target_backend: str) -> Union[BaseQueryCompiler, Any]:
         return NotImplemented
 
     @classmethod
-    def _move_from(
-        cls, source_qc: BaseQueryCompiler, **kwargs
-    ) -> Union[BaseQueryCompiler, Any]:
+    def move_from(cls, source_qc: BaseQueryCompiler) -> Union[BaseQueryCompiler, Any]:
         return NotImplemented
 
     @classmethod

--- a/modin/core/storage_formats/pandas/native_query_compiler.py
+++ b/modin/core/storage_formats/pandas/native_query_compiler.py
@@ -214,13 +214,13 @@ class NativeQueryCompiler(BaseQueryCompiler):
     def finalize(self):
         return
 
-    def _move_to(self, target_backend: str, **kwargs) -> Optional[BaseQueryCompiler]:
+    def _move_to(self, target_backend: str, **kwargs) -> Union[BaseQueryCompiler, Any]:
         return NotImplemented
 
     @classmethod
     def _move_from(
         cls, source_qc: BaseQueryCompiler, **kwargs
-    ) -> Optional[BaseQueryCompiler]:
+    ) -> Union[BaseQueryCompiler, Any]:
         return NotImplemented
 
     @classmethod

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -25,7 +25,7 @@ import hashlib
 import re
 import warnings
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Hashable, List, Literal, Optional
+from typing import TYPE_CHECKING, Any, Hashable, List, Literal, Optional, Union
 
 import numpy as np
 import pandas
@@ -511,13 +511,13 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # END Data Management Methods
 
     # Data Movement Methods
-    def _move_to(self, target_backend: str, **kwargs) -> Optional[BaseQueryCompiler]:
+    def _move_to(self, target_backend: str, **kwargs) -> Union[BaseQueryCompiler, Any]:
         return NotImplemented
 
     @classmethod
     def _move_from(
         cls, source_qc: BaseQueryCompiler, **kwargs
-    ) -> Optional[BaseQueryCompiler]:
+    ) -> Union[BaseQueryCompiler, Any]:
         return NotImplemented
 
     # END Data Movement Methods

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -510,6 +510,18 @@ class PandasQueryCompiler(BaseQueryCompiler):
 
     # END Data Management Methods
 
+    # Data Movement Methods
+    def _move_to(self, target_backend: str, **kwargs) -> Optional[BaseQueryCompiler]:
+        return NotImplemented
+
+    @classmethod
+    def _move_from(
+        cls, source_qc: BaseQueryCompiler, **kwargs
+    ) -> Optional[BaseQueryCompiler]:
+        return NotImplemented
+
+    # END Data Movement Methods
+
     # To NumPy
     def to_numpy(self, **kwargs):
         return self._modin_frame.to_numpy(**kwargs)

--- a/modin/core/storage_formats/pandas/query_compiler.py
+++ b/modin/core/storage_formats/pandas/query_compiler.py
@@ -511,13 +511,11 @@ class PandasQueryCompiler(BaseQueryCompiler):
     # END Data Management Methods
 
     # Data Movement Methods
-    def _move_to(self, target_backend: str, **kwargs) -> Union[BaseQueryCompiler, Any]:
+    def move_to(self, target_backend: str) -> Union[BaseQueryCompiler, Any]:
         return NotImplemented
 
     @classmethod
-    def _move_from(
-        cls, source_qc: BaseQueryCompiler, **kwargs
-    ) -> Union[BaseQueryCompiler, Any]:
+    def move_from(cls, source_qc: BaseQueryCompiler) -> Union[BaseQueryCompiler, Any]:
         return NotImplemented
 
     # END Data Movement Methods

--- a/modin/logging/logger_decorator.py
+++ b/modin/logging/logger_decorator.py
@@ -114,7 +114,7 @@ def enable_logging(
                         )(attr_value)
 
                     setattr(obj, attr_name, wrapped)
-            return obj  # type: ignore [return-value]
+            return obj
         elif isinstance(obj, classmethod):
             return classmethod(decorator(obj.__func__))  # type: ignore [return-value, arg-type]
         elif isinstance(obj, staticmethod):

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4501,7 +4501,8 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
 
         def transfer_data() -> BaseQueryCompiler:
             """
-            Attempts to transfer data based on this preference order:
+            Attempt to transfer data based on the following preference order.
+
             1. The `self._query_compiler.move_to()`, if implemented.
             2. Otherwise, tries the other `query_compiler`'s `move_from()` method.
             3. If both methods return `NotImplemented`, it falls back to materializing

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4502,27 +4502,22 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
         def transfer_data() -> BaseQueryCompiler:
             """
             Attempts to transfer data based on this preference order:
-            1. The `self._query_compiler._move_to()`, if implemented.
-            2. Otherwise, tries the other `query_compiler`'s `_move_from()` method.
+            1. The `self._query_compiler.move_to()`, if implemented.
+            2. Otherwise, tries the other `query_compiler`'s `move_from()` method.
             3. If both methods return `NotImplemented`, it falls back to materializing
                as a pandas DataFrame, and then creates a new `query_compiler` on the
                specified backend using `from_pandas`.
             """
-            query_compiler = self._query_compiler._move_to(backend)
+            query_compiler = self._query_compiler.move_to(backend)
             if query_compiler is NotImplemented:
                 query_compiler = FactoryDispatcher._get_prepared_factory_for_backend(
                     backend
-                ).io_cls.query_compiler_cls._move_from(
+                ).io_cls.query_compiler_cls.move_from(
                     self._query_compiler,
                 )
             if query_compiler is NotImplemented:
-                # Avoid an additional data copy if possible
-                if self.get_backend() == "Pandas":
-                    pandas_self = self._query_compiler._modin_frame
-                else:
-                    pandas_self = self._query_compiler.to_pandas()
                 query_compiler = FactoryDispatcher.from_pandas(
-                    df=pandas_self, backend=backend
+                    df=self._query_compiler.to_pandas(), backend=backend
                 )
             return query_compiler
 

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4550,11 +4550,13 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
                 self._query_compiler,
             )
         if query_compiler is NotImplemented:
+            pandas_self = self._query_compiler.to_pandas()
+            next(progress_iter)
             query_compiler = FactoryDispatcher.from_pandas(
-                df=self._query_compiler.to_pandas(), backend=backend
+                df=pandas_self, backend=backend
             )
-
-        next(progress_iter)
+        else:
+            next(progress_iter)
         try:
             next(progress_iter)
         except StopIteration:

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -76,7 +76,8 @@ Returns
 
 Notes
 -----
-This method will
+This method will attempt to use an efficient data transfer method if _move_to
+or _move_from are implemented by the backends. Otherwise, it will
     1) convert the data in this ``{class_name}`` to a pandas DataFrame in this
        Python process
     2) load the data from pandas to the new backend.

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -76,8 +76,8 @@ Returns
 
 Notes
 -----
-This method will attempt to use an efficient data transfer method if _move_to
-or _move_from are implemented by the backends. Otherwise, it will
+This method will attempt to use the starting and new backend's move_from or move_to
+methods if the backends implement them. Otherwise, it will
     1) convert the data in this ``{class_name}`` to a pandas DataFrame in this
        Python process
     2) load the data from pandas to the new backend.

--- a/modin/pandas/utils.py
+++ b/modin/pandas/utils.py
@@ -78,6 +78,7 @@ Notes
 -----
 This method will attempt to use the starting and new backend's move_from or move_to
 methods if the backends implement them. Otherwise, it will
+
     1) convert the data in this ``{class_name}`` to a pandas DataFrame in this
        Python process
     2) load the data from pandas to the new backend.


### PR DESCRIPTION
## What do these changes do?

Defines the `move_to()` and `move_from()` methods as an interface for moving data between query compilers. Changes `set_backend()` to initially try those methods before falling back to the original implementation.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [X] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [X] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [X] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [X] Resolves #7627
