### PR TITLE
PERF-#7435: Use shallow copies in native pandas mode

### DIFF
--- a/modin/config/__init__.py
+++ b/modin/config/__init__.py
@@ -44,6 +44,7 @@ from modin.config.envvars import (
     MinPartitionSize,
     MinRowPartitionSize,
     ModinNumpy,
+    NativePandasDeepCopy,
     NativePandasMaxRows,
     NativePandasTransferThreshold,
     NPartitions,
@@ -92,6 +93,7 @@ __all__ = [
     # Native Pandas Specific
     "NativePandasMaxRows",
     "NativePandasTransferThreshold",
+    "NativePandasDeepCopy",
     # Partitioning
     "NPartitions",
     "MinPartitionSize",

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -1346,6 +1346,43 @@ class NativePandasTransferThreshold(EnvironmentVariable, type=int):
     default = 10_000_000
 
 
+class NativePandasDeepCopy(EnvironmentVariable, type=bool):
+    """
+    Whether the native pandas backend performs a deep copy of the wrapped pandas DataFrame when
+    constructing a modin frame from a native pandas object, or when creating a native pandas
+    frame from a modin one via `df.modin.to_pandas()`.
+
+    Disabling this flag produces significant performance improvements by reducing the number of
+    copy operations performed. However, it may create unexpected results if the user mutates
+    the modin frame or native pandas frame in-place while pandas's copy-on-write option is disabled:
+
+    >>> import pandas  # doctest: +SKIP
+    >>> import modin.pandas as pd  # doctest: +SKIP
+    >>> from modin.config import Backend  # doctest: + SKIP
+    >>> Backend.put("Pandas")  # doctest: +SKIP
+    >>> pandas.set_option("mode.copy_on_write", False)  # doctest: +SKIP
+    >>> native_df = pandas.DataFrame([0])  # doctest: +SKIP
+    >>> modin_df = pd.DataFrame(native_df)  # doctest: +SKIP
+    >>> native_df.loc[0, 0] = -1  # doctest: +SKIP
+    >>> modin_df  # doctest: +SKIP
+       0
+    0 -1
+    """
+
+    varname = "MODIN_NATIVE_DEEP_COPY"
+    default = False
+
+    @classmethod
+    def enable(cls) -> None:
+        """Enable deep copy on frames with the native pandas backend."""
+        cls.put(True)
+
+    @classmethod
+    def disable(cls) -> None:
+        """Disable deep copy on frames with the native pandas backend."""
+        cls.put(False)
+
+
 class DynamicPartitioning(EnvironmentVariable, type=bool):
     """
     Set to true to use Modin's dynamic-partitioning implementation where possible.

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -1349,12 +1349,12 @@ class NativePandasTransferThreshold(EnvironmentVariable, type=int):
 class NativePandasDeepCopy(EnvironmentVariable, type=bool):
     """
     Whether the native pandas backend performs a deep copy of the wrapped pandas DataFrame when
-    constructing a modin frame from a native pandas object, or when creating a native pandas
-    frame from a modin one via `df.modin.to_pandas()`.
+    constructing a Modin frame from a native pandas object, or when creating a native pandas
+    frame from a Modin one via `df.modin.to_pandas()`.
 
     Disabling this flag produces significant performance improvements by reducing the number of
     copy operations performed. However, it may create unexpected results if the user mutates
-    the modin frame or native pandas frame in-place while pandas's copy-on-write option is disabled:
+    the Modin frame or native pandas frame in-place while pandas's copy-on-write option is disabled:
 
     >>> import pandas  # doctest: +SKIP
     >>> import modin.pandas as pd  # doctest: +SKIP

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -1348,13 +1348,15 @@ class NativePandasTransferThreshold(EnvironmentVariable, type=int):
 
 class NativePandasDeepCopy(EnvironmentVariable, type=bool):
     """
-    Whether the native pandas backend performs a deep copy of the wrapped pandas DataFrame when
-    constructing a Modin frame from a native pandas object, or when creating a native pandas
-    frame from a Modin one via `df.modin.to_pandas()`.
+    Whether to perform deep copies when transferring data with the native pandas backend.
 
-    Disabling this flag produces significant performance improvements by reducing the number of
-    copy operations performed. However, it may create unexpected results if the user mutates
-    the Modin frame or native pandas frame in-place while pandas's copy-on-write option is disabled:
+    Copies occur when constructing a Modin frame from a native pandas object with
+    `pd.DataFrame(pandas.DataFrame([]))`, or when creating a native pandas frame from a Modin one
+    via `df.modin.to_pandas()`.
+
+    Leaving this flag disabled produces significant performance improvements by reducing the number
+    of copy operations performed. However, it may create unexpected results if the user mutates
+    the Modin frame or native pandas frame in-place.
 
     >>> import pandas  # doctest: +SKIP
     >>> import modin.pandas as pd  # doctest: +SKIP

--- a/modin/core/storage_formats/pandas/native_query_compiler.py
+++ b/modin/core/storage_formats/pandas/native_query_compiler.py
@@ -112,13 +112,10 @@ class NativeQueryCompiler(BaseQueryCompiler):
         if is_scalar(pandas_frame):
             pandas_frame = pandas.DataFrame([pandas_frame])
         elif isinstance(pandas_frame, pandas.DataFrame):
-            # For performance purposes, we create "shallow" copies with CoW enabled.
-            # Per pandas documentation, mutations on the `pandas_frame` will _not_ be reflected
-            # on the original input frame.
-            # pandas frames remember whether they were created with CoW even if the option is
-            # later disabled. For some reason, CoW seems not to apply for deep copies with the
-            # default numpy backend.
-            # TODO: check if the context manager actually matters (i think it does not)
+            # For performance purposes, we create "shallow" copies when NativePandasDeepCopy
+            # is disabled (the default value). This may cause unexpected behavior if the
+            # parent native frame is mutated, but creates a very significant performance
+            # improvement on large data.
             pandas_frame = pandas_frame.copy(deep=NativePandasDeepCopy.get())
         else:
             pandas_frame = pandas.DataFrame(pandas_frame)
@@ -136,7 +133,7 @@ class NativeQueryCompiler(BaseQueryCompiler):
     @property
     def frame_has_materialized_dtypes(self) -> bool:
         """
-        Check if the undelying dataframe has materialized dtypes.
+        Check if the underlying dataframe has materialized dtypes.
 
         Returns
         -------
@@ -200,13 +197,10 @@ class NativeQueryCompiler(BaseQueryCompiler):
         return self.__constructor__(self._modin_frame)
 
     def to_pandas(self):
-        # For performance purposes, we create "shallow" copies with CoW enabled.
-        # Per pandas documentation, mutations on the returned frame will _not_ be reflected
-        # on the original `_modin_frame` field.
-        # pandas frames remember whether they were created with CoW even if the option is
-        # later disabled. For some reason, CoW seems not to apply for deep copies with the
-        # default numpy backend.
-        # TODO: check if the context manager actually matters (i think it does not)
+        # For performance purposes, we create "shallow" copies when NativePandasDeepCopy
+        # is disabled (the default value). This may cause unexpected behavior if the
+        # parent native frame is mutated, but creates a very significant performance
+        # improvement on large data.
         return self._modin_frame.copy(deep=NativePandasDeepCopy.get())
 
     @classmethod

--- a/modin/core/storage_formats/pandas/native_query_compiler.py
+++ b/modin/core/storage_formats/pandas/native_query_compiler.py
@@ -24,7 +24,11 @@ import numpy as np
 import pandas
 from pandas.core.dtypes.common import is_scalar
 
-from modin.config.envvars import NativePandasMaxRows, NativePandasTransferThreshold
+from modin.config.envvars import (
+    NativePandasMaxRows,
+    NativePandasTransferThreshold,
+    NativePandasDeepCopy,
+)
 from modin.core.dataframe.base.interchange.dataframe_protocol.dataframe import (
     ProtocolDataframe,
 )
@@ -115,8 +119,7 @@ class NativeQueryCompiler(BaseQueryCompiler):
             # later disabled. For some reason, CoW seems not to apply for deep copies with the
             # default numpy backend.
             # TODO: check if the context manager actually matters (i think it does not)
-            with pandas.option_context("mode.copy_on_write", True):
-                pandas_frame = pandas_frame.copy(deep=False)
+            pandas_frame = pandas_frame.copy(deep=NativePandasDeepCopy.get())
         else:
             pandas_frame = pandas.DataFrame(pandas_frame)
 
@@ -204,8 +207,7 @@ class NativeQueryCompiler(BaseQueryCompiler):
         # later disabled. For some reason, CoW seems not to apply for deep copies with the
         # default numpy backend.
         # TODO: check if the context manager actually matters (i think it does not)
-        with pandas.option_context("mode.copy_on_write", True):
-            return self._modin_frame.copy(deep=False)
+        return self._modin_frame.copy(deep=NativePandasDeepCopy.get())
 
     @classmethod
     def from_pandas(cls, df, data_cls):

--- a/modin/core/storage_formats/pandas/native_query_compiler.py
+++ b/modin/core/storage_formats/pandas/native_query_compiler.py
@@ -194,7 +194,13 @@ class NativeQueryCompiler(BaseQueryCompiler):
         return True
 
     def copy(self):
-        return self.__constructor__(self._modin_frame)
+        # If NativePandasDeepCopy is enabled, no need to perform an explicit copy here since the
+        # constructor will perform one anyway.
+        # If it is disabled, then we need to perform a deep copy.
+        if NativePandasDeepCopy.get():
+            return self.__constructor__(self._modin_frame)
+        else:
+            return self.__constructor__(self._modin_frame.copy(deep=True))
 
     def to_pandas(self):
         # For performance purposes, we create "shallow" copies when NativePandasDeepCopy

--- a/modin/core/storage_formats/pandas/native_query_compiler.py
+++ b/modin/core/storage_formats/pandas/native_query_compiler.py
@@ -25,9 +25,9 @@ import pandas
 from pandas.core.dtypes.common import is_scalar
 
 from modin.config.envvars import (
+    NativePandasDeepCopy,
     NativePandasMaxRows,
     NativePandasTransferThreshold,
-    NativePandasDeepCopy,
 )
 from modin.core.dataframe.base.interchange.dataframe_protocol.dataframe import (
     ProtocolDataframe,

--- a/modin/tests/pandas/dataframe/test_default.py
+++ b/modin/tests/pandas/dataframe/test_default.py
@@ -24,7 +24,7 @@ from numpy.testing import assert_array_equal
 from packaging.version import Version
 
 import modin.pandas as pd
-from modin.config import Engine, NPartitions, StorageFormat
+from modin.config import Backend, Engine, NPartitions, StorageFormat
 from modin.pandas.io import to_pandas
 from modin.tests.pandas.utils import (
     axis_keys,
@@ -1464,7 +1464,9 @@ def test___array__(data, copy_kwargs, get_array, get_array_name):
 
 
 @pytest.mark.xfail(
-    raises=AssertionError, reason="https://github.com/modin-project/modin/issues/4650"
+    condition=Backend.get() != "Pandas",
+    raises=AssertionError,
+    reason="https://github.com/modin-project/modin/issues/4650",
 )
 def test___array__copy_false_creates_view():
     def do_in_place_update_via_copy(df):

--- a/modin/tests/pandas/dataframe/test_window.py
+++ b/modin/tests/pandas/dataframe/test_window.py
@@ -29,6 +29,7 @@ from modin.tests.pandas.utils import (
     eval_general,
     int_arg_keys,
     int_arg_values,
+    is_native_shallow_copy,
     name_contains,
     no_numeric_dfs,
     quantiles_keys,
@@ -239,6 +240,11 @@ def test_fillna_4660():
     )
 
 
+@pytest.mark.xfail(
+    condition=is_native_shallow_copy(),
+    reason="native pandas backend does not deep copy inputs by default",
+    strict=True,
+)
 def test_fillna_inplace():
     frame_data = random_state.randn(10, 4)
     df = pandas.DataFrame(frame_data)

--- a/modin/tests/pandas/native_df_interoperability/test_copy_on_write.py
+++ b/modin/tests/pandas/native_df_interoperability/test_copy_on_write.py
@@ -1,0 +1,85 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+# Tests that ensure copy-on-write is properly enforced when the Backend environment variable
+# is set to pandas.
+
+
+import pandas
+from pandas import option_context
+import pytest
+
+from modin.config import Backend, context as config_context
+import modin.pandas as pd
+
+
+@pytest.fixture(scope="function", autouse=True)
+def mutation_cow_test():
+    if Backend.get() != "Pandas":
+        pytest.skip(reason="test is only meaningful with pandas backend")
+    with config_context(Backend="Pandas"), option_context("mode.copy_on_write", False):
+        yield
+
+
+def test_mutate_input_metadata():
+    # When constructing a modin frame from a native pandas frame, changes to the native pandas
+    # frame should not reflect in the modin frame's data or vice versa.
+    input_native_df = pandas.DataFrame({"A": [0, 1], "B": [2, 3]})
+    modin_df = pd.DataFrame(input_native_df)
+    input_native_df.columns.name = "x"
+    assert input_native_df.columns.name == "x"
+    assert modin_df.columns.name is None
+    modin_df.columns.name = "y"
+    assert input_native_df.columns.name == "x"
+    assert modin_df.columns.name == "y"
+
+
+def test_mutate_input_data():
+    # When constructing a modin frame from a native pandas frame, changes to the native pandas
+    # frame should not reflect in the modin frame's data or vice versa.
+    input_native_df = pandas.DataFrame({"A": [0, 1], "B": [2, 3]})
+    modin_df = pd.DataFrame(input_native_df)
+    input_native_df.loc[0, "A"] = -1
+    assert input_native_df.loc[0, "A"] == -1
+    # Fails when copy_on_write is False
+    assert modin_df.loc[0, "A"] == 0
+    modin_df.loc[1, "B"] = 999
+    assert input_native_df.loc[1, "B"] == 3
+    assert modin_df.loc[1, "B"] == 999
+
+
+def test_mutate_to_pandas_metadata():
+    # After calling to_pandas on a modin frame, changes to the native pandas frame should not reflect
+    # in the the modin frame's data or vice versa.
+    modin_df = pd.DataFrame({"A": [0, 1], "B": [2, 3]})
+    output_native_df = modin_df.modin.to_pandas()
+    output_native_df.columns.name = "x"
+    assert output_native_df.columns.name == "x"
+    assert modin_df.columns.name is None
+    modin_df.columns.name = "y"
+    assert output_native_df.columns.name == "x"
+    assert modin_df.columns.name == "y"
+
+
+def test_mutate_to_pandas_data():
+    # After calling to_pandas on a modin frame, changes to the native pandas frame should not reflect
+    # in the the modin frame's data or vice versa.
+    modin_df = pd.DataFrame({"A": [0, 1], "B": [2, 3]})
+    output_native_df = modin_df.modin.to_pandas()
+    output_native_df.loc[0, "A"] = -1
+    assert output_native_df.loc[0, "A"] == -1
+    # Fails when copy_on_write is False
+    assert modin_df.loc[0, "A"] == 0
+    modin_df.loc[1, "B"] = 999
+    assert output_native_df.loc[1, "B"] == 3
+    assert modin_df.loc[1, "B"] == 999

--- a/modin/tests/pandas/native_df_interoperability/test_copy_on_write.py
+++ b/modin/tests/pandas/native_df_interoperability/test_copy_on_write.py
@@ -168,3 +168,16 @@ def test_column_reassign(copy_on_write, df_factory):
     df2["B"] = df2["B"] + 1
     assert df1["B"].tolist() == [2, 3]
     assert df2["B"].tolist() == [3, 4]
+
+
+@pytest.mark.parametrize("always_deep", [True, False])
+def test_explicit_copy(always_deep):
+    # Test that making an explicit copy with deep=True actually makes a deep copy.
+    with config_context(NativePandasDeepCopy=always_deep):
+        df = pd.DataFrame([[0]])
+        # We don't really care about behavior with shallow copy, since modin semantics don't line up
+        # perfectly with native pandas.
+        df_copy = df.copy(deep=True)
+        df.loc[0, 0] = -1
+        assert df.loc[0, 0] == -1
+        assert df_copy.loc[0, 0] == 0

--- a/modin/tests/pandas/native_df_interoperability/test_copy_on_write.py
+++ b/modin/tests/pandas/native_df_interoperability/test_copy_on_write.py
@@ -11,10 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific language
 # governing permissions and limitations under the License.
 
-# Tests that ensure copy-on-write is properly enforced when the Backend environment variable
-# is set to pandas.
 
-
+import functools
 import pandas
 from pandas import option_context
 import pytest
@@ -23,63 +21,156 @@ from modin.config import Backend, context as config_context
 import modin.pandas as pd
 
 
-@pytest.fixture(scope="function", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def mutation_cow_test():
     if Backend.get() != "Pandas":
-        pytest.skip(reason="test is only meaningful with pandas backend")
-    with config_context(Backend="Pandas"), option_context("mode.copy_on_write", False):
-        yield
+        pytest.skip(
+            reason="tests are only meaningful with pandas backend",
+            allow_module_level=True,
+        )
 
 
-def test_mutate_input_metadata():
-    # When constructing a modin frame from a native pandas frame, changes to the native pandas
-    # frame should not reflect in the modin frame's data or vice versa.
-    input_native_df = pandas.DataFrame({"A": [0, 1], "B": [2, 3]})
-    modin_df = pd.DataFrame(input_native_df)
-    input_native_df.columns.name = "x"
-    assert input_native_df.columns.name == "x"
-    assert modin_df.columns.name is None
-    modin_df.columns.name = "y"
-    assert input_native_df.columns.name == "x"
-    assert modin_df.columns.name == "y"
+@pytest.fixture(scope="function")
+def copy_on_write(request):
+    # Indirect fixture for toggling copy-on-write when tests are run
+    with config_context(Backend="Pandas", NativePandasDeepCopy=False), option_context(
+        "mode.copy_on_write", request.param
+    ):
+        yield request.param
 
 
-def test_mutate_input_data():
-    # When constructing a modin frame from a native pandas frame, changes to the native pandas
-    # frame should not reflect in the modin frame's data or vice versa.
-    input_native_df = pandas.DataFrame({"A": [0, 1], "B": [2, 3]})
-    modin_df = pd.DataFrame(input_native_df)
-    input_native_df.loc[0, "A"] = -1
-    assert input_native_df.loc[0, "A"] == -1
-    # Fails when copy_on_write is False
-    assert modin_df.loc[0, "A"] == 0
-    modin_df.loc[1, "B"] = 999
-    assert input_native_df.loc[1, "B"] == 3
-    assert modin_df.loc[1, "B"] == 999
+def get_mutation_fixtures(data, **kwargs):
+    # Return a fixture that sets the copy_on_write fixture, then passes a modin and native DF together for mutation testing.
+    # One parameter combination creates a modin DF from a native DF.
+    # The other creates a native DF by calling to_pandas on a modin DF.
+    def wrapper(f):
+        # Need to create separate functions so parametrized runs don't affect each other.
+        def native_first():
+            native_input = pandas.DataFrame(data, **kwargs)
+            return native_input, pd.DataFrame(native_input)
+
+        def modin_first():
+            modin_input = pd.DataFrame(data, **kwargs)
+            return modin_input, modin_input.modin.to_pandas()
+
+        # def native_both():
+        #     native_input = pandas.DataFrame(data, **kwargs)
+        #     return native_input, pandas.DataFrame(native_input)
+        # def modin_both():
+        #     modin_input = pd.DataFrame(data, **kwargs)
+        #     return modin_input, pd.DataFrame(modin_input)
+        @pytest.mark.parametrize("df_factory", [native_first, modin_first])
+        @pytest.mark.parametrize(
+            "copy_on_write",
+            [pytest.param(True, id="CoW"), pytest.param(False, id="no_CoW")],
+            indirect=True,
+        )
+        # UNCOMMENT THESE FOR TESTING SPECIFIC CONFIGURATIONS
+        # @pytest.mark.parametrize("df_factory", [modin_both])
+        # @pytest.mark.parametrize("copy_on_write", [pytest.param(True, id="CoW")], indirect=True)
+        # @pytest.mark.parametrize("copy_on_write", [pytest.param(False, id="no_CoW")], indirect=True)
+        @functools.wraps(f)
+        def test_runner(*args, **kwargs):
+            return f(*args, **kwargs)
+
+        return test_runner
+
+    return wrapper
 
 
-def test_mutate_to_pandas_metadata():
-    # After calling to_pandas on a modin frame, changes to the native pandas frame should not reflect
-    # in the the modin frame's data or vice versa.
-    modin_df = pd.DataFrame({"A": [0, 1], "B": [2, 3]})
-    output_native_df = modin_df.modin.to_pandas()
-    output_native_df.columns.name = "x"
-    assert output_native_df.columns.name == "x"
-    assert modin_df.columns.name is None
-    modin_df.columns.name = "y"
-    assert output_native_df.columns.name == "x"
-    assert modin_df.columns.name == "y"
+@pytest.mark.parametrize(
+    "axis", [pytest.param(0, id="index"), pytest.param(1, id="columns")]
+)
+@get_mutation_fixtures({"A": [0, 1], "B": [2, 3]})
+def test_set_axis_name(axis, copy_on_write, df_factory):
+    df1, df2 = df_factory()
+    df1.axes[axis].name = "x"
+    assert df1.axes[axis].name == "x"
+    # Changes do not propagate when copy-on-write is enabled.
+    if copy_on_write:
+        assert df2.axes[axis].name is None
+    else:
+        assert df2.axes[axis].name == "x"
+    df2.axes[axis].name = "y"
+    assert df1.axes[axis].name == ("x" if copy_on_write else "y")
+    assert df2.axes[axis].name == "y"
 
 
-def test_mutate_to_pandas_data():
-    # After calling to_pandas on a modin frame, changes to the native pandas frame should not reflect
-    # in the the modin frame's data or vice versa.
-    modin_df = pd.DataFrame({"A": [0, 1], "B": [2, 3]})
-    output_native_df = modin_df.modin.to_pandas()
-    output_native_df.loc[0, "A"] = -1
-    assert output_native_df.loc[0, "A"] == -1
-    # Fails when copy_on_write is False
-    assert modin_df.loc[0, "A"] == 0
-    modin_df.loc[1, "B"] = 999
-    assert output_native_df.loc[1, "B"] == 3
-    assert modin_df.loc[1, "B"] == 999
+@pytest.mark.parametrize(
+    "axis", [pytest.param(0, id="index"), pytest.param(1, id="columns")]
+)
+@get_mutation_fixtures({"A": [0, 1], "B": [2, 3]}, index=["A", "B"])
+def test_rename_axis(axis, copy_on_write, df_factory):
+    df1, df2 = df_factory()
+    # Renames don't propagate, regardless of CoW.
+    df1.rename({"A": "aprime"}, axis=axis, inplace=True)
+    assert df1.axes[axis].tolist() == ["aprime", "B"]
+    assert df2.axes[axis].tolist() == ["A", "B"]
+    df2.rename({"B": "bprime"}, axis=axis, inplace=True)
+    assert df1.axes[axis].tolist() == ["aprime", "B"]
+    assert df2.axes[axis].tolist() == ["A", "bprime"]
+
+
+@get_mutation_fixtures({"A": [0, 1], "B": [2, 3]})
+def test_locset(copy_on_write, df_factory):
+    df1, df2 = df_factory()
+    df1.loc[0, "A"] = -1
+    assert df1.loc[0, "A"] == -1
+    assert df2.loc[0, "A"] == (0 if copy_on_write else -1)
+    df2.loc[1, "B"] = 999
+    assert df1.loc[1, "B"] == (3 if copy_on_write else 999)
+    assert df2.loc[1, "B"] == 999
+
+
+@get_mutation_fixtures({"A": [0, 1], "B": [2, 3]})
+def test_add_column(copy_on_write, df_factory):
+    df1, df2 = df_factory()
+    df1["C"] = [4, 5]
+    assert df1["C"].tolist() == [4, 5]
+    # Even with CoW disabled, the new column is not added to df2.
+    assert df2.columns.tolist() == ["A", "B"]
+    df2["D"] = [6, 7]
+    assert df2["D"].tolist() == [6, 7]
+    assert df1.columns.tolist() == ["A", "B", "C"]
+
+
+@get_mutation_fixtures({"A": [0, 1], "B": [2, 3]})
+def test_add_row(copy_on_write, df_factory):
+    df1, df2 = df_factory()
+    df1.loc[9] = [4, 5]
+    assert df1.loc[9].tolist() == [4, 5]
+    # Even with CoW disabled, the new row is not added to df2.
+    assert df2.index.tolist() == [0, 1]
+    df2.loc[10] = [6, 7]
+    assert df2.loc[10].tolist() == [6, 7]
+    assert df1.index.tolist() == [0, 1, 9]
+
+
+@pytest.mark.filterwarnings("ignore::FutureWarning")
+@pytest.mark.filterwarnings("ignore::pandas.errors.ChainedAssignmentError")
+@get_mutation_fixtures({"A": [0, 1], "B": [2, 3]})
+def test_chained_assignment(copy_on_write, df_factory):
+    df1, df2 = df_factory()
+    is_assign_noop = copy_on_write and isinstance(df1, pandas.DataFrame)
+    df1["A"][0] = -1
+    assert df1["A"][0] == (0 if is_assign_noop else -1)
+    assert df2["A"][0] == (
+        0 if copy_on_write or isinstance(df2, pandas.DataFrame) else -1
+    )
+    is_assign_noop = copy_on_write and isinstance(df2, pandas.DataFrame)
+    df2["B"][1] = 999
+    assert df1["B"][1] == (
+        3 if copy_on_write or isinstance(df1, pandas.DataFrame) else 999
+    )
+    assert df2["B"][1] == (3 if is_assign_noop else 999)
+
+
+@get_mutation_fixtures({"A": [0, 1], "B": [2, 3]})
+def test_column_reassign(copy_on_write, df_factory):
+    df1, df2 = df_factory()
+    df1["A"] = df1["A"] - 1
+    assert df1["A"].tolist() == [-1, 0]
+    assert df2["A"].tolist() == [0, 1]
+    df2["B"] = df2["B"] + 1
+    assert df1["B"].tolist() == [2, 3]
+    assert df2["B"].tolist() == [3, 4]

--- a/modin/tests/pandas/test_general.py
+++ b/modin/tests/pandas/test_general.py
@@ -33,6 +33,7 @@ from .utils import (
     create_test_dfs,
     df_equals,
     eval_general,
+    is_native_shallow_copy,
     sort_if_range_partitioning,
     sort_index_for_equal_values,
     test_data_keys,
@@ -980,6 +981,11 @@ def test_get(key):
     eval_general(modin_df, pandas_df, lambda df: df.get(key))
 
 
+@pytest.mark.xfail(
+    condition=is_native_shallow_copy(),
+    reason="native pandas backend does not deep copy inputs by default",
+    strict=True,
+)
 def test_df_immutability():
     """
     Verify that modifications of the source data doesn't propagate to Modin's DataFrame objects.

--- a/modin/tests/pandas/test_groupby.py
+++ b/modin/tests/pandas/test_groupby.py
@@ -124,7 +124,7 @@ pytestmark = [
         "ignore:.*In a future version of pandas, the provided callable will be used directly.*:FutureWarning"
     ),
     pytest.mark.filterwarnings(
-        "ignore:(DataFrameGroupBy|SeriesGroupBy)\.apply operated on the grouping columns:FutureWarning"
+        "ignore:(DataFrameGroupBy|SeriesGroupBy).apply operated on the grouping columns:FutureWarning"
     ),
 ]
 

--- a/modin/tests/pandas/utils.py
+++ b/modin/tests/pandas/utils.py
@@ -42,9 +42,11 @@ from pandas.core.dtypes.common import (
 import modin.pandas as pd
 from modin import set_execution
 from modin.config import (
+    Backend,
     Engine,
     MinColumnPartitionSize,
     MinRowPartitionSize,
+    NativePandasDeepCopy,
     NPartitions,
     RangePartitioning,
     StorageFormat,
@@ -1694,3 +1696,12 @@ def switch_execution(engine: str, storage_format: str):
         yield
     finally:
         set_execution(old_engine, old_storage)
+
+
+def is_native_shallow_copy() -> bool:
+    """Return if the current configuration uses native pandas execution and performs shallow copies."""
+    return (
+        Backend.get() == "Pandas"
+        and not NativePandasDeepCopy.get()
+        and not pandas.get_option("mode.copy_on_write")
+    )


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7435 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

Uses shallow copies by default in native pandas execution mode, significantly improving performance. This behavior can be changed by setting `NativePandasDeepCopy.enable()`.

Summary of mutation behavior, with and without pandas copy-on-write:
<img width="1319" height="661" alt="Screenshot 2025-07-31 at 12 29 21" src="https://github.com/user-attachments/assets/8094487c-b8a6-4f4f-a0ab-97bdaf799bd2" />

Unscientific sanity check benchmark:
```
import modin.pandas as pd
import numpy as np
from modin.config import Backend
Backend.put("Pandas")

from time import perf_counter

def bm(f):
    start = perf_counter()
    f() 
    print(perf_counter() - start)

df = pd.DataFrame(np.random.randint(0,100,size=(2**22,2**8)))
bm(lambda: repr(df.sort_values(0)))
```

Native pandas w/ CoW: 2.41s
Native pandas w/o CoW: 4.54s
Modin w/ NativePandasDeepCopy set (equivalent to current main): 7.03s
Modin w/ NativePandasDeepCopy disabled (this PR): 2.30s