### PR TITLE
FEAT-#7604: Support pandas 2.3

### DIFF
--- a/environment-dev.yml
+++ b/environment-dev.yml
@@ -5,7 +5,7 @@ dependencies:
   - pip
 
   # required dependencies
-  - pandas>=2.2,<2.3
+  - pandas>=2.2,<2.4
   - numpy>=1.22.4
   - fsspec>=2022.11.0
   - packaging>=21.0

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -6614,10 +6614,13 @@ class BaseQueryCompiler(
         refer_to="decode",
         params="""
                 encoding : str,
-                errors : str, default = 'strict'""",
+                errors : str, default = 'strict'
+                dtype : str or dtype, optional""",
     )
     def str_decode(self, encoding, errors, dtype):
-        return StrDefault.register(pandas.Series.str.decode)(self, encoding, errors, dtype)
+        return StrDefault.register(pandas.Series.str.decode)(
+            self, encoding, errors, dtype
+        )
 
     @doc_utils.doc_str_method(
         refer_to="cat",

--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -6616,8 +6616,8 @@ class BaseQueryCompiler(
                 encoding : str,
                 errors : str, default = 'strict'""",
     )
-    def str_decode(self, encoding, errors):
-        return StrDefault.register(pandas.Series.str.decode)(self, encoding, errors)
+    def str_decode(self, encoding, errors, dtype):
+        return StrDefault.register(pandas.Series.str.decode)(self, encoding, errors, dtype)
 
     @doc_utils.doc_str_method(
         refer_to="cat",

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -29,7 +29,7 @@ if pandas_version < version.parse(
     )
 
 # to not pollute namespace
-del version
+del version, pandas_version, __min_pandas_version__, __max_pandas_version__
 
 
 with warnings.catch_warnings():

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -20,10 +20,9 @@ __min_pandas_version__ = "2.2"
 __max_pandas_version__ = "2.4"
 
 pandas_version = version.parse(pandas.__version__)
-if (
-    pandas_version < version.parse(__min_pandas_version__)
-    or pandas_version >= version.parse(__max_pandas_version__)
-):
+if pandas_version < version.parse(
+    __min_pandas_version__
+) or pandas_version >= version.parse(__max_pandas_version__):
     warnings.warn(
         f"The pandas version installed ({pandas.__version__}) is outside the supported range in Modin"
         + f" ({__min_pandas_version__} to {__max_pandas_version__}). This may cause undesired side effects!"

--- a/modin/pandas/__init__.py
+++ b/modin/pandas/__init__.py
@@ -16,17 +16,18 @@ import warnings
 import pandas
 from packaging import version
 
-__pandas_version__ = "2.2"
+__min_pandas_version__ = "2.2"
+__max_pandas_version__ = "2.4"
 
+pandas_version = version.parse(pandas.__version__)
 if (
-    version.parse(pandas.__version__).release[:2]
-    != version.parse(__pandas_version__).release[:2]
+    pandas_version < version.parse(__min_pandas_version__)
+    or pandas_version >= version.parse(__max_pandas_version__)
 ):
     warnings.warn(
-        f"The pandas version installed ({pandas.__version__}) does not match the supported pandas version in"
-        + f" Modin ({__pandas_version__}.X). This may cause undesired side effects!"
+        f"The pandas version installed ({pandas.__version__}) is outside the supported range in Modin"
+        + f" ({__min_pandas_version__} to {__max_pandas_version__}). This may cause undesired side effects!"
     )
-
 
 # to not pollute namespace
 del version

--- a/modin/pandas/series_utils.py
+++ b/modin/pandas/series_utils.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 
 import numpy as np
 import pandas
+from pandas._libs import lib
 
 from modin.logging import ClassLogger
 from modin.utils import _inherit_docstrings
@@ -226,9 +227,9 @@ class StringMethods(ClassLogger):
             else self._Series(query_compiler=compiler_result)
         )
 
-    def decode(self, encoding, errors="strict"):
+    def decode(self, encoding, errors="strict", dtype=None):
         return self._Series(
-            query_compiler=self._query_compiler.str_decode(encoding, errors)
+            query_compiler=self._query_compiler.str_decode(encoding, errors, dtype)
         )
 
     def split(self, pat=None, *, n=-1, expand=False, regex=None):
@@ -277,9 +278,11 @@ class StringMethods(ClassLogger):
     def get_dummies(self, sep="|"):
         return self._Series(query_compiler=self._query_compiler.str_get_dummies(sep))
 
-    def contains(self, pat, case=True, flags=0, na=None, regex=True):
+    def contains(self, pat, case=True, flags=0, na=lib.no_default, regex=True):
         if pat is None and not case:
             raise AttributeError("'NoneType' object has no attribute 'upper'")
+        if na is lib.no_default:
+            na = None
         return self._Series(
             query_compiler=self._query_compiler.str_contains(
                 pat, case=case, flags=flags, na=na, regex=regex
@@ -358,7 +361,9 @@ class StringMethods(ClassLogger):
             query_compiler=self._query_compiler.str_count(pat, flags=flags)
         )
 
-    def startswith(self, pat, na=None):
+    def startswith(self, pat, na=lib.no_default):
+        if na is lib.no_default:
+            na = None
         return self._Series(
             query_compiler=self._query_compiler.str_startswith(pat, na=na)
         )
@@ -368,7 +373,9 @@ class StringMethods(ClassLogger):
             query_compiler=self._query_compiler.str_encode(encoding, errors)
         )
 
-    def endswith(self, pat, na=None):
+    def endswith(self, pat, na=lib.no_default):
+        if na is lib.no_default:
+            na = None
         return self._Series(
             query_compiler=self._query_compiler.str_endswith(pat, na=na)
         )
@@ -380,18 +387,22 @@ class StringMethods(ClassLogger):
             query_compiler=self._query_compiler.str_findall(pat, flags=flags)
         )
 
