### PR TITLE
FIX-#7667: Fix `axis=None` case for `DataFrame.rename`

### DIFF
--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1831,7 +1831,7 @@ class DataFrame(BasePandasDataset):
         kwargs["inplace"] = False
         if axis is not None:
             axis = self._get_axis_number(axis)
-        if index is not None or (mapper is not None and axis == 0):
+        if index is not None or (mapper is not None and axis in [0, None]):
             new_index = pandas.DataFrame(index=self.index).rename(**kwargs).index
         else:
             new_index = None

--- a/modin/pandas/dataframe.py
+++ b/modin/pandas/dataframe.py
@@ -1829,9 +1829,8 @@ class DataFrame(BasePandasDataset):
         # inplace should always be true because this is just a copy, and we will use the
         # results after.
         kwargs["inplace"] = False
-        if axis is not None:
-            axis = self._get_axis_number(axis)
-        if index is not None or (mapper is not None and axis in [0, None]):
+        axis = self._get_axis_number(axis)
+        if index is not None or (mapper is not None and axis == 0):
             new_index = pandas.DataFrame(index=self.index).rename(**kwargs).index
         else:
             new_index = None

--- a/modin/tests/pandas/dataframe/test_indexing.py
+++ b/modin/tests/pandas/dataframe/test_indexing.py
@@ -1150,6 +1150,9 @@ def test_rename_sanity():
         modin_df.rename(str.upper, axis=1).columns,
         df.rename(str.upper, axis=1).columns,
     )
+    assert_index_equal(
+        modin_df.rename(str.upper).index, df.rename(str.upper).index
+    )
 
     # have to pass something
     with pytest.raises(TypeError):

--- a/modin/tests/pandas/dataframe/test_indexing.py
+++ b/modin/tests/pandas/dataframe/test_indexing.py
@@ -1150,9 +1150,7 @@ def test_rename_sanity():
         modin_df.rename(str.upper, axis=1).columns,
         df.rename(str.upper, axis=1).columns,
     )
-    assert_index_equal(
-        modin_df.rename(str.upper).index, df.rename(str.upper).index
-    )
+    assert_index_equal(modin_df.rename(str.upper).index, df.rename(str.upper).index)
 
     # have to pass something
     with pytest.raises(TypeError):


### PR DESCRIPTION
Resolves #7667

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [ ] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [ ] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [ ] Resolves #? <!-- issue must be created for each patch -->
- [ ] tests added and passing
- [ ] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
