### PR TITLE
FIX-#0000: Correct typos 'occured' and 'recieved'

### DIFF
--- a/modin/core/dataframe/base/interchange/dataframe_protocol/utils.py
+++ b/modin/core/dataframe/base/interchange/dataframe_protocol/utils.py
@@ -177,9 +177,9 @@ def raise_copy_alert(copy_reason: Optional[str] = None) -> None:
     ----------
     copy_reason : str, optional
         The reason of making a copy. Should fit to the following format:
-        'The copy occured due to {copy_reason}.'.
+        'The copy occurred due to {copy_reason}.'.
     """
     msg = "Copy required but 'allow_copy=False' is set."
     if copy_reason:
-        msg += f" The copy occured due to {copy_reason}."
+        msg += f" The copy occurred due to {copy_reason}."
     raise RuntimeError(msg)

--- a/modin/core/execution/ray/common/engine_wrapper.py
+++ b/modin/core/execution/ray/common/engine_wrapper.py
@@ -255,7 +255,7 @@ class SignalActor:  # pragma: no cover
 
     def send(self, event_idx: int):
         """
-        Indicate that event with `event_idx` has occured.
+        Indicate that event with `event_idx` has occurred.
 
         Parameters
         ----------
@@ -265,7 +265,7 @@ class SignalActor:  # pragma: no cover
 
     async def wait(self, event_idx: int):
         """
-        Wait until event with `event_idx` has occured.
+        Wait until event with `event_idx` has occurred.
 
         Parameters
         ----------
@@ -275,7 +275,7 @@ class SignalActor:  # pragma: no cover
 
     def is_set(self, event_idx: int) -> bool:
         """
-        Check that event with `event_idx` had occured or not.
+        Check that event with `event_idx` had occurred or not.
 
         Parameters
         ----------

--- a/modin/core/execution/unidist/common/engine_wrapper.py
+++ b/modin/core/execution/unidist/common/engine_wrapper.py
@@ -181,7 +181,7 @@ class SignalActor:  # pragma: no cover
 
     def send(self, event_idx: int):
         """
-        Indicate that event with `event_idx` has occured.
+        Indicate that event with `event_idx` has occurred.
 
         Parameters
         ----------
@@ -191,7 +191,7 @@ class SignalActor:  # pragma: no cover
 
     async def wait(self, event_idx: int):
         """
-        Wait until event with `event_idx` has occured.
+        Wait until event with `event_idx` has occurred.
 
         Parameters
         ----------

--- a/modin/distributed/dataframe/pandas/partitions.py
+++ b/modin/distributed/dataframe/pandas/partitions.py
@@ -104,7 +104,7 @@ def unwrap_partitions(
                     blocks = partition.list_of_blocks
                 assert (
                     len(blocks) == 1
-                ), f"Implementation assumes that partition contains a single block, but {len(blocks)} recieved."
+                ), f"Implementation assumes that partition contains a single block, but {len(blocks)} received."
                 return blocks[0]
 
             if get_ip:


### PR DESCRIPTION
Fixed typos across 4 files:
- 'occured' → 'occurred' (7 occurrences)
- 'recieved' → 'received' (1 occurrence)