### PR TITLE
FIX-#7653: Respect `AutoSwitchBackend` for `DataFrame.T`/`Series.T~

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -633,7 +633,12 @@ class DataFrame(BasePandasDataset):
             query_compiler=self._query_compiler.transpose(*args)
         )
 
-    T: DataFrame = property(transpose)
+    # To enable dynamic backend switching, we must use a `def` so the lookup of `self.transpose`
+    # is performed dynamically, whereas declaring `T = property(transpose)` makes it always use
+    # the originally-defined version without the switching wrapper.
+    @property
+    def T(self) -> DataFrame:
+        return self.transpose()
 
     def add(
         self, other, axis="columns", level=None, fill_value=None

--- a/modin/pandas/series.py
+++ b/modin/pandas/series.py
@@ -2273,7 +2273,12 @@ class Series(BasePandasDataset):
         """
         return self
 
-    T: Series = property(transpose)
+    # To enable dynamic backend switching, we must use a `def` so the lookup of `self.transpose`
+    # is performed dynamically, whereas declaring `T = property(transpose)` makes it always use
+    # the originally-defined version without the switching wrapper.
+    @property
+    def T(self) -> Series:
+        return self.transpose()
 
     def truediv(
         self, other, level=None, fill_value=None, axis=0


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

Currently, `DataFrame.T` is declared like so:

```python

    def transpose(self, copy=False, *args) -> DataFrame:  # noqa: PR01, RT01, D200
        """
        Transpose index and columns.
        """
        # FIXME: Judging by pandas docs `*args` serves only compatibility purpose
        # and does not affect the result, we shouldn't pass it to the query compiler.
        return self.__constructor__(
            query_compiler=self._query_compiler.transpose(*args)
        )

    T: DataFrame = property(transpose)
```

This breaks automatic backend switching in a very subtle way. Because we use the `QueryCompilerCaster` ABC to replace all methods with a wrapper that picks the correct backend, the `transpose` referenced in `property(transpose)` is actually the original, unwrapped method, and therefore never uses the switching code path. This PR replaces the definition of `T` with
```python
    @property
    def T(self):
        return self.transpose()
```
which defers lookup of `transpose` to runtime, and therefore uses the caster wrapper correctly.

I initially attempted to add special logic to wrap `fget`/`fset`/`fdel` or property objects in `QueryCompilerCaster`, but this became complicated and also didn't work for some reason--somehow, even though I was able to wrap `fget`, the wrapped function was never called. The approach in this PR is simpler, and runs a lower risk of breaking behavior or accidentally causing thrashing for other commonly-accessed properties like `columns` and `index`.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7653 <!-- issue must be created for each patch -->
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
