### PR TITLE
TEST-#7686: Fix comparisons in caster tests to check the backend instead of type

### DIFF
--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -718,7 +718,7 @@ def test_merge_in_place(default_df, lazy_df, cloud_df):
         lazy_df = lazy_df.move_to("Lazy")
         cloud_df = cloud_df.move_to("Cloud")
         df = cloud_df.merge(lazy_df)
-        assert type(df) is type(cloud_df)
+        assert df.get_backend() is cloud_df.get_backend()
         assert lazy_df.get_backend() == "Lazy"
         assert cloud_df.get_backend() == "Cloud"
 

--- a/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
+++ b/modin/tests/pandas/native_df_interoperability/test_compiler_caster.py
@@ -729,15 +729,15 @@ def test_information_asymmetry(default_df, cloud_df, eager_df, lazy_df):
     # the other way around, eager has a special ability to
     # control the directionality of the cast.
     df = default_df.merge(eager_df)
-    assert type(df) is type(eager_df)
+    assert df.get_backend() is eager_df.get_backend()
     df = cloud_df.merge(eager_df)
-    assert type(df) is type(eager_df)
+    assert df.get_backend() is eager_df.get_backend()
 
     # lazy_df tries to pawn off work on other engines
     df = default_df.merge(lazy_df)
-    assert type(df) is type(default_df)
+    assert df.get_backend() is default_df.get_backend()
     df = cloud_df.merge(lazy_df)
-    assert type(df) is type(cloud_df)
+    assert df.get_backend() is cloud_df.get_backend()
 
 
 def test_setitem_in_place_with_self_switching_backend(cloud_df, local_df):


### PR DESCRIPTION
Originally the tests in `test_compiler_caster.py` only tested against query compilers; so checking that a cast occurred correctly was performed with an assert similar to `assert type(qc1) == type(qc2)`.  Eventually the changes were lifted up into the DataFrame object so these asserts became invalid although they continued to pass. A recent test, `test_merge_in_place` was added recently where I accidentally used the old pattern. While fixing this I also discovered that `test_information_asymmetry` was also still using the old style.

- [x] first commit message and PR title follow format outlined [here](https://modin.readthedocs.io/en/latest/development/contributing.html#commit-message-formatting)
  > **_NOTE:_**  If you edit the PR title to match this format, you need to add another commit (even if it's empty) or amend your last commit for the CI job that checks the PR title to pick up the new PR title.
- [x] passes `flake8 modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] passes `black --check modin/ asv_bench/benchmarks scripts/doc_checker.py`
- [x] signed commit with `git commit -s` <!-- you can amend your commit with a signature via `git commit -amend -s` -->
- [x] Resolves #7686 
- [x] tests added and passing
- [x] module layout described at `docs/development/architecture.rst` is up-to-date <!-- if you have added, renamed or removed files or directories please update the documentation accordingly -->
