### PR TITLE
FEAT-#7647: Shorten the hybrid progress bar text

### DIFF
--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4522,7 +4522,7 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
                 try:
                     from tqdm.auto import trange
 
-                    progress_iter = iter(trange(progress_split_count, desc=desc))
+                    progress_iter = iter(trange(progress_split_count, desc=desc, bar_format='{desc} [{bar}]'))
                 except ImportError:
                     # Fallback to simple print statement when tqdm is not available.
                     # Print to stderr to match tqdm's behavior.

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4513,9 +4513,10 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
                 operation_str = ""
             # Provide the switch_operation; and specifically only the method, so
             # DataFrame.merge would become "merge"
+            max_shape_str = f"({max_rows:.0g},{max_cols:.0g})"
             desc = (
                 f"Transferring: {self_backend:>10.10} → {normalized_backend:<10.10} "
-                + f" | {operation_str.split('.')[-1]:^10.10} | est. max shape ({max_rows:^5g},{max_cols:^5g})"
+                + f" | {operation_str.split('.')[-1]:^10.10} | est. max shape {max_shape_str:<10.10}"
             )
 
             if ShowBackendSwitchProgress.get():

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4505,16 +4505,18 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
         normalized_backend = Backend.normalize(backend)
         if normalized_backend != self_backend:
             max_rows, max_cols = self._query_compiler._max_shape()
+            # Format the transfer string to be relatively short, but informative. Each
+            # backend is given an allowable width of 10 and the shape integers use the
+            # general format to use scientific notation when needed.
+            operation_str = switch_operation
             if switch_operation is None:
-                desc = (
-                    f"Transferring data from {self_backend} to {normalized_backend}"
-                    + f" with max estimated shape {max_rows}x{max_cols}"
-                )
-            else:
-                desc = (
-                    f"Transferring data from {self_backend} to {normalized_backend} for"
-                    + f" '{switch_operation}' with max estimated shape {max_rows}x{max_cols}"
-                )
+                operation_str = ""
+            # Provide the switch_operation; and specifically only the method, so
+            # DataFrame.merge would become "merge"
+            desc = (
+                f"Transferring: {self_backend:>10.10} => {normalized_backend:<10.10} "
+                + f" | {operation_str.split('.')[-1]:^10.10} | ~({max_rows:^5g},{max_cols:^5g})"
+            )
 
             if ShowBackendSwitchProgress.get():
                 try:

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4516,7 +4516,7 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
             max_shape_str = f"({max_rows:.0g},{max_cols:.0g})"
             desc = (
                 f"Transferring: {self_backend:>10.10} → {normalized_backend:<10.10} "
-                + f" | {operation_str.split('.')[-1]:^10.10} | est. max shape {max_shape_str:<10.10}"
+                + f" | {operation_str.split('.')[-1]:^10.10} | est. max shape {max_shape_str:<13.13}"
             )
 
             if ShowBackendSwitchProgress.get():

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4523,7 +4523,11 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
                 try:
                     from tqdm.auto import trange
 
-                    progress_iter = iter(trange(progress_split_count, desc=desc, bar_format='{desc} [{bar}]'))
+                    progress_iter = iter(
+                        trange(
+                            progress_split_count, desc=desc, bar_format="{desc} [{bar}]"
+                        )
+                    )
                 except ImportError:
                     # Fallback to simple print statement when tqdm is not available.
                     # Print to stderr to match tqdm's behavior.

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4508,15 +4508,30 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
             # Format the transfer string to be relatively short, but informative. Each
             # backend is given an allowable width of 10 and the shape integers use the
             # general format to use scientific notation when needed.
+            std_field_length = 10
             operation_str = switch_operation
+            self_backend_str = self_backend
+            normalized_backend_str = normalized_backend
             if switch_operation is None:
                 operation_str = ""
             # Provide the switch_operation; and specifically only the method, so
             # DataFrame.merge would become "merge"
-            max_shape_str = f"({max_rows:.0g},{max_cols:.0g})"
+            operation_str = operation_str.split(".")[-1]
+            # truncate all strings to the field length if needed
+            if len(operation_str) > 15:
+                operation_str = operation_str[: 15 - 3] + "..."
+            if len(self_backend_str) > std_field_length:
+                self_backend_str = self_backend_str[: std_field_length - 3] + "..."
+            if len(normalized_backend_str) > std_field_length:
+                normalized_backend_str = (
+                    normalized_backend_str[: std_field_length - 3] + "..."
+                )
+
+            # format the estimated max shape
+            max_shape_str = f"({max_rows:.0g}, {max_cols:.0g})"
             desc = (
-                f"Transferring: {self_backend:>10.10} → {normalized_backend:<10.10} "
-                + f" | {operation_str.split('.')[-1]:^10.10} | est. max shape {max_shape_str:<13.13}"
+                f"Transfer: {self_backend_str:>10.10} → {normalized_backend_str:<10.10} "
+                + f" | {operation_str:^15.15} ≃ {max_shape_str:<10.10}"
             )
 
             if ShowBackendSwitchProgress.get():

