### PR TITLE
FIX-#7638: Suppress default to pandas warnings on native pandas backend

### DIFF
--- a/modin/core/storage_formats/base/query_compiler.py
+++ b/modin/core/storage_formats/base/query_compiler.py
@@ -206,7 +206,8 @@ class BaseQueryCompiler(
     _shape_hint: Optional[str]
     _should_warn_on_default_to_pandas: bool = True
 
-    def _maybe_warn_on_default(self, *, message: str = "", reason: str = "") -> None:
+    @classmethod
+    def _maybe_warn_on_default(cls, *, message: str = "", reason: str = "") -> None:
         """
         If this class is configured to warn on default to pandas, warn.
 
@@ -217,7 +218,7 @@ class BaseQueryCompiler(
         reason : str, default: ""
             Reason for default.
         """
-        if self._should_warn_on_default_to_pandas:
+        if cls._should_warn_on_default_to_pandas:
             ErrorMessage.default_to_pandas(message=message, reason=reason)
 
     @disable_logging

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -561,8 +561,8 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
             Result of operation.
         """
         empty_self_str = "" if not self.empty else " for empty DataFrame"
-        ErrorMessage.default_to_pandas(
-            "`{}.{}`{}".format(
+        self._query_compiler._maybe_warn_on_default(
+            message="`{}.{}`{}".format(
                 type(self).__name__,
                 op if isinstance(op, str) else op.__name__,
                 empty_self_str,

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -28,7 +28,6 @@ from modin.core.storage_formats import BaseQueryCompiler
 from modin.core.storage_formats.pandas.query_compiler_caster import (
     wrap_free_function_in_argument_caster,
 )
-from modin.error_message import ErrorMessage
 from modin.logging import enable_logging
 from modin.pandas.io import to_pandas
 from modin.utils import _inherit_docstrings, _maybe_warn_on_default

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -31,7 +31,7 @@ from modin.core.storage_formats.pandas.query_compiler_caster import (
 from modin.error_message import ErrorMessage
 from modin.logging import enable_logging
 from modin.pandas.io import to_pandas
-from modin.utils import _inherit_docstrings
+from modin.utils import _inherit_docstrings, _maybe_warn_on_default
 
 from .base import BasePandasDataset
 from .dataframe import DataFrame
@@ -193,7 +193,7 @@ def merge_asof(
         raise ValueError(
             "can not merge DataFrame with instance of type {}".format(type(right))
         )
-    ErrorMessage.default_to_pandas("`merge_asof`")
+    left._maybe_warn_on_default("`merge_asof`")
 
     # As of Pandas 1.2 these should raise an error; before that it did
     # something likely random:
@@ -345,7 +345,7 @@ def cut(
     if isinstance(x, DataFrame):
         raise ValueError("Input array must be 1 dimensional")
     if not isinstance(x, Series):
-        ErrorMessage.default_to_pandas(
+        _maybe_warn_on_default(
             reason=f"pd.cut is not supported on objects of type {type(x)}"
         )
         import pandas
@@ -656,7 +656,7 @@ def get_dummies(
             + "github.com/modin-project/modin."
         )
     if not isinstance(data, DataFrame):
-        ErrorMessage.default_to_pandas("`get_dummies` on non-DataFrame")
+        _maybe_warn_on_default("`get_dummies` on non-DataFrame")
         if isinstance(data, Series):
             data = data._to_pandas()
         return DataFrame(
@@ -726,7 +726,7 @@ def crosstab(
     """
     Compute a simple cross tabulation of two (or more) factors.
     """
-    ErrorMessage.default_to_pandas("`crosstab`")
+    _maybe_warn_on_default("`crosstab`")
     pandas_crosstab = pandas.crosstab(
         index,
         columns,
@@ -769,7 +769,7 @@ def lreshape(data: DataFrame, groups, dropna=True) -> DataFrame:
     """
     if not isinstance(data, DataFrame):
         raise ValueError("can not lreshape with instance of type {}".format(type(data)))
-    ErrorMessage.default_to_pandas("`lreshape`")
+    data._maybe_warn_on_default("`lreshape`")
     return DataFrame(pandas.lreshape(to_pandas(data), groups, dropna=dropna))
 
 

--- a/modin/pandas/general.py
+++ b/modin/pandas/general.py
@@ -192,7 +192,7 @@ def merge_asof(
         raise ValueError(
             "can not merge DataFrame with instance of type {}".format(type(right))
         )
-    left._maybe_warn_on_default("`merge_asof`")
+    left._query_compiler._maybe_warn_on_default(message="`merge_asof`")
 
     # As of Pandas 1.2 these should raise an error; before that it did
     # something likely random:
@@ -768,7 +768,7 @@ def lreshape(data: DataFrame, groups, dropna=True) -> DataFrame:
     """
     if not isinstance(data, DataFrame):
         raise ValueError("can not lreshape with instance of type {}".format(type(data)))
-    data._maybe_warn_on_default("`lreshape`")
+    data._query_compiler._maybe_warn_on_default(message="`lreshape`")
     return DataFrame(pandas.lreshape(to_pandas(data), groups, dropna=dropna))
 
 

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -71,7 +71,6 @@ from modin.core.dataframe.base.interchange.dataframe_protocol.dataframe import (
 from modin.core.storage_formats.pandas.query_compiler_caster import (
     wrap_free_function_in_argument_caster,
 )
-from modin.error_message import ErrorMessage
 from modin.logging import ClassLogger, enable_logging
 from modin.utils import (
     SupportsPrivateToNumPy,

--- a/modin/pandas/io.py
+++ b/modin/pandas/io.py
@@ -78,6 +78,7 @@ from modin.utils import (
     SupportsPublicToNumPy,
     SupportsPublicToPandas,
     _inherit_docstrings,
+    _maybe_warn_on_default,
     classproperty,
     expanduser_path_arg,
 )
@@ -156,7 +157,7 @@ def read_xml(
     storage_options: StorageOptions = None,
     dtype_backend: Union[DtypeBackend, NoDefault] = no_default,
 ) -> DataFrame:
-    ErrorMessage.default_to_pandas("read_xml")
+    _maybe_warn_on_default("read_xml")
     _, _, _, kwargs = inspect.getargvalues(inspect.currentframe())
     return ModinObjects.DataFrame(pandas.read_xml(**kwargs))
 
@@ -658,7 +659,7 @@ def read_sql(
     from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     if kwargs.get("chunksize") is not None:
-        ErrorMessage.default_to_pandas("Parameters provided [chunksize]")
+        _maybe_warn_on_default("Parameters provided [chunksize]")
         df_gen = pandas.read_sql(**kwargs)
         return (
             ModinObjects.DataFrame(query_compiler=FactoryDispatcher.from_pandas(df))
@@ -818,7 +819,7 @@ def json_normalize(
     """
     Normalize semi-structured JSON data into a flat table.
     """
-    ErrorMessage.default_to_pandas("json_normalize")
+    _maybe_warn_on_default("json_normalize")
     return ModinObjects.DataFrame(
         pandas.json_normalize(
             data, record_path, meta, meta_prefix, record_prefix, errors, sep, max_level
@@ -840,7 +841,7 @@ def read_orc(
     """
     Load an ORC object from the file path, returning a DataFrame.
     """
-    ErrorMessage.default_to_pandas("read_orc")
+    _maybe_warn_on_default("read_orc")
     return ModinObjects.DataFrame(
         pandas.read_orc(
             path,
@@ -886,7 +887,7 @@ class HDFStore(ClassLogger, pandas.HDFStore):  # noqa: PR01, D200
                     # We don't want to constantly be giving this error message for
                     # internal methods.
                     if item[0] != "_":
-                        ErrorMessage.default_to_pandas("`{}`".format(item))
+                        _maybe_warn_on_default("`{}`".format(item))
                     args = [
                         (
                             to_pandas(arg)
@@ -952,7 +953,7 @@ class ExcelFile(ClassLogger, pandas.ExcelFile):  # noqa: PR01, D200
                     # We don't want to constantly be giving this error message for
                     # internal methods.
                     if item[0] != "_":
-                        ErrorMessage.default_to_pandas("`{}`".format(item))
+                        _maybe_warn_on_default("`{}`".format(item))
                     args = [
                         (
                             to_pandas(arg)

--- a/modin/tests/experimental/test_io_exp.py
+++ b/modin/tests/experimental/test_io_exp.py
@@ -29,7 +29,7 @@ from modin.tests.pandas.utils import (
     time_parsing_csv_path,
 )
 from modin.tests.test_utils import (
-    warns_that_defaulting_to_pandas,
+    current_execution_is_native,
     warns_that_defaulting_to_pandas_if,
 )
 from modin.utils import try_cast_to_pandas
@@ -129,7 +129,7 @@ class TestCsvGlob:
 
     def test_read_csv_without_glob(self):
         with pytest.raises(FileNotFoundError):
-            with warns_that_defaulting_to_pandas():
+            with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
                 pd.read_csv_glob(
                     "s3://dask-data/nyc-taxi/2015/yellow_tripdata_2015-",
                     storage_options={"anon": True},

--- a/modin/tests/interchange/dataframe_protocol/pandas/test_protocol.py
+++ b/modin/tests/interchange/dataframe_protocol/pandas/test_protocol.py
@@ -20,7 +20,6 @@ from modin.pandas.io import from_dataframe
 from modin.tests.pandas.utils import df_equals, test_data
 from modin.tests.test_utils import (
     df_or_series_using_native_execution,
-    warns_that_defaulting_to_pandas,
     warns_that_defaulting_to_pandas_if,
 )
 
@@ -66,7 +65,9 @@ def test_categorical_from_dataframe():
 
 def test_from_dataframe_with_empty_dataframe():
     modin_df = pd.DataFrame({"foo_col": pd.Series([], dtype="int64")})
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(
+        not df_or_series_using_native_execution(modin_df)
+    ):
         eval_df_protocol(modin_df)
 
 

--- a/modin/tests/pandas/dataframe/test_iter.py
+++ b/modin/tests/pandas/dataframe/test_iter.py
@@ -147,7 +147,7 @@ def test_display_options_for___repr__(max_rows_columns, expand_frame_repr, frame
 def test___finalize__():
     data = test_data_values[0]
     # NOTE: __finalize__() defaults to pandas at the API layer.
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         pd.DataFrame(data).__finalize__(None)
 
 

--- a/modin/tests/pandas/dataframe/test_iter.py
+++ b/modin/tests/pandas/dataframe/test_iter.py
@@ -35,7 +35,6 @@ from modin.tests.pandas.utils import (
 )
 from modin.tests.test_utils import (
     current_execution_is_native,
-    warns_that_defaulting_to_pandas,
     warns_that_defaulting_to_pandas_if,
 )
 

--- a/modin/tests/pandas/dataframe/test_udf.py
+++ b/modin/tests/pandas/dataframe/test_udf.py
@@ -43,7 +43,10 @@ from modin.tests.pandas.utils import (
     udf_func_keys,
     udf_func_values,
 )
-from modin.tests.test_utils import warns_that_defaulting_to_pandas
+from modin.tests.test_utils import (
+    current_execution_is_native,
+    warns_that_defaulting_to_pandas_if,
+)
 from modin.utils import get_current_execution
 
 NPartitions.put(4)
@@ -126,10 +129,10 @@ def test_aggregate_alias():
 def test_aggregate_error_checking():
     modin_df = pd.DataFrame(test_data["float_nan_data"])
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         modin_df.aggregate({modin_df.columns[0]: "sum", modin_df.columns[1]: "mean"})
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         modin_df.aggregate("arcsin")
 
 

--- a/modin/tests/pandas/extensions/test_groupby_extensions.py
+++ b/modin/tests/pandas/extensions/test_groupby_extensions.py
@@ -24,7 +24,10 @@ from modin.pandas.api.extensions import (
 )
 from modin.pandas.groupby import DataFrameGroupBy, SeriesGroupBy
 from modin.tests.pandas.utils import default_to_pandas_ignore_string, df_equals
-from modin.tests.test_utils import warns_that_defaulting_to_pandas
+from modin.tests.test_utils import (
+    current_execution_is_native,
+    warns_that_defaulting_to_pandas_if,
+)
 
 
 @pytest.mark.parametrize(
@@ -150,10 +153,7 @@ class TestProperty:
         # Check that the accessor doesn't work on the Python_Test backend.
         python_test_df = pandas_df.move_to("Python_Test")
         groupby = get_groupby(python_test_df)
-        # groupby.ngroups defaults to pandas at the API layer,
-        # where it warns that it's doing so, even for dataframes using the
-        # Pandas backend.
-        with warns_that_defaulting_to_pandas():
+        with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
             assert groupby.ngroups == 3
 
     def test_add_ngroups_setter_and_deleter_for_one_backend(
@@ -179,7 +179,7 @@ class TestProperty:
 
         python_test_groupby = get_groupby(python_test_df)
 
-        with warns_that_defaulting_to_pandas():
+        with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
             assert python_test_groupby.ngroups == 3
 
         with pytest.raises(AttributeError):

--- a/modin/tests/pandas/native_df_interoperability/test_default_to_pandas_without_warnings.py
+++ b/modin/tests/pandas/native_df_interoperability/test_default_to_pandas_without_warnings.py
@@ -1,0 +1,78 @@
+# Licensed to Modin Development Team under one or more contributor license agreements.
+# See the NOTICE file distributed with this work for additional information regarding
+# copyright ownership.  The Modin Development Team licenses this file to you under the
+# Apache License, Version 2.0 (the "License"); you may not use this file except in
+# compliance with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed under
+# the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific language
+# governing permissions and limitations under the License.
+
+# While other modin backends raise a warning when defaulting to pandas, it does not make sense to
+# do so when we're running on the native pandas backend already. These tests ensure such warnings
+# are not raised with the pandas backend.
+
+import numpy as np
+import pandas
+import pytest
+
+import modin.pandas as pd
+from modin.config import Backend
+from modin.tests.pandas.utils import df_equals
+
+pytestmark = [
+    pytest.mark.skipif(
+        Backend.get() != "Pandas",
+        reason="warnings only suppressed on native pandas backend",
+        allow_module_level=True,
+    ),
+    # Error if a default to pandas warning is detected.
+    pytest.mark.filterwarnings("error:is not supported by NativeOnNative:UserWarning"),
+]
+
+
+def test_crosstab_no_warning():
+    # Example from pandas docs
+    # https://pandas.pydata.org/docs/reference/api/pandas.crosstab.html
+    a = np.array(
+        ["foo", "foo", "foo", "foo", "bar", "bar", "bar", "bar", "foo", "foo", "foo"],
+        dtype=object,
+    )
+    b = np.array(
+        ["one", "one", "one", "two", "one", "one", "one", "two", "two", "two", "one"],
+        dtype=object,
+    )
+    c = np.array(
+        [
+            "dull",
+            "dull",
+            "shiny",
+            "dull",
+            "dull",
+            "shiny",
+            "shiny",
+            "dull",
+            "shiny",
+            "shiny",
+            "shiny",
+        ],
+        dtype=object,
+    )
+    df_equals(
+        pd.crosstab(a, [b, c], rownames=["a"], colnames=["b", "c"]),
+        pandas.crosstab(a, [b, c], rownames=["a"], colnames=["b", "c"]),
+    )
+
+
+def test_json_normalize_no_warning():
+    # Example from pandas docs
+    # https://pandas.pydata.org/docs/reference/api/pandas.json_normalize.html
+    data = [
+        {"id": 1, "name": {"first": "Coleen", "last": "Volk"}},
+        {"name": {"given": "Mark", "family": "Regner"}},
+        {"id": 2, "name": "Faye Raker"},
+    ]
+    df_equals(pd.json_normalize(data), pandas.json_normalize(data))

--- a/modin/tests/pandas/test_general.py
+++ b/modin/tests/pandas/test_general.py
@@ -22,7 +22,6 @@ from modin.pandas.testing import assert_frame_equal
 from modin.tests.test_utils import (
     current_execution_is_native,
     df_or_series_using_native_execution,
-    warns_that_defaulting_to_pandas,
     warns_that_defaulting_to_pandas_if,
 )
 from modin.utils import get_current_execution
@@ -276,7 +275,9 @@ def test_merge_asof_suffixes():
             right_index=True,
             suffixes=(False, False),
         )
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(
             modin_left,
             modin_right,
@@ -297,7 +298,9 @@ def test_merge_asof_bad_arguments():
         pandas.merge_asof(
             pandas_left, pandas_right, on="a", by="b", left_by="can't do with by"
         )
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(
             modin_left, modin_right, on="a", by="b", left_by="can't do with by"
         )
@@ -305,7 +308,9 @@ def test_merge_asof_bad_arguments():
         pandas.merge_asof(
             pandas_left, pandas_right, by="b", on="a", right_by="can't do with by"
         )
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(
             modin_left, modin_right, by="b", on="a", right_by="can't do with by"
         )
@@ -313,25 +318,37 @@ def test_merge_asof_bad_arguments():
     # Can't mix on with left_on/right_on
     with pytest.raises(ValueError):
         pandas.merge_asof(pandas_left, pandas_right, on="a", left_on="can't do with by")
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(modin_left, modin_right, on="a", left_on="can't do with by")
     with pytest.raises(ValueError):
         pandas.merge_asof(
             pandas_left, pandas_right, on="a", right_on="can't do with by"
         )
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(modin_left, modin_right, on="a", right_on="can't do with by")
 
     # Can't mix left_index with left_on or on, similarly for right.
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(modin_left, modin_right, on="a", right_index=True)
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(
             modin_left, modin_right, left_on="a", right_on="a", right_index=True
         )
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(modin_left, modin_right, on="a", left_index=True)
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(
             modin_left, modin_right, left_on="a", right_on="a", left_index=True
         )
@@ -339,15 +356,21 @@ def test_merge_asof_bad_arguments():
     # Need both left and right
     with pytest.raises(Exception):  # Pandas bug, didn't validate inputs sufficiently
         pandas.merge_asof(pandas_left, pandas_right, left_on="a")
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(modin_left, modin_right, left_on="a")
     with pytest.raises(Exception):  # Pandas bug, didn't validate inputs sufficiently
         pandas.merge_asof(pandas_left, pandas_right, right_on="a")
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(modin_left, modin_right, right_on="a")
     with pytest.raises(ValueError):
         pandas.merge_asof(pandas_left, pandas_right)
-    with pytest.raises(ValueError), warns_that_defaulting_to_pandas():
+    with pytest.raises(ValueError), warns_that_defaulting_to_pandas_if(
+        not current_execution_is_native()
+    ):
         pd.merge_asof(modin_left, modin_right)
 
 
@@ -386,7 +409,7 @@ def test_merge_asof_merge_options():
     pandas_quotes, pandas_trades = to_pandas(modin_quotes), to_pandas(modin_trades)
 
     # left_by + right_by
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         modin_result = pd.merge_asof(
             modin_quotes,
             modin_trades,
@@ -408,7 +431,7 @@ def test_merge_asof_merge_options():
     # Just by:
     pandas_trades["ticker"] = pandas_trades["ticker2"]
     modin_trades["ticker"] = modin_trades["ticker2"]
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         modin_result = pd.merge_asof(
             modin_quotes,
             modin_trades,
@@ -426,7 +449,7 @@ def test_merge_asof_merge_options():
     )
 
     # Tolerance
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         modin_result = pd.merge_asof(
             modin_quotes,
             modin_trades,
@@ -446,7 +469,7 @@ def test_merge_asof_merge_options():
     )
 
     # Direction
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         modin_result = pd.merge_asof(
             modin_quotes,
             modin_trades,
@@ -466,7 +489,7 @@ def test_merge_asof_merge_options():
     )
 
     # Allow exact matches
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         modin_result = pd.merge_asof(
             modin_quotes,
             modin_trades,
@@ -643,7 +666,7 @@ def test_value_counts(normalize, bins, dropna):
     )
     df_equals(modin_result, pandas_result)
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         modin_result = sort_index_for_equal_values(
             pd.value_counts(values, bins=bins, ascending=False), False
         )
@@ -720,7 +743,7 @@ def test_qcut(retbins):
     modin_series = pd.Series(range(10))
     pandas_result = pandas.qcut(pandas_series, 4, retbins=retbins)
     # NOTE that qcut() defaults to pandas at the API layer.
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         modin_result = pd.qcut(modin_series, 4, retbins=retbins)
     if retbins:
         df_equals(modin_result[0], pandas_result[0])
@@ -812,7 +835,7 @@ def test_cut_fallback():
     pandas_result = pandas.cut(range(5), 4)
     # note that we default to pandas at the API layer here, so we warn
     # regardless of whether we are on native execution.
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         modin_result = pd.cut(range(5), 4)
     df_equals(modin_result, pandas_result)
 
@@ -930,7 +953,7 @@ def test_default_to_pandas_warning_message(func, regex):
 def test_empty_dataframe():
     df = pd.DataFrame(columns=["a", "b"])
     # NOTE that we default to pandas at the API layer.
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         df[(df.a == 1) & (df.b == 2)]
 
 

--- a/modin/tests/pandas/test_general.py
+++ b/modin/tests/pandas/test_general.py
@@ -185,26 +185,26 @@ def test_merge_asof(right_index):
         {"a": [1, 2, 3, 6, 7], "right_val": [1, 2, 3, 6, 7]}, index=right_index
     )
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         df = pd.merge_asof(left, right, on="a")
         assert isinstance(df, pd.DataFrame)
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         df = pd.merge_asof(left, right, on="a", allow_exact_matches=False)
         assert isinstance(df, pd.DataFrame)
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         df = pd.merge_asof(left, right, on="a", direction="forward")
         assert isinstance(df, pd.DataFrame)
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         df = pd.merge_asof(left, right, on="a", direction="nearest")
         assert isinstance(df, pd.DataFrame)
 
     left = pd.DataFrame({"left_val": ["a", "b", "c"]}, index=[1, 5, 10])
     right = pd.DataFrame({"right_val": [1, 2, 3, 6, 7]}, index=[1, 2, 3, 6, 7])
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         df = pd.merge_asof(left, right, left_index=True, right_index=True)
         assert isinstance(df, pd.DataFrame)
 
@@ -239,7 +239,7 @@ def test_merge_asof_on_variations():
         {"left_index": True, "right_index": True},
     ]:
         pandas_merged = pandas.merge_asof(pandas_left, pandas_right, **on_arguments)
-        with warns_that_defaulting_to_pandas():
+        with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
             modin_merged = pd.merge_asof(modin_left, modin_right, **on_arguments)
         df_equals(pandas_merged, modin_merged)
 
@@ -258,7 +258,7 @@ def test_merge_asof_suffixes():
             right_index=True,
             suffixes=suffixes,
         )
-        with warns_that_defaulting_to_pandas():
+        with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
             modin_merged = pd.merge_asof(
                 modin_left,
                 modin_right,

--- a/modin/tests/pandas/test_reshape.py
+++ b/modin/tests/pandas/test_reshape.py
@@ -20,8 +20,8 @@ import pytest
 import modin.pandas as pd
 from modin.config import StorageFormat
 from modin.tests.test_utils import (
+    current_execution_is_native,
     df_or_series_using_native_execution,
-    warns_that_defaulting_to_pandas,
     warns_that_defaulting_to_pandas_if,
 )
 
@@ -30,14 +30,14 @@ from .utils import df_equals, test_data_values
 
 def test_get_dummies():
     s = pd.Series(list("abca"))
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         pd.get_dummies(s)
 
     s1 = ["a", "b", np.nan]
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         pd.get_dummies(s1)
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         pd.get_dummies(s1, dummy_na=True)
 
     data = {"A": ["a", "b", "a"], "B": ["b", "a", "c"], "C": [1, 2, 3]}
@@ -61,16 +61,16 @@ def test_get_dummies():
     with pytest.raises(NotImplementedError):
         pd.get_dummies(modin_df, prefix=["col1", "col2"], sparse=True)
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         pd.get_dummies(pd.Series(list("abcaa")))
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         pd.get_dummies(pd.Series(list("abcaa")), drop_first=True)
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         pd.get_dummies(pd.Series(list("abc")), dtype=float)
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         pd.get_dummies(1)
 
     # test from #5184
@@ -120,18 +120,18 @@ def test_crosstab():
         dtype=object,
     )
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         df = pd.crosstab(a, [b, c], rownames=["a"], colnames=["b", "c"])
         assert isinstance(df, pd.DataFrame)
 
     foo = pd.Categorical(["a", "b"], categories=["a", "b", "c"])
     bar = pd.Categorical(["d", "e"], categories=["d", "e", "f"])
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         df = pd.crosstab(foo, bar)
         assert isinstance(df, pd.DataFrame)
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         df = pd.crosstab(foo, bar, dropna=False)
         assert isinstance(df, pd.DataFrame)
 
@@ -147,7 +147,7 @@ def test_lreshape():
         }
     )
 
-    with warns_that_defaulting_to_pandas():
+    with warns_that_defaulting_to_pandas_if(not current_execution_is_native()):
         df = pd.lreshape(data, {"year": ["year1", "year2"], "hr": ["hr1", "hr2"]})
         assert isinstance(df, pd.DataFrame)
 

--- a/modin/tests/test_utils.py
+++ b/modin/tests/test_utils.py
@@ -271,11 +271,10 @@ def warns_that_defaulting_to_pandas_if(
     Returns
     -------
     pytest.recwarn.WarningsChecker or contextlib.nullcontext
-        If Modin is not operating in ``NativeDataframeMode``, a ``WarningsChecker``
-        is returned, which will check for a ``UserWarning`` indicating that Modin
-        is defaulting to Pandas. If ``NativeDataframeMode`` is set, a
-        ``nullcontext`` is returned to avoid the warning about defaulting to Pandas,
-        as this occurs due to user setting of ``NativeDataframeMode``.
+        If ``condition`` is True, ``WarningsChecker`` is returned, which will check for a
+        ``UserWarning`` indicating that Modin is defaulting to Pandas.
+        If it is False, a ``nullcontext`` is returned to avoid checking for the warning about
+        defaulting to Pandas.
     """
     assert isinstance(condition, bool)
     return (

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -974,9 +974,7 @@ def _maybe_warn_on_default(message: str = "", *, reason: str = "") -> None:
         The reason for defaulting.
     """
     # Avoids a module-level circular import
-    from modin.core.execution.dispatching.factories.dispatcher import (
-        FactoryDispatcher,
-    )
+    from modin.core.execution.dispatching.factories.dispatcher import FactoryDispatcher
 
     FactoryDispatcher.get_factory().io_cls.query_compiler_cls._maybe_warn_on_default(
         message=message, reason=reason

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -959,6 +959,27 @@ class ModinAssumptionError(Exception):
     pass
 
 
+def _maybe_warn_on_default(message: str = "", *, reason: str = "") -> None:
+    """
+    Raise a warning on an operation that defaults to pandas if necessary.
+
+    This checks the query compiler used by the current configured active backend, and prints
+    a warning message about defaulting to pandas if needed.
+
+    Parameters
+    ----------
+    message : str
+        The message to show.
+    reason : str
+        The reason for defaulting.
+    """
+    # Prevent circular import
+    from modin.core.execution.dispatching.factories.dispatcher import (
+        FactoryDispatcher,
+    )
+    FactoryDispatcher.get_factory().io_cls.query_compiler_cls._maybe_warn_on_default(message=message, reason=reason)
+
+
 class classproperty:
     """
     Decorator that allows creating read-only class properties.

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -973,7 +973,7 @@ def _maybe_warn_on_default(message: str = "", *, reason: str = "") -> None:
     reason : str
         The reason for defaulting.
     """
-    # Prevent circular import
+    # Avoids a module-level circular import
     from modin.core.execution.dispatching.factories.dispatcher import (
         FactoryDispatcher,
     )

--- a/modin/utils.py
+++ b/modin/utils.py
@@ -968,16 +968,19 @@ def _maybe_warn_on_default(message: str = "", *, reason: str = "") -> None:
 
     Parameters
     ----------
-    message : str
+    message : str, default: ""
         The message to show.
-    reason : str
+    reason : str, default: ""
         The reason for defaulting.
     """
     # Avoids a module-level circular import
     from modin.core.execution.dispatching.factories.dispatcher import (
         FactoryDispatcher,
     )
-    FactoryDispatcher.get_factory().io_cls.query_compiler_cls._maybe_warn_on_default(message=message, reason=reason)
+
+    FactoryDispatcher.get_factory().io_cls.query_compiler_cls._maybe_warn_on_default(
+        message=message, reason=reason
+    )
 
 
 class classproperty:


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

IO and general module functions now all share a code path that checks whether the active backend's query compiler should warn on default to pandas. Methods that default to pandas directly in the base.py frontend layer (rather than at the query compiler level) also now use this code path.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7638 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
