### PR TITLE
FEAT-#7636: Make AutoSwitchBackend False by default.

### DIFF
--- a/docs/usage_guide/optimization_notes/index.rst
+++ b/docs/usage_guide/optimization_notes/index.rst
@@ -419,6 +419,9 @@ when automatic switching occurs:
     backend="Pandas",
   )
 
+  # Enable automatic switching globally (use .disable() to turn off)
+  AutoSwitchBackend.enable()
+
   df = pd.DataFrame([[1, 2, 3]])
   # "pin" a single DataFrame/Series, preventing it from
   # automatically switching backends
@@ -426,10 +429,6 @@ when automatic switching occurs:
   # "unpin" it to re-enable automatic switching
   df.unpin_backend(inplace=True)
 
-  # To disable automatic backend switching, use AutoSwitchBackend,
-  # a configuration variable that is on by default:
-
-  AutoSwitchBackend.put(False)
 
 Operation-specific optimizations
 """"""""""""""""""""""""""""""""

--- a/docs/usage_guide/optimization_notes/index.rst
+++ b/docs/usage_guide/optimization_notes/index.rst
@@ -419,9 +419,6 @@ when automatic switching occurs:
     backend="Pandas",
   )
 
-  # Enable automatic switching globally (use .disable() to turn off)
-  AutoSwitchBackend.enable()
-
   df = pd.DataFrame([[1, 2, 3]])
   # "pin" a single DataFrame/Series, preventing it from
   # automatically switching backends
@@ -429,6 +426,10 @@ when automatic switching occurs:
   # "unpin" it to re-enable automatic switching
   df.unpin_backend(inplace=True)
 
+  # To disable automatic backend switching, use AutoSwitchBackend,
+  # a configuration variable that is on by default:
+
+  AutoSwitchBackend.put(False)
 
 Operation-specific optimizations
 """"""""""""""""""""""""""""""""

--- a/modin/config/envvars.py
+++ b/modin/config/envvars.py
@@ -634,7 +634,7 @@ class AutoSwitchBackend(EnvironmentVariable, type=bool):
     """
 
     varname = "MODIN_AUTO_SWITCH_BACKENDS"
-    default = True
+    default = False
 
     @classmethod
     def enable(cls) -> None:

--- a/modin/tests/pandas/extensions/test_groupby_extensions.py
+++ b/modin/tests/pandas/extensions/test_groupby_extensions.py
@@ -16,7 +16,7 @@ from functools import cached_property
 import pytest
 
 import modin.pandas as pd
-from modin.config import Backend
+from modin.config import AutoSwitchBackend, Backend
 from modin.config import context as config_context
 from modin.pandas.api.extensions import (
     register_dataframe_groupby_accessor,
@@ -271,9 +271,9 @@ def test_deleting_extension_that_is_not_property_raises_attribute_error():
 
 @pytest.mark.skipif(Backend.get() == "Pandas", reason="already on pandas backend")
 def test_get_extension_from_dataframe_that_is_on_non_default_backend_when_auto_switch_is_false():
-    with config_context(AutoSwitchBackend=False):
-        pandas_df = pd.DataFrame([1, 2]).move_to("Pandas")
-        register_dataframe_groupby_accessor("sum", backend="Pandas")(
-            lambda df: "small_sum_result"
-        )
-        assert pandas_df.groupby(0).sum() == "small_sum_result"
+    assert not AutoSwitchBackend.get()
+    pandas_df = pd.DataFrame([1, 2]).move_to("Pandas")
+    register_dataframe_groupby_accessor("sum", backend="Pandas")(
+        lambda df: "small_sum_result"
+    )
+    assert pandas_df.groupby(0).sum() == "small_sum_result"

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -349,6 +349,12 @@ register_backend("Big_Data_Cloud", CloudForBigDataQC)
 register_backend("Small_Data_Local", LocalForSmallDataQC)
 
 
+@pytest.fixture(autouse=True)
+def turn_on_auto_switch_backend():
+    with config_context(AutoSwitchBackend=True):
+        yield
+
+
 @pytest.fixture()
 def cloud_df():
     return pd.DataFrame(query_compiler=CloudQC(pandas.DataFrame([0, 1, 2])))

--- a/modin/tests/test_metrics.py
+++ b/modin/tests/test_metrics.py
@@ -71,7 +71,7 @@ def test_df_metrics(metric_client):
     add_metric_handler(metric_client._metric_handler)
     df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
     df.sum()
-    assert len(metric_client._metrics) == 55
+    assert len(metric_client._metrics) == 54
     assert metric_client._metrics["modin.pandas-api.dataframe.sum"] is not None
     assert metric_client._metrics["modin.pandas-api.dataframe.sum"] > 0.0
 


### PR DESCRIPTION
AutoSwitchBackend is a new feature that may hurt performance in some cases once we start adding rules for automatically switching backends. We should disable it by default.

Resolves #7636