### PR TITLE
FIX-#7664: Add typing_extensions dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,6 +56,7 @@ setup(
         "numpy>=1.22.4",
         "fsspec>=2022.11.0",
         "psutil>=5.8.0",
+        "typing-extensions",
     ],
     extras_require={
         # can be installed by pip install modin[dask]


### PR DESCRIPTION
<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

`typing_extensions` (used to get the `Self` type) is included as a tertiary dependency of Ray for Python 3.12 and below, but it is no longer included for 3.13. This PR makes it a direct dependency of modin.

The [conda-forge](https://github.com/conda-forge/modin-feedstock) recipe (which has been broken for a while) will need to be updated.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7664 <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
