### PR TITLE
TEST-#7681: Interop Tests should all use Backend.get instead of "Ray"

### DIFF
--- a/modin/tests/pandas/native_df_interoperability/utils.py
+++ b/modin/tests/pandas/native_df_interoperability/utils.py
@@ -62,7 +62,7 @@ def create_test_series_in_defined_mode(
     if not isinstance(native, bool):
         raise ValueError("`native` should be True or False.")
 
-    hybrid_backend = "Pandas" if native else "Ray"
+    hybrid_backend = "Pandas" if native else Backend.get()
     with switch_to_native_execution() if native else nullcontext():
         with config_context(AutoSwitchBackend=False, Backend=hybrid_backend):
             modin_ser, pandas_ser = create_test_series(

--- a/modin/tests/pandas/native_df_interoperability/utils.py
+++ b/modin/tests/pandas/native_df_interoperability/utils.py
@@ -45,6 +45,8 @@ def create_test_df_in_defined_mode(
 
     if not isinstance(native, bool):
         raise ValueError("`native` should be True or False.")
+
+     # Use the default backend unless native
     hybrid_backend = "Pandas" if native else Backend.get()
     with switch_to_native_execution() if native else nullcontext():
         with config_context(AutoSwitchBackend=False, Backend=hybrid_backend):
@@ -62,6 +64,7 @@ def create_test_series_in_defined_mode(
     if not isinstance(native, bool):
         raise ValueError("`native` should be True or False.")
 
+    # Use the default backend unless native
     hybrid_backend = "Pandas" if native else Backend.get()
     with switch_to_native_execution() if native else nullcontext():
         with config_context(AutoSwitchBackend=False, Backend=hybrid_backend):

--- a/modin/tests/pandas/native_df_interoperability/utils.py
+++ b/modin/tests/pandas/native_df_interoperability/utils.py
@@ -46,7 +46,7 @@ def create_test_df_in_defined_mode(
     if not isinstance(native, bool):
         raise ValueError("`native` should be True or False.")
 
-     # Use the default backend unless native
+    # Use the default backend unless native
     hybrid_backend = "Pandas" if native else Backend.get()
     with switch_to_native_execution() if native else nullcontext():
         with config_context(AutoSwitchBackend=False, Backend=hybrid_backend):


### PR DESCRIPTION
Missed a line in create_test_series_in_defined_mode where we want to get the default Backend instead of "Ray"

<!--
Thank you for your contribution!
Please review the contributing docs: https://modin.readthedocs.io/en/latest/development/contributing.html
if you have questions about contributing.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7681
- [x] tests added and passing (NA)
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
