### PR TITLE
FIX-#7669: Respect eval(inplace=False).

### DIFF
--- a/modin/core/computation/eval.py
+++ b/modin/core/computation/eval.py
@@ -381,7 +381,7 @@ def eval(
                 try:
                     target = env.target
                     if isinstance(target, BasePandasDataset):
-                        target = target.copy(deep=None)
+                        target = target.copy(deep=True)
                     else:
                         target = target.copy()
                 except AttributeError as err:

--- a/modin/tests/pandas/dataframe/test_udf.py
+++ b/modin/tests/pandas/dataframe/test_udf.py
@@ -385,6 +385,17 @@ def test_eval_scalar():
     assert df.eval("1") == 1
 
 
+@pytest.mark.parametrize("engine", ("numexpr", "python"))
+def test_eval_not_inplace_does_not_change_input_dataframe(engine):
+    snow_df, pandas_df = create_test_dfs({"a": [1, 2, 3]})
+    original_pandas = pandas_df.copy()
+    snow_result = snow_df.eval("b = a + 1", inplace=False, engine=engine)
+    pandas_result = pandas_df.eval("b = a + 1", inplace=False, engine=engine)
+    df_equals(snow_df, original_pandas)
+    df_equals(pandas_df, original_pandas)
+    df_equals(snow_result, pandas_result)
+
+
 TEST_VAR = 2
 
 


### PR DESCRIPTION
Prior to this commit, calling `DataFrame.eval(inplace=False, engine='python')` with an assignment would incorrectly update the input dataframe. The root cause was calling `copy(deep=None)` instead of `copy(deep=True)`. We need to insert new columns to a deep copy of the input dataframe. `deep=None` is not part of the `copy` API at all, so we don't need to fix `copy()` behavior. It happens that `deep=None` does a deep copy in pandas, which is where we got the `deep=None` code from.

Resolves #7669