-    def fullmatch(self, pat, case=True, flags=0, na=None):
+    def fullmatch(self, pat, case=True, flags=0, na=lib.no_default):
         if not isinstance(pat, (str, re.Pattern)):
             raise TypeError("first argument must be string or compiled pattern")
+        if na is lib.no_default:
+            na = None
         return self._Series(
             query_compiler=self._query_compiler.str_fullmatch(
                 pat, case=case, flags=flags, na=na
             )
         )
 
-    def match(self, pat, case=True, flags=0, na=None):
+    def match(self, pat, case=True, flags=0, na=lib.no_default):
         if not isinstance(pat, (str, re.Pattern)):
             raise TypeError("first argument must be string or compiled pattern")
+        if na is lib.no_default:
+            na = None
         return self._Series(
             query_compiler=self._query_compiler.str_match(
                 pat, case=case, flags=flags, na=na

--- a/modin/tests/pandas/test_api.py
+++ b/modin/tests/pandas/test_api.py
@@ -82,7 +82,7 @@ def test_top_level_api_equality():
     ), "Differences found in API: {}".format(extra_in_modin - set(ignore_modin))
 
     difference = []
-    allowed_different = ["Interval", "datetime"]
+    allowed_different = ["Interval", "datetime", "StringDtype"]
 
     # Check that we have all keywords and defaults in pandas
     for m in set(pandas_dir) - set(ignore_pandas):

--- a/modin/tests/pandas/test_groupby.py
+++ b/modin/tests/pandas/test_groupby.py
@@ -124,7 +124,7 @@ pytestmark = [
         "ignore:.*In a future version of pandas, the provided callable will be used directly.*:FutureWarning"
     ),
     pytest.mark.filterwarnings(
-        "ignore:(DataFrameGroupBy|SeriesGroupBy).apply operated on the grouping columns:FutureWarning"
+        "ignore:(DataFrameGroupBy|SeriesGroupBy)\.apply operated on the grouping columns:FutureWarning"
     ),
 ]
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,5 @@
 ## required dependencies
-pandas>=2.2,<2.3
+pandas>=2.2,<2.4
 numpy>=1.22.4
 fsspec>=2022.11.0
 packaging>=21.0

--- a/requirements/env_unidist_linux.yml
+++ b/requirements/env_unidist_linux.yml
@@ -5,7 +5,7 @@ dependencies:
   - pip
 
   # required dependencies
-  - pandas>=2.2,<2.3
+  - pandas>=2.2,<2.4
   - numpy>=1.22.4
   - unidist-mpi>=0.2.1
   - mpich

--- a/requirements/env_unidist_win.yml
+++ b/requirements/env_unidist_win.yml
@@ -5,7 +5,7 @@ dependencies:
   - pip
 
   # required dependencies
-  - pandas>=2.2,<2.3
+  - pandas>=2.2,<2.4
   - numpy>=1.22.4
   - unidist-mpi>=0.2.1
   - msmpi

--- a/requirements/requirements-no-engine.yml
+++ b/requirements/requirements-no-engine.yml
@@ -4,7 +4,7 @@ dependencies:
   - pip
 
   # required dependencies
-  - pandas>=2.2,<2.3
+  - pandas>=2.2,<2.4
   - numpy>=1.22.4
   - fsspec>=2022.11.0
   - packaging>=21.0

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     install_requires=[
-        "pandas>=2.2,<2.3",
+        "pandas>=2.2,<2.4",
         "packaging>=21.0",
         "numpy>=1.22.4",
         "fsspec>=2022.11.0",


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7604 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

Increases the range of supported pandas versions to >2.2, <2.4.

Changes:
- `Series.str.decode` now has a `dtype `argument
- The `na` parameter of many string methods now uses `lib.no_default` instead of None, but we still pass `None` internally.
- `include_groups=True` in `groupby.apply` is now deprecated in pandas 2.3. This change is very far-reaching, and since many other methods use apply under the hood, I found it too difficult to change `include_groups` for every single possible function call. The warning is filtered instead.