### PR TITLE
TEST-#7643: Fix residual failures from pandas 2.3

### DIFF
--- a/modin/core/dataframe/base/dataframe/utils.py
+++ b/modin/core/dataframe/base/dataframe/utils.py
@@ -105,10 +105,12 @@ def join_columns(
             left_on = []
             right_on = []
         # in other cases, we can simply add the index name to columns and proceed as normal
+        # in pandas-stubs 2.2, these lines will warn about insert being an untyped call,
+        # but this error is no longer present on higher versions
         elif left_on[0] not in left:
-            left = left.insert(loc=0, item=left_on[0])
+            left = left.insert(loc=0, item=left_on[0])  # type: ignore[no-untyped-calls, unused-ignore]
         elif right_on[0] not in right:
-            right = right.insert(loc=0, item=right_on[0])
+            right = right.insert(loc=0, item=right_on[0])  # type: ignore[no-untyped-calls, unused-ignore]
 
     if any(col not in left for col in left_on) or any(
         col not in right for col in right_on

--- a/modin/core/dataframe/base/dataframe/utils.py
+++ b/modin/core/dataframe/base/dataframe/utils.py
@@ -106,9 +106,9 @@ def join_columns(
             right_on = []
         # in other cases, we can simply add the index name to columns and proceed as normal
         elif left_on[0] not in left:
-            left = left.insert(loc=0, item=left_on[0])  # type: ignore
+            left = left.insert(loc=0, item=left_on[0])
         elif right_on[0] not in right:
-            right = right.insert(loc=0, item=right_on[0])  # type: ignore
+            right = right.insert(loc=0, item=right_on[0])
 
     if any(col not in left for col in left_on) or any(
         col not in right for col in right_on

--- a/modin/core/dataframe/base/dataframe/utils.py
+++ b/modin/core/dataframe/base/dataframe/utils.py
@@ -105,12 +105,12 @@ def join_columns(
             left_on = []
             right_on = []
         # in other cases, we can simply add the index name to columns and proceed as normal
-        # in pandas-stubs 2.2, these lines will warn about insert being an untyped call,
+        # on python 3.9 with pandas-stubs 2.2, these lines will warn about insert being an untyped call,
         # but this error is no longer present on higher versions
         elif left_on[0] not in left:
-            left = left.insert(loc=0, item=left_on[0])  # type: ignore[no-untyped-calls, unused-ignore]
+            left = left.insert(loc=0, item=left_on[0])  # type: ignore[no-untyped-call, unused-ignore]
         elif right_on[0] not in right:
-            right = right.insert(loc=0, item=right_on[0])  # type: ignore[no-untyped-calls, unused-ignore]
+            right = right.insert(loc=0, item=right_on[0])  # type: ignore[no-untyped-call, unused-ignore]
 
     if any(col not in left for col in left_on) or any(
         col not in right for col in right_on

--- a/modin/tests/pandas/dataframe/test_udf.py
+++ b/modin/tests/pandas/dataframe/test_udf.py
@@ -130,7 +130,7 @@ def test_aggregate_error_checking():
         modin_df.aggregate({modin_df.columns[0]: "sum", modin_df.columns[1]: "mean"})
 
     with warns_that_defaulting_to_pandas():
-        modin_df.aggregate("cumproduct")
+        modin_df.aggregate("cumprod")
 
 
 @pytest.mark.parametrize(

--- a/modin/tests/pandas/dataframe/test_udf.py
+++ b/modin/tests/pandas/dataframe/test_udf.py
@@ -130,7 +130,7 @@ def test_aggregate_error_checking():
         modin_df.aggregate({modin_df.columns[0]: "sum", modin_df.columns[1]: "mean"})
 
     with warns_that_defaulting_to_pandas():
-        modin_df.aggregate("cumprod")
+        modin_df.aggregate("arcsin")
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7643 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->

2 failures are fixed here: 
- `DataFrame.insert` apparently is now typed with `pandas-stubs==2.3`, but was not typed before. Since pandas 2.3 is compatible with Python 3.9 all CI runs should pick up this change, but if it continues to be an issue I'll look into a workaround for seeing if it's possible to conditionally add the `type: ignore` directive.
- `np.cumproduct` was [deprecated](https://numpy.org/doc/1.26/release/1.25.0-notes.html#deprecations) some time ago, and removed in numpy>2. We've supported numpy>2 for a while, so it's unclear why this issue only just triggered.