--- a/modin/pandas/base.py
+++ b/modin/pandas/base.py
@@ -4514,8 +4514,8 @@ class BasePandasDataset(QueryCompilerCaster, ClassLogger):
             # Provide the switch_operation; and specifically only the method, so
             # DataFrame.merge would become "merge"
             desc = (
-                f"Transferring: {self_backend:>10.10} => {normalized_backend:<10.10} "
-                + f" | {operation_str.split('.')[-1]:^10.10} | ~({max_rows:^5g},{max_cols:^5g})"
+                f"Transferring: {self_backend:>10.10} → {normalized_backend:<10.10} "
+                + f" | {operation_str.split('.')[-1]:^10.10} | est. max shape ({max_rows:^5g},{max_cols:^5g})"
             )
 
             if ShowBackendSwitchProgress.get():

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -857,7 +857,7 @@ class TestSwitchBackendPostOpDependingOnDataSize:
             desc = call_args[1]["desc"]  # Get the 'desc' keyword argument
 
             assert desc.startswith(
-                "Transferring: Big_Data_C => Small_Data  | read_json  | ~(  9  ,  1  )"
+                "Transferring: Big_Data_C → Small_Data  | read_json  | est. max shape (  9  ,  1  )"
             )
 
     def test_agg(self):

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -857,7 +857,7 @@ class TestSwitchBackendPostOpDependingOnDataSize:
             desc = call_args[1]["desc"]  # Get the 'desc' keyword argument
 
             assert desc.startswith(
-                "Transferring data from Big_Data_Cloud to Small_Data_Local for 'modin.pandas.read_json'"
+                "Transferring: Big_Data_C => Small_Data  | read_json  | ~(  9  ,  1  )"
             )
 
     def test_agg(self):

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -857,7 +857,7 @@ class TestSwitchBackendPostOpDependingOnDataSize:
             desc = call_args[1]["desc"]  # Get the 'desc' keyword argument
 
             assert desc.startswith(
-                "Transferring: Big_Data_C → Small_Data  | read_json  | est. max shape (9,1)     "
+                "Transfer: Big_Dat... → Small_D...  |    read_json    ≃ (9, 1)    "
             )
 
     def test_agg(self):

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -857,7 +857,7 @@ class TestSwitchBackendPostOpDependingOnDataSize:
             desc = call_args[1]["desc"]  # Get the 'desc' keyword argument
 
             assert desc.startswith(
-                "Transferring: Big_Data_C → Small_Data  | read_json  | est. max shape (  9  ,  1  )"
+                "Transferring: Big_Data_C → Small_Data  | read_json  | est. max shape (9,1)     "
             )
 
     def test_agg(self):

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -422,10 +422,10 @@ class TestGroupbySetBackend:
 @pytest.mark.parametrize(
     "switch_operation,expected_output",
     [
-        (None, "Transferring: Python_Tes => Pandas      |            | ~(  3  ,  1  )"),
+        (None, "Transferring: Python_Tes → Pandas      |            | est. max shape (  3  ,  1  )"),
         (
             "test_operation",
-            "Transferring: Python_Tes => Pandas      | test_opera | ~(  3  ,  1  )",
+            "Transferring: Python_Tes → Pandas      | test_opera | est. max shape (  3  ,  1  )",
         ),
     ],
 )

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -422,10 +422,10 @@ class TestGroupbySetBackend:
 @pytest.mark.parametrize(
     "switch_operation,expected_output",
     [
-        (None, "Transferring data from Python_Test to Pandas with max estimated shape"),
+        (None, "Transferring: Python_Tes => Pandas      |            | ~(  3  ,  1  )"),
         (
             "test_operation",
-            "Transferring data from Python_Test to Pandas for 'test_operation' with max estimated shape",
+            "Transferring: Python_Tes => Pandas      | test_opera | ~(  3  ,  1  )",
         ),
     ],
 )

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -424,11 +424,11 @@ class TestGroupbySetBackend:
     [
         (
             None,
-            "Transferring: Python_Tes → Pandas      |            | est. max shape (3,1)     ",
+            "Transfer: Python_... → Pandas      |                 ≃ (3, 1)    ",
         ),
         (
             "test_operation",
-            "Transferring: Python_Tes → Pandas      | test_opera | est. max shape (3,1)     ",
+            "Transfer: Python_... → Pandas      | test_operation  ≃ (3, 1)    ",
         ),
     ],
 )

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -422,10 +422,10 @@ class TestGroupbySetBackend:
 @pytest.mark.parametrize(
     "switch_operation,expected_output",
     [
-        (None, "Transferring: Python_Tes → Pandas      |            | est. max shape (  3  ,  1  )"),
+        (None, "Transferring: Python_Tes → Pandas      |            | est. max shape (3,1)     "),
         (
             "test_operation",
-            "Transferring: Python_Tes → Pandas      | test_opera | est. max shape (  3  ,  1  )",
+            "Transferring: Python_Tes → Pandas      | test_opera | est. max shape (3,1)     ",
         ),
     ],
 )

--- a/modin/tests/pandas/test_backend.py
+++ b/modin/tests/pandas/test_backend.py
@@ -422,7 +422,10 @@ class TestGroupbySetBackend:
 @pytest.mark.parametrize(
     "switch_operation,expected_output",
     [
-        (None, "Transferring: Python_Tes → Pandas      |            | est. max shape (3,1)     "),
+        (
+            None,
+            "Transferring: Python_Tes → Pandas      |            | est. max shape (3,1)     ",
+        ),
         (
             "test_operation",
             "Transferring: Python_Tes → Pandas      | test_opera | est. max shape (3,1)     ",


### PR DESCRIPTION
- Make it fixed width
- Format row/col estimates with general formatting and limit to 6 characters
- Trim the operation name if needed, prefer the method over the object

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7647 